### PR TITLE
Fixed up Sorcerer's Elemental Sympathy

### DIFF
--- a/src/map/elemental.c
+++ b/src/map/elemental.c
@@ -109,8 +109,8 @@ int elemental_create(struct map_session_data *sd, int class_, unsigned int lifet
 	}
 
 	if( (i=pc_checkskill(sd,SO_EL_SYMPATHY)) > 0 ){
-		ele.hp = ele.max_hp = ele.max_hp * 5 * i / 100;
-		ele.sp = ele.max_sp = ele.max_sp * 5 * i / 100;
+		ele.hp = ele.max_hp += ele.max_hp * 5 * i / 100;
+		ele.sp = ele.max_sp += ele.max_sp * 5 * i / 100;
 		ele.atk += 25 * i;
 		ele.atk2 += 25 * i;
 		ele.matk += 25 * i;


### PR DESCRIPTION
Without this, having level 1 ES would set your Elemental Summon to only have 5% of their original health, instead of adding 5% to the max HP.