### PR TITLE
Makes 'default' = date2version(PACKETVER)

### DIFF
--- a/db/import-tmpl/packet_db.txt
+++ b/db/import-tmpl/packet_db.txt
@@ -15,21 +15,29 @@
 // The packet database allows you to add support for new clients,
 // because packets change every release.
 //
-// Note: Every packet version needs a wanttoconnection specification, since
+// NOTE: Every packet version needs a wanttoconnection specification, since
 // that is the packet used to identify a client's version.
 // If multiple versions have the same connection packet, the higher version
 // will be used (unless the lower one is specified as the default)
 //
 // Incoming packets have their parser function and layout specified, which enables
-// them for the current and all higher versions, unless explicitely disabled.
+// them for the current and all higher versions, unless explicitly disabled.
 //
 // Outgoing packets must be specified in order to enable them for the current
-// and all higher versions, unless explicitely disabled. Packets that are not
+// and all higher versions, unless explicitly disabled. Packets that are not
 // enabled for a packet version are silently discarded when sent as multicast.
 //
 // Every packet version inherits packet definitions from the previous (lower)
 // packet version.
 //
-// Main packet version of the DB to use (default = max available version)
+// If 'packet_db_ver' is 'default', the main packet version used is determined
+// by PACKETVER in src/common/mmo.h, see src/common/utils::date2version() for
+// equalizations.
 // Client detection is faster when all clients use this version.
 // Version 23 is the latest Sakexe (above versions are for Renewal clients)
+//
+// packet_keys values are default value for each packet version, if no value
+// or value is 'default' in packet_keys_use, server will uses default keys
+// according to used packet_db_ver. packet_keys_use is user-defined keys.
+// Maximum key value is 0x7FFFFFFF.
+// NOTE: Keys won't be reloaded, initialized on first load only.

--- a/db/packet_db.txt
+++ b/db/packet_db.txt
@@ -15,22 +15,24 @@
 // The packet database allows you to add support for new clients,
 // because packets change every release.
 //
-// Note: Every packet version needs a wanttoconnection specification, since
+// NOTE: Every packet version needs a wanttoconnection specification, since
 // that is the packet used to identify a client's version.
 // If multiple versions have the same connection packet, the higher version
 // will be used (unless the lower one is specified as the default)
 //
 // Incoming packets have their parser function and layout specified, which enables
-// them for the current and all higher versions, unless explicitely disabled.
+// them for the current and all higher versions, unless explicitly disabled.
 //
 // Outgoing packets must be specified in order to enable them for the current
-// and all higher versions, unless explicitely disabled. Packets that are not
+// and all higher versions, unless explicitly disabled. Packets that are not
 // enabled for a packet version are silently discarded when sent as multicast.
 //
 // Every packet version inherits packet definitions from the previous (lower)
 // packet version.
 //
-// Main packet version of the DB to use (default = max available version)
+// If 'packet_db_ver' is 'default', the main packet version used is determined
+// by PACKETVER in src/common/mmo.h, see src/common/utils::date2version() for
+// equalizations.
 // Client detection is faster when all clients use this version.
 // Version 23 is the latest Sakexe (above versions are for Renewal clients)
 //

--- a/src/char/char_logif.c
+++ b/src/char/char_logif.c
@@ -19,6 +19,7 @@
 //early declaration
 void chlogif_on_ready(void);
 void chlogif_on_disconnect(void);
+static uint32 packet_ver;
 
 int chlogif_pincode_notifyLoginPinError( uint32 account_id ){
 	if (login_fd > 0 && session[login_fd] && !session[login_fd]->flag.eof){
@@ -271,9 +272,9 @@ int chlogif_parse_ackaccreq(int fd, struct char_session_data* sd){
 			int client_fd = request_id;
 			sd->version = version;
 			sd->clienttype = clienttype;
-			if(sd->version != date2version(PACKETVER))
-				ShowWarning("s aid=%d has an incorect version=%d in clientinfo. Server compiled for %d\n",
-					sd->account_id,sd->version,date2version(PACKETVER));
+			if(sd->version != packet_ver)
+				ShowWarning("AID=%"PRIu32" has an incorect version=%"PRIu32" in clientinfo. Server compiled for %"PRIu32"\n",
+					sd->account_id,sd->version,packet_ver);
 
 			switch( result )
 			{
@@ -758,6 +759,8 @@ void do_init_chlogif(void) {
 	// send a list of all online account IDs to login server
 	add_timer_func_list(chlogif_send_acc_tologin, "send_accounts_tologin");
 	add_timer_interval(gettick() + 1000, chlogif_send_acc_tologin, 0, 0, 3600 * 1000); //Sync online accounts every hour
+
+	packet_ver = date2version(PACKETVER);
 }
 
 /// Resets all the data.

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -18434,7 +18434,7 @@ void packetdb_readdb(bool reload)
 					continue;
 				} else if(strcmpi(w1,"packet_db_ver")==0) {
 					if (strcmpi(w2,"default") == 0) //This is the preferred version.
-						clif_config.packet_db_ver = MAX_PACKET_VER;
+						clif_config.packet_db_ver = date2version(PACKETVER);
 					else // to manually set the packet DB version
 						clif_config.packet_db_ver = cap_value(atoi(w2), 0, MAX_PACKET_VER);
 					continue;
@@ -18558,6 +18558,9 @@ void packetdb_readdb(bool reload)
 		ShowStatus("Done reading '"CL_WHITE"%d"CL_RESET"' entries in '"CL_WHITE"%s"CL_RESET"'.\n", entries, line);
 	}
 	ShowStatus("Using default packet version: "CL_WHITE"%d"CL_RESET".\n", clif_config.packet_db_ver);
+
+	if (clif_config.packet_db_ver != date2version(PACKETVER))
+		ShowWarning("Packet version used: '%d'. Server compiled with PACKETVER '%d': '%d'\n", clif_config.packet_db_ver, PACKETVER, date2version(PACKETVER));
 
 #ifdef PACKET_OBFUSCATION
 	if (!key_defined && !clif_cryptKey[0] && !clif_cryptKey[1] && !clif_cryptKey[2]) { // Not defined


### PR DESCRIPTION
* If `packet_db_ver` is 'default', use packet version based on PACKETVER on mmo.h
* Shows warning if packet version is not match.

Signed-off-by: Cydh Ramdh <house.bad@gmail.com>