### PR TITLE
groups.conf import support

### DIFF
--- a/conf/import-tmpl/groups.conf
+++ b/conf/import-tmpl/groups.conf
@@ -1,0 +1,1 @@
+// See conf/groups.conf

--- a/conf/map_athena.conf
+++ b/conf/map_athena.conf
@@ -116,6 +116,9 @@ help_txt: conf/help.txt
 help2_txt: conf/help2.txt
 charhelp_txt: conf/charhelp.txt
 
+// Groups file
+groups_conf_file: conf/groups.conf
+
 // Maps:
 import: conf/maps_athena.conf
 

--- a/src/common/core.c
+++ b/src/common/core.c
@@ -32,6 +32,7 @@ void (*shutdown_callback)(void) = NULL;
 
 int runflag = CORE_ST_RUN;
 char db_path[12] = "db"; /// relative path for db from server
+char groups_conf_file[32] = "conf/groups.conf";
 
 char *SERVER_NAME = NULL;
 char SERVER_TYPE = ATHENA_SERVER_NONE;

--- a/src/common/core.h
+++ b/src/common/core.h
@@ -22,6 +22,7 @@ extern char **arg_v;
 extern int runflag;
 extern char *SERVER_NAME;
 extern char db_path[12]; /// relative path for db from servers
+extern char groups_conf_file[32];
 
 enum {
 	ATHENA_SERVER_NONE = 0,	// not defined

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3638,6 +3638,8 @@ int map_config_read(char *cfgName)
 			enable_grf = config_switch(w2);
 		else if (strcmpi(w1, "console_msg_log") == 0)
 			console_msg_log = atoi(w2);//[Ind]
+		else if (strcmpi(w1, "groups_conf_file") == 0)
+			safestrncpy(groups_conf_file, w2, sizeof(groups_conf_file));
 		else if (strcmpi(w1, "import") == 0)
 			map_config_read(w2);
 		else

--- a/src/map/pc_groups.c
+++ b/src/map/pc_groups.c
@@ -61,11 +61,12 @@ static inline GroupSettings* name2group(const char* group_name)
 static void read_config(void)
 {
 	config_setting_t *groups = NULL;
-	const char *config_filename = "conf/groups.conf"; // FIXME hardcoded name
 	int group_count = 0;
 	
-	if (conf_read_file(&pc_group_config, config_filename))
+	if (conf_read_file(&pc_group_config, groups_conf_file)) {
+		ShowError("Cannot read Groups file \"%s\".\n", groups_conf_file);
 		return;
+	}
 
 	groups = config_lookup(&pc_group_config, "groups");
 
@@ -244,7 +245,7 @@ static void read_config(void)
 
 			if (++loop > group_count) {
 				ShowWarning("pc_groups:read_config: Could not process inheritance rules, check your config '%s' for cycles...\n",
-				            config_filename);
+				            groups_conf_file);
 				break;
 			}
 		} // while(i < group_count)
@@ -270,7 +271,7 @@ static void read_config(void)
 		dbi_destroy(iter);
 	}
 
-	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", group_count, config_filename);
+	ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' groups in '"CL_WHITE"%s"CL_RESET"'.\n", group_count, groups_conf_file);
 
 	
 	if( ( pc_group_max = group_count ) ) {

--- a/vcproj-10/map-server.vcxproj
+++ b/vcproj-10/map-server.vcxproj
@@ -280,6 +280,7 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="..\conf\import-tmpl\battle_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\battle_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\char_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\char_conf.txt')" />
+    <Copy SourceFiles="..\conf\import-tmpl\groups.conf" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\groups.conf')" />
     <Copy SourceFiles="..\conf\import-tmpl\inter_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\inter_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\log_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\log_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\login_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\login_conf.txt')" />

--- a/vcproj-12/map-server.vcxproj
+++ b/vcproj-12/map-server.vcxproj
@@ -284,6 +284,7 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="..\conf\import-tmpl\battle_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\battle_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\char_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\char_conf.txt')" />
+    <Copy SourceFiles="..\conf\import-tmpl\groups.conf" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\groups.conf')" />
     <Copy SourceFiles="..\conf\import-tmpl\inter_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\inter_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\log_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\log_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\login_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\login_conf.txt')" />

--- a/vcproj-13/map-server.vcxproj
+++ b/vcproj-13/map-server.vcxproj
@@ -284,6 +284,7 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="..\conf\import-tmpl\battle_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\battle_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\char_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\char_conf.txt')" />
+    <Copy SourceFiles="..\conf\import-tmpl\groups.conf" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\groups.conf')" />
     <Copy SourceFiles="..\conf\import-tmpl\inter_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\inter_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\log_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\log_conf.txt')" />
     <Copy SourceFiles="..\conf\import-tmpl\login_conf.txt" DestinationFolder="..\conf\import\" ContinueOnError="true" Condition="!Exists('..\conf\import\login_conf.txt')" />


### PR DESCRIPTION
* Moved hardcoded groups.conf filename on `src/map/pc_groups.c` to `conf/map_athena.conf`
* Defined the path with `groups_conf_file: conf/groups.conf`. So in `conf/import/maps_conf.txt` file (imported map_athena.conf file) can be used to redefine the path, `groups_conf_file: conf/import/groups.conf`

Signed-off-by: Cydh Ramdh <house.bad@gmail.com>