### PR TITLE
Added optional param (CharID/AccountID/Nick) for some script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1226,7 +1226,7 @@ Returns the variable reference (since trunk r12870).
 
 ---------------------------------------
 
-*setd "<variable name>",<value>;
+*setd "<variable name>",<value>{,<char_id>};
 
 Works almost identically as set, except the variable name is identified as a string 
 and can thus be constructed dynamically.
@@ -1241,6 +1241,9 @@ Examples:
 
   setd ".@" + .@var$ + "123$", "Poporing is cool";
   mes .@Poporing123$; // Displays "Poporing is cool".
+
+NOTE:
+  'char_id' only works for non-server variables.
 
 ---------------------------------------
 
@@ -4132,7 +4135,7 @@ they will also have their skills reset upon 'changesex'.
 
 ---------------------------------------
 
-*getexp <base xp>,<job xp>;
+*getexp <base xp>,<job xp>{,<char_id>};
 
 This command will give the invoking character a specified number of base and job 
 experience points. Can be used as a quest reward. Negative values won't work.
@@ -4846,7 +4849,7 @@ appropriate messages into their chat window.
 
 ---------------------------------------
 
-*unequip <equipment slot>;
+*unequip <equipment slot>{,<char_id>};
 
 This command will unequip whatever is currently equipped in the invoking 
 character's specified equipment slot. For a full list of possible equipment 
@@ -4857,7 +4860,7 @@ them.
 
 ---------------------------------------
 
-*delequip <equipment slot>;
+*delequip <equipment slot>{,<char_id>};
 
 This command will destroy whatever is currently equipped in the invoking
 character's specified equipment slot. For a full list of possible equipment 
@@ -4867,7 +4870,7 @@ This command will return 1 if an item was deleted and 0 otherwise.
 
 ---------------------------------------
 
-*breakequip <equipment slot>;
+*breakequip <equipment slot>{,<char_id>};
 
 This command will break and unequip whatever is currently equipped in the
 invoking character's specified equipment slot. For a full list of possible
@@ -4877,7 +4880,7 @@ This command will return 1 if an item was broken and 0 otherwise.
 
 ---------------------------------------
 
-*clearitem;
+*clearitem {,<char_id>};
 
 This command will destroy all items the invoking character has in their 
 inventory (including equipped items). It will not affect anything else, like 
@@ -4885,7 +4888,7 @@ storage or cart.
 
 ---------------------------------------
 
-*equip <item id>;
+*equip <item id>{,<char_id>};
 *autoequip <item id>,<option>;
 
 These commands are to equip a equipment on the attached character. 
@@ -4968,7 +4971,7 @@ window, to avoid any disruption when both windows overlap.
 
 ---------------------------------------
 
-*openmail;
+*openmail {<char_id>};
 
 This will open a character's Mail window on the client connected to the 
 invoking character.
@@ -4980,7 +4983,7 @@ invoking character.
 
 ---------------------------------------
 
-*openauction;
+*openauction {<char_id>};
 
 This will open the Auction window on the client connected to the invoking character.
 
@@ -7767,7 +7770,7 @@ izlude,100,100,4	script	Test	844,{
 
 ---------------------------------------
 
-*setquest <ID>;
+*setquest <ID>{,<char_id>};
 
 Place quest of <ID> in the users quest log, the state of which is "active".
 
@@ -7775,26 +7778,26 @@ If *questinfo is set, and the same ID is specified here, the icon will be cleare
 
 ---------------------------------------
 
-*completequest <ID>;
+*completequest <ID>{,<char_id>};
 
 Change the state for the given quest <ID> to "complete" and remove from the users quest log.
 
 ---------------------------------------
 
-*erasequest <ID>;
+*erasequest <ID>{,<char_id>};
 
 Remove the quest of the given <ID> from the user's quest log.
 
 ---------------------------------------
 
-*changequest <ID>,<ID2>;
+*changequest <ID>,<ID2>{,<char_id>};
 
 Remove quest of the given <ID> from the user's quest log.
 Add quest of the <ID2> to the the quest log, and the state is "active".
 
 ---------------------------------------
 
-*checkquest(<ID>{,PLAYTIME|HUNTING})
+*checkquest(<ID>{,PLAYTIME|HUNTING{,<char_id>}})
 
 If no additional argument supplied, return the state of the quest: 
 	-1 = Quest not started (not in quest log)
@@ -7816,7 +7819,7 @@ If parameter "HUNTING" is supplied:
 
 ---------------------------------------
 
-*isbegin_quest(<ID>)
+*isbegin_quest(<ID>{,<char_id>})
 
 Return the state of the quest: 
 	0  = Quest not started (not in quest log)
@@ -7825,7 +7828,7 @@ Return the state of the quest:
 
 ---------------------------------------
 
-*showevent <icon>{,<mark color>}
+*showevent <icon>{,<mark color>{,<char_id>}}
 
 Show an emotion on top of a NPC, and optionally,
 a colored mark in the mini-map like "viewpoint".

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -376,7 +376,7 @@ Another way would be to right click on a mob,
 NPC or char as GM sprited char to view the GID.
 
 This is mostly used for the new version of skill and the mob control commands
-implemented (but NEVER documented by Lance. Shame on you...).
+implemented.
 
 Item and pet scripts
 --------------------
@@ -933,7 +933,8 @@ chosen once the triggering character leaves the area.
 
 OnTouchNPC:
 
-Similar to OnTouch, but will only trigger for monsters.
+Similar to OnTouch, but will only trigger for monsters. For this case, by using
+'getattachedrid' will returns GID (ID that returned when use 'monster').
 
 OnPCLoginEvent:
 OnPCLogoutEvent:
@@ -3357,6 +3358,12 @@ server. It is wise to check for the attached player in script functions that
 deal with timers as there's no guarantee the player will still be logged on
 when the timer triggers. Note that the ID of a player is actually their
 account ID.
+
+---------------------------------------
+
+*getattachedrid();
+
+Returns RID from running script. Script may does not have RID.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4978,7 +4978,7 @@ window, to avoid any disruption when both windows overlap.
 
 ---------------------------------------
 
-*openmail {<char_id>};
+*openmail({<char_id>});
 
 This will open a character's Mail window on the client connected to the 
 invoking character.
@@ -4990,7 +4990,7 @@ invoking character.
 
 ---------------------------------------
 
-*openauction {<char_id>};
+*openauction({<char_id>});
 
 This will open the Auction window on the client connected to the invoking character.
 
@@ -7733,7 +7733,7 @@ if (instance_check_party(getcharid(1),2,2,149)) {
 =========================
 ---------------------------------------
 
-*questinfo <Quest ID>, <Icon> {, <Map Mark Color>{, <Job Class>}};
+*questinfo <Quest ID>,<Icon>{,<Map Mark Color>{,<Job Class>}};
 
 This is esentially a combination of checkquest and showevent. Use this only
 in an OnInit label. For the Quest ID, specify the quest ID that you want

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1203,8 +1203,8 @@ of 'end' stops this, and ends the script.
 
 ---------------------------------------
 
-*set <variable>,<expression>;
-*set(<variable>,<expression>)
+*set <variable>,<expression>{,<charid>};
+*set(<variable>,<expression>{,<charid>})
 
 This command will set a variable to the value that the expression results in. 
 Variables may either be set through this command or directly, much like any
@@ -2229,7 +2229,7 @@ array, shifting all the elements beyond this towards the beginning.
 ======================================
 ---------------------------------------
 
-*strcharinfo(<type>)
+*strcharinfo(<type>{,<char_id>})
 
 This function will return either the name, party name or guild name for the 
 invoking character. Whatever it returns is determined by type.
@@ -2588,7 +2588,7 @@ will return the second one, etc. Will return 0 if no such item is found.
 
 ---------------------------------------
 
-*getequipisequiped(<equipment slot>)
+*getequipisequiped(<equipment slot>{,<char_id>})
 
 This functions will return 1 if there is an equipment placed on the specified
 equipment slot and 0 otherwise. For a list of equipment slots 
@@ -4416,8 +4416,8 @@ Example:
 
 ---------------------------------------
 
-*rentitem <item id>,<time>;
-*rentitem "<item name>",<time>;
+*rentitem <item id>,<time>{,<account_id>};
+*rentitem "<item name>",<time>{,<account_id>};
 
 Creates a rental item in the attached character's inventory. The item will expire 
 in <time> seconds and be automatically deleted. When receiving a rental item, 
@@ -4430,8 +4430,8 @@ Note: 'delitem' in an NPC script can still remove rental items.
 
 ---------------------------------------
 
-*rentitem2 <item id>,<time>,<identify>,<refine>,<attribute>,<card1>,<card2>,<card3>,<card4>;
-*rentitem2 "<item name>",<time>,<identify>,<refine>,<attribute>,<card1>,<card2>,<card3>,<card4>;
+*rentitem2 <item id>,<time>,<identify>,<refine>,<attribute>,<card1>,<card2>,<card3>,<card4>{,<account_id>};
+*rentitem2 "<item name>",<time>,<identify>,<refine>,<attribute>,<card1>,<card2>,<card3>,<card4>{,<account_id>};
 
 Creates a rental item in the attached character's inventory. The item will expire 
 in <time> seconds and be automatically deleted. See 'rentitem' for further details.
@@ -4802,14 +4802,14 @@ Whatever the type is, it will also show a failure effect on screen.
 
 ---------------------------------------
 
-*repair <broken item number>;
+*repair <broken item number>{,<char_id>};
 
 This command repairs a broken piece of equipment, using the same list of broken 
 items as available through 'getbrokenid'.
 
 ---------------------------------------
 
-*repairall;
+*repairall {<char_id>};
 
 This command repairs all broken equipment in the attached player's inventory.
 A repair effect will be shown if any items are repaired, else the command will

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2372,9 +2372,9 @@ If an invalid type is given or the NPC does not exist, 0 is returned.
 
 ---------------------------------------
 
-*getchildid()
-*getmotherid()
-*getfatherid()
+*getchildid({<char_id>})
+*getmotherid({<char_id>})
+*getfatherid({<char_id>})
 
 These functions return the character ID of the attached player's child,
 mother, mother, or father, respectively. It returns 0 if no ID is found.
@@ -2383,14 +2383,14 @@ mother, mother, or father, respectively. It returns 0 if no ID is found.
 
 ---------------------------------------
 
-*ispartneron()
+*ispartneron({<char_id>})
 
 This function returns 1 if the invoking character's marriage partner is 
 currently online and 0 if they are not or if the character has no partner.
 
 ---------------------------------------
 
-*getpartnerid()
+*getpartnerid({<char_id>})
 
 This function returns the character ID of the invoking character's marriage 
 partner, if any. If the invoking character is not married, it will return 0, 
@@ -2401,7 +2401,7 @@ which is a quick way to see if they are married:
 
 ---------------------------------------
 
-*getlook(<type>)
+*getlook(<type>{,<char_id>})
 
 This function will return the number for the current character look value 
 specified by type. See 'setlook' for valid look types.
@@ -2411,7 +2411,7 @@ dressed in black. :)
 
 ---------------------------------------
 
-*getsavepoint(<information type>)
+*getsavepoint(<information type>{,<char_id>})
 
 This function will return information about the invoking character's save point. 
 You can use it to let a character swap between several recorded save points. 
@@ -2722,7 +2722,7 @@ of possible equipment slots.
 
 ---------------------------------------
 
-*getinventorylist;
+*getinventorylist {<char_id>};
 
 This command sets a bunch of arrays with a complete list of whatever the 
 invoking character has in their inventory, including all the data needed to 
@@ -2848,8 +2848,8 @@ It's useful for when you want to check whether an item contains cards or if it's
 
 ---------------------------------------
 
-*mergeitem({<item_id>});
-*mergeitem({"<item name>"});
+*mergeitem({<item_id>{,<char_id>}});
+*mergeitem({"<item name>"{,<char_id>}});
 
 Merge all stackable items that separated by GUID flags
 (either by flag 4 item_flag.txt or GUID  in item_group).
@@ -2913,7 +2913,7 @@ Notice that NPC objects disabled with 'disablenpc' will still be located.
 
 ---------------------------------------
 
-*getgmlevel()
+*getgmlevel({<char_id>})
 
 This function will return the (GM) level associated with the player group to which
 the invoking character belongs. If this is somehow executed from a console command,
@@ -2926,7 +2926,7 @@ specially when talked to by GMs.
 
 ---------------------------------------
 
-*getgroupid()
+*getgroupid({<char_id>})
 
 This function will return the group id to which the invoking player belongs.
 
@@ -3208,7 +3208,7 @@ Example 2:
 
 ---------------------------------------
 
-*getskilllist;
+*getskilllist({<char_id>});
 
 This command sets a bunch of arrays with a complete list of skills the
 invoking character has. Here's what you get:
@@ -3313,7 +3313,7 @@ Example:
 
 ---------------------------------------
 
-*skillpointcount()
+*skillpointcount({<char_id>})
 
 Returns the total amount of skill points a character possesses (SkillPoint+SP's used in skills)
 This command can be used to check the currently attached characters total amount of skill points.
@@ -3417,10 +3417,10 @@ things might in some cases be required.
 
 ---------------------------------------
 
-*checkoption(<option number>)
-*checkoption1(<option number>)
-*checkoption2(<option number>)
-*setoption <option number>{,<flag>};
+*checkoption(<option number>{,<char_id>})
+*checkoption1(<option number>{,<char_id>})
+*checkoption2(<option number>{,<char_id>})
+*setoption <option number>{,<flag>{,<char_id>}};
 
 The 'setoption' series of functions check for a so-called option that is set on 
 the invoking character. 'Options' are used to store status conditions and a lot 
@@ -3482,8 +3482,8 @@ core developer (or read the source: src/map/status.h) for the full list.
 
 ---------------------------------------
 
-*setcart {<type>};
-*checkcart()
+*setcart {<type>{,<char_id>}};
+*checkcart({<char_id>});
 
 If <type> is 0 this command will remove the cart from the character.
 Otherwise it gives the invoking character a cart. The cart given will be 
@@ -3498,8 +3498,8 @@ The accompanying function will return 1 if the invoking character has a cart
 
 ---------------------------------------
 
-*setfalcon {<flag>};
-*checkfalcon()
+*setfalcon {<flag>{,<char_id>}};
+*checkfalcon({<char_id>});
 
 If <flag> is 0 this command will remove the falcon from the character.
 Otherwise it gives the invoking character a falcon. The falcon will be there 
@@ -3514,8 +3514,8 @@ and 0 if they don't.
 
 ---------------------------------------
 
-*setriding {<flag>};
-*checkriding()
+*setriding {<flag>{,<char_id>}};
+*checkriding({<char_id>});
 
 If <flag> is 0 this command will remove the mount from the character.
 Otherwise it gives the invoking character a PecoPeco (if they are a Knight 
@@ -3531,8 +3531,8 @@ bird and 0 if they aren't.
 
 ---------------------------------------
 
-*setdragon {<color>};
-*checkdragon()
+*setdragon {<color>{,<char_id>}};
+*checkdragon({<char_id>});
 
 The 'setdragon' function toggles mounting a dragon for the invoking character.
 It will return 1 if successful, 0 otherwise.
@@ -3551,8 +3551,8 @@ dragon and 0 if they aren't.
 
 ---------------------------------------
 
-*setmadogear {<flag>};
-*checkmadogear()
+*setmadogear {<flag>{,<char_id>}};
+*checkmadogear({<char_id>});
 
 If <flag> is 0 this command will remove the mount from the character.
 Otherwise it gives the invoking character a Mado (if they are a Mechanic).
@@ -3562,8 +3562,8 @@ Mado and 0 if they don't.
 
 ---------------------------------------
 
-*setmounting;
-*ismounting()
+*setmounting {<char_id>};
+*ismounting({<char_id>});
 
 The 'setmounting' function toggles cash mount for the invoking character.
 It will return 1 if successful, 0 otherwise.
@@ -3575,7 +3575,7 @@ cash mount and 0 if they don't.
 
 ---------------------------------------
 
-*checkwug()
+*checkwug({<char_id>});
 
 This function will return 1 if the invoking character has a
 warg and 0 if they don't.
@@ -3780,7 +3780,7 @@ be seen by anyone else.
 
 ---------------------------------------
 
-*dispbottom "<message>"{,<color>};
+*dispbottom "<message>"{,<color>{,<char_id>}};
 
 This command will send the given message with color into the invoking character's chat 
 window. The color format is in RGB (0xRRGGBB). The color is
@@ -3909,8 +3909,8 @@ normally translate to random coordinates.
 
 ---------------------------------------
 
-*savepoint "<map name>",<x>,<y>;
-*save "<map name>",<x>,<y>;
+*savepoint "<map name>",<x>,<y>{,<char_id>};
+*save "<map name>",<x>,<y>{,<char_id>};
 
 These commands save where the invoking character will return to upon clicking
 "Return to Save Point", after death and in some other cases. The two versions are 
@@ -4121,7 +4121,7 @@ do, but this will only happen in a later SVN revision.
 
 ---------------------------------------
 
-*changesex;
+*changesex({<char_id>});
 
 This command will change the gender for the attached character's account. If it 
 was male, it will become female, if it was female, it will become male. The 
@@ -4591,7 +4591,7 @@ cart or storage. If no cart is mounted, 'cartcountitem2' will return -1.
 
 ---------------------------------------
 
-*countbound({<bound type>})
+*countbound({<bound type>{,<char_id>}})
 
 This function will return the number of bounded items in the character's
 inventory, and sets an array @bound_items[] containing all item IDs of the
@@ -4704,8 +4704,8 @@ target cursor is shown.
 
 ---------------------------------------
 
-*consumeitem <item id>;
-*consumeitem "<item name>";
+*consumeitem <item id>{,<char_id>};
+*consumeitem "<item name>"{,<char_id>};
 
 This command will run the item script of the specified item on the invoking
 character. The character does not need to possess the item, and the item will
@@ -4770,7 +4770,7 @@ to cook the dish the command works.
 
 ---------------------------------------
 
-*makerune <% success bonus>;
+*makerune <% success bonus>{,<char_id>};
 
 This command will open a rune crafting window on the client connected to the
 invoking character. Since this command is officially used in rune ores, a bonus
@@ -5056,7 +5056,7 @@ a fun quest. (Wasting a level point on that is really annoying :D)
 //
 ---------------------------------------
 
-*resetlvl <action type>;
+*resetlvl <action type>{,<char_id>};
 
 This is a character reset command, meant mostly for rebirth script supporting 
 Advanced jobs, which will reset the invoking character's stats and level 
@@ -5078,7 +5078,7 @@ rebirth scripts. Ask AppleGirl why.
 
 ---------------------------------------
 
-*resetstatus;
+*resetstatus({<char_id>});
 
 This is a character reset command, which will reset the stats on the invoking 
 character and give back all the stat points used to raise them previously. 
@@ -5088,7 +5088,7 @@ Used in reset NPC's (duh!)
 
 ---------------------------------------
 
-*resetskill;
+*resetskill({<char_id>});
 
 This command takes off all the skill points on the invoking character, so they 
 only have Basic Skill blanked out (lvl 0) left, and returns the points for them 
@@ -5162,7 +5162,7 @@ Note: to use SC_NOCHAT you should alter Manner
 
 ---------------------------------------
 
-*getstatus(<effect type>{,<type>})
+*getstatus(<effect type>{,<type>{,<char_id>}})
 
 Retrieve information about a specific status effect when called. Depending on <type>
 specified the function will return different information.
@@ -5430,7 +5430,7 @@ Flag contants:
 
 ---------------------------------------
 
-*nude;
+*nude {<char_id>};
 
 This command will unequip anything equipped on the invoking character.
 
@@ -5447,8 +5447,8 @@ If no character is specified, the command will run for the invoking character.
 
 ---------------------------------------
 
-*disguise <Monster ID>;
-*undisguise;
+*disguise <Monster ID>{,<char_id>};
+*undisguise {<char_id>};
 
 This command disguises the current player with a monster sprite.
 The disguise lasts until 'undisguise' is issued or the player logs out.
@@ -5494,7 +5494,7 @@ the invoking character. Example can be found in the wedding script.
 
 ---------------------------------------
 
-*divorce()
+*divorce({<char_id>})
 
 This function will "un-marry" the invoking character from whoever they were 
 married to. Both will no longer be each other's marriage partner, (at least in 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3734,7 +3734,7 @@ int run_func(struct script_state *st)
 /*==========================================
  * script execution
  *------------------------------------------*/
-void run_script(struct script_code *rootscript,int pos,int rid,int oid)
+void run_script(struct script_code *rootscript, int pos, int rid, int oid)
 {
 	struct script_state *st;
 
@@ -19254,6 +19254,15 @@ BUILDIN_FUNC(mergeitem) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * Get rid from running script.
+ * getattachedrid();
+ **/
+BUILDIN_FUNC(getattachedrid) {
+	script_pushint(st, st->rid);
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include "../custom/script.inc"
 
 // declarations that were supposed to be exported from npc_chat.c
@@ -19797,6 +19806,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(delspiritball,"i?"),
 	BUILDIN_DEF(countspiritball,"?"),
 	BUILDIN_DEF(mergeitem,"??"),
+	BUILDIN_DEF(getattachedrid,""),
 
 #include "../custom/script_def.inc"
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -177,15 +177,17 @@ TBL_PC *script_rid2sd(struct script_state *st);
  * @param st Script
  * @param loc Location to look account id in script parameter
  * @param sd Variable that will be assigned
+ * @return True if `sd` is assigned, false otherwise
  **/
-static void script_accid2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
+static bool script_accid2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
 	if (script_hasdata(st, loc)) {
 		int id_ = script_getnum(st, loc);
 		if (!(*sd = map_id2sd(id_)))
-			ShowError("%s: Player with account id '%s' is not found.\n", func, id_);
+			ShowError("%s: Player with account id '%d' is not found.\n", func, id_);
 	}
 	else
 		*sd = script_rid2sd(st);
+	return (*sd) ? true : false;
 }
 
 /**
@@ -193,8 +195,9 @@ static void script_accid2sd_(struct script_state *st, uint8 loc, struct map_sess
  * @param st Script
  * @param loc Location to look char id in script parameter
  * @param sd Variable that will be assigned
+ * @return True if `sd` is assigned, false otherwise
  **/
-static void script_charid2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
+static bool script_charid2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
 	if (script_hasdata(st, loc)) {
 		int id_ = script_getnum(st, loc);
 		if (!(*sd = map_charid2sd(id_)))
@@ -202,6 +205,7 @@ static void script_charid2sd_(struct script_state *st, uint8 loc, struct map_ses
 	}
 	else
 		*sd = script_rid2sd(st);
+	return (*sd) ? true : false;
 }
 
 /**
@@ -209,8 +213,9 @@ static void script_charid2sd_(struct script_state *st, uint8 loc, struct map_ses
  * @param st Script
  * @param loc Location to look nick in script parameter
  * @param sd Variable that will be assigned
+ * @return True if `sd` is assigned, false otherwise
  **/
-static void script_nick2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
+static bool script_nick2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
 	if (script_hasdata(st, loc)) {
 		const char *name_ = script_getstr(st, loc);
 		if (!(*sd = map_nick2sd(name_)))
@@ -218,6 +223,7 @@ static void script_nick2sd_(struct script_state *st, uint8 loc, struct map_sessi
 	}
 	else
 		*sd = script_rid2sd(st);
+	return (*sd) ? true : false;
 }
 
 #define script_accid2sd(loc,sd) script_accid2sd_(st,(loc),&(sd),__FUNCTION__)
@@ -5736,11 +5742,8 @@ BUILDIN_FUNC(set)
 	name = reference_getname(data);
 	prefix = *name;
 
-	if (not_server_variable(prefix)) {
-		script_charid2sd(4,sd);
-		if (!sd)
-			return SCRIPT_CMD_FAILURE;
-	}
+	if (not_server_variable(prefix) && !script_charid2sd(4,sd))
+		return SCRIPT_CMD_FAILURE;
 
 #if 0
 	if( data_isreference(datavalue) )
@@ -6746,8 +6749,7 @@ BUILDIN_FUNC(rentitem) {
 	data = script_getdata(st,2);
 	get_val(st,data);
 
-	script_accid2sd(4,sd);
-	if (!sd)
+	if (!script_accid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( data_isstring(data) )
@@ -6808,8 +6810,7 @@ BUILDIN_FUNC(rentitem2) {
 	data = script_getdata(st,2);
 	get_val(st,data);
 
-	script_accid2sd(11,sd);
-	if (!sd)
+	if (!script_accid2sd(11,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( data_isstring(data) ) {
@@ -7480,8 +7481,7 @@ BUILDIN_FUNC(readparam)
 	TBL_PC *sd;
 
 	type = script_getnum(st,2);
-	script_nick2sd(3,sd);
-	if (!sd) {
+	if (!script_nick2sd(3,sd)) {
 		script_pushint(st,-1);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -7725,8 +7725,7 @@ BUILDIN_FUNC(strcharinfo)
 	struct guild* g;
 	struct party_data* p;
 
-	script_charid2sd(3,sd);
-	if (!sd) {
+	if (!script_charid2sd(3,sd)) {
 		script_pushconststr(st,"");
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -7996,8 +7995,7 @@ BUILDIN_FUNC(repair)
 	int repaircounter=0;
 	TBL_PC *sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	num=script_getnum(st,2);
@@ -8025,8 +8023,7 @@ BUILDIN_FUNC(repairall)
 	int i, repaircounter = 0;
 	TBL_PC *sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	for(i = 0; i < MAX_INVENTORY; i++)
@@ -8059,8 +8056,7 @@ BUILDIN_FUNC(getequipisequiped)
 
 	num = script_getnum(st,2);
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if (num > 0 && num <= ARRAYLENGTH(equip))
@@ -8331,8 +8327,7 @@ BUILDIN_FUNC(delequip) {
 	TBL_PC *sd;
 
 	pos = script_getnum(st,2);
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if (pos > 0 && pos <= ARRAYLENGTH(equip))
@@ -8360,8 +8355,7 @@ BUILDIN_FUNC(breakequip) {
 	TBL_PC *sd;
 
 	pos = script_getnum(st,2);
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if (pos > 0 && pos <= ARRAYLENGTH(equip))
@@ -8765,8 +8759,7 @@ BUILDIN_FUNC(getgmlevel)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	script_pushint(st, pc_get_group_level(sd));
 	return SCRIPT_CMD_SUCCESS;
@@ -8779,8 +8772,7 @@ BUILDIN_FUNC(getgroupid)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	script_pushint(st, pc_get_group_id(sd));
 	return SCRIPT_CMD_SUCCESS;
@@ -8814,8 +8806,7 @@ BUILDIN_FUNC(checkoption)
 	int option;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	option = script_getnum(st,2);
@@ -8835,8 +8826,7 @@ BUILDIN_FUNC(checkoption1)
 	int opt1;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	opt1 = script_getnum(st,2);
@@ -8856,8 +8846,7 @@ BUILDIN_FUNC(checkoption2)
 	int opt2;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	opt2 = script_getnum(st,2);
@@ -8881,8 +8870,7 @@ BUILDIN_FUNC(setoption)
 	int flag = 1;
 	TBL_PC* sd;
 
-	script_charid2sd(4,sd);
-	if (!sd)
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	option = script_getnum(st,2);
@@ -8914,8 +8902,7 @@ BUILDIN_FUNC(checkcart)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( pc_iscarton(sd) )
@@ -8941,8 +8928,7 @@ BUILDIN_FUNC(setcart)
 	int type = 1;
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
@@ -8961,8 +8947,7 @@ BUILDIN_FUNC(checkfalcon)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( pc_isfalcon(sd) )
@@ -8982,8 +8967,7 @@ BUILDIN_FUNC(setfalcon)
 	int flag = 1;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
@@ -9003,8 +8987,7 @@ BUILDIN_FUNC(checkriding)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( pc_isriding(sd) )
@@ -9024,8 +9007,7 @@ BUILDIN_FUNC(setriding)
 	int flag = 1;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
@@ -9043,8 +9025,7 @@ BUILDIN_FUNC(checkwug)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( pc_iswug(sd) || pc_isridingwug(sd) )
@@ -9063,8 +9044,7 @@ BUILDIN_FUNC(checkmadogear)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( pc_ismadogear(sd) )
@@ -9084,8 +9064,7 @@ BUILDIN_FUNC(setmadogear)
 	int flag = 1;
 	TBL_PC* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
@@ -9107,8 +9086,7 @@ BUILDIN_FUNC(savepoint)
 	const char* str;
 	TBL_PC* sd;
 
-	script_charid2sd(4,sd);
-	if( sd == NULL )
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;// no player attached, report source
 
 	str = script_getstr(st, 2);
@@ -9347,8 +9325,7 @@ BUILDIN_FUNC(getexp)
 	int base=0,job=0;
 	double bonus;
 
-	script_charid2sd(4,sd);
-	if (!sd)
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	base=script_getnum(st,2);
@@ -10550,8 +10527,7 @@ BUILDIN_FUNC(getstatus)
 	int id, type;
 	struct map_session_data* sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	id = script_getnum(st, 2);
@@ -10828,8 +10804,7 @@ BUILDIN_FUNC(resetlvl)
 
 	int type=script_getnum(st,2);
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	pc_resetlvl(sd,type);
@@ -10841,8 +10816,7 @@ BUILDIN_FUNC(resetlvl)
 BUILDIN_FUNC(resetstatus)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	pc_resetstate(sd);
 	return SCRIPT_CMD_SUCCESS;
@@ -10854,8 +10828,7 @@ BUILDIN_FUNC(resetstatus)
 BUILDIN_FUNC(resetskill)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	pc_resetskill(sd,1);
 	return SCRIPT_CMD_SUCCESS;
@@ -10867,8 +10840,7 @@ BUILDIN_FUNC(resetskill)
 BUILDIN_FUNC(skillpointcount)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	script_pushint(st,sd->status.skill_point + pc_resetskill(sd,2));
 	return SCRIPT_CMD_SUCCESS;
@@ -10918,8 +10890,8 @@ BUILDIN_FUNC(changesex)
 {
 	int i;
 	TBL_PC *sd = NULL;
-	script_charid2sd(2,sd);
-	if (!sd)
+
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	pc_resetskill(sd,4);
@@ -12326,8 +12298,8 @@ BUILDIN_FUNC(wedding_effect)
 BUILDIN_FUNC(divorce)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (!sd || !pc_divorce(sd)) {
+
+	if (!script_charid2sd(2,sd) || !pc_divorce(sd)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -12338,8 +12310,8 @@ BUILDIN_FUNC(divorce)
 BUILDIN_FUNC(ispartneron)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (!sd || !pc_ismarried(sd) ||
+
+	if (!script_charid2sd(2,sd) || !pc_ismarried(sd) ||
 		map_charid2sd(sd->status.partner_id) == NULL)
 	{
 		script_pushint(st,0);
@@ -12353,8 +12325,8 @@ BUILDIN_FUNC(ispartneron)
 BUILDIN_FUNC(getpartnerid)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (sd == NULL) {
+
+	if (!script_charid2sd(2,sd)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -12366,8 +12338,8 @@ BUILDIN_FUNC(getpartnerid)
 BUILDIN_FUNC(getchildid)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (sd == NULL) {
+
+	if (!script_charid2sd(2,sd)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -12379,8 +12351,8 @@ BUILDIN_FUNC(getchildid)
 BUILDIN_FUNC(getmotherid)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (sd == NULL) {
+
+	if (!script_charid2sd(2,sd)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -12392,8 +12364,8 @@ BUILDIN_FUNC(getmotherid)
 BUILDIN_FUNC(getfatherid)
 {
 	TBL_PC *sd;
-	script_charid2sd(2,sd);
-	if (sd == NULL) {
+
+	if (!script_charid2sd(2,sd)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -12832,8 +12804,7 @@ BUILDIN_FUNC(getinventorylist)
 	char card_var[NAME_LENGTH];
 	int i,j=0,k;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	for(i=0;i<MAX_INVENTORY;i++){
 		if(sd->status.inventory[i].nameid > 0 && sd->status.inventory[i].amount > 0){
@@ -12864,8 +12835,8 @@ BUILDIN_FUNC(getskilllist)
 {
 	TBL_PC *sd;
 	int i,j=0;
-	script_charid2sd(2,sd);
-	if (!sd)
+
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	for(i=0;i<MAX_SKILL;i++){
 		if(sd->status.skill[i].id > 0 && sd->status.skill[i].lv > 0){
@@ -12887,8 +12858,7 @@ BUILDIN_FUNC(clearitem)
 	TBL_PC *sd;
 	int i;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	for (i=0; i<MAX_INVENTORY; i++) {
@@ -12906,8 +12876,8 @@ BUILDIN_FUNC(disguise)
 {
 	int id;
 	TBL_PC* sd;
-	script_charid2sd(3,sd);
-	if (sd == NULL)
+
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	id = script_getnum(st,2);
@@ -12926,8 +12896,8 @@ BUILDIN_FUNC(disguise)
 BUILDIN_FUNC(undisguise)
 {
 	TBL_PC* sd;
-	script_charid2sd(2,sd);
-	if (sd == NULL)
+
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if (sd->disguise) {
@@ -13397,8 +13367,7 @@ BUILDIN_FUNC(nude)
 	TBL_PC *sd;
 	int i, calcflag = 0;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	for( i = 0 ; i < EQI_MAX; i++ ) {
@@ -13468,8 +13437,7 @@ BUILDIN_FUNC(dispbottom)
 	int color = 0;
 	const char *message;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	message = script_getstr(st,2);
@@ -13916,8 +13884,8 @@ BUILDIN_FUNC(getlook)
 {
 	int type,val;
 	TBL_PC *sd;
-	script_charid2sd(3,sd);
-	if (!sd) {
+
+	if (!script_charid2sd(3,sd)) {
 		script_pushint(st,-1);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -13949,8 +13917,7 @@ BUILDIN_FUNC(getsavepoint)
 	TBL_PC* sd;
 	int type;
 
-	script_charid2sd(3,sd);
-	if (sd == NULL) {
+	if (!script_charid2sd(3,sd)) {
 		script_pushint(st,0);
 		return 0;
 	}
@@ -14413,8 +14380,7 @@ BUILDIN_FUNC(unequip) {
 	int pos;
 	TBL_PC *sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	pos = script_getnum(st,2);
@@ -14436,8 +14402,7 @@ BUILDIN_FUNC(equip) {
 	TBL_PC *sd;
 	struct item_data *item_data;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	nameid = script_getnum(st,2);
@@ -15482,7 +15447,7 @@ BUILDIN_FUNC(md5)
 
 BUILDIN_FUNC(setd)
 {
-	TBL_PC *sd=NULL;
+	TBL_PC *sd = NULL;
 	char varname[100];
 	const char *buffer;
 	int elem;
@@ -15491,10 +15456,8 @@ BUILDIN_FUNC(setd)
 	if(sscanf(buffer, "%99[^[][%d]", varname, &elem) < 2)
 		elem = 0;
 
-	if( not_server_variable(*varname) )
-	{
-		script_charid2sd(4,sd);
-		if (!sd)
+	if( not_server_variable(*varname) ) {
+		if (!script_charid2sd(4,sd))
 			return SCRIPT_CMD_FAILURE;
 	}
 
@@ -16703,8 +16666,7 @@ BUILDIN_FUNC(openmail)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	mail_openmail(sd);
@@ -16716,8 +16678,7 @@ BUILDIN_FUNC(openauction)
 {
 	TBL_PC* sd;
 
-	script_charid2sd(2,sd);
-	if (!sd)
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( !battle_config.feature_auction ) {
@@ -17029,8 +16990,7 @@ BUILDIN_FUNC(setquest)
 
 	quest_id = script_getnum(st, 2);
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	quest_add(sd, quest_id);
@@ -17053,8 +17013,7 @@ BUILDIN_FUNC(erasequest)
 {
 	struct map_session_data *sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	quest_delete(sd, script_getnum(st, 2));
@@ -17065,8 +17024,7 @@ BUILDIN_FUNC(completequest)
 {
 	struct map_session_data *sd;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	quest_update_status(sd, script_getnum(st, 2), Q_COMPLETE);
@@ -17077,8 +17035,7 @@ BUILDIN_FUNC(changequest)
 {
 	struct map_session_data *sd;
 	
-	script_charid2sd(4,sd);
-	if (!sd)
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	quest_change(sd, script_getnum(st, 2),script_getnum(st, 3));
@@ -17093,8 +17050,7 @@ BUILDIN_FUNC(checkquest)
 	if( script_hasdata(st, 3) )
 		type = (enum quest_check_type)script_getnum(st, 3);
 
-	script_charid2sd(4,sd);
-	if (!sd)
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	script_pushint(st, quest_check(sd, script_getnum(st, 2), type));
@@ -17107,8 +17063,7 @@ BUILDIN_FUNC(isbegin_quest)
 	struct map_session_data *sd;
 	int i;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	i = quest_check(sd, script_getnum(st, 2), (enum quest_check_type) HAVEQUEST);
@@ -17123,8 +17078,7 @@ BUILDIN_FUNC(showevent)
 	struct npc_data *nd = map_id2nd(st->oid);
 	int icon, color = 0;
 
-	script_charid2sd(4,sd);
-	if (!sd)
+	if (!script_charid2sd(4,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( sd == NULL || nd == NULL )
@@ -17937,8 +17891,8 @@ BUILDIN_FUNC(showdigit)
  **/
 BUILDIN_FUNC(makerune) {
 	TBL_PC* sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	clif_skill_produce_mix_list(sd,RK_RUNEMASTERY,24);
 	sd->itemid = script_getnum(st,2);
@@ -17949,8 +17903,8 @@ BUILDIN_FUNC(makerune) {
  **/
 BUILDIN_FUNC(checkdragon) {
 	TBL_PC* sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	if( pc_isridingdragon(sd) )
 		script_pushint(st,1);
@@ -17972,8 +17926,7 @@ BUILDIN_FUNC(setdragon) {
 	TBL_PC* sd;
 	int color = script_hasdata(st,2) ? script_getnum(st,2) : 0;
 
-	script_charid2sd(3,sd);
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 	if( !pc_checkskill(sd,RK_DRAGONTRAINING) || (sd->class_&MAPID_THIRDMASK) != MAPID_RUNE_KNIGHT )
 		script_pushint(st,0);//Doesn't have the skill or it's not a Rune Knight
@@ -18004,8 +17957,8 @@ BUILDIN_FUNC(setdragon) {
  **/
 BUILDIN_FUNC(ismounting) {
 	TBL_PC* sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	if( &sd->sc && sd->sc.data[SC_ALL_RIDING] )
 		script_pushint(st,1);
@@ -18022,8 +17975,8 @@ BUILDIN_FUNC(ismounting) {
  **/
 BUILDIN_FUNC(setmounting) {
 	TBL_PC* sd;
-	script_charid2sd(2,sd);
-	if (!sd)
+	
+	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 	if( &sd->sc && sd->sc.option&(OPTION_WUGRIDER|OPTION_RIDING|OPTION_DRAGON|OPTION_MADOGEAR) ) {
 		clif_msgtable(sd->fd, NEED_REINS_OF_MOUNT);
@@ -18471,8 +18424,7 @@ BUILDIN_FUNC(consumeitem)
 	struct script_data *data;
 	struct item_data *item_data;
 
-	script_charid2sd(3, sd);
-	if (!sd)
+	if (!script_charid2sd(3, sd))
 		return SCRIPT_CMD_FAILURE;
 
 	data = script_getdata( st, 2 );
@@ -18560,9 +18512,7 @@ BUILDIN_FUNC(countbound)
 	int i, type, j = 0, k = 0;
 	TBL_PC *sd;
 
-	script_charid2sd(3,sd);
-
-	if (!sd)
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	type = script_getnum(st,2);
@@ -19230,8 +19180,7 @@ BUILDIN_FUNC(mergeitem) {
 	uint16 i, count = 0;
 	int nameid = 0;
 
-	script_charid2sd(3, sd);
-	if (!sd)
+	if (!script_charid2sd(3, sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if (script_hasdata(st, 2)) {

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -204,11 +204,9 @@ enum { LABEL_NEXTLINE=1,LABEL_START };
 			return SCRIPT_CMD_FAILURE;\
 		}\
 	}\
-	else {\
-		if (!((sd) = script_rid2sd(st))) {\
-			(ret);\
-			return SCRIPT_CMD_FAILURE;\
-		}\
+	else if (!((sd) = script_rid2sd(st))) {\
+		(ret);\
+		return SCRIPT_CMD_FAILURE;\
 	}\
 }
 
@@ -226,11 +224,9 @@ enum { LABEL_NEXTLINE=1,LABEL_START };
 			return SCRIPT_CMD_FAILURE;\
 		}\
 	}\
-	else {\
-		if (!((sd) = script_rid2sd(st))) {\
-			(ret);\
-			return SCRIPT_CMD_FAILURE;\
-		}\
+	else if (!((sd) = script_rid2sd(st))) {\
+		(ret);\
+		return SCRIPT_CMD_FAILURE;\
 	}\
 }
 
@@ -8321,9 +8317,7 @@ BUILDIN_FUNC(delequip) {
 	TBL_PC *sd;
 
 	pos = script_getnum(st,2);
-	sd = script_rid2sd(st);
-	if (sd == NULL)
-		return 0;
+	script_charid2sd(3,sd,NULL);
 
 	if (pos > 0 && pos <= ARRAYLENGTH(equip))
 		i = pc_checkequip(sd,equip[pos-1]);
@@ -8350,9 +8344,7 @@ BUILDIN_FUNC(breakequip) {
 	TBL_PC *sd;
 
 	pos = script_getnum(st,2);
-	sd = script_rid2sd(st);
-	if (sd == NULL)
-		return 0;
+	script_charid2sd(3,sd,NULL);
 
 	if (pos > 0 && pos <= ARRAYLENGTH(equip))
 		i = pc_checkequip(sd,equip[pos-1]);
@@ -9342,9 +9334,7 @@ BUILDIN_FUNC(getexp)
 	int base=0,job=0;
 	double bonus;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;
+	script_charid2sd(4,sd,NULL);
 
 	base=script_getnum(st,2);
 	job =script_getnum(st,3);
@@ -12856,9 +12846,11 @@ BUILDIN_FUNC(getskilllist)
 
 BUILDIN_FUNC(clearitem)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
 	int i;
-	if(sd==NULL) return 0;
+
+	script_charid2sd(2,sd,NULL);
+
 	for (i=0; i<MAX_INVENTORY; i++) {
 		if (sd->status.inventory[i].amount) {
 			pc_delitem(sd, i, sd->status.inventory[i].amount, 0, 0, LOG_TYPE_SCRIPT);
@@ -14367,8 +14359,7 @@ BUILDIN_FUNC(unequip) {
 	int pos;
 	TBL_PC *sd;
 
-	if (!(sd = script_rid2sd(st)))
-		return SCRIPT_CMD_SUCCESS;
+	script_charid2sd(3,sd,NULL);
 
 	pos = script_getnum(st,2);
 	if (pos >= 1 && pos <= ARRAYLENGTH(equip)) {
@@ -14389,8 +14380,7 @@ BUILDIN_FUNC(equip) {
 	TBL_PC *sd;
 	struct item_data *item_data;
 
-	if (!(sd = script_rid2sd(st)))
-		return SCRIPT_CMD_SUCCESS;
+	script_charid2sd(3,sd,NULL);
 
 	nameid = script_getnum(st,2);
 	if ((item_data = itemdb_exists(nameid))) {
@@ -15445,12 +15435,7 @@ BUILDIN_FUNC(setd)
 
 	if( not_server_variable(*varname) )
 	{
-		sd = script_rid2sd(st);
-		if( sd == NULL )
-		{
-			ShowError("script:setd: no player attached for player variable '%s'\n", buffer);
-			return 0;
-		}
+		script_charid2sd(4,sd,NULL);
 	}
 
 	if( is_string_variable(varname) ) {
@@ -16658,9 +16643,7 @@ BUILDIN_FUNC(openmail)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;
+	script_charid2sd(2,sd,NULL);
 
 	mail_openmail(sd);
 
@@ -16671,9 +16654,7 @@ BUILDIN_FUNC(openauction)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;
+	script_charid2sd(2,sd,NULL);
 
 	if( !battle_config.feature_auction ) {
 		clif_colormes(sd, color_table[COLOR_RED], msg_txt(sd, 517));
@@ -16978,13 +16959,13 @@ BUILDIN_FUNC(questinfo)
 
 BUILDIN_FUNC(setquest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
+	struct map_session_data *sd;
 	unsigned short i;
 	int quest_id;
 
-	nullpo_retr(1, sd);
-
 	quest_id = script_getnum(st, 2);
+
+	script_charid2sd(3,sd,NULL);
 
 	quest_add(sd, quest_id);
 
@@ -17004,8 +16985,9 @@ BUILDIN_FUNC(setquest)
 
 BUILDIN_FUNC(erasequest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
-	nullpo_ret(sd);
+	struct map_session_data *sd;
+
+	script_charid2sd(3,sd,NULL);
 
 	quest_delete(sd, script_getnum(st, 2));
 	return SCRIPT_CMD_SUCCESS;
@@ -17013,8 +16995,9 @@ BUILDIN_FUNC(erasequest)
 
 BUILDIN_FUNC(completequest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
-	nullpo_ret(sd);
+	struct map_session_data *sd;
+
+	script_charid2sd(3,sd,NULL);
 
 	quest_update_status(sd, script_getnum(st, 2), Q_COMPLETE);
 	return SCRIPT_CMD_SUCCESS;
@@ -17022,8 +17005,9 @@ BUILDIN_FUNC(completequest)
 
 BUILDIN_FUNC(changequest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
-	nullpo_ret(sd);
+	struct map_session_data *sd;
+	
+	script_charid2sd(4,sd,NULL);
 
 	quest_change(sd, script_getnum(st, 2),script_getnum(st, 3));
 	return SCRIPT_CMD_SUCCESS;
@@ -17031,13 +17015,13 @@ BUILDIN_FUNC(changequest)
 
 BUILDIN_FUNC(checkquest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
+	struct map_session_data *sd;
 	enum quest_check_type type = HAVEQUEST;
-
-	nullpo_ret(sd);
 
 	if( script_hasdata(st, 3) )
 		type = (enum quest_check_type)script_getnum(st, 3);
+
+	script_charid2sd(4,sd,NULL);
 
 	script_pushint(st, quest_check(sd, script_getnum(st, 2), type));
 
@@ -17046,10 +17030,10 @@ BUILDIN_FUNC(checkquest)
 
 BUILDIN_FUNC(isbegin_quest)
 {
-	struct map_session_data *sd = script_rid2sd(st);
+	struct map_session_data *sd;
 	int i;
 
-	nullpo_ret(sd);
+	script_charid2sd(3,sd,NULL);
 
 	i = quest_check(sd, script_getnum(st, 2), (enum quest_check_type) HAVEQUEST);
 	script_pushint(st, i + (i < 1));
@@ -17059,12 +17043,14 @@ BUILDIN_FUNC(isbegin_quest)
 
 BUILDIN_FUNC(showevent)
 {
-	TBL_PC *sd = script_rid2sd(st);
+	TBL_PC *sd;
 	struct npc_data *nd = map_id2nd(st->oid);
 	int icon, color = 0;
 
+	script_charid2sd(4,sd,NULL);
+
 	if( sd == NULL || nd == NULL )
-	return 0;
+		return 0;
 
 	icon = script_getnum(st, 2);
 	if( script_hasdata(st, 3) ) {
@@ -19501,10 +19487,10 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getitemname,"v"),
 	BUILDIN_DEF(getitemslots,"i"),
 	BUILDIN_DEF(makepet,"i"),
-	BUILDIN_DEF(getexp,"ii"),
+	BUILDIN_DEF(getexp,"ii?"),
 	BUILDIN_DEF(getinventorylist,""),
 	BUILDIN_DEF(getskilllist,""),
-	BUILDIN_DEF(clearitem,""),
+	BUILDIN_DEF(clearitem,"?"),
 	BUILDIN_DEF(classchange,"ii"),
 	BUILDIN_DEF(misceffect,"i"),
 	BUILDIN_DEF(playBGM,"s"),
@@ -19568,7 +19554,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(checkequipedcard,"i"),
 	BUILDIN_DEF(jump_zero,"il"), //for future jA script compatibility
 	BUILDIN_DEF(globalmes,"s?"), //end jA addition
-	BUILDIN_DEF(unequip,"i"), // unequip command [Spectre]
+	BUILDIN_DEF(unequip,"i?"), // unequip command [Spectre]
 	BUILDIN_DEF(getstrlen,"s"), //strlen [Valaris]
 	BUILDIN_DEF(charisalpha,"si"), //isalpha [Valaris]
 	BUILDIN_DEF(charat,"si"),
@@ -19601,13 +19587,13 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(md5,"s"),
 	// [zBuffer] List of dynamic var commands --->
 	BUILDIN_DEF(getd,"s"),
-	BUILDIN_DEF(setd,"sv"),
+	BUILDIN_DEF(setd,"sv?"),
 	BUILDIN_DEF(callshop,"s?"), // [Skotlex]
 	BUILDIN_DEF(npcshopitem,"sii*"), // [Lance]
 	BUILDIN_DEF(npcshopadditem,"sii*"),
 	BUILDIN_DEF(npcshopdelitem,"si*"),
 	BUILDIN_DEF(npcshopattach,"s?"),
-	BUILDIN_DEF(equip,"i"),
+	BUILDIN_DEF(equip,"i?"),
 	BUILDIN_DEF(autoequip,"ii"),
 	BUILDIN_DEF(setbattleflag,"si"),
 	BUILDIN_DEF(getbattleflag,"s"),
@@ -19655,8 +19641,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(checkvending,"?"),
 	BUILDIN_DEF(checkchatting,"?"),
 	BUILDIN_DEF(checkidle,"?"),
-	BUILDIN_DEF(openmail,""),
-	BUILDIN_DEF(openauction,""),
+	BUILDIN_DEF(openmail,"?"),
+	BUILDIN_DEF(openauction,"?"),
 	BUILDIN_DEF(checkcell,"siii"),
 	BUILDIN_DEF(setcell,"siiiiii"),
 	BUILDIN_DEF(setwall,"siiiiis"),
@@ -19728,8 +19714,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(cleanmap,"cleanarea","siiii"),
 	BUILDIN_DEF(npcskill,"viii"),
 	BUILDIN_DEF(consumeitem,"v"),
-	BUILDIN_DEF(delequip,"i"),
-	BUILDIN_DEF(breakequip,"i"),
+	BUILDIN_DEF(delequip,"i?"),
+	BUILDIN_DEF(breakequip,"i?"),
 	BUILDIN_DEF(sit,"?"),
 	BUILDIN_DEF(stand,"?"),
 	//@commands (script based)
@@ -19739,13 +19725,13 @@ struct script_function buildin_func[] = {
 
 	//Quest Log System [Inkfish]
 	BUILDIN_DEF(questinfo, "ii??"),
-	BUILDIN_DEF(setquest, "i"),
-	BUILDIN_DEF(erasequest, "i"),
-	BUILDIN_DEF(completequest, "i"),
-	BUILDIN_DEF(checkquest, "i?"),
-	BUILDIN_DEF(isbegin_quest,"i"),
-	BUILDIN_DEF(changequest, "ii"),
-	BUILDIN_DEF(showevent, "i?"),
+	BUILDIN_DEF(setquest, "i?"),
+	BUILDIN_DEF(erasequest, "i?"),
+	BUILDIN_DEF(completequest, "i?"),
+	BUILDIN_DEF(checkquest, "i??"),
+	BUILDIN_DEF(isbegin_quest,"i?"),
+	BUILDIN_DEF(changequest, "ii?"),
+	BUILDIN_DEF(showevent, "i??"),
 
 	//Bound items [Xantara] & [Akinari]
 	BUILDIN_DEF2(getitem,"getitembound","vii?"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8317,9 +8317,10 @@ BUILDIN_FUNC(downrefitem) {
 	return SCRIPT_CMD_FAILURE;
 }
 
-/*==========================================
+/**
  * Delete the item equipped at pos.
- *------------------------------------------*/
+ * delequip <equipment slot>{,<char_id>};
+ **/
 BUILDIN_FUNC(delequip) {
 	short i = -1;
 	int pos;
@@ -8327,8 +8328,10 @@ BUILDIN_FUNC(delequip) {
 	TBL_PC *sd;
 
 	pos = script_getnum(st,2);
-	if (!script_charid2sd(3,sd))
+	if (!script_charid2sd(3,sd)) {
+		st->state = END;
 		return SCRIPT_CMD_FAILURE;
+	}
 
 	if (pos > 0 && pos <= ARRAYLENGTH(equip))
 		i = pc_checkequip(sd,equip[pos-1]);
@@ -8346,9 +8349,10 @@ BUILDIN_FUNC(delequip) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
+/**
  * Break the item equipped at pos.
- *------------------------------------------*/
+ * breakequip <equipment slot>{,<char_id>};
+ **/
 BUILDIN_FUNC(breakequip) {
 	short i = -1;
 	int pos;
@@ -8928,7 +8932,7 @@ BUILDIN_FUNC(setcart)
 	int type = 1;
 	TBL_PC* sd;
 
-	if (!script_charid2sd(2,sd))
+	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
@@ -9316,9 +9320,11 @@ BUILDIN_FUNC(makepet)
 
 	return SCRIPT_CMD_SUCCESS;
 }
-/*==========================================
+
+/**
  * Give player exp base,job * quest_exp_rate/100
- *------------------------------------------*/
+ * getexp <base xp>,<job xp>{,<char_id>};
+ **/
 BUILDIN_FUNC(getexp)
 {
 	TBL_PC* sd;
@@ -10519,9 +10525,9 @@ BUILDIN_FUNC(getscrate)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
+/**
  * getstatus(<effect type>{,<type>{,<char_id>}});
- *------------------------------------------*/
+ **/
 BUILDIN_FUNC(getstatus)
 {
 	int id, type;
@@ -10790,14 +10796,15 @@ BUILDIN_FUNC(birthpet)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
- * Added - AppleGirl For Advanced Classes, (Updated for Cleaner Script Purposes)
- * @type
+/**
+ * resetlvl <action type>{,<char_id>};
+ * @param action_type:
  *	1 : make like after rebirth
  *	2 : blvl,jlvl=1, skillpoint=0
  * 	3 : don't reset skill, blvl=1
  *	4 : jlvl=0
- *------------------------------------------*/
+ * @author AppleGirl
+ **/
 BUILDIN_FUNC(resetlvl)
 {
 	TBL_PC *sd;
@@ -10810,9 +10817,11 @@ BUILDIN_FUNC(resetlvl)
 	pc_resetlvl(sd,type);
 	return SCRIPT_CMD_SUCCESS;
 }
-/*==========================================
+
+/**
  * Reset a player status point
- *------------------------------------------*/
+ * resetstatus({<char_id>});
+ **/
 BUILDIN_FUNC(resetstatus)
 {
 	TBL_PC *sd;
@@ -10822,9 +10831,10 @@ BUILDIN_FUNC(resetstatus)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
- * script command resetskill
- *------------------------------------------*/
+/**
+ * Reset player's skill
+ * resetskill({<char_id>});
+ **/
 BUILDIN_FUNC(resetskill)
 {
 	TBL_PC *sd;
@@ -10834,9 +10844,10 @@ BUILDIN_FUNC(resetskill)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
+/**
  * Counts total amount of skill points.
- *------------------------------------------*/
+ * skillpointcount({<char_id>})
+ **/
 BUILDIN_FUNC(skillpointcount)
 {
 	TBL_PC *sd;
@@ -10883,9 +10894,10 @@ BUILDIN_FUNC(changebase)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
- * Unequip all item and request for a changesex to char-serv
- *------------------------------------------*/
+/**
+ * Change sec and unequip all item and request for a changesex to char-serv
+ * changesex({<char_id>});
+ **/
 BUILDIN_FUNC(changesex)
 {
 	int i;
@@ -12295,6 +12307,9 @@ BUILDIN_FUNC(wedding_effect)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * divorce({<char_id>})
+ **/
 BUILDIN_FUNC(divorce)
 {
 	TBL_PC *sd;
@@ -12307,6 +12322,9 @@ BUILDIN_FUNC(divorce)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * ispartneron({<char_id>})
+ **/
 BUILDIN_FUNC(ispartneron)
 {
 	TBL_PC *sd;
@@ -12322,6 +12340,9 @@ BUILDIN_FUNC(ispartneron)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * getpartnerid({<char_id>})
+ **/
 BUILDIN_FUNC(getpartnerid)
 {
 	TBL_PC *sd;
@@ -12335,6 +12356,9 @@ BUILDIN_FUNC(getpartnerid)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * getchildid({<char_id>})
+ **/
 BUILDIN_FUNC(getchildid)
 {
 	TBL_PC *sd;
@@ -12348,6 +12372,9 @@ BUILDIN_FUNC(getchildid)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * getmotherid({<char_id>})
+ **/
 BUILDIN_FUNC(getmotherid)
 {
 	TBL_PC *sd;
@@ -12361,6 +12388,9 @@ BUILDIN_FUNC(getmotherid)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * getfatherid({<char_id>})
+ **/
 BUILDIN_FUNC(getfatherid)
 {
 	TBL_PC *sd;
@@ -12869,9 +12899,10 @@ BUILDIN_FUNC(clearitem)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
+/**
  * Disguise Player (returns Mob/NPC ID if success, 0 on fail)
- *------------------------------------------*/
+ * disguise <Monster ID>{,<char_id>};
+ **/
 BUILDIN_FUNC(disguise)
 {
 	int id;
@@ -12890,9 +12921,10 @@ BUILDIN_FUNC(disguise)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
+/**
  * Undisguise Player (returns 1 if success, 0 on fail)
- *------------------------------------------*/
+ * undisguise {<char_id>};
+ **/
 BUILDIN_FUNC(undisguise)
 {
 	TBL_PC* sd;
@@ -13359,9 +13391,10 @@ BUILDIN_FUNC(specialeffect2)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
- * Nude [Valaris]
- *------------------------------------------*/
+/**
+ * nude({<char_id>});
+ * @author [Valaris]
+ **/
 BUILDIN_FUNC(nude)
 {
 	TBL_PC *sd;
@@ -13877,9 +13910,9 @@ BUILDIN_FUNC(npcstop)
 }
 
 
-/*==========================================
- * getlook char info. getlook(arg)
- *------------------------------------------*/
+/**
+ * getlook(<type>{,<char_id>})
+ **/
 BUILDIN_FUNC(getlook)
 {
 	int type,val;
@@ -13909,9 +13942,10 @@ BUILDIN_FUNC(getlook)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-/*==========================================
- *     get char save point. argument: 0- map name, 1- x, 2- y
- *------------------------------------------*/
+/**
+ * getsavepoint(<information type>{,<char_id>})
+ * @param type 0- map name, 1- x, 2- y
+ **/
 BUILDIN_FUNC(getsavepoint)
 {
 	TBL_PC* sd;
@@ -14373,9 +14407,10 @@ BUILDIN_FUNC(day)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-//=======================================================
-// Unequip [Spectre]
-//-------------------------------------------------------
+/**
+ * unequip <equipment slot>{,<char_id>};
+ * @author [Spectre]
+ **/
 BUILDIN_FUNC(unequip) {
 	int pos;
 	TBL_PC *sd;
@@ -14397,6 +14432,9 @@ BUILDIN_FUNC(unequip) {
 	return SCRIPT_CMD_FAILURE;
 }
 
+/**
+ * equip <item id>{,<char_id>};
+ **/
 BUILDIN_FUNC(equip) {
 	unsigned short nameid = 0;
 	TBL_PC *sd;
@@ -15444,7 +15482,9 @@ BUILDIN_FUNC(md5)
 }
 
 // [zBuffer] List of dynamic var commands --->
-
+/**
+ * setd "<variable name>",<value>{,<char_id>};
+ **/
 BUILDIN_FUNC(setd)
 {
 	TBL_PC *sd = NULL;
@@ -16662,6 +16702,9 @@ BUILDIN_FUNC(warpportal)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * openmail({<char_id>});
+ **/
 BUILDIN_FUNC(openmail)
 {
 	TBL_PC* sd;
@@ -16674,6 +16717,9 @@ BUILDIN_FUNC(openmail)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * openauction({<char_id>});
+ **/
 BUILDIN_FUNC(openauction)
 {
 	TBL_PC* sd;
@@ -16928,6 +16974,9 @@ BUILDIN_FUNC(readbook)
 Questlog script commands
 *******************/
 
+/**
+ * questinfo <Quest ID>,<Icon>{,<Map Mark Color>{,<Job Class>}};
+ **/
 BUILDIN_FUNC(questinfo)
 {
 	TBL_NPC* nd = map_id2nd(st->oid);
@@ -16982,6 +17031,9 @@ BUILDIN_FUNC(questinfo)
 	return true;
 }
 
+/**
+ * setquest <ID>{,<char_id>};
+ **/
 BUILDIN_FUNC(setquest)
 {
 	struct map_session_data *sd;
@@ -17009,6 +17061,9 @@ BUILDIN_FUNC(setquest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * erasequest <ID>{,<char_id>};
+ **/
 BUILDIN_FUNC(erasequest)
 {
 	struct map_session_data *sd;
@@ -17020,6 +17075,9 @@ BUILDIN_FUNC(erasequest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * completequest <ID>{,<char_id>};
+ **/
 BUILDIN_FUNC(completequest)
 {
 	struct map_session_data *sd;
@@ -17031,6 +17089,9 @@ BUILDIN_FUNC(completequest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * changequest <ID>,<ID2>{,<char_id>};
+ **/
 BUILDIN_FUNC(changequest)
 {
 	struct map_session_data *sd;
@@ -17042,6 +17103,9 @@ BUILDIN_FUNC(changequest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * checkquest(<ID>{,PLAYTIME|HUNTING{,<char_id>}})
+ **/
 BUILDIN_FUNC(checkquest)
 {
 	struct map_session_data *sd;
@@ -17058,6 +17122,9 @@ BUILDIN_FUNC(checkquest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * isbegin_quest(<ID>{,<char_id>})
+ **/
 BUILDIN_FUNC(isbegin_quest)
 {
 	struct map_session_data *sd;
@@ -17072,6 +17139,9 @@ BUILDIN_FUNC(isbegin_quest)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * showevent <icon>{,<mark color>{,<char_id>}}
+ **/
 BUILDIN_FUNC(showevent)
 {
 	TBL_PC *sd;
@@ -17888,6 +17958,7 @@ BUILDIN_FUNC(showdigit)
 }
 /**
  * Rune Knight
+ * makerune({<char_id>});
  **/
 BUILDIN_FUNC(makerune) {
 	TBL_PC* sd;
@@ -17899,7 +17970,7 @@ BUILDIN_FUNC(makerune) {
 	return SCRIPT_CMD_SUCCESS;
 }
 /**
- * checkdragon() returns 1 if mounting a dragon or 0 otherwise.
+ * checkdragon({<char_id>}) returns 1 if mounting a dragon or 0 otherwise.
  **/
 BUILDIN_FUNC(checkdragon) {
 	TBL_PC* sd;
@@ -17913,7 +17984,7 @@ BUILDIN_FUNC(checkdragon) {
 	return SCRIPT_CMD_SUCCESS;
 }
 /**
- * setdragon({optional Color}) returns 1 on success or 0 otherwise
+ * setdragon({optional Color{,<char_id>}}) returns 1 on success or 0 otherwise
  * - Toggles the dragon on a RK if he can mount;
  * @param Color - when not provided uses the green dragon;
  * - 1 : Green Dragon
@@ -17953,7 +18024,7 @@ BUILDIN_FUNC(setdragon) {
 }
 
 /**
- * ismounting() returns 1 if mounting a new mount or 0 otherwise
+ * ismounting({<char_id>}) returns 1 if mounting a new mount or 0 otherwise
  **/
 BUILDIN_FUNC(ismounting) {
 	TBL_PC* sd;
@@ -17968,7 +18039,7 @@ BUILDIN_FUNC(ismounting) {
 }
 
 /**
- * setmounting() returns 1 on success or 0 otherwise
+ * setmounting({<char_id>}) returns 1 on success or 0 otherwise
  * - Toggles new mounts on a player when he can mount
  * - Will fail if the player is mounting a non-new mount, e.g. dragon, peco, wug, etc.
  * - Will unmount the player is he is already mounting

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -210,7 +210,7 @@ static void script_charid2sd_(struct script_state *st, uint8 loc, struct map_ses
  * @param loc Location to look nick in script parameter
  * @param sd Variable that will be assigned
  **/
-static bool script_nick2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
+static void script_nick2sd_(struct script_state *st, uint8 loc, struct map_session_data **sd, const char *func) {
 	if (script_hasdata(st, loc)) {
 		const char *name_ = script_getstr(st, loc);
 		if (!(*sd = map_nick2sd(name_)))
@@ -8760,28 +8760,28 @@ BUILDIN_FUNC(basicskillcheck)
 
 /// Returns the GM level of the player.
 ///
-/// getgmlevel() -> <level>
+/// getgmlevel({<char_id>}) -> <level>
 BUILDIN_FUNC(getgmlevel)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	script_pushint(st, pc_get_group_level(sd));
 	return SCRIPT_CMD_SUCCESS;
 }
 
 /// Returns the group ID of the player.
 ///
-/// getgroupid() -> <int>
+/// getgroupid({<char_id>}) -> <int>
 BUILDIN_FUNC(getgroupid)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if (sd == NULL)
-		return 1; // no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	script_pushint(st, pc_get_group_id(sd));
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -8808,15 +8808,15 @@ BUILDIN_FUNC(end)
 
 /// Checks if the player has that effect state (option).
 ///
-/// checkoption(<option>) -> <bool>
+/// checkoption(<option>{,<char_id>}) -> <bool>
 BUILDIN_FUNC(checkoption)
 {
 	int option;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	option = script_getnum(st,2);
 	if( sd->sc.option&option )
@@ -8829,15 +8829,15 @@ BUILDIN_FUNC(checkoption)
 
 /// Checks if the player is in that body state (opt1).
 ///
-/// checkoption1(<opt1>) -> <bool>
+/// checkoption1(<opt1>{,<char_id>}) -> <bool>
 BUILDIN_FUNC(checkoption1)
 {
 	int opt1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	opt1 = script_getnum(st,2);
 	if( sd->sc.opt1 == opt1 )
@@ -8850,15 +8850,15 @@ BUILDIN_FUNC(checkoption1)
 
 /// Checks if the player has that health state (opt2).
 ///
-/// checkoption2(<opt2>) -> <bool>
+/// checkoption2(<opt2>{,<char_id>}) -> <bool>
 BUILDIN_FUNC(checkoption2)
 {
 	int opt2;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	opt2 = script_getnum(st,2);
 	if( sd->sc.opt2&opt2 )
@@ -8874,17 +8874,16 @@ BUILDIN_FUNC(checkoption2)
 /// <flag>=0 : removes the option
 /// <flag>=other : adds the option
 ///
-/// setoption <option>,<flag>;
-/// setoption <option>;
+/// setoption <option>{,<flag>{,<char_id>}};
 BUILDIN_FUNC(setoption)
 {
 	int option;
 	int flag = 1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(4,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	option = script_getnum(st,2);
 	if( script_hasdata(st,3) )
@@ -8908,16 +8907,16 @@ BUILDIN_FUNC(setoption)
 
 /// Returns if the player has a cart.
 ///
-/// checkcart() -> <bool>
+/// checkcart({char_id}) -> <bool>
 ///
 /// @author Valaris
 BUILDIN_FUNC(checkcart)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( pc_iscarton(sd) )
 		script_pushint(st, 1);
@@ -8936,16 +8935,15 @@ BUILDIN_FUNC(checkcart)
 /// <type>=4 : Wooden cart with a Panda doll on the back
 /// <type>=5 : Normal cart with bigger wheels, a roof and a banner on the back
 ///
-/// setcart <type>;
-/// setcart;
+/// setcart {<type>{,<char_id>}};
 BUILDIN_FUNC(setcart)
 {
 	int type = 1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
 		type = script_getnum(st,2);
@@ -8956,16 +8954,16 @@ BUILDIN_FUNC(setcart)
 
 /// Returns if the player has a falcon.
 ///
-/// checkfalcon() -> <bool>
+/// checkfalcon({char_id}) -> <bool>
 ///
 /// @author Valaris
 BUILDIN_FUNC(checkfalcon)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( pc_isfalcon(sd) )
 		script_pushint(st, 1);
@@ -8978,16 +8976,15 @@ BUILDIN_FUNC(checkfalcon)
 /// Sets if the player has a falcon or not.
 /// <flag> defaults to 1
 ///
-/// setfalcon <flag>;
-/// setfalcon;
+/// setfalcon {<flag>{,<char_id>}};
 BUILDIN_FUNC(setfalcon)
 {
 	int flag = 1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
 		flag = script_getnum(st,2);
@@ -8999,16 +8996,16 @@ BUILDIN_FUNC(setfalcon)
 
 /// Returns if the player is riding.
 ///
-/// checkriding() -> <bool>
+/// checkriding({char_id}) -> <bool>
 ///
 /// @author Valaris
 BUILDIN_FUNC(checkriding)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( pc_isriding(sd) )
 		script_pushint(st, 1);
@@ -9021,16 +9018,15 @@ BUILDIN_FUNC(checkriding)
 /// Sets if the player is riding.
 /// <flag> defaults to 1
 ///
-/// setriding <flag>;
-/// setriding;
+/// setriding {<flag>{,<char_id>}};
 BUILDIN_FUNC(setriding)
 {
 	int flag = 1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
 		flag = script_getnum(st,2);
@@ -9041,15 +9037,15 @@ BUILDIN_FUNC(setriding)
 
 /// Returns if the player has a warg.
 ///
-/// checkwug() -> <bool>
+/// checkwug({char_id}) -> <bool>
 ///
 BUILDIN_FUNC(checkwug)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( pc_iswug(sd) || pc_isridingwug(sd) )
 		script_pushint(st, 1);
@@ -9061,15 +9057,15 @@ BUILDIN_FUNC(checkwug)
 
 /// Returns if the player is wearing MADO Gear.
 ///
-/// checkmadogear() -> <bool>
+/// checkmadogear({<char_id>}) -> <bool>
 ///
 BUILDIN_FUNC(checkmadogear)
 {
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( pc_ismadogear(sd) )
 		script_pushint(st, 1);
@@ -9082,16 +9078,15 @@ BUILDIN_FUNC(checkmadogear)
 /// Sets if the player is riding MADO Gear.
 /// <flag> defaults to 1
 ///
-/// setmadogear <flag>;
-/// setmadogear;
+/// setmadogear {<flag>{,<char_id>}};
 BUILDIN_FUNC(setmadogear)
 {
 	int flag = 1;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
-	if( sd == NULL )
-		return 0;// no player attached, report source
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	if( script_hasdata(st,2) )
 		flag = script_getnum(st,2);
@@ -9102,8 +9097,8 @@ BUILDIN_FUNC(setmadogear)
 
 /// Sets the save point of the player.
 ///
-/// save "<map name>",<x>,<y>
-/// savepoint "<map name>",<x>,<y>
+/// save "<map name>",<x>,<y>{,<char_id>}
+/// savepoint "<map name>",<x>,<y>{,<char_id>}
 BUILDIN_FUNC(savepoint)
 {
 	int x;
@@ -9112,9 +9107,9 @@ BUILDIN_FUNC(savepoint)
 	const char* str;
 	TBL_PC* sd;
 
-	sd = script_rid2sd(st);
+	script_charid2sd(4,sd);
 	if( sd == NULL )
-		return 0;// no player attached, report source
+		return SCRIPT_CMD_FAILURE;// no player attached, report source
 
 	str = script_getstr(st, 2);
 	x   = script_getnum(st,3);
@@ -10548,17 +10543,16 @@ BUILDIN_FUNC(getscrate)
 }
 
 /*==========================================
- * getstatus <type>{, <info>};
+ * getstatus(<effect type>{,<type>{,<char_id>}});
  *------------------------------------------*/
 BUILDIN_FUNC(getstatus)
 {
 	int id, type;
-	struct map_session_data* sd = script_rid2sd(st);
+	struct map_session_data* sd;
 
-	if( sd == NULL )
-	{// no player attached
-		return 0;
-	}
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	id = script_getnum(st, 2);
 	type = script_hasdata(st, 3) ? script_getnum(st, 3) : 0;
@@ -10834,9 +10828,9 @@ BUILDIN_FUNC(resetlvl)
 
 	int type=script_getnum(st,2);
 
-	sd=script_rid2sd(st);
-	if( sd == NULL )
-		return 0;
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	pc_resetlvl(sd,type);
 	return SCRIPT_CMD_SUCCESS;
@@ -10847,7 +10841,9 @@ BUILDIN_FUNC(resetlvl)
 BUILDIN_FUNC(resetstatus)
 {
 	TBL_PC *sd;
-	sd=script_rid2sd(st);
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	pc_resetstate(sd);
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -10858,7 +10854,9 @@ BUILDIN_FUNC(resetstatus)
 BUILDIN_FUNC(resetskill)
 {
 	TBL_PC *sd;
-	sd=script_rid2sd(st);
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	pc_resetskill(sd,1);
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -10869,7 +10867,9 @@ BUILDIN_FUNC(resetskill)
 BUILDIN_FUNC(skillpointcount)
 {
 	TBL_PC *sd;
-	sd=script_rid2sd(st);
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	script_pushint(st,sd->status.skill_point + pc_resetskill(sd,2));
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -10918,7 +10918,9 @@ BUILDIN_FUNC(changesex)
 {
 	int i;
 	TBL_PC *sd = NULL;
-	sd = script_rid2sd(st);
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	pc_resetskill(sd,4);
 	// to avoid any problem with equipment and invalid sex, equipment is unequiped.
@@ -12323,10 +12325,11 @@ BUILDIN_FUNC(wedding_effect)
 
 BUILDIN_FUNC(divorce)
 {
-	TBL_PC *sd=script_rid2sd(st);
-	if(!sd || !pc_divorce(sd)){
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
+	if (!sd || !pc_divorce(sd)) {
 		script_pushint(st,0);
-		return 0;
+		return SCRIPT_CMD_FAILURE;
 	}
 	script_pushint(st,1);
 	return SCRIPT_CMD_SUCCESS;
@@ -12334,12 +12337,13 @@ BUILDIN_FUNC(divorce)
 
 BUILDIN_FUNC(ispartneron)
 {
-	TBL_PC *sd=script_rid2sd(st);
-
-	if(sd==NULL || !pc_ismarried(sd) ||
-		map_charid2sd(sd->status.partner_id) == NULL) {
-			script_pushint(st,0);
-			return 0;
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
+	if (!sd || !pc_ismarried(sd) ||
+		map_charid2sd(sd->status.partner_id) == NULL)
+	{
+		script_pushint(st,0);
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	script_pushint(st,1);
@@ -12348,10 +12352,11 @@ BUILDIN_FUNC(ispartneron)
 
 BUILDIN_FUNC(getpartnerid)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
 	if (sd == NULL) {
 		script_pushint(st,0);
-		return 0;
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	script_pushint(st,sd->status.partner_id);
@@ -12360,10 +12365,11 @@ BUILDIN_FUNC(getpartnerid)
 
 BUILDIN_FUNC(getchildid)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
 	if (sd == NULL) {
 		script_pushint(st,0);
-		return 0;
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	script_pushint(st,sd->status.child);
@@ -12372,10 +12378,11 @@ BUILDIN_FUNC(getchildid)
 
 BUILDIN_FUNC(getmotherid)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
 	if (sd == NULL) {
 		script_pushint(st,0);
-		return 0;
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	script_pushint(st,sd->status.mother);
@@ -12384,10 +12391,11 @@ BUILDIN_FUNC(getmotherid)
 
 BUILDIN_FUNC(getfatherid)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
+	script_charid2sd(2,sd);
 	if (sd == NULL) {
 		script_pushint(st,0);
-		return 0;
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	script_pushint(st,sd->status.father);
@@ -12820,11 +12828,13 @@ BUILDIN_FUNC(petloot)
  *------------------------------------------*/
 BUILDIN_FUNC(getinventorylist)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
 	char card_var[NAME_LENGTH];
-
 	int i,j=0,k;
-	if(!sd) return 0;
+
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	for(i=0;i<MAX_INVENTORY;i++){
 		if(sd->status.inventory[i].nameid > 0 && sd->status.inventory[i].amount > 0){
 			pc_setreg(sd,reference_uid(add_str("@inventorylist_id"), j),sd->status.inventory[i].nameid);
@@ -12847,11 +12857,16 @@ BUILDIN_FUNC(getinventorylist)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * getskilllist ({<char_id>});
+ **/
 BUILDIN_FUNC(getskilllist)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
 	int i,j=0;
-	if(!sd) return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	for(i=0;i<MAX_SKILL;i++){
 		if(sd->status.skill[i].id > 0 && sd->status.skill[i].lv > 0){
 			pc_setreg(sd,reference_uid(add_str("@skilllist_id"), j),sd->status.skill[i].id);
@@ -12864,6 +12879,9 @@ BUILDIN_FUNC(getskilllist)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/**
+ * clearitem ({<char_id>});
+ **/
 BUILDIN_FUNC(clearitem)
 {
 	TBL_PC *sd;
@@ -12887,8 +12905,10 @@ BUILDIN_FUNC(clearitem)
 BUILDIN_FUNC(disguise)
 {
 	int id;
-	TBL_PC* sd = script_rid2sd(st);
-	if (sd == NULL) return 0;
+	TBL_PC* sd;
+	script_charid2sd(3,sd);
+	if (sd == NULL)
+		return SCRIPT_CMD_FAILURE;
 
 	id = script_getnum(st,2);
 
@@ -12905,8 +12925,10 @@ BUILDIN_FUNC(disguise)
  *------------------------------------------*/
 BUILDIN_FUNC(undisguise)
 {
-	TBL_PC* sd = script_rid2sd(st);
-	if (sd == NULL) return 0;
+	TBL_PC* sd;
+	script_charid2sd(2,sd);
+	if (sd == NULL)
+		return SCRIPT_CMD_FAILURE;
 
 	if (sd->disguise) {
 		pc_disguise(sd, 0);
@@ -13372,11 +13394,12 @@ BUILDIN_FUNC(specialeffect2)
  *------------------------------------------*/
 BUILDIN_FUNC(nude)
 {
-	TBL_PC *sd = script_rid2sd(st);
+	TBL_PC *sd;
 	int i, calcflag = 0;
 
-	if( sd == NULL )
-		return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	for( i = 0 ; i < EQI_MAX; i++ ) {
 		if( sd->equip_index[ i ] >= 0 ) {
@@ -13435,15 +13458,20 @@ BUILDIN_FUNC(atcommand) {
 }
 
 /** Displays a message for the player only (like system messages like "you got an apple" )
-* dispbottom("<message>"{,<color>})
+* dispbottom("<message>"{,<color>{,<char_id>}})
 * @param message 
 * @param color Hex color default (Green)
 */
 BUILDIN_FUNC(dispbottom)
 {
-	TBL_PC *sd=script_rid2sd(st);
+	TBL_PC *sd;
 	int color = 0;
 	const char *message;
+
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
+
 	message = script_getstr(st,2);
 
 	if (script_hasdata(st,3))
@@ -13888,7 +13916,11 @@ BUILDIN_FUNC(getlook)
 {
 	int type,val;
 	TBL_PC *sd;
-	sd=script_rid2sd(st);
+	script_charid2sd(3,sd);
+	if (!sd) {
+		script_pushint(st,-1);
+		return SCRIPT_CMD_FAILURE;
+	}
 
 	type=script_getnum(st,2);
 	val=-1;
@@ -13917,7 +13949,7 @@ BUILDIN_FUNC(getsavepoint)
 	TBL_PC* sd;
 	int type;
 
-	sd = script_rid2sd(st);
+	script_charid2sd(3,sd);
 	if (sd == NULL) {
 		script_pushint(st,0);
 		return 0;
@@ -17905,8 +17937,9 @@ BUILDIN_FUNC(showdigit)
  **/
 BUILDIN_FUNC(makerune) {
 	TBL_PC* sd;
-	if( (sd = script_rid2sd(st)) == NULL )
-		return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	clif_skill_produce_mix_list(sd,RK_RUNEMASTERY,24);
 	sd->itemid = script_getnum(st,2);
 	return SCRIPT_CMD_SUCCESS;
@@ -17916,8 +17949,9 @@ BUILDIN_FUNC(makerune) {
  **/
 BUILDIN_FUNC(checkdragon) {
 	TBL_PC* sd;
-	if( (sd = script_rid2sd(st)) == NULL )
-		return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	if( pc_isridingdragon(sd) )
 		script_pushint(st,1);
 	else
@@ -17938,8 +17972,9 @@ BUILDIN_FUNC(setdragon) {
 	TBL_PC* sd;
 	int color = script_hasdata(st,2) ? script_getnum(st,2) : 0;
 
-	if( (sd = script_rid2sd(st)) == NULL )
-		return 0;
+	script_charid2sd(3,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	if( !pc_checkskill(sd,RK_DRAGONTRAINING) || (sd->class_&MAPID_THIRDMASK) != MAPID_RUNE_KNIGHT )
 		script_pushint(st,0);//Doesn't have the skill or it's not a Rune Knight
 	else if ( pc_isridingdragon(sd) ) {//Is mounted; release
@@ -17969,8 +18004,9 @@ BUILDIN_FUNC(setdragon) {
  **/
 BUILDIN_FUNC(ismounting) {
 	TBL_PC* sd;
-	if( (sd = script_rid2sd(st)) == NULL )
-		return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	if( &sd->sc && sd->sc.data[SC_ALL_RIDING] )
 		script_pushint(st,1);
 	else
@@ -17986,8 +18022,9 @@ BUILDIN_FUNC(ismounting) {
  **/
 BUILDIN_FUNC(setmounting) {
 	TBL_PC* sd;
-	if( (sd = script_rid2sd(st)) == NULL )
-		return 0;
+	script_charid2sd(2,sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 	if( &sd->sc && sd->sc.option&(OPTION_WUGRIDER|OPTION_RIDING|OPTION_DRAGON|OPTION_MADOGEAR) ) {
 		clif_msgtable(sd->fd, NEED_REINS_OF_MOUNT);
 		script_pushint(st,0); //can't mount with one of these
@@ -18424,8 +18461,8 @@ BUILDIN_FUNC(npcskill)
 }
 
 /* Consumes an item.
- * consumeitem <item id>;
- * consumeitem "<item name>";
+ * consumeitem <item id>{,<char_id>};
+ * consumeitem "<item name>"{,<char_id>};
  * @param item: Item ID or name
  */
 BUILDIN_FUNC(consumeitem)
@@ -18434,7 +18471,9 @@ BUILDIN_FUNC(consumeitem)
 	struct script_data *data;
 	struct item_data *item_data;
 
-	nullpo_retr( 1, ( sd = script_rid2sd( st ) ) );
+	script_charid2sd(3, sd);
+	if (!sd)
+		return SCRIPT_CMD_FAILURE;
 
 	data = script_getdata( st, 2 );
 	get_val( st, data );
@@ -18512,7 +18551,7 @@ BUILDIN_FUNC(stand)
 }
 
 /** Creates an array of bounded item IDs
- * countbound {<type>};
+ * countbound {<type>{,<char_id>}};
  * @param type: 0 - All bound items; 1 - Account Bound; 2 - Guild Bound; 3 - Party Bound
  * @return amt: Amount of items found
  */
@@ -18521,7 +18560,9 @@ BUILDIN_FUNC(countbound)
 	int i, type, j = 0, k = 0;
 	TBL_PC *sd;
 
-	if( (sd = script_rid2sd(st)) == NULL )
+	script_charid2sd(3,sd);
+
+	if (!sd)
 		return SCRIPT_CMD_FAILURE;
 
 	type = script_getnum(st,2);
@@ -19156,7 +19197,7 @@ BUILDIN_FUNC(delspiritball) {
 }
 
 /** Counts the spirit ball that player has
-* countspiritball {,<char_id>};
+* countspiritball {<char_id>};
 * @param char_id Target player (Optional)
 * @author [Cydh]
 */
@@ -19178,19 +19219,20 @@ BUILDIN_FUNC(countspiritball) {
 }
 
 /** Merges separated stackable items because of guid
-* mergeitem {<item_id>};
-* mergeitem {"<item name>"};
+* mergeitem {<item_id>,{<char_id>}};
+* mergeitem {"<item name>",{<char_id>}};
 * @param item Item ID/Name for merging specific item (Optional)
 * @author [Cydh]
 */
 BUILDIN_FUNC(mergeitem) {
-	struct map_session_data *sd = script_rid2sd(st);
+	struct map_session_data *sd;
 	struct item *items = NULL;
 	uint16 i, count = 0;
 	int nameid = 0;
 
+	script_charid2sd(3, sd);
 	if (!sd)
-		return SCRIPT_CMD_SUCCESS;
+		return SCRIPT_CMD_FAILURE;
 
 	if (script_hasdata(st, 2)) {
 		struct script_data *data = script_getdata(st, 2);
@@ -19416,22 +19458,22 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getskilllv,"v"),
 	BUILDIN_DEF(getgdskilllv,"iv"),
 	BUILDIN_DEF(basicskillcheck,""),
-	BUILDIN_DEF(getgmlevel,""),
-	BUILDIN_DEF(getgroupid,""),
+	BUILDIN_DEF(getgmlevel,"?"),
+	BUILDIN_DEF(getgroupid,"?"),
 	BUILDIN_DEF(end,""),
-	BUILDIN_DEF(checkoption,"i"),
-	BUILDIN_DEF(setoption,"i?"),
-	BUILDIN_DEF(setcart,"?"),
-	BUILDIN_DEF(checkcart,""),
-	BUILDIN_DEF(setfalcon,"?"),
-	BUILDIN_DEF(checkfalcon,""),
-	BUILDIN_DEF(setriding,"?"),
-	BUILDIN_DEF(checkriding,""),
-	BUILDIN_DEF(checkwug,""),
-	BUILDIN_DEF(checkmadogear,""),
-	BUILDIN_DEF(setmadogear,"?"),
-	BUILDIN_DEF2(savepoint,"save","sii"),
-	BUILDIN_DEF(savepoint,"sii"),
+	BUILDIN_DEF(checkoption,"i?"),
+	BUILDIN_DEF(setoption,"i??"),
+	BUILDIN_DEF(setcart,"??"),
+	BUILDIN_DEF(checkcart,"?"),
+	BUILDIN_DEF(setfalcon,"??"),
+	BUILDIN_DEF(checkfalcon,"?"),
+	BUILDIN_DEF(setriding,"??"),
+	BUILDIN_DEF(checkriding,"?"),
+	BUILDIN_DEF(checkwug,"?"),
+	BUILDIN_DEF(checkmadogear,"?"),
+	BUILDIN_DEF(setmadogear,"??"),
+	BUILDIN_DEF2(savepoint,"save","sii?"),
+	BUILDIN_DEF(savepoint,"sii?"),
 	BUILDIN_DEF(gettimetick,"i"),
 	BUILDIN_DEF(gettime,"i"),
 	BUILDIN_DEF(gettimestr,"si"),
@@ -19476,17 +19518,17 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(sc_start,"sc_start2","iiii???"),
 	BUILDIN_DEF2(sc_start,"sc_start4","iiiiii???"),
 	BUILDIN_DEF(sc_end,"i?"),
-	BUILDIN_DEF(getstatus, "i?"),
+	BUILDIN_DEF(getstatus, "i??"),
 	BUILDIN_DEF(getscrate,"ii?"),
 	BUILDIN_DEF(debugmes,"s"),
 	BUILDIN_DEF2(catchpet,"pet","i"),
 	BUILDIN_DEF2(birthpet,"bpet",""),
-	BUILDIN_DEF(resetlvl,"i"),
-	BUILDIN_DEF(resetstatus,""),
-	BUILDIN_DEF(resetskill,""),
-	BUILDIN_DEF(skillpointcount,""),
+	BUILDIN_DEF(resetlvl,"i?"),
+	BUILDIN_DEF(resetstatus,"?"),
+	BUILDIN_DEF(resetskill,"?"),
+	BUILDIN_DEF(skillpointcount,"?"),
 	BUILDIN_DEF(changebase,"i?"),
-	BUILDIN_DEF(changesex,""),
+	BUILDIN_DEF(changesex,"?"),
 	BUILDIN_DEF(waitingroom,"si?????"),
 	BUILDIN_DEF(delwaitingroom,"?"),
 	BUILDIN_DEF2(waitingroomkickall,"kickwaitingroomall","?"),
@@ -19523,19 +19565,19 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(failedremovecards,"ii"),
 	BUILDIN_DEF(marriage,"s"),
 	BUILDIN_DEF2(wedding_effect,"wedding",""),
-	BUILDIN_DEF(divorce,""),
-	BUILDIN_DEF(ispartneron,""),
-	BUILDIN_DEF(getpartnerid,""),
-	BUILDIN_DEF(getchildid,""),
-	BUILDIN_DEF(getmotherid,""),
-	BUILDIN_DEF(getfatherid,""),
+	BUILDIN_DEF(divorce,"?"),
+	BUILDIN_DEF(ispartneron,"?"),
+	BUILDIN_DEF(getpartnerid,"?"),
+	BUILDIN_DEF(getchildid,"?"),
+	BUILDIN_DEF(getmotherid,"?"),
+	BUILDIN_DEF(getfatherid,"?"),
 	BUILDIN_DEF(warppartner,"sii"),
 	BUILDIN_DEF(getitemname,"v"),
 	BUILDIN_DEF(getitemslots,"i"),
 	BUILDIN_DEF(makepet,"i"),
 	BUILDIN_DEF(getexp,"ii?"),
-	BUILDIN_DEF(getinventorylist,""),
-	BUILDIN_DEF(getskilllist,""),
+	BUILDIN_DEF(getinventorylist,"?"),
+	BUILDIN_DEF(getskilllist,"?"),
 	BUILDIN_DEF(clearitem,"?"),
 	BUILDIN_DEF(classchange,"ii"),
 	BUILDIN_DEF(misceffect,"i"),
@@ -19557,7 +19599,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(npcskilleffect,"viii"), // npc skill effect [Valaris]
 	BUILDIN_DEF(specialeffect,"i??"), // npc skill effect [Valaris]
 	BUILDIN_DEF(specialeffect2,"i??"), // skill effect on players[Valaris]
-	BUILDIN_DEF(nude,""), // nude command [Valaris]
+	BUILDIN_DEF(nude,"?"), // nude command [Valaris]
 	BUILDIN_DEF(mapwarp,"ssii??"),		// Added by RoVeRT
 	BUILDIN_DEF(atcommand,"s"), // [MouseJstr]
 	BUILDIN_DEF2(atcommand,"charcommand","s"), // [MouseJstr]
@@ -19565,14 +19607,14 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(message,"ss"), // [MouseJstr]
 	BUILDIN_DEF(npctalk,"s"), // [Valaris]
 	BUILDIN_DEF(mobcount,"ss"),
-	BUILDIN_DEF(getlook,"i"),
-	BUILDIN_DEF(getsavepoint,"i"),
+	BUILDIN_DEF(getlook,"i?"),
+	BUILDIN_DEF(getsavepoint,"i?"),
 	BUILDIN_DEF(npcspeed,"i"), // [Valaris]
 	BUILDIN_DEF(npcwalkto,"ii"), // [Valaris]
 	BUILDIN_DEF(npcstop,""), // [Valaris]
 	BUILDIN_DEF(getmapxy,"rrri?"),	//by Lorky [Lupus]
-	BUILDIN_DEF(checkoption1,"i"),
-	BUILDIN_DEF(checkoption2,"i"),
+	BUILDIN_DEF(checkoption1,"i?"),
+	BUILDIN_DEF(checkoption2,"i?"),
 	BUILDIN_DEF(guildgetexp,"i"),
 	BUILDIN_DEF(guildchangegm,"is"),
 	BUILDIN_DEF(logmes,"s"), //this command actls as MES but rints info into LOG file either SQL/TXT [Lupus]
@@ -19592,7 +19634,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(deletepset,"i"), // Delete a pattern set [MouseJstr]
 #endif
 	BUILDIN_DEF(preg_match,"ss?"),
-	BUILDIN_DEF(dispbottom,"s?"), //added from jA [Lupus]
+	BUILDIN_DEF(dispbottom,"s??"), //added from jA [Lupus]
 	BUILDIN_DEF(recovery,"i???"),
 	BUILDIN_DEF(getpetinfo,"i"),
 	BUILDIN_DEF(gethominfo,"i"),
@@ -19644,8 +19686,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(setbattleflag,"si"),
 	BUILDIN_DEF(getbattleflag,"s"),
 	BUILDIN_DEF(setitemscript,"is?"), //Set NEW item bonus script. Lupus
-	BUILDIN_DEF(disguise,"i"), //disguise player. Lupus
-	BUILDIN_DEF(undisguise,""), //undisguise player. Lupus
+	BUILDIN_DEF(disguise,"i?"), //disguise player. Lupus
+	BUILDIN_DEF(undisguise,"?"), //undisguise player. Lupus
 	BUILDIN_DEF(getmonsterinfo,"ii"), //Lupus
 	BUILDIN_DEF(addmonsterdrop,"vii"), //Akinari [Lupus]
 	BUILDIN_DEF(delmonsterdrop,"vi"), //Akinari [Lupus]
@@ -19740,11 +19782,11 @@ struct script_function buildin_func[] = {
 	/**
 	 * 3rd-related
 	 **/
-	BUILDIN_DEF(makerune,"i"),
-	BUILDIN_DEF(checkdragon,""),//[Ind]
-	BUILDIN_DEF(setdragon,"?"),//[Ind]
-	BUILDIN_DEF(ismounting,""),//[Ind]
-	BUILDIN_DEF(setmounting,""),//[Ind]
+	BUILDIN_DEF(makerune,"i?"),
+	BUILDIN_DEF(checkdragon,"?"),//[Ind]
+	BUILDIN_DEF(setdragon,"??"),//[Ind]
+	BUILDIN_DEF(ismounting,"?"),//[Ind]
+	BUILDIN_DEF(setmounting,"?"),//[Ind]
 	BUILDIN_DEF(checkre,"i"),
 	/**
 	 * rAthena and beyond!
@@ -19759,7 +19801,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(cleanmap,"s"),
 	BUILDIN_DEF2(cleanmap,"cleanarea","siiii"),
 	BUILDIN_DEF(npcskill,"viii"),
-	BUILDIN_DEF(consumeitem,"v"),
+	BUILDIN_DEF(consumeitem,"v?"),
 	BUILDIN_DEF(delequip,"i?"),
 	BUILDIN_DEF(breakequip,"i?"),
 	BUILDIN_DEF(sit,"?"),
@@ -19782,7 +19824,7 @@ struct script_function buildin_func[] = {
 	//Bound items [Xantara] & [Akinari]
 	BUILDIN_DEF2(getitem,"getitembound","vii?"),
 	BUILDIN_DEF2(getitem2,"getitembound2","viiiiiiiii?"),
-	BUILDIN_DEF(countbound, "?"),
+	BUILDIN_DEF(countbound, "??"),
 
 	// Party related
 	BUILDIN_DEF(party_create,"s???"),
@@ -19805,7 +19847,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(addspiritball,"ii?"),
 	BUILDIN_DEF(delspiritball,"i?"),
 	BUILDIN_DEF(countspiritball,"?"),
-	BUILDIN_DEF(mergeitem,"?"),
+	BUILDIN_DEF(mergeitem,"??"),
 
 #include "../custom/script_def.inc"
 

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -159,7 +159,7 @@ void script_warning(const char* src, const char* file, int start_line, const cha
 
 struct script_code* parse_script(const char* src,const char* file,int line,int options);
 void run_script_sub(struct script_code *rootscript,int pos,int rid,int oid, char* file, int lineno);
-void run_script(struct script_code*,int,int,int);
+void run_script(struct script_code *rootscript,int pos,int rid,int oid);
 
 int set_var(struct map_session_data *sd, char *name, void *val);
 int conv_num(struct script_state *st,struct script_data *data);


### PR DESCRIPTION
Just somehow `attachrid` and `addrid` (or else) are annoying in some cases. I prefer direct char_id, account_id, or nick assignment for script commands.

__Current list:__
* `setd "<variable name>",<value>{,<char_id>};`
* `set <var>,<value>{,<charid>}`
* `rentitem <item id>,<time>{,<account_id>};`
* `rentitem2 <item id>,<time>,<identify>,<refine>,<attribute>,<card1>,<card2>,<card3>,<card4>{,<account_id>};`
* `strcharinfo <type>{,<char_id>};`
* `getequipisequiped <equipment slot>{,<char_id>};`
* `repair <broken item number>{,<char_id>};`
* `repairall {<char_id>};`
* `getexp <base xp>,<job xp>{,<char_id>};`
* `equip <item id>{,<char_id>};`
* `unequip <equipment slot>{,<char_id>};`
* `delequip <equipment slot>{,<char_id>};`
* `breakequip <equipment slot>{,<char_id>};`
* `clearitem {,<char_id>};`
* `openmail {<char_id>};`
* `openauction {<char_id>};`
* `setquest <ID>{,<char_id>};`
* `completequest <ID>{,<char_id>};`
* `erasequest <ID>{,<char_id>};`
* `changequest <ID>,<ID2>{,<char_id>};`
* `checkquest <ID>{,PLAYTIME|HUNTING{,<char_id>}};`
* `isbegin_quest <ID>{,<char_id>};`
* `showevent <icon>{,<mark color>{,<char_id>}};`


__Question__
_"Anyone also think something like `getvariableofnpc` but for player is needed? As I said, `attachrid` in some ways are annoying"_