### PR TITLE
Doubled the hostname length

### DIFF
--- a/src/login/loginlog.c
+++ b/src/login/loginlog.c
@@ -16,14 +16,14 @@
 #include <stdlib.h> // exit
 
 // global sql settings (in ipban_sql.c)
-static char   global_db_hostname[32] = "127.0.0.1";
+static char   global_db_hostname[64] = "127.0.0.1"; // Doubled to reflect the change on commit #0f2dd7f
 static uint16 global_db_port = 3306;
 static char   global_db_username[32] = "ragnarok";
 static char   global_db_password[32] = ""; //empty by default since mysql is empty by default as well
 static char   global_db_database[32] = "ragnarok";
 static char   global_codepage[32] = "";
 // local sql settings
-static char   log_db_hostname[32] = "";
+static char   log_db_hostname[64] = ""; // Doubled to reflect the change on commit #0f2dd7f
 static uint16 log_db_port = 0;
 static char   log_db_username[32] = "";
 static char   log_db_password[32] = "";


### PR DESCRIPTION
The hostname char array was doubled on commit #0f2dd7f but wasn't reflected later on in further file modifications.
