### PR TITLE
Fixes #296

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -971,7 +971,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 						skill_castend_damage_id(src,bl,HT_BLITZBEAT,(skill<rate)?skill:rate,tick,SD_LEVEL);
 					}
 					// Automatic trigger of Warg Strike [Jobbie]
-					if( pc_iswug(sd) && (sd->status.weapon == W_BOW || sd->status.weapon == W_FIST) && (skill=pc_checkskill(sd,RA_WUGSTRIKE)) > 0 && rnd()%1000 <= sstatus->luk*10/3+1 )
+					if( pc_iswug(sd) && (skill = pc_checkskill(sd,RA_WUGSTRIKE)) > 0 && rnd()%1000 <= sstatus->luk*10/3+1 )
 						skill_castend_damage_id(src,bl,RA_WUGSTRIKE,skill,tick,0);
 					// Gank
 					if(dstmd && sd->status.weapon != W_BOW &&


### PR DESCRIPTION
Warg Strike can now trigger by Fist, Dagger, and Bow (no restrictions).