### PR TITLE
3rd Job Quest compatibility fix

### DIFF
--- a/npc/re/jobs/3-1/archbishop.txt
+++ b/npc/re/jobs/3-1/archbishop.txt
@@ -55,7 +55,7 @@ prt_church,103,88,3	script	Praying Minister#arch	60,{
 		mes "I'm going to make them ministers worthy of serving Odin.";
 		close;
 	}
-	if ((BaseLevel == 99) && (JobLevel > 49)) {
+	if ((BaseLevel > 98) && (JobLevel > 49)) {
 		if (job_arch == 0) {
 			if (SkillPoint) {
 				mes "You can't change jobs without using all your skill points. Please use all of your skill points before applying to change jobs~";

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -24,7 +24,7 @@
 que_job01,75,96,3	script	Guild Member#3rdgc01	997,{
 	if (job_3rd_gc == 0) {
 		if (Class == Job_Assassin || Class == Job_Assassin_Cross || Class == Job_Baby_Assassin) {
-			if (BaseLevel == 99) {
+			if (BaseLevel > 98) {
 			L_Mission:
 				mes "[Ahcart]";
 				mes "Finally, it's time...";
@@ -120,7 +120,7 @@ que_job01,75,96,3	script	Guild Member#3rdgc01	997,{
 		mes "You are not an assassin.";
 		close;
 	} else if (job_3rd_gc == 1) {
-		if (BaseLevel == 99) goto L_Mission;
+		if (BaseLevel > 98) goto L_Mission;
 		mes "[Ahcart]";
 		mes "If you become stronger and more skillful, then the assassin's guild will give you a special task.";
 		mes "Go for it.";

--- a/npc/re/jobs/3-1/mechanic.txt
+++ b/npc/re/jobs/3-1/mechanic.txt
@@ -18,7 +18,7 @@
 
 yuno,129,156,3	script	Chainheart	923,{
 	mes "[Chainheart]";
-	if (BaseLevel > 99) {
+	if (eaclass() & EAJL_THIRD) {
 		mes "Living as a Mechanic is tough,";
 		mes "but I am happy that I can";
 		mes "always do what I want.";

--- a/npc/re/jobs/3-2/shadow_chaser.txt
+++ b/npc/re/jobs/3-2/shadow_chaser.txt
@@ -95,7 +95,7 @@ in_rogue,376,100,5	script	Guild Member#sc01	828,{
 			mes "[Vin]";
 			mes "What?";
 			next;
-			if (BaseLevel == 99) {
+			if (BaseLevel > 98) {
 				mes "[Scary man]";
 				mes "Hey there?";
 				next;


### PR DESCRIPTION
The job quests now (all) support servers where the 2nd classes can be over baselevel 99.
Most of them were correct anyway, because they check for BaseLevel > 98 and JobLevel > 49.