### PR TITLE
Fixed #180

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -51,6 +51,7 @@ char map_server_id[32] = "ragnarok";
 char map_server_pw[32] = "";
 char map_server_db[32] = "ragnarok";
 Sql* mmysql_handle;
+Sql* qsmysql_handle; /// For query_sql
 
 int db_use_sqldbs = 0;
 char buyingstores_db[32] = "buyingstores";
@@ -3769,20 +3770,28 @@ int map_sql_init(void)
 {
 	// main db connection
 	mmysql_handle = Sql_Malloc();
+	qsmysql_handle = Sql_Malloc();
 
 	ShowInfo("Connecting to the Map DB Server....\n");
-	if( SQL_ERROR == Sql_Connect(mmysql_handle, map_server_id, map_server_pw, map_server_ip, map_server_port, map_server_db) ){
+	if( SQL_ERROR == Sql_Connect(mmysql_handle, map_server_id, map_server_pw, map_server_ip, map_server_port, map_server_db) ||
+		SQL_ERROR == Sql_Connect(qsmysql_handle, map_server_id, map_server_pw, map_server_ip, map_server_port, map_server_db) )
+	{
             ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
                         map_server_id, map_server_pw, map_server_ip, map_server_port, map_server_db);
             Sql_ShowDebug(mmysql_handle);
             Sql_Free(mmysql_handle);
+            Sql_ShowDebug(qsmysql_handle);
+            Sql_Free(qsmysql_handle);
             exit(EXIT_FAILURE);
         }
 	ShowStatus("Connect success! (Map Server Connection)\n");
 
-	if( strlen(default_codepage) > 0 )
+	if( strlen(default_codepage) > 0 ) {
 		if ( SQL_ERROR == Sql_SetEncoding(mmysql_handle, default_codepage) )
 			Sql_ShowDebug(mmysql_handle);
+		if ( SQL_ERROR == Sql_SetEncoding(qsmysql_handle, default_codepage) )
+			Sql_ShowDebug(qsmysql_handle);
+	}
 
 	return 0;
 }
@@ -3791,7 +3800,9 @@ int map_sql_close(void)
 {
 	ShowStatus("Close Map DB Connection....\n");
 	Sql_Free(mmysql_handle);
+	Sql_Free(qsmysql_handle);
 	mmysql_handle = NULL;
+	qsmysql_handle = NULL;
 #ifndef BETA_THREAD_TEST
 	if (log_config.sql_logs)
 	{

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -957,6 +957,7 @@ extern char log_db_db[32];
 extern int db_use_sqldbs;
 
 extern Sql* mmysql_handle;
+extern Sql* qsmysql_handle;
 extern Sql* logmysql_handle;
 
 extern char buyingstores_db[32];

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -15425,7 +15425,6 @@ int buildin_query_sql_sub(struct script_state* st, Sql* handle)
 	int max_rows = SCRIPT_MAX_ARRAYSIZE; // maximum number of rows
 	int num_vars;
 	int num_cols;
-	int64 num_rows = 0;
 
 	// check target variables
 	for( i = 3; script_hasdata(st,i); ++i ) {
@@ -15476,8 +15475,6 @@ int buildin_query_sql_sub(struct script_state* st, Sql* handle)
 		script_reportsrc(st);
 	}
 
-	num_rows = Sql_NumRows(handle);
-
 	// Store data
 	for( i = 0; i < max_rows && SQL_SUCCESS == Sql_NextRow(handle); ++i ) {
 		for( j = 0; j < num_vars; ++j ) {
@@ -15494,11 +15491,7 @@ int buildin_query_sql_sub(struct script_state* st, Sql* handle)
 				setd_sub(st, sd, name, i, (void *)__64BPRTSIZE((str?atoi(str):0)), reference_getref(data));
 		}
 	}
-	if (i < num_rows) {
-		ShowWarning("script:query_sql: Only %d/%u rows have been stored.\n", i, num_rows);
-		script_reportsrc(st);
-	}
-	else if( i == max_rows && max_rows < Sql_NumRows(handle) ) {
+	if( i == max_rows && max_rows < Sql_NumRows(handle) ) {
 		ShowWarning("script:query_sql: Only %d/%u rows have been stored.\n", max_rows, (unsigned int)Sql_NumRows(handle));
 		script_reportsrc(st);
 	}


### PR DESCRIPTION
* Separated Sql handle for `query_sql` to avoid `mmysql_handle` session is being overwrite by `mapreg_setreg`/`mapreg_setregstr`.
* New handle for query_sql: `qsmysql_handle`

Signed-off-by: Cydh Ramdh <house.bad@gmail.com>