### PR TITLE
Removed a redundant call to clif_party_info on party loading.

### DIFF
--- a/src/map/party.c
+++ b/src/map/party.c
@@ -319,7 +319,8 @@ int party_recv_info(struct party* sp, uint32 char_id)
 
 		clif_charnameupdate(sd); //Update other people's display. [Skotlex]
 		clif_party_member_info(p,sd);
-		clif_party_option(p,sd,0x100);
+		// Will be sent by party_send_movemap [Lemongrass]
+		//clif_party_option(p,sd,0x100);
 		clif_party_info(p,NULL);
 
 		if( p->instance_id != 0 )

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -319,8 +319,10 @@ int party_recv_info(struct party* sp, uint32 char_id)
 
 		clif_charnameupdate(sd); //Update other people's display. [Skotlex]
 		clif_party_member_info(p,sd);
-		// Will be sent by party_send_movemap [Lemongrass]
-		//clif_party_option(p,sd,0x100);
+		// Only send this on party creation, otherwise it will be sent by party_send_movemap [Lemongrass]
+		if( sd->party_creating ){
+			clif_party_option(p,sd,0x100);
+		}
 		clif_party_info(p,NULL);
 
 		if( p->instance_id != 0 )


### PR DESCRIPTION
As you can see here the info messages get displayed twice:
![screenrathena001](https://cloud.githubusercontent.com/assets/3517879/5561321/c35bac54-8dd0-11e4-9a67-4e066dd67b45.jpg)

Here is the call hirachy in a diagram:
![preview](https://cloud.githubusercontent.com/assets/3517879/5561320/bf54b45c-8dd0-11e4-8bfe-ba0f59dff555.PNG)

How to reproduce?
1) Start your server
2) Log in with a user that has a party
3) The server will load the party and notify all party player[this is the first message that will be sent to the player]
4) When the client finished loading and requests the party information the function will be called again[this is the second time the player will see the info]

After this everything will be only displayed once as long as the server is up and running(at least for this party).