### PR TITLE
Doubled the hostname length

### DIFF
--- a/src/login/ipban.c
+++ b/src/login/ipban.c
@@ -22,7 +22,7 @@
 #include <string.h>
 
 // login sql settings
-static char   ipban_db_hostname[32] = "127.0.0.1";
+static char   ipban_db_hostname[64] = "127.0.0.1"; // Doubled to reflect the change on commit #0f2dd7f
 static uint16 ipban_db_port = 3306;
 static char   ipban_db_username[32] = "ragnarok";
 static char   ipban_db_password[32] = "";


### PR DESCRIPTION
The hostname char array was doubled on commit #0f2dd7f but wasn't reflected later on in further file modifications.
