### PR TITLE
Init `warp` support for other map in other map-server.

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -1739,6 +1739,9 @@ int map_quit(struct map_session_data *sd) {
 	if (sd->autotrade_tid != INVALID_TIMER)
 		delete_timer(sd->autotrade_tid, pc_autotrade_timer);
 
+	if (sd->warp.tid != INVALID_TIMER)
+		delete_timer(sd->warp.tid, pc_warp_timer);
+
 	if (sd->npc_id)
 		npc_event_dequeue(sd);
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1119,6 +1119,7 @@ bool pc_authok(struct map_session_data *sd, uint32 login_id2, time_t expiration_
 	sd->pvp_timer = INVALID_TIMER;
 	sd->expiration_tid = INVALID_TIMER;
 	sd->autotrade_tid = INVALID_TIMER;
+	sd->warp.tid = INVALID_TIMER;
 
 #ifdef SECURE_NPCTIMEOUT
 	// Initialize to defaults/expected
@@ -11439,6 +11440,29 @@ bool pc_is_same_equip_index(enum equip_index eqi, short *equip_index, short inde
 uint64 pc_generate_unique_id(struct map_session_data *sd) {
 	nullpo_ret(sd);
 	return ((uint64)sd->status.char_id << 32) | sd->status.uniqueitem_counter++;
+}
+
+/**
+* Moves player to another map on other map-server
+* @param tid
+* @param tick
+* @param id
+* @param data
+* @author [Cydh]
+**/
+int pc_warp_timer(int tid, unsigned int tick, int id, intptr_t data) {
+	struct map_session_data *sd;
+
+	if (!(sd = map_id2sd(id))) {
+		ShowDebug("pc_warp_timer: Null pointer id: %d data: %d\n",id,data);
+		return 0;
+	}
+
+	if (pc_setpos(sd, mapindex_name2id(sd->warp.map), sd->warp.x, sd->warp.y, CLR_TELEPORT)) {
+		clif_displaymessage(sd->fd, msg_txt(sd,1)); // Map not found.
+		return 0;
+	}
+	return 1;
 }
 
 /*==========================================

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -626,6 +626,13 @@ struct map_session_data {
 
 	short last_addeditem_index; /// Index of latest item added
 	int autotrade_tid;
+
+	/// Timer data for warp to other map-server
+	struct s_warp {
+		char map[MAP_NAME_LENGTH_EXT];
+		uint16 x, y;
+		int tid;
+	} warp;
 };
 
 struct eri *pc_sc_display_ers; /// Player's SC display table
@@ -1135,6 +1142,7 @@ struct s_bonus_script_entry *pc_bonus_script_add(struct map_session_data *sd, co
 void pc_bonus_script_clear(struct map_session_data *sd, uint16 flag);
 
 void pc_cell_basilica(struct map_session_data *sd);
+int pc_warp_timer(int tid, unsigned int tick, int id, intptr_t data);
 
 void pc_itemgrouphealrate_clear(struct map_session_data *sd);
 short pc_get_itemgroup_bonus(struct map_session_data* sd, unsigned short nameid);
@@ -1145,6 +1153,7 @@ bool pc_is_same_equip_index(enum equip_index eqi, short *equip_index, short inde
 #define pc_is_taekwon_ranker(sd) (((sd)->class_&MAPID_UPPERMASK) == MAPID_TAEKWON && (sd)->status.base_level >= battle_config.taekwon_ranker_min_lv && pc_famerank((sd)->status.char_id,MAPID_TAEKWON))
 
 int pc_autotrade_timer(int tid, unsigned int tick, int id, intptr_t data);
+int pc_warp_timer(int tid, unsigned int tick, int id, intptr_t data);
 
 #if defined(RENEWAL_DROP) || defined(RENEWAL_EXP)
 int pc_level_penalty_mod(struct map_session_data *sd, int mob_level, uint32 mob_class, int type);


### PR DESCRIPTION
* Added warp timer if the map destination is in other map-server, all opened script will be terminated immediately!
* Make sure your 'warp' is always in the end of NPC, like `... close2; warp "payon",0,0; end; ...'

TODO:
* `warpparty`
* `warppguild`
* `areawarp`
* `warppartner`
* `warpwaitingpc`
* `warpchar` (eh?? why don't just merge this to `warp` and add optional param for char_id?)

Signed-off-by: Cydh Ramdh <house.bad@gmail.com>