### PR TITLE
Cleanup item maxlv and clif_equipitemack

### DIFF
--- a/db/import-tmpl/item_db.txt
+++ b/db/import-tmpl/item_db.txt
@@ -1,7 +1,7 @@
 // Items Additional Database
 //
 // Structure of Database:
-// ID,Name,Name,Type,Price,Sell,Weight,ATK,DEF,Range,Slot,Job,Class,Gender,Loc,wLV,eLV,Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
+// ID,Name,Name,Type,Price,Sell,Weight,ATK[:MATK],DEF,Range,Slot,Job,Class,Gender,Loc,wLV,eLV[:maxLevel],Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
 //
 // THQ Quest Items
 //=============================================================

--- a/db/packet_db.txt
+++ b/db/packet_db.txt
@@ -107,7 +107,7 @@ packet_ver: 5
 0x00a7,8,useitem,2:4
 0x00a8,7
 0x00a9,6,equipitem,2:4
-0x00aa,7
+0x00aa,7,ZC_WEAR_EQUIP_ACK,2:4:6
 0x00ab,4,unequipitem,2
 0x00ac,7
 //0x00ad,-1
@@ -1586,7 +1586,7 @@ packet_ver: 25
 //0x083F,22
 
 //2010-06-29aRagexeRE
-0x00AA,9
+0x00AA,9,ZC_WEAR_EQUIP_ACK,2:4:6:8
 //0x07F1,18
 //0x07F2,8
 //0x07F3,6
@@ -1631,7 +1631,7 @@ packet_ver: 26
 0x0857,-1
 0x0858,-1
 0x0859,-1
-0x08d0,9
+0x08d0,9,ZC_WEAR_EQUIP_ACK,2:4:6:8
 
 //2011-10-05aRagexeRE
 packet_ver: 27
@@ -1869,7 +1869,7 @@ packet_ver: 34
 0x0996,-1 //store itemlist equip
 0x0997,-1 //ZC_EQUIPWIN_MICROSCOPE_V5
 0x0998,8,equipitem,2:4 // CZ_REQ_WEAR_EQUIP_V5
-0x0999,11 // cz_wear_equipv5
+0x0999,11,ZC_WEAR_EQUIP_ACK,2:4:8:10 // cz_wear_equipv5
 0x099a,9 // take_off_equipv5
 0x099b,8 //maptypeproperty2
 

--- a/db/pre-re/item_db.txt
+++ b/db/pre-re/item_db.txt
@@ -1,7 +1,7 @@
 // Items Database
 //
 // Structure of Database:
-// ID,AegisName,Name,Type,Buy,Sell,Weight,ATK,DEF,Range,Slots,Job,Class,Gender,Loc,wLV,eLV,Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
+// ID,AegisName,Name,Type,Buy,Sell,Weight,ATK,DEF,Range,Slots,Job,Class,Gender,Loc,wLV,eLV[:maxLevel],Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
 //
 // Healing Items
 //=============================================================

--- a/db/re/item_db.txt
+++ b/db/re/item_db.txt
@@ -1,7 +1,7 @@
 // Items Database
 //
 // Structure of Database:
-// ID,AegisName,Name,Type,Buy,Sell,Weight,ATK,DEF,Range,Slots,Job,Class,Gender,Loc,wLV,eLV,Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
+// ID,AegisName,Name,Type,Buy,Sell,Weight,ATK[:MATK],DEF,Range,Slots,Job,Class,Gender,Loc,wLV,eLV[:maxLevel],Refineable,View,{ Script },{ OnEquip_Script },{ OnUnequip_Script }
 //
 // Healing Items
 //=============================================================

--- a/doc/item_db.txt
+++ b/doc/item_db.txt
@@ -56,6 +56,8 @@ Weight: Item's weight. Each 10 is 1 weight.
 
 ATK: Weapon's attack
 
+MATK: Weapon's magic attack (Renewal only)
+
 ---------------------------------------
 
 DEF: Armor's defense
@@ -153,6 +155,8 @@ wLV: Weapon level.
 ---------------------------------------
 
 eLV: Base level required to be able to equip.
+
+maxLevel: Only able to equip if base level is lower than this.
 
 ---------------------------------------
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -3388,39 +3388,36 @@ void clif_statusupack(struct map_session_data *sd,int type,int ok,int val)
 ///     0 = failure
 ///     1 = success
 ///     2 = failure due to low level
-void clif_equipitemack(struct map_session_data *sd,int n,int pos,int ok)
+void clif_equipitemack(struct map_session_data *sd,int n,int pos,uint8 flag)
 {
-	int fd,header,offs=0,success;
+	int fd, header, offs = 0;
 #if PACKETVER < 20110824
 	header = 0xaa;
-	success = (ok==1);
 #elif PACKETVER < 20120925
 	header = 0x8d0;
-	success = ok ? 0:1;
 #else
 	header = 0x999;
-	success = ok ? 0:1;
 #endif
 	nullpo_retv(sd);
 
-	fd=sd->fd;
+	fd = sd->fd;
 	WFIFOHEAD(fd,packet_len(header));
-	WFIFOW(fd,offs+0)=header;
-	WFIFOW(fd,offs+2)=n+2;
+	WFIFOW(fd,offs+0) = header;
+	WFIFOW(fd,offs+2) = n+2;
 #if PACKETVER >= 20120925
-	WFIFOL(fd,offs+4)=pos;
-	offs+=2;
+	WFIFOL(fd,offs+4) = pos;
+	offs += 2;
 #else
-	WFIFOW(fd,offs+4)=(int)pos;
+	WFIFOW(fd,offs+4) = (int)pos;
 #endif
 #if PACKETVER < 20100629
-	WFIFOB(fd,offs+6)=success;
+	WFIFOB(fd,offs+6) = flag;
 #else
-	if (ok && sd->inventory_data[n]->equip&EQP_VISIBLE)
-		WFIFOW(fd,offs+6)=sd->inventory_data[n]->look;
+	if (flag == ITEM_EQUIP_ACK_OK && sd->inventory_data[n]->equip&EQP_VISIBLE)
+		WFIFOW(fd,offs+6) = sd->inventory_data[n]->look;
 	else
-		WFIFOW(fd,offs+6)=0;
-	WFIFOB(fd,offs+8)=success;
+		WFIFOW(fd,offs+6) = 0;
+	WFIFOB(fd,offs+8) = flag;
 #endif
 	WFIFOSET(fd,packet_len(header));
 }
@@ -10743,7 +10740,7 @@ void clif_parse_EquipItem(int fd,struct map_session_data *sd)
 		return;
 
 	if(!sd->status.inventory[index].identify) {
-		clif_equipitemack(sd,index,0,0);	// fail
+		clif_equipitemack(sd,index,0,ITEM_EQUIP_ACK_FAIL);	// fail
 		return;
 	}
 

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -3390,36 +3390,46 @@ void clif_statusupack(struct map_session_data *sd,int type,int ok,int val)
 ///     2 = failure due to low level
 void clif_equipitemack(struct map_session_data *sd,int n,int pos,uint8 flag)
 {
-	int fd, header, offs = 0;
-#if PACKETVER < 20110824
-	header = 0xaa;
-#elif PACKETVER < 20120925
-	header = 0x8d0;
-#else
-	header = 0x999;
-#endif
+	int fd = 0, cmd = 0, look = 0;
+	struct s_packet_db *info = NULL;
+
 	nullpo_retv(sd);
 
+	cmd = packet_db_ack[sd->packet_ver][ZC_WEAR_EQUIP_ACK];
+	if (!cmd || !(info = &packet_db[sd->packet_ver][cmd]) || !info->len)
+		return;
+
 	fd = sd->fd;
-	WFIFOHEAD(fd,packet_len(header));
-	WFIFOW(fd,offs+0) = header;
-	WFIFOW(fd,offs+2) = n+2;
-#if PACKETVER >= 20120925
-	WFIFOL(fd,offs+4) = pos;
-	offs += 2;
-#else
-	WFIFOW(fd,offs+4) = (int)pos;
-#endif
-#if PACKETVER < 20100629
-	WFIFOB(fd,offs+6) = flag;
-#else
+
 	if (flag == ITEM_EQUIP_ACK_OK && sd->inventory_data[n]->equip&EQP_VISIBLE)
-		WFIFOW(fd,offs+6) = sd->inventory_data[n]->look;
-	else
-		WFIFOW(fd,offs+6) = 0;
-	WFIFOB(fd,offs+8) = flag;
-#endif
-	WFIFOSET(fd,packet_len(header));
+		look = sd->inventory_data[n]->look;
+
+	WFIFOHEAD(fd, info->len);
+	WFIFOW(fd, 0) = cmd;
+	WFIFOW(fd, info->pos[0]) = n+2;
+	switch (cmd) {
+		case 0xaa:
+			WFIFOW(fd, info->pos[1]) = pos;
+			if (sd->packet_ver < date2version(20100629))
+				WFIFOW(fd, info->pos[2]) = (flag == ITEM_EQUIP_ACK_OK ? 1 : 0);
+			else {
+				WFIFOL(fd, info->pos[2]) = look;
+				WFIFOW(fd, info->pos[3]) = (flag == ITEM_EQUIP_ACK_OK ? 1 : 0);
+			}
+			break;
+		case 0x8d0:
+			if (flag == ITEM_EQUIP_ACK_FAILLEVEL)
+				flag = 1;
+		case 0x999:
+			if (cmd == 0x999)
+				WFIFOL(fd, info->pos[1]) = pos;
+			else
+				WFIFOW(fd, info->pos[1]) = pos;
+			WFIFOL(fd, info->pos[2]) = look;
+			WFIFOW(fd, info->pos[3]) = flag;
+			break;
+	}
+	WFIFOSET(fd, info->len);
 }
 
 
@@ -18123,6 +18133,7 @@ void packetdb_readdb(void)
 		{ "ZC_CLEAR_DIALOG", ZC_CLEAR_DIALOG},
 		{ "ZC_C_MARKERINFO", ZC_C_MARKERINFO},
 		{ "ZC_NOTIFY_BIND_ON_EQUIP", ZC_NOTIFY_BIND_ON_EQUIP },
+		{ "ZC_WEAR_EQUIP_ACK", ZC_WEAR_EQUIP_ACK },
 	};
 	const char *filename[] = { "packet_db.txt", DBIMPORT"/packet_db.txt"};
 	int f;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -48,6 +48,7 @@ enum e_packet_ack {
 	ZC_CLEAR_DIALOG,
 	ZC_C_MARKERINFO,
 	ZC_NOTIFY_BIND_ON_EQUIP,
+	ZC_WEAR_EQUIP_ACK,
 	//add other here
 	MAX_ACK_FUNC //auto upd len
 };
@@ -365,23 +366,14 @@ enum useskill_fail_cause
 
 enum clif_messages {
 	/* Constant values */
+	// clif_cart_additem_ack flags
 	ADDITEM_TO_CART_FAIL_WEIGHT = 0x0,
 	ADDITEM_TO_CART_FAIL_COUNT = 0x1,
 
-	// clif_equipitemack flag
-#if PACKETVER < 20110824
-	ITEM_EQUIP_ACK_OK = 1,
-	ITEM_EQUIP_ACK_FAIL = 0,
-	ITEM_EQUIP_ACK_FAILLEVEL = 0,
-#elif PACKETVER < 20120925
-	ITEM_EQUIP_ACK_OK = 0,
-	ITEM_EQUIP_ACK_FAIL = 1,
-	ITEM_EQUIP_ACK_FAILLEVEL = 1,
-#else
+	// clif_equipitemack flags
 	ITEM_EQUIP_ACK_OK = 0,
 	ITEM_EQUIP_ACK_FAIL = 1,
 	ITEM_EQUIP_ACK_FAILLEVEL = 2,
-#endif
 	/* -end- */
 
 	//! NOTE: These values below need client version validation

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -364,8 +364,27 @@ enum useskill_fail_cause
 };
 
 enum clif_messages {
+	/* Constant values */
 	ADDITEM_TO_CART_FAIL_WEIGHT = 0x0,
 	ADDITEM_TO_CART_FAIL_COUNT = 0x1,
+
+	// clif_equipitemack flag
+#if PACKETVER < 20110824
+	ITEM_EQUIP_ACK_OK = 1,
+	ITEM_EQUIP_ACK_FAIL = 0,
+	ITEM_EQUIP_ACK_FAILLEVEL = 0,
+#elif PACKETVER < 20120925
+	ITEM_EQUIP_ACK_OK = 0,
+	ITEM_EQUIP_ACK_FAIL = 1,
+	ITEM_EQUIP_ACK_FAILLEVEL = 1,
+#else
+	ITEM_EQUIP_ACK_OK = 0,
+	ITEM_EQUIP_ACK_FAIL = 1,
+	ITEM_EQUIP_ACK_FAILLEVEL = 2,
+#endif
+	/* -end- */
+
+	//! NOTE: These values below need client version validation
 	ITEM_CANT_OBTAIN_WEIGHT = 0x34, /* You cannot carry more items because you are overweight. */
 	ITEM_NOUSE_SITTING = 0x297,
 	MERC_MSG_BASE = 0x4f2,
@@ -461,7 +480,7 @@ void clif_arrowequip(struct map_session_data *sd,int val); //self
 void clif_arrow_fail(struct map_session_data *sd,int type); //self
 void clif_arrow_create_list(struct map_session_data *sd);	//self
 void clif_statusupack(struct map_session_data *sd,int type,int ok,int val);	// self
-void clif_equipitemack(struct map_session_data *sd,int n,int pos,int ok);	// self
+void clif_equipitemack(struct map_session_data *sd,int n,int pos,uint8 flag);	// self
 void clif_unequipitemack(struct map_session_data *sd,int n,int pos,int ok);	// self
 void clif_misceffect(struct block_list* bl,int type);	// area
 void clif_changeoption(struct block_list* bl);	// area

--- a/src/map/itemdb.c
+++ b/src/map/itemdb.c
@@ -1095,7 +1095,6 @@ static char itemdb_gendercheck(struct item_data *id)
  * For backwards compatibility, in Renewal mode, MATK from weapons comes from the atk slot
  * We use a ':' delimiter which, if not found, assumes the weapon does not provide any matk.
  **/
-#ifdef RENEWAL
 static void itemdb_re_split_atoi(char *str, int *val1, int *val2) {
 	int i, val[2];
 
@@ -1120,7 +1119,7 @@ static void itemdb_re_split_atoi(char *str, int *val1, int *val2) {
 	*val2 = val[1];
 	return;
 }
-#endif
+
 /**
 * Processes one itemdb entry
 */
@@ -1221,11 +1220,7 @@ static bool itemdb_parse_dbrow(char** str, const char* source, int line, int scr
 	}
 
 	id->wlv = cap_value(atoi(str[15]), REFINE_TYPE_ARMOR, REFINE_TYPE_MAX);
-#ifdef RENEWAL
 	itemdb_re_split_atoi(str[16],&id->elv,&id->elvmax);
-#else
-	id->elv = atoi(str[16]);
-#endif
 	id->flag.no_refine = atoi(str[17]) ? 0 : 1; //FIXME: verify this
 	id->look = atoi(str[18]);
 

--- a/src/map/itemdb.h
+++ b/src/map/itemdb.h
@@ -386,11 +386,11 @@ struct item_data
 	int slot;
 	int look;
 	int elv;
+	int elvmax; ///< Maximum level for this item
 	int wlv;
 	int view_id;
 #ifdef RENEWAL
 	int matk;
-	int elvmax;/* maximum level for this item */
 #endif
 
 	int delay;

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1813,8 +1813,8 @@ int map_quit(struct map_session_data *sd) {
 
 	for (i = 0; i < EQI_MAX; i++) {
 		if (sd->equip_index[i] >= 0)
-			if (!pc_isequip(sd,sd->equip_index[i]))
-				pc_unequipitem(sd,sd->equip_index[i],2);
+			if (pc_isequip(sd,sd->equip_index[i]) != ITEM_EQUIP_ACK_OK)
+				pc_unequipitem(sd,sd->equip_index[i],ITEM_EQUIP_ACK_FAIL);
 	}
 
 	// Return loot to owner

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1813,8 +1813,8 @@ int map_quit(struct map_session_data *sd) {
 
 	for (i = 0; i < EQI_MAX; i++) {
 		if (sd->equip_index[i] >= 0)
-			if (pc_isequip(sd,sd->equip_index[i]) != ITEM_EQUIP_ACK_OK)
-				pc_unequipitem(sd,sd->equip_index[i],ITEM_EQUIP_ACK_FAIL);
+			if (pc_isequip(sd,sd->equip_index[i]))
+				pc_unequipitem(sd,sd->equip_index[i],2);
 	}
 
 	// Return loot to owner

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -998,7 +998,7 @@ static bool pc_isItemClass (struct map_session_data *sd, struct item_data* item)
  * Checks if the player can equip the item at index n in inventory.
  * @param sd
  * @param n Item index in inventory
- * @return ITEM_EQUIP_ACK_OK if can be equipped, or ITEM_EQUIP_ACK_FAIL/ITEM_EQUIP_ACK_FAILLEVEL if can't
+ * @return ITEM_EQUIP_ACK_OK(0) if can be equipped, or ITEM_EQUIP_ACK_FAIL(1)/ITEM_EQUIP_ACK_FAILLEVEL(2) if can't
  *------------------------------------------------*/
 uint8 pc_isequip(struct map_session_data *sd,int n)
 {
@@ -5202,8 +5202,8 @@ char pc_setpos(struct map_session_data* sd, unsigned short mapindex, int x, int 
 		}
 		for( i = 0; i < EQI_MAX; i++ ) {
 			if( sd->equip_index[i] >= 0 )
-				if( pc_isequip(sd,sd->equip_index[i]) != ITEM_EQUIP_ACK_OK )
-					pc_unequipitem(sd,sd->equip_index[i],ITEM_EQUIP_ACK_FAIL );
+				if( pc_isequip(sd,sd->equip_index[i]) )
+					pc_unequipitem(sd,sd->equip_index[i],2);
 		}
 		if (battle_config.clear_unit_onwarp&BL_PC)
 			skill_clear_unitgroup(&sd->bl);
@@ -6811,8 +6811,8 @@ int pc_resetlvl(struct map_session_data* sd,int type)
 
 	for(i=0;i<EQI_MAX;i++) { // unequip items that can't be equipped by base 1 [Valaris]
 		if(sd->equip_index[i] >= 0)
-			if(pc_isequip(sd,sd->equip_index[i]) != ITEM_EQUIP_ACK_OK)
-				pc_unequipitem(sd,sd->equip_index[i],ITEM_EQUIP_ACK_FAILLEVEL);
+			if(pc_isequip(sd,sd->equip_index[i]))
+				pc_unequipitem(sd,sd->equip_index[i],2);
 	}
 
 	if ((type == 1 || type == 2 || type == 3) && sd->status.party_id)
@@ -8088,8 +8088,8 @@ bool pc_jobchange(struct map_session_data *sd,int job, char upper)
 
 	for(i=0;i<EQI_MAX;i++) {
 		if(sd->equip_index[i] >= 0)
-			if(pc_isequip(sd,sd->equip_index[i]) != ITEM_EQUIP_ACK_OK)
-				pc_unequipitem(sd,sd->equip_index[i],ITEM_EQUIP_ACK_FAILLEVEL);	// unequip invalid item for class
+			if(pc_isequip(sd,sd->equip_index[i]))
+				pc_unequipitem(sd,sd->equip_index[i],2);	// unequip invalid item for class
 	}
 
 	//Change look, if disguised, you need to undisguise
@@ -9149,7 +9149,7 @@ bool pc_equipitem(struct map_session_data *sd,short n,int req_pos)
 	if(battle_config.battle_log)
 		ShowInfo("equip %hu(%d) %x:%x\n",sd->status.inventory[n].nameid,n,id?id->equip:0,req_pos);
 
-	if((res = pc_isequip(sd,n)) != ITEM_EQUIP_ACK_OK) {
+	if((res = pc_isequip(sd,n))) {
 		clif_equipitemack(sd,n,0,res);	// fail
 		return false;
 	}

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -845,7 +845,7 @@ void pc_reg_received(struct map_session_data *sd);
 void pc_close_npc(struct map_session_data *sd,int flag);
 int pc_close_npc_timer(int tid, unsigned int tick, int id, intptr_t data);
 
-bool pc_isequip(struct map_session_data *sd,int n);
+uint8 pc_isequip(struct map_session_data *sd,int n);
 int pc_equippoint(struct map_session_data *sd,int n);
 void pc_setinventorydata(struct map_session_data *sd);
 

--- a/src/map/pet.c
+++ b/src/map/pet.c
@@ -868,7 +868,7 @@ int pet_equipitem(struct map_session_data *sd,int index)
 	nameid = sd->status.inventory[index].nameid;
 
 	if(pd->petDB->AcceID == 0 || nameid != pd->petDB->AcceID || pd->pet.equip != 0) {
-		clif_equipitemack(sd,0,0,0);
+		clif_equipitemack(sd,0,0,ITEM_EQUIP_ACK_FAIL);
 		return 1;
 	}
 


### PR DESCRIPTION
* Max level to equip item now works for Pre-Renewal too, since the field is optional. 0 means no max level limit.
* Fixed fail message on clif_equipitemack when item cannot be equipped because level limitation
* Multi-client support for clif_equipitemack with packet identifier ZC_WEAR_EQUIP_ACK