### PR TITLE
Follow up 9b4d922.

### DIFF
--- a/src/map/mail.c
+++ b/src/map/mail.c
@@ -52,6 +52,8 @@ int mail_removezeny(struct map_session_data *sd, short flag)
 	{  //Zeny send
 		pc_payzeny(sd,sd->mail.zeny,LOG_TYPE_MAIL, NULL);
 	}
+	if (sd->mail.zeny > 0)
+		clif_updatestatus(sd, SP_ZENY);
 	sd->mail.zeny = 0;
 
 	return 1;


### PR DESCRIPTION
- Fixed Zeny doesn't updated when player cancels to send a mail with attached Zeny. Thank a91323

Signed-off-by: Cydh Ramdh house.bad@gmail.com
