### PR TITLE
fix issue 8439: bonus3 baddmonsterdropitem not specified on one item

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -2438,10 +2438,8 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 			int itemid = 0;
 			for (i = 0; i < ARRAYLENGTH(sd->add_drop) && (sd->add_drop[i].id || sd->add_drop[i].group); i++) {
 				if ( sd->add_drop[i].race == -md->mob_id ||
-					( (sd->add_drop[i].race > 0 || sd->add_drop[i].class_ > 0) && (
-						(sd->add_drop[i].race > 0 && (sd->add_drop[i].race & (1<<status->race))) ||
-						(sd->add_drop[i].class_ > 0 && (sd->add_drop[i].class_ & (1<<status->class_)))
-					)))
+				   ( sd->add_drop[i].race > 0 && (sd->add_drop[i].race & (1<<status->race))) ||
+				   ( sd->add_drop[i].class_ > 0 && (sd->add_drop[i].class_ & (1<<status->class_))) )
 				{
 					//check if the bonus item drop rate should be multiplied with mob level/10 [Lupus]
 					if(sd->add_drop[i].rate < 0) {


### PR DESCRIPTION
sd->add_drop[i].race and sd->add_drop[i].class_ can be -1 here, which causes any item drop to pass this - see http://rathena.org/board/tracker/issue-8439-bonus3-baddmonsterdropitem-not-specified-on-one-item%EF%BC%81/
