### PR TITLE
Fixed SC_ALL_RIDING for Rangers

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7799,7 +7799,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	break;
 
 	case SC_ALL_RIDING:
-		if( !sd || !&sd->sc || sc->option&(OPTION_RIDING|OPTION_DRAGON|OPTION_WUG|OPTION_MADOGEAR) )
+		if( !sd || !&sd->sc || sc->option&(OPTION_RIDING|OPTION_DRAGON|OPTION_WUGRIDER|OPTION_MADOGEAR) )
 			return 0;
 		if( sc->data[type] )
 		{	// Already mounted, just dismount.


### PR DESCRIPTION
Due to this being OPTION_WUG before, Rangers who had a Warg but weren't riding it were unable to use Reins of Mount, but once you got on your Warg you were able to get on your mount while on a Warg.