### PR TITLE
Skill target cleanup

### DIFF
--- a/db/import-tmpl/skill_unit_db.txt
+++ b/db/import-tmpl/skill_unit_db.txt
@@ -1,28 +1,52 @@
 // Skill Unit Database
 //
 // Structure of Database:
-// ID,unit ID,unit ID 2,layout,range,interval,target,flag
+// SkillID,UnitID,UnitID2,Layout,Range,Interval,Target1[:Target2],Flag
 //
-// layout = -1:special, 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
-// target = friend (party +guildmates +neutral players) / party / guild
-//          ally (party +guildmates) / all / enemy
-// flag 0x0001(UF_DEFNOTENEMY)		If 'defunit_not_enemy' is set, the target is changed to 'friend'
-//      0x0002(UF_NOREITERRATION)	Spell cannot be stacked
-//      0x0004(UF_NOFOOTSET)		Spell cannot be cast near/on targets
-//      0x0008(UF_NOOVERLAP)		Spell effects do not overlap
-//      0x0010(UF_PATHCHECK)		Only cells with a shootable path will be placed
-//      0x0020(UF_NOPC)				Spell cannot affect players.
-//      0x0040(UF_NOMOB)			Spell cannot affect mobs.
-//      0x0080(UF_SKILL)			Spell CAN affect skills.
-//      0x0100(UF_DANCE)			Dance skill
-//      0x0200(UF_ENSEMBLE)			Ensemble skill
-//      0x0400(UF_SONG)				Song skill
-//      0x0800(UF_DUALMODE)			Spell has effects both at an interval and when you step in/out
-//      0x2000(UF_RANGEDSINGLEUNIT)	Layout hack, use layout range propriety but only display center.
+// SkillID  = ID of available skill in skill_db
+// UnitID   = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum)
+// UnitID2  = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum) (Optional, hardcoded usage)
+// Layout   = 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
+//            -1: Special layout. Must be defined in skill.c::skill_init_unit_layout or skill_init_nounit_layout
+//                and accessible in skill.c::skill_get_unit_layout
+// Range    = Effect range of each cell created in layout
+// Interval = Time interval
+// Target1  = friend (party +guildmates +neutral players) / party / guild (sameguild+guildally)
+//            ally (party +guildmates) / all / sameguild (guild but no allies) / enemy
+//            partywos / guildwos / allywos / sameguildwos / allwos (* without self)
+// Target2  = Alternative target. Example if 'Target1' is used for global and skill_castend_nodamage_id
+//            iteration target check, this is for skill_castend_damage_id.
+// Flag 0x00001(UF_DEFNOTENEMY)			If 'defunit_not_enemy' is set, the target is changed to 'friend'
+//      0x00002(UF_NOREITERATION)		Spell cannot be stacked
+//      0x00004(UF_NOFOOTSET)			Spell cannot be cast near/on targets
+//      0x00008(UF_NOOVERLAP)			Spell effects do not overlap
+//      0x00010(UF_PATHCHECK)			Only cells with a shootable path will be placed
+//      0x00020(UF_NOPC)				Spell cannot affect players.
+//      0x00040(UF_NOMOB)				Spell cannot affect mobs.
+//      0x00080(UF_SKILL)				Spell CAN affect skills.
+//      0x00100(UF_DANCE)				Dance skill
+//      0x00200(UF_ENSEMBLE)			Ensemble skill
+//      0x00400(UF_SONG)				Song skill
+//      0x00800(UF_DUALMODE)			Spell has effects both at an interval and when you step in/out
+//      0x01000(UF_NOKNOCKBACK)			Cannot be knocked back (only unit that can be damaged)
+//      0x02000(UF_RANGEDSINGLEUNIT)	Layout hack, use layout range propriety but only display center.
+//      0x04000(UF_REM_CRAZYWEED)		Removed if be overlapped by GN_CRAZYWEED
+//      0x08000(UF_REM_FIRERAIN)		Removed if be overlapped by RL_FIRE_RAIN
+//      0x10000(UF_KNOCKBACK_GROUP) 	Knock back a whole skill group (by default, skill unit is knocked back each unit)
 // 	Example: 0x006 = 0x002+0x004 -> Cannot be stacked nor cast near targets
 //
 // Notes:
-//    0x89,0x8a,0x8b without indication
+// - Dummy unit, without indication: 0x89,0x8a,0x8b
+// - 'Target1:Target2' explanation:
+//   By default, if listed skill is 'real' skill unit (initialized in skill_unitsetting), only 'Target1'
+//   that will be used in unit timer to check unit target. 
+//   This value is used also to determines 'normal' skill area/splash with assumptions,
+//   -> 'Target1' is used in iteration for 'skill_castend_nodamage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target1>, skill_castend_nodamage_id); ...
+//   -> 'Target2' is used in iteration for 'skill_castend_damage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target2>, skill_castend_damage_id); ...
+//   If 'Target2' is not defined, the value is same with 'Target1'.
+//   NOTE: Not all skills are coded for splash/area effect.
 //
 //    u1   u2 lay  r intr target  flag
 //

--- a/db/pre-re/skill_unit_db.txt
+++ b/db/pre-re/skill_unit_db.txt
@@ -39,13 +39,14 @@
 // - Dummy unit, without indication: 0x89,0x8a,0x8b
 // - 'Target1:Target2' explanation:
 //   By default, if listed skill is 'real' skill unit (initialized in skill_unitsetting), only 'Target1'
-//   that will be used in unit timer to check unit target.
-//   But since this value is used to determines 'normal' skill area/splash (to remove hardcoded target),
-//   -> 'Target1' supposed to be used in iteration for 'skill_castend_nodamage_id'
+//   that will be used in unit timer to check unit target. 
+//   This value is used also to determines 'normal' skill area/splash with assumptions,
+//   -> 'Target1' is used in iteration for 'skill_castend_nodamage_id'
 //      ... map_foreachinrange(skill_area_sub, .... , <Target1>, skill_castend_nodamage_id); ...
-//   -> 'Target2' supposed to be used in iteration for 'skill_castend_damage_id'
+//   -> 'Target2' is used in iteration for 'skill_castend_damage_id'
 //      ... map_foreachinrange(skill_area_sub, .... , <Target2>, skill_castend_damage_id); ...
-//   If 'Target2' is not defined, the value is same with 'Target1'
+//   If 'Target2' is not defined, the value is same with 'Target1'.
+//   NOTE: Not all skills are coded for splash/area effect.
 //
 //    u1   u2 lay  r intr target  flag
 //
@@ -124,7 +125,7 @@
 
 //706,0xfd,    ,  0, 0,1000,all, 0x000	//NPC_VENOMFOG
 
-2044,0xca,    ,  0, 2,3000,all,   0x018	//AB_EPICLESIS
+2044,0xca,    ,  0, 2,3000,all:noenemy,   0x018	//AB_EPICLESIS
 
 2032,0xe1,    ,  2, 0,1000,enemy, 0x8018	//GC_POISONSMOKE
 
@@ -222,7 +223,6 @@
  33, 0x0,    ,  0, 0,   0,    party, 0x0	//AL_ANGELUS                 (BCT_PARTY)
  74, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_MAGNIFICAT              (BCT_PARTY)
  75, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_GLORIA                  (BCT_PARTY)
- 47, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AC_SHOWER                  (BCT_ENEMY)
  57, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BRANDISHSPEAR           (BCT_ENEMY)
  58, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_SPEARSTAB               (BCT_ENEMY)
  62, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BOWLINGBASH             (BCT_ENEMY)
@@ -250,9 +250,7 @@
 417, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_TURNKICK                (BCT_ENEMY)
 478, 0x0,    ,  0, 0,   0,     ally, 0x0	//CR_SLIMPITCHER             (BCT_GUILD|BCT_PARTY)
 459, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE2             (BCT_PARTY)
-516, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_DESPERADO               (BCT_ENEMY)
 520, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_SPREADATTACK            (BCT_ENEMY)
-525, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HUUMA                   (BCT_ENEMY)
 536, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_BAKUENRYU               (BCT_ENEMY)
 539, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HYOUSYOURAKU            (BCT_ENEMY)
 541, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_RAIGEKISAI              (BCT_ENEMY)
@@ -306,7 +304,6 @@
 2041, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CLEMENTIA               (BCT_PARTY)
 2042, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CANTO                   (BCT_PARTY)
 2043, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CHEAL                   (BCT_PARTY)
-2044, 0x0,    ,  0, 0,   0,  noenemy, 0x0	//AB_EPICLESIS               (BCT_NOENEMY)
 2045, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_PRAEFATIO               (BCT_PARTY)
 2047, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDAAGNUS              (BCT_PARTY)
 2048, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDARAMUS              (BCT_PARTY)
@@ -318,7 +315,6 @@
 2207, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SIENNAEXECRATE          (BCT_ENEMY)
 2209, 0x0,    ,  0, 0,   0,all:0x030000, 0x0	//WL_STASIS              ((pvp)?BCT_ALL:BCT_ENEMY|BCT_SELF)
 2211, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_CRIMSONROCK             (BCT_ENEMY)
-2213, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_COMET                   (BCT_ENEMY)
 2233, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_ARROWSTORM              (BCT_ENEMY)
 2242, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_WUGDASH                 (BCT_ENEMY)
 2246, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_SENSITIVEKEEN           (BCT_ENEMY)
@@ -352,7 +348,6 @@
 2352, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_MOONLIT_SERENADE        (BCT_PARTY)
 2381, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_RUSH_WINDMILL           (BCT_PARTY)
 2382, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_ECHOSONG                (BCT_PARTY)
-2415, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_REVERBERATION           (BCT_ENEMY)
 2420, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_VOICEOFSIREN            (BCT_ALL|BCT_WOS)
 2422, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_LULLABY_DEEPSLEEP       (BCT_ALL|BCT_WOS)
 2423, 0x0,    ,  0, 0,   0,      all, 0x0	//WM_SIRCLEOFNATURE          (BCT_ALL)
@@ -384,10 +379,7 @@
 2565, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_R_TRIP                  (BCT_ENEMY)
 2571, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_HAMMER_OF_GOD           (BCT_ENEMY)
 
-3006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_BAKURETSU               (BCT_ENEMY)
 3007, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HAPPOKUNAI              (BCT_ENEMY)
-3008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_MUCHANAGE               (BCT_ENEMY)
-3009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HUUMARANKA              (BCT_ENEMY)
 3023, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KG_KAGEHUMI                (BCT_ENEMY)
 
 5003, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_ILLUSIONDOPING          (BCT_ENEMY)
@@ -395,12 +387,10 @@
 5007, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_FRIGG_SONG              (BCT_PARTY)
 
 8016, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//HVAN_EXPLOSION             ((pvp)?BCT_ALL:BCT_ENEMY)
-8025, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_XENO_SLASHER            (BCT_ENEMY)
 8034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_HEILIGE_STANGE          (BCT_ENEMY)
 8039, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_MAGMA_FLOW              (BCT_ENEMY)
 8202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_MAGNUM                  (BCT_ENEMY)
 8203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_BOWLINGBASH             (BCT_ENEMY)
-8208, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHOWER                  (BCT_ENEMY)
 8215, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHARPSHOOTING           (BCT_ENEMY)
 8217, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ML_BRANDISH                (BCT_ENEMY)
 8222, 0x0,    ,  0, 0,   0,    party, 0x0	//MER_MAGNIFICAT             (BCT_PARTY)

--- a/db/pre-re/skill_unit_db.txt
+++ b/db/pre-re/skill_unit_db.txt
@@ -1,12 +1,22 @@
 // Skill Unit Database
 //
 // Structure of Database:
-// Skill ID,Unit ID,Unit ID 2,Layout,Range,Interval,Target,Flag
+// SkillID,UnitID,UnitID2,Layout,Range,Interval,Target1[:Target2],Flag
 //
-// layout = -1:special, 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
-// target = friend (party +guildmates +neutral players) / party / guild
-//          ally (party +guildmates) / all / sameguild (guild but no allies) / enemy
-// flag 0x00001(UF_DEFNOTENEMY)			If 'defunit_not_enemy' is set, the target is changed to 'friend'
+// SkillID  = ID of available skill in skill_db
+// UnitID   = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum)
+// UnitID2  = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum) (Optional, hardcoded usage)
+// Layout   = 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
+//            -1: Special layout. Must be defined in skill.c::skill_init_unit_layout or skill_init_nounit_layout
+//                and accessible in skill.c::skill_get_unit_layout
+// Range    = Effect range of each cell created in layout
+// Interval = Time interval
+// Target1  = friend (party +guildmates +neutral players) / party / guild (sameguild+guildally)
+//            ally (party +guildmates) / all / sameguild (guild but no allies) / enemy
+//            partywos / guildwos / allywos / sameguildwos / allwos (* without self)
+// Target2  = Alternative target. Example if 'Target1' is used for global and skill_castend_nodamage_id
+//            iteration target check, this is for skill_castend_damage_id.
+// Flag 0x00001(UF_DEFNOTENEMY)			If 'defunit_not_enemy' is set, the target is changed to 'friend'
 //      0x00002(UF_NOREITERATION)		Spell cannot be stacked
 //      0x00004(UF_NOFOOTSET)			Spell cannot be cast near/on targets
 //      0x00008(UF_NOOVERLAP)			Spell effects do not overlap
@@ -26,7 +36,16 @@
 // 	Example: 0x006 = 0x002+0x004 -> Cannot be stacked nor cast near targets
 //
 // Notes:
-//    0x89,0x8a,0x8b without indication
+// - Dummy unit, without indication: 0x89,0x8a,0x8b
+// - 'Target1:Target2' explanation:
+//   By default, if listed skill is 'real' skill unit (initialized in skill_unitsetting), only 'Target1'
+//   that will be used in unit timer to check unit target.
+//   But since this value is used to determines 'normal' skill area/splash (to remove hardcoded target),
+//   -> 'Target1' supposed to be used in iteration for 'skill_castend_nodamage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target1>, skill_castend_nodamage_id); ...
+//   -> 'Target2' supposed to be used in iteration for 'skill_castend_damage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target2>, skill_castend_damage_id); ...
+//   If 'Target2' is not defined, the value is same with 'Target1'
 //
 //    u1   u2 lay  r intr target  flag
 //
@@ -194,3 +213,204 @@
 10007,0xc2,   ,  2, 0,  -1,guild, 0x040	//GD_GLORYWOUNDS
 10008,0xc3,   ,  2, 0,  -1,guild, 0x040	//GD_SOULCOLD
 10009,0xc4,   ,  2, 0,  -1,guild, 0x040	//GD_HAWKEYES
+
+// Skill Targets
+  7, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SM_MAGNUM                  (BCT_ENEMY)
+ 11, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MG_NAPALMBEAT              (BCT_ENEMY)
+ 17, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MG_FIREBALL                (BCT_ENEMY)
+ 32, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AL_CRUCIS                  (BCT_ENEMY)
+ 33, 0x0,    ,  0, 0,   0,    party, 0x0	//AL_ANGELUS                 (BCT_PARTY)
+ 74, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_MAGNIFICAT              (BCT_PARTY)
+ 75, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_GLORIA                  (BCT_PARTY)
+ 47, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AC_SHOWER                  (BCT_ENEMY)
+ 57, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BRANDISHSPEAR           (BCT_ENEMY)
+ 58, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_SPEARSTAB               (BCT_ENEMY)
+ 62, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BOWLINGBASH             (BCT_ENEMY)
+ 69, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//PR_BENEDICTIO              (BCT_ALL:BCT_ENEMY)
+ 81, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WZ_SIGHTRASHER             (BCT_ENEMY)
+ 88, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WZ_FROSTNOVA               (BCT_ENEMY)
+110, 0x0,    ,  0, 0,   0,    enemy, 0x0	//BS_HAMMERFAL               (BCT_ENEMY)
+111, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE              (BCT_PARTY)
+112, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_WEAPONPERFECT           (BCT_PARTY)
+113, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_OVERTHRUST              (BCT_PARTY)
+129, 0x0,    ,  0, 0,   0,    enemy, 0x0	//HT_BLITZBEAT               (BCT_ENEMY)
+137, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AS_GRIMTOOTH               (BCT_ENEMY)
+141, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AS_SPLASHER                (BCT_ENEMY)
+153, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MC_CARTREVOLUTION          (BCT_ENEMY)
+173, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//NPC_SELFDESTRUCTION        ((pvp)?BCT_ALL:BCT_ENEMY))
+174, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_SPLASHATTACK           (BCT_ENEMY)
+214, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RG_RAID                    (BCT_ENEMY)
+273, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MO_COMBOFINISH             (BCT_ENEMY)
+361, 0x0,    ,  0, 0,   0,      all, 0x0	//HP_ASSUMPTIO               (BCT_ALL)
+382, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SN_SHARPSHOOTING           (BCT_ENEMY)
+383, 0x0,    ,  0, 0,   0,    party, 0x0	//SN_WINDWALK                (BCT_PARTY)
+400, 0x0,    ,  0, 0,   0,    enemy, 0x0	//HW_NAPALMVULCAN            (BCT_ENEMY)
+406, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ASC_METEORASSAULT          (BCT_ENEMY)
+413, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_STORMKICK               (BCT_ENEMY)
+417, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_TURNKICK                (BCT_ENEMY)
+478, 0x0,    ,  0, 0,   0,     ally, 0x0	//CR_SLIMPITCHER             (BCT_GUILD|BCT_PARTY)
+459, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE2             (BCT_PARTY)
+516, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_DESPERADO               (BCT_ENEMY)
+520, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_SPREADATTACK            (BCT_ENEMY)
+525, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HUUMA                   (BCT_ENEMY)
+536, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_BAKUENRYU               (BCT_ENEMY)
+539, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HYOUSYOURAKU            (BCT_ENEMY)
+541, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_RAIGEKISAI              (BCT_ENEMY)
+542, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_KAMAITACHI              (BCT_ENEMY)
+653, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_EARTHQUAKE             (BCT_ENEMY)
+654, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_FIREBREATH             (BCT_ENEMY)
+655, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_ICEBREATH              (BCT_ENEMY)
+656, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_THUNDERBREATH          (BCT_ENEMY)
+657, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_ACIDBREATH             (BCT_ENEMY)
+658, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_DARKNESSBREATH         (BCT_ENEMY)
+661, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_PULSESTRIKE            (BCT_ENEMY)
+662, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_HELLJUDGEMENT          (BCT_ENEMY)
+653, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_EARTHQUAKE             (BCT_ENEMY)
+663, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESILENCE            (BCT_ENEMY)
+664, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEFREEZE             (BCT_ENEMY)
+665, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEBLEEDING           (BCT_ENEMY)
+666, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESTONE              (BCT_ENEMY)
+667, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECONFUSE            (BCT_ENEMY)
+668, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESLEEP              (BCT_ENEMY)
+672, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_SLOWCAST               (BCT_ENEMY)
+677, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECURSE              (BCT_ENEMY)
+678, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESTUN               (BCT_ENEMY)
+679, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_VAMPIRE_GIFT           (BCT_ENEMY)
+680, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESOULDRAIN          (BCT_ENEMY)
+684, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEHELLDIGNITY        (BCT_ENEMY)
+689, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_BLESSING              (BCT_PARTY)
+690, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_INCAGI                (BCT_PARTY)
+691, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_ASSUMPTIO             (BCT_PARTY)
+693, 0x0,    ,  0, 0,   0,    party, 0x0	//ALL_PARTYFLEE              (BCT_PARTY)
+
+//700, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEHEALTHFEAR         (BCT_ENEMY)
+//701, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEBODYBURNNING       (BCT_ENEMY)
+//702, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEFROSTMISTY         (BCT_ENEMY)
+//703, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECOLD               (BCT_ENEMY)
+//704, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDE_DEEP_SLEEP        (BCT_ENEMY)
+//705, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESIREN              (BCT_ENEMY)
+
+1014, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_REDEMPTIO               (BCT_PARTY)
+1016, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MO_BALKYOUNG               (BCT_ENEMY)
+
+2005, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_WINDCUTTER              (BCT_ENEMY)
+2006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_IGNITIONBREAK           (BCT_ENEMY)
+2008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONBREATH            (BCT_ENEMY)
+2009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONHOWLING           (BCT_ENEMY)
+2017, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_STORMBLAST              (BCT_ENEMY)
+2018, 0x0,    ,  0, 0,   0,    party, 0x0	//RK_FIGHTINGSPIRIT          (BCT_PARTY)
+2029, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_COUNTERSLASH            (BCT_ENEMY)
+2034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_PHANTOMMENACE           (BCT_ENEMY)
+2036, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_ROLLINGCUTTER           (BCT_ENEMY)
+2038, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AB_JUDEX                   (BCT_ENEMY)
+2041, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CLEMENTIA               (BCT_PARTY)
+2042, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CANTO                   (BCT_PARTY)
+2043, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CHEAL                   (BCT_PARTY)
+2044, 0x0,    ,  0, 0,   0,  noenemy, 0x0	//AB_EPICLESIS               (BCT_NOENEMY)
+2045, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_PRAEFATIO               (BCT_PARTY)
+2047, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDAAGNUS              (BCT_PARTY)
+2048, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDARAMUS              (BCT_PARTY)
+2057, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AB_SILENTIUM               (BCT_ENEMY)
+2202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SOULEXPANSION           (BCT_ENEMY)
+2204, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_JACKFROST               (BCT_ENEMY)
+2203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_FROSTMISTY              (BCT_ENEMY)
+2204, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_JACKFROST               (BCT_ENEMY)
+2207, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SIENNAEXECRATE          (BCT_ENEMY)
+2209, 0x0,    ,  0, 0,   0,all:0x030000, 0x0	//WL_STASIS              ((pvp)?BCT_ALL:BCT_ENEMY|BCT_SELF)
+2211, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_CRIMSONROCK             (BCT_ENEMY)
+2213, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_COMET                   (BCT_ENEMY)
+2233, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_ARROWSTORM              (BCT_ENEMY)
+2242, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_WUGDASH                 (BCT_ENEMY)
+2246, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_SENSITIVEKEEN           (BCT_ENEMY)
+2258, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_VULCANARM               (BCT_ENEMY)
+2259, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_FLAMELAUNCHER           (BCT_ENEMY)
+2260, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_COLDSLOWER              (BCT_ENEMY)
+2261, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_ARMSCANNON              (BCT_ENEMY)
+2267, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_SELFDESTRUCTION         (BCT_ENEMY)
+2270, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_INFRAREDSCAN            (BCT_ENEMY)
+2272, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_MAGNETICFIELD           (BCT_ENEMY)
+2280, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_AXETORNADO              (BCT_ENEMY)
+2284, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SC_FATALMENACE             (BCT_ENEMY)
+2289, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SC_BODYPAINT               (BCT_ENEMY)
+2307, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_CANNONSPEAR             (BCT_ENEMY)
+2315, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_SHIELDSPELL             (BCT_ENEMY)
+2317, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_OVERBRAND               (BCT_ENEMY)
+2320, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_MOONSLASHER             (BCT_ENEMY)
+2321, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_RAYOFGENESIS            (BCT_ENEMY)
+2323, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_EARTHDRIVE              (BCT_ENEMY)
+2322, 0x0,    ,  0, 0,   0, 0x050000, 0x0	//LG_PIETY                   (BCT_PARTY|BCT_SELF)
+2323, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_EARTHDRIVE              (BCT_ENEMY)
+2327, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_SKYNETBLOW              (BCT_ENEMY)
+2328, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_EARTHSHAKER             (BCT_ENEMY)
+2330, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_TIGERCANNON             (BCT_ENEMY)
+2332, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_RAMPAGEBLASTER          (BCT_ENEMY)
+2334, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_CURSEDCIRCLE            (BCT_ENEMY)
+2337, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_WINDMILL                (BCT_ENEMY)
+2340, 0x0,    ,  0, 0,   0, 0x030000, 0x0	//SR_ASSIMILATEPOWER         (BCT_ENEMY|BCT_SELF)
+2350, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_SWING_DANCE             (BCT_PARTY)
+2351, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_SYMPHONY_OF_LOVER       (BCT_PARTY)
+2352, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_MOONLIT_SERENADE        (BCT_PARTY)
+2381, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_RUSH_WINDMILL           (BCT_PARTY)
+2382, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_ECHOSONG                (BCT_PARTY)
+2415, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_REVERBERATION           (BCT_ENEMY)
+2420, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_VOICEOFSIREN            (BCT_ALL|BCT_WOS)
+2422, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_LULLABY_DEEPSLEEP       (BCT_ALL|BCT_WOS)
+2423, 0x0,    ,  0, 0,   0,      all, 0x0	//WM_SIRCLEOFNATURE          (BCT_ALL)
+2426, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_GREAT_ECHO              (BCT_ENEMY)
+2427, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_SONG_OF_MANA            (BCT_PARTY)
+2428, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_DANCE_WITH_WUG          (BCT_PARTY)
+2429, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_SOUND_OF_DESTRUCTION    (BCT_ENEMY)
+2430, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_SATURDAY_NIGHT_FEVER    (BCT_ENEMY)
+2431, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_LERADS_DEW              (BCT_PARTY)
+2432, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_MELODYOFSINK            (BCT_ENEMY)
+2433, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_BEYOND_OF_WARCRY        (BCT_ENEMY)
+2434, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_UNLIMITED_HUMMING_VOICE (BCT_PARTY)
+2454, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SO_VARETYR_SPEAR           (BCT_ENEMY)
+2455, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SO_ARRULLO                 (BCT_ENEMY)
+2476, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_CART_TORNADO            (BCT_ENEMY)
+2477, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_CARTCANNON              (BCT_ENEMY)
+2481, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_SPORE_EXPLOSION         (BCT_ENEMY)
+2486, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_FIRE_EXPANSION          (BCT_ENEMY)
+2492, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_MANDRAGORA              (BCT_ENEMY)
+2493, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_SLINGITEM               (BCT_ENEMY)
+2517, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_HOWLINGOFLION           (BCT_ENEMY)
+2518, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_RIDEINLIGHTNING         (BCT_ENEMY)
+2519, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_OVERBRAND_BRANDISH      (BCT_ENEMY)
+
+2554, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_BANISHING_BUSTER        (BCT_ENEMY)
+2557, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_S_STORM                 (BCT_ENEMY)
+2561, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_FIREDANCE               (BCT_ENEMY)
+2562, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_H_MINE                  (BCT_ENEMY)
+2565, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_R_TRIP                  (BCT_ENEMY)
+2571, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_HAMMER_OF_GOD           (BCT_ENEMY)
+
+3006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_BAKURETSU               (BCT_ENEMY)
+3007, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HAPPOKUNAI              (BCT_ENEMY)
+3008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_MUCHANAGE               (BCT_ENEMY)
+3009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HUUMARANKA              (BCT_ENEMY)
+3023, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KG_KAGEHUMI                (BCT_ENEMY)
+
+5003, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_ILLUSIONDOPING          (BCT_ENEMY)
+5004, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONBREATH_WATER      (BCT_ENEMY)
+5007, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_FRIGG_SONG              (BCT_PARTY)
+
+8016, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//HVAN_EXPLOSION             ((pvp)?BCT_ALL:BCT_ENEMY)
+8025, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_XENO_SLASHER            (BCT_ENEMY)
+8034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_HEILIGE_STANGE          (BCT_ENEMY)
+8039, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_MAGMA_FLOW              (BCT_ENEMY)
+8202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_MAGNUM                  (BCT_ENEMY)
+8203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_BOWLINGBASH             (BCT_ENEMY)
+8208, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHOWER                  (BCT_ENEMY)
+8215, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHARPSHOOTING           (BCT_ENEMY)
+8217, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ML_BRANDISH                (BCT_ENEMY)
+8222, 0x0,    ,  0, 0,   0,    party, 0x0	//MER_MAGNIFICAT             (BCT_PARTY)
+8426, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_FIRE_BOMB               (BCT_ENEMY)
+8428, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_FIRE_WAVE               (BCT_ENEMY)
+8431, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_WATER_SCREW             (BCT_ENEMY)
+8435, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_HURRICANE               (BCT_ENEMY)
+8437, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_TYPOON_MIS              (BCT_ENEMY)
+8442, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_STONE_RAIN              (BCT_ENEMY)
+
+10010, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_BATTLEORDER             (BCT_GUILD)
+10011, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_REGENERATION            (BCT_GUILD)
+10012, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_RESTORE                 (BCT_GUILD)

--- a/db/re/skill_unit_db.txt
+++ b/db/re/skill_unit_db.txt
@@ -1,12 +1,22 @@
 // Skill Unit Database
 //
 // Structure of Database:
-// Skill ID,Unit ID,Unit ID 2,Layout,Range,Interval,Target,Flag
+// SkillID,UnitID,UnitID2,Layout,Range,Interval,Target1[:Target2],Flag
 //
-// layout = -1:special, 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
-// target = friend (party +guildmates +neutral players) / party / guild
-//          ally (party +guildmates) / all / sameguild (guild but no allies) / enemy
-// flag 0x00001(UF_DEFNOTENEMY)			If 'defunit_not_enemy' is set, the target is changed to 'friend'
+// SkillID  = ID of available skill in skill_db
+// UnitID   = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum)
+// UnitID2  = Unit ID (hex), must be defined in skill.h::s_skill_unit_id (enum) (Optional, hardcoded usage)
+// Layout   = 0:1*1, 1:3*3, 2:5*5, up to 5:11*11
+//            -1: Special layout. Must be defined in skill.c::skill_init_unit_layout or skill_init_nounit_layout
+//                and accessible in skill.c::skill_get_unit_layout
+// Range    = Effect range of each cell created in layout
+// Interval = Time interval
+// Target1  = friend (party +guildmates +neutral players) / party / guild (sameguild+guildally)
+//            ally (party +guildmates) / all / sameguild (guild but no allies) / enemy
+//            partywos / guildwos / allywos / sameguildwos / allwos (* without self)
+// Target2  = Alternative target. Example if 'Target1' is used for global and skill_castend_nodamage_id
+//            iteration target check, this is for skill_castend_damage_id.
+// Flag 0x00001(UF_DEFNOTENEMY)			If 'defunit_not_enemy' is set, the target is changed to 'friend'
 //      0x00002(UF_NOREITERATION)		Spell cannot be stacked
 //      0x00004(UF_NOFOOTSET)			Spell cannot be cast near/on targets
 //      0x00008(UF_NOOVERLAP)			Spell effects do not overlap
@@ -26,7 +36,16 @@
 // 	Example: 0x006 = 0x002+0x004 -> Cannot be stacked nor cast near targets
 //
 // Notes:
-//    0x89,0x8a,0x8b without indication
+// - Dummy unit, without indication: 0x89,0x8a,0x8b
+// - 'Target1:Target2' explanation:
+//   By default, if listed skill is 'real' skill unit (initialized in skill_unitsetting), only 'Target1'
+//   that will be used in unit timer to check unit target.
+//   But since this value is used to determines 'normal' skill area/splash (to remove hardcoded target),
+//   -> 'Target1' supposed to be used in iteration for 'skill_castend_nodamage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target1>, skill_castend_nodamage_id); ...
+//   -> 'Target2' supposed to be used in iteration for 'skill_castend_damage_id'
+//      ... map_foreachinrange(skill_area_sub, .... , <Target2>, skill_castend_damage_id); ...
+//   If 'Target2' is not defined, the value is same with 'Target1'.
 //
 //    u1   u2 lay  r intr target  flag
 //
@@ -196,3 +215,204 @@
 10007,0xc2,   ,  2, 0,  -1,guild, 0x040	//GD_GLORYWOUNDS
 10008,0xc3,   ,  2, 0,  -1,guild, 0x040	//GD_SOULCOLD
 10009,0xc4,   ,  2, 0,  -1,guild, 0x040	//GD_HAWKEYES
+
+// Skill Targets
+  7, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SM_MAGNUM                  (BCT_ENEMY)
+ 11, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MG_NAPALMBEAT              (BCT_ENEMY)
+ 17, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MG_FIREBALL                (BCT_ENEMY)
+ 32, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AL_CRUCIS                  (BCT_ENEMY)
+ 33, 0x0,    ,  0, 0,   0,    party, 0x0	//AL_ANGELUS                 (BCT_PARTY)
+ 74, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_MAGNIFICAT              (BCT_PARTY)
+ 75, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_GLORIA                  (BCT_PARTY)
+ 47, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AC_SHOWER                  (BCT_ENEMY)
+ 57, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BRANDISHSPEAR           (BCT_ENEMY)
+ 58, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_SPEARSTAB               (BCT_ENEMY)
+ 62, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BOWLINGBASH             (BCT_ENEMY)
+ 69, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//PR_BENEDICTIO              (BCT_ALL:BCT_ENEMY)
+ 81, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WZ_SIGHTRASHER             (BCT_ENEMY)
+ 88, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WZ_FROSTNOVA               (BCT_ENEMY)
+110, 0x0,    ,  0, 0,   0,    enemy, 0x0	//BS_HAMMERFAL               (BCT_ENEMY)
+111, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE              (BCT_PARTY)
+112, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_WEAPONPERFECT           (BCT_PARTY)
+113, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_OVERTHRUST              (BCT_PARTY)
+129, 0x0,    ,  0, 0,   0,    enemy, 0x0	//HT_BLITZBEAT               (BCT_ENEMY)
+137, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AS_GRIMTOOTH               (BCT_ENEMY)
+141, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AS_SPLASHER                (BCT_ENEMY)
+153, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MC_CARTREVOLUTION          (BCT_ENEMY)
+173, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//NPC_SELFDESTRUCTION        ((pvp)?BCT_ALL:BCT_ENEMY))
+174, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_SPLASHATTACK           (BCT_ENEMY)
+214, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RG_RAID                    (BCT_ENEMY)
+273, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MO_COMBOFINISH             (BCT_ENEMY)
+361, 0x0,    ,  0, 0,   0,      all, 0x0	//HP_ASSUMPTIO               (BCT_ALL)
+382, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SN_SHARPSHOOTING           (BCT_ENEMY)
+383, 0x0,    ,  0, 0,   0,    party, 0x0	//SN_WINDWALK                (BCT_PARTY)
+400, 0x0,    ,  0, 0,   0,    enemy, 0x0	//HW_NAPALMVULCAN            (BCT_ENEMY)
+406, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ASC_METEORASSAULT          (BCT_ENEMY)
+413, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_STORMKICK               (BCT_ENEMY)
+417, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_TURNKICK                (BCT_ENEMY)
+478, 0x0,    ,  0, 0,   0,     ally, 0x0	//CR_SLIMPITCHER             (BCT_GUILD|BCT_PARTY)
+459, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE2             (BCT_PARTY)
+516, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_DESPERADO               (BCT_ENEMY)
+520, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_SPREADATTACK            (BCT_ENEMY)
+525, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HUUMA                   (BCT_ENEMY)
+536, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_BAKUENRYU               (BCT_ENEMY)
+539, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HYOUSYOURAKU            (BCT_ENEMY)
+541, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_RAIGEKISAI              (BCT_ENEMY)
+542, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_KAMAITACHI              (BCT_ENEMY)
+653, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_EARTHQUAKE             (BCT_ENEMY)
+654, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_FIREBREATH             (BCT_ENEMY)
+655, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_ICEBREATH              (BCT_ENEMY)
+656, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_THUNDERBREATH          (BCT_ENEMY)
+657, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_ACIDBREATH             (BCT_ENEMY)
+658, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_DARKNESSBREATH         (BCT_ENEMY)
+661, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_PULSESTRIKE            (BCT_ENEMY)
+662, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_HELLJUDGEMENT          (BCT_ENEMY)
+653, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_EARTHQUAKE             (BCT_ENEMY)
+663, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESILENCE            (BCT_ENEMY)
+664, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEFREEZE             (BCT_ENEMY)
+665, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEBLEEDING           (BCT_ENEMY)
+666, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESTONE              (BCT_ENEMY)
+667, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECONFUSE            (BCT_ENEMY)
+668, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESLEEP              (BCT_ENEMY)
+672, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_SLOWCAST               (BCT_ENEMY)
+677, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECURSE              (BCT_ENEMY)
+678, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESTUN               (BCT_ENEMY)
+679, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_VAMPIRE_GIFT           (BCT_ENEMY)
+680, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESOULDRAIN          (BCT_ENEMY)
+684, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEHELLDIGNITY        (BCT_ENEMY)
+689, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_BLESSING              (BCT_PARTY)
+690, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_INCAGI                (BCT_PARTY)
+691, 0x0,    ,  0, 0,   0,    party, 0x0	//CASH_ASSUMPTIO             (BCT_PARTY)
+693, 0x0,    ,  0, 0,   0,    party, 0x0	//ALL_PARTYFLEE              (BCT_PARTY)
+
+//700, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEHEALTHFEAR         (BCT_ENEMY)
+//701, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEBODYBURNNING       (BCT_ENEMY)
+//702, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDEFROSTMISTY         (BCT_ENEMY)
+//703, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDECOLD               (BCT_ENEMY)
+//704, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDE_DEEP_SLEEP        (BCT_ENEMY)
+//705, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_WIDESIREN              (BCT_ENEMY)
+
+1014, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_REDEMPTIO               (BCT_PARTY)
+1016, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MO_BALKYOUNG               (BCT_ENEMY)
+
+2005, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_WINDCUTTER              (BCT_ENEMY)
+2006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_IGNITIONBREAK           (BCT_ENEMY)
+2008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONBREATH            (BCT_ENEMY)
+2009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONHOWLING           (BCT_ENEMY)
+2017, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_STORMBLAST              (BCT_ENEMY)
+2018, 0x0,    ,  0, 0,   0,    party, 0x0	//RK_FIGHTINGSPIRIT          (BCT_PARTY)
+2029, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_COUNTERSLASH            (BCT_ENEMY)
+2034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_PHANTOMMENACE           (BCT_ENEMY)
+2036, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GC_ROLLINGCUTTER           (BCT_ENEMY)
+2038, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AB_JUDEX                   (BCT_ENEMY)
+2041, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CLEMENTIA               (BCT_PARTY)
+2042, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CANTO                   (BCT_PARTY)
+2043, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CHEAL                   (BCT_PARTY)
+2044, 0x0,    ,  0, 0,   0,  noenemy, 0x0	//AB_EPICLESIS               (BCT_NOENEMY)
+2045, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_PRAEFATIO               (BCT_PARTY)
+2047, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDAAGNUS              (BCT_PARTY)
+2048, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDARAMUS              (BCT_PARTY)
+2057, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AB_SILENTIUM               (BCT_ENEMY)
+2202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SOULEXPANSION           (BCT_ENEMY)
+2204, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_JACKFROST               (BCT_ENEMY)
+2203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_FROSTMISTY              (BCT_ENEMY)
+2204, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_JACKFROST               (BCT_ENEMY)
+2207, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SIENNAEXECRATE          (BCT_ENEMY)
+2209, 0x0,    ,  0, 0,   0,all:0x030000, 0x0	//WL_STASIS              ((pvp)?BCT_ALL:BCT_ENEMY|BCT_SELF)
+2211, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_CRIMSONROCK             (BCT_ENEMY)
+2213, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_COMET                   (BCT_ENEMY)
+2233, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_ARROWSTORM              (BCT_ENEMY)
+2242, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_WUGDASH                 (BCT_ENEMY)
+2246, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_SENSITIVEKEEN           (BCT_ENEMY)
+2258, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_VULCANARM               (BCT_ENEMY)
+2259, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_FLAMELAUNCHER           (BCT_ENEMY)
+2260, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_COLDSLOWER              (BCT_ENEMY)
+2261, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_ARMSCANNON              (BCT_ENEMY)
+2267, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_SELFDESTRUCTION         (BCT_ENEMY)
+2270, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_INFRAREDSCAN            (BCT_ENEMY)
+2272, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_MAGNETICFIELD           (BCT_ENEMY)
+2280, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NC_AXETORNADO              (BCT_ENEMY)
+2284, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SC_FATALMENACE             (BCT_ENEMY)
+2289, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SC_BODYPAINT               (BCT_ENEMY)
+2307, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_CANNONSPEAR             (BCT_ENEMY)
+2315, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_SHIELDSPELL             (BCT_ENEMY)
+2317, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_OVERBRAND               (BCT_ENEMY)
+2320, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_MOONSLASHER             (BCT_ENEMY)
+2321, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_RAYOFGENESIS            (BCT_ENEMY)
+2323, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_EARTHDRIVE              (BCT_ENEMY)
+2322, 0x0,    ,  0, 0,   0, 0x050000, 0x0	//LG_PIETY                   (BCT_PARTY|BCT_SELF)
+2323, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_EARTHDRIVE              (BCT_ENEMY)
+2327, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_SKYNETBLOW              (BCT_ENEMY)
+2328, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_EARTHSHAKER             (BCT_ENEMY)
+2330, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_TIGERCANNON             (BCT_ENEMY)
+2332, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_RAMPAGEBLASTER          (BCT_ENEMY)
+2334, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_CURSEDCIRCLE            (BCT_ENEMY)
+2337, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_WINDMILL                (BCT_ENEMY)
+2340, 0x0,    ,  0, 0,   0, 0x030000, 0x0	//SR_ASSIMILATEPOWER         (BCT_ENEMY|BCT_SELF)
+2350, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_SWING_DANCE             (BCT_PARTY)
+2351, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_SYMPHONY_OF_LOVER       (BCT_PARTY)
+2352, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_MOONLIT_SERENADE        (BCT_PARTY)
+2381, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_RUSH_WINDMILL           (BCT_PARTY)
+2382, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_ECHOSONG                (BCT_PARTY)
+2415, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_REVERBERATION           (BCT_ENEMY)
+2420, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_VOICEOFSIREN            (BCT_ALL|BCT_WOS)
+2422, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_LULLABY_DEEPSLEEP       (BCT_ALL|BCT_WOS)
+2423, 0x0,    ,  0, 0,   0,      all, 0x0	//WM_SIRCLEOFNATURE          (BCT_ALL)
+2426, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_GREAT_ECHO              (BCT_ENEMY)
+2427, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_SONG_OF_MANA            (BCT_PARTY)
+2428, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_DANCE_WITH_WUG          (BCT_PARTY)
+2429, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_SOUND_OF_DESTRUCTION    (BCT_ENEMY)
+2430, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_SATURDAY_NIGHT_FEVER    (BCT_ENEMY)
+2431, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_LERADS_DEW              (BCT_PARTY)
+2432, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_MELODYOFSINK            (BCT_ENEMY)
+2433, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_BEYOND_OF_WARCRY        (BCT_ENEMY)
+2434, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_UNLIMITED_HUMMING_VOICE (BCT_PARTY)
+2454, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SO_VARETYR_SPEAR           (BCT_ENEMY)
+2455, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SO_ARRULLO                 (BCT_ENEMY)
+2476, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_CART_TORNADO            (BCT_ENEMY)
+2477, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_CARTCANNON              (BCT_ENEMY)
+2481, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_SPORE_EXPLOSION         (BCT_ENEMY)
+2486, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_FIRE_EXPANSION          (BCT_ENEMY)
+2492, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_MANDRAGORA              (BCT_ENEMY)
+2493, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_SLINGITEM               (BCT_ENEMY)
+2517, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_HOWLINGOFLION           (BCT_ENEMY)
+2518, 0x0,    ,  0, 0,   0,    enemy, 0x0	//SR_RIDEINLIGHTNING         (BCT_ENEMY)
+2519, 0x0,    ,  0, 0,   0,    enemy, 0x0	//LG_OVERBRAND_BRANDISH      (BCT_ENEMY)
+
+2554, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_BANISHING_BUSTER        (BCT_ENEMY)
+2557, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_S_STORM                 (BCT_ENEMY)
+2561, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_FIREDANCE               (BCT_ENEMY)
+2562, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_H_MINE                  (BCT_ENEMY)
+2565, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_R_TRIP                  (BCT_ENEMY)
+2571, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_HAMMER_OF_GOD           (BCT_ENEMY)
+
+3006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_BAKURETSU               (BCT_ENEMY)
+3007, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HAPPOKUNAI              (BCT_ENEMY)
+3008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_MUCHANAGE               (BCT_ENEMY)
+3009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HUUMARANKA              (BCT_ENEMY)
+3023, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KG_KAGEHUMI                (BCT_ENEMY)
+
+5003, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_ILLUSIONDOPING          (BCT_ENEMY)
+5004, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RK_DRAGONBREATH_WATER      (BCT_ENEMY)
+5007, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_FRIGG_SONG              (BCT_PARTY)
+
+8016, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//HVAN_EXPLOSION             ((pvp)?BCT_ALL:BCT_ENEMY)
+8025, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_XENO_SLASHER            (BCT_ENEMY)
+8034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_HEILIGE_STANGE          (BCT_ENEMY)
+8039, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_MAGMA_FLOW              (BCT_ENEMY)
+8202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_MAGNUM                  (BCT_ENEMY)
+8203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_BOWLINGBASH             (BCT_ENEMY)
+8208, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHOWER                  (BCT_ENEMY)
+8215, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHARPSHOOTING           (BCT_ENEMY)
+8217, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ML_BRANDISH                (BCT_ENEMY)
+8222, 0x0,    ,  0, 0,   0,    party, 0x0	//MER_MAGNIFICAT             (BCT_PARTY)
+8426, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_FIRE_BOMB               (BCT_ENEMY)
+8428, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_FIRE_WAVE               (BCT_ENEMY)
+8431, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_WATER_SCREW             (BCT_ENEMY)
+8435, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_HURRICANE               (BCT_ENEMY)
+8437, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_TYPOON_MIS              (BCT_ENEMY)
+8442, 0x0,    ,  0, 0,   0,    enemy, 0x0	//EL_STONE_RAIN              (BCT_ENEMY)
+
+10010, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_BATTLEORDER             (BCT_GUILD)
+10011, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_REGENERATION            (BCT_GUILD)
+10012, 0x0,    ,  0, 0,   0,   guild, 0x0	//GD_RESTORE                 (BCT_GUILD)

--- a/db/re/skill_unit_db.txt
+++ b/db/re/skill_unit_db.txt
@@ -39,13 +39,14 @@
 // - Dummy unit, without indication: 0x89,0x8a,0x8b
 // - 'Target1:Target2' explanation:
 //   By default, if listed skill is 'real' skill unit (initialized in skill_unitsetting), only 'Target1'
-//   that will be used in unit timer to check unit target.
-//   But since this value is used to determines 'normal' skill area/splash (to remove hardcoded target),
-//   -> 'Target1' supposed to be used in iteration for 'skill_castend_nodamage_id'
+//   that will be used in unit timer to check unit target. 
+//   This value is used also to determines 'normal' skill area/splash with assumptions,
+//   -> 'Target1' is used in iteration for 'skill_castend_nodamage_id'
 //      ... map_foreachinrange(skill_area_sub, .... , <Target1>, skill_castend_nodamage_id); ...
-//   -> 'Target2' supposed to be used in iteration for 'skill_castend_damage_id'
+//   -> 'Target2' is used in iteration for 'skill_castend_damage_id'
 //      ... map_foreachinrange(skill_area_sub, .... , <Target2>, skill_castend_damage_id); ...
 //   If 'Target2' is not defined, the value is same with 'Target1'.
+//   NOTE: Not all skills are coded for splash/area effect.
 //
 //    u1   u2 lay  r intr target  flag
 //
@@ -126,7 +127,7 @@
 
 //706,0xfd,    ,  0, 0,1000,all, 0x000	//NPC_VENOMFOG
 
-2044,0xca,    ,  0, 2,3000,all,   0x018	//AB_EPICLESIS
+2044,0xca,    ,  0, 2,3000,all:noenemy,   0x018	//AB_EPICLESIS
 
 2032,0xe1,    ,  2, 0,1000,enemy, 0x8018	//GC_POISONSMOKE
 
@@ -224,7 +225,6 @@
  33, 0x0,    ,  0, 0,   0,    party, 0x0	//AL_ANGELUS                 (BCT_PARTY)
  74, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_MAGNIFICAT              (BCT_PARTY)
  75, 0x0,    ,  0, 0,   0,    party, 0x0	//PR_GLORIA                  (BCT_PARTY)
- 47, 0x0,    ,  0, 0,   0,    enemy, 0x0	//AC_SHOWER                  (BCT_ENEMY)
  57, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BRANDISHSPEAR           (BCT_ENEMY)
  58, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_SPEARSTAB               (BCT_ENEMY)
  62, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KN_BOWLINGBASH             (BCT_ENEMY)
@@ -252,12 +252,9 @@
 417, 0x0,    ,  0, 0,   0,    enemy, 0x0	//TK_TURNKICK                (BCT_ENEMY)
 478, 0x0,    ,  0, 0,   0,     ally, 0x0	//CR_SLIMPITCHER             (BCT_GUILD|BCT_PARTY)
 459, 0x0,    ,  0, 0,   0,    party, 0x0	//BS_ADRENALINE2             (BCT_PARTY)
-516, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_DESPERADO               (BCT_ENEMY)
 520, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GS_SPREADATTACK            (BCT_ENEMY)
-525, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HUUMA                   (BCT_ENEMY)
 536, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_BAKUENRYU               (BCT_ENEMY)
 539, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_HYOUSYOURAKU            (BCT_ENEMY)
-541, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_RAIGEKISAI              (BCT_ENEMY)
 542, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NJ_KAMAITACHI              (BCT_ENEMY)
 653, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_EARTHQUAKE             (BCT_ENEMY)
 654, 0x0,    ,  0, 0,   0,    enemy, 0x0	//NPC_FIREBREATH             (BCT_ENEMY)
@@ -308,7 +305,6 @@
 2041, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CLEMENTIA               (BCT_PARTY)
 2042, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CANTO                   (BCT_PARTY)
 2043, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_CHEAL                   (BCT_PARTY)
-2044, 0x0,    ,  0, 0,   0,  noenemy, 0x0	//AB_EPICLESIS               (BCT_NOENEMY)
 2045, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_PRAEFATIO               (BCT_PARTY)
 2047, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDAAGNUS              (BCT_PARTY)
 2048, 0x0,    ,  0, 0,   0,    party, 0x0	//AB_LAUDARAMUS              (BCT_PARTY)
@@ -320,7 +316,6 @@
 2207, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_SIENNAEXECRATE          (BCT_ENEMY)
 2209, 0x0,    ,  0, 0,   0,all:0x030000, 0x0	//WL_STASIS              ((pvp)?BCT_ALL:BCT_ENEMY|BCT_SELF)
 2211, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_CRIMSONROCK             (BCT_ENEMY)
-2213, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WL_COMET                   (BCT_ENEMY)
 2233, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_ARROWSTORM              (BCT_ENEMY)
 2242, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_WUGDASH                 (BCT_ENEMY)
 2246, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RA_SENSITIVEKEEN           (BCT_ENEMY)
@@ -354,7 +349,6 @@
 2352, 0x0,    ,  0, 0,   0,    party, 0x0	//WA_MOONLIT_SERENADE        (BCT_PARTY)
 2381, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_RUSH_WINDMILL           (BCT_PARTY)
 2382, 0x0,    ,  0, 0,   0,    party, 0x0	//MI_ECHOSONG                (BCT_PARTY)
-2415, 0x0,    ,  0, 0,   0,    enemy, 0x0	//WM_REVERBERATION           (BCT_ENEMY)
 2420, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_VOICEOFSIREN            (BCT_ALL|BCT_WOS)
 2422, 0x0,    ,  0, 0,   0,   allwos, 0x0	//WM_LULLABY_DEEPSLEEP       (BCT_ALL|BCT_WOS)
 2423, 0x0,    ,  0, 0,   0,      all, 0x0	//WM_SIRCLEOFNATURE          (BCT_ALL)
@@ -386,10 +380,7 @@
 2565, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_R_TRIP                  (BCT_ENEMY)
 2571, 0x0,    ,  0, 0,   0,    enemy, 0x0	//RL_HAMMER_OF_GOD           (BCT_ENEMY)
 
-3006, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_BAKURETSU               (BCT_ENEMY)
 3007, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HAPPOKUNAI              (BCT_ENEMY)
-3008, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_MUCHANAGE               (BCT_ENEMY)
-3009, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KO_HUUMARANKA              (BCT_ENEMY)
 3023, 0x0,    ,  0, 0,   0,    enemy, 0x0	//KG_KAGEHUMI                (BCT_ENEMY)
 
 5003, 0x0,    ,  0, 0,   0,    enemy, 0x0	//GN_ILLUSIONDOPING          (BCT_ENEMY)
@@ -397,12 +388,10 @@
 5007, 0x0,    ,  0, 0,   0,    party, 0x0	//WM_FRIGG_SONG              (BCT_PARTY)
 
 8016, 0x0,    ,  0, 0,   0,all:enemy, 0x0	//HVAN_EXPLOSION             ((pvp)?BCT_ALL:BCT_ENEMY)
-8025, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_XENO_SLASHER            (BCT_ENEMY)
 8034, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_HEILIGE_STANGE          (BCT_ENEMY)
 8039, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MH_MAGMA_FLOW              (BCT_ENEMY)
 8202, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_MAGNUM                  (BCT_ENEMY)
 8203, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MS_BOWLINGBASH             (BCT_ENEMY)
-8208, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHOWER                  (BCT_ENEMY)
 8215, 0x0,    ,  0, 0,   0,    enemy, 0x0	//MA_SHARPSHOOTING           (BCT_ENEMY)
 8217, 0x0,    ,  0, 0,   0,    enemy, 0x0	//ML_BRANDISH                (BCT_ENEMY)
 8222, 0x0,    ,  0, 0,   0,    party, 0x0	//MER_MAGNIFICAT             (BCT_PARTY)

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -48,6 +48,9 @@ enum e_battle_check_target {
 	BCT_ALL			= 0x3F0000, ///< All targets
 
 	BCT_WOS			= 0x400000, ///< Except self (currently used for skipping if src == bl in skill_area_sub)
+
+	BCT_ALLFLAGS	= 0x7F0000, ///< Mask all valid BCT
+
 	BCT_GUILD		= BCT_SAMEGUILD|BCT_GUILDALLY,	///< Guild AND Allies (BCT_SAMEGUILD|BCT_GUILDALLY)
 	BCT_NOGUILD		= BCT_ALL&~BCT_GUILD,			///< Except guildmates
 	BCT_NOPARTY		= BCT_ALL&~BCT_PARTY,			///< Except party members

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3724,14 +3724,16 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 	struct unit_data *ud = unit_bl2ud(src);
 	struct skill_timerskill *skl;
 	int range, target_flag = BCT_NOONE, target_flag2 = BCT_NOONE;
+	uint16 idx;
 
 	nullpo_ret(src);
 	nullpo_ret(ud);
 	skl = ud->skilltimerskill[data];
 	nullpo_ret(skl);
 	ud->skilltimerskill[data] = NULL;
-	target_flag = skill_get_unit_target(skl->skill_id);
-	target_flag2 = skill_get_unit_target2(skl->skill_id);
+	idx = skill_get_index(skl->skill_id);
+	target_flag = skill_db[idx]->unit_target&BCT_ALLFLAGS;
+	target_flag2 = skill_db[idx]->unit_target2&BCT_ALLFLAGS;
 
 	do {
 		if(src->prev == NULL)
@@ -4087,6 +4089,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	struct status_change *sc, *tsc;
 	int target_flag = BCT_NOONE;
 	int target_flag2 = BCT_NOONE;
+	uint16 idx;
 
 	if (skill_id > 0 && !skill_lv) return 0;
 
@@ -4121,8 +4124,9 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		tsc = NULL;
 
 	tstatus = status_get_status_data(bl);
-	target_flag = skill_get_unit_target(skill_id);
-	target_flag2 = skill_get_unit_target2(skill_id);
+	idx = skill_get_index(skill_id);
+	target_flag = skill_db[idx]->unit_target&BCT_ALLFLAGS;
+	target_flag2 = skill_db[idx]->unit_target2&BCT_ALLFLAGS;
 
 	map_freeblock_lock();
 
@@ -5591,9 +5595,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	int chorusbonus = 0;
 	int target_flag = BCT_NOONE;
 	int target_flag2 = BCT_NOONE;
-
 	int i = 0;
 	enum sc_type type;
+	uint16 idx;
 
 	if(skill_id > 0 && !skill_lv) return 0;	// celest
 
@@ -5631,8 +5635,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	tstatus = status_get_status_data(bl);
 	sstatus = status_get_status_data(src);
 
-	target_flag = skill_get_unit_target(skill_id);
-	target_flag2 = skill_get_unit_target2(skill_id);
+	idx = skill_get_index(skill_id);
+	target_flag = skill_db[idx]->unit_target&BCT_ALLFLAGS;
+	target_flag2 = skill_db[idx]->unit_target2&BCT_ALLFLAGS;
 
 	// Minstrel/Wanderer number check for chorus skills.
 	// Bonus remains 0 unless 3 or more Minstrels/Wanderers are in the party.
@@ -10952,6 +10957,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	struct skill_unit_group* sg;
 	enum sc_type type;
 	int i, target_flag = BCT_NOONE, target_flag2 = BCT_NOONE;
+	uint16 idx;
 
 	//if(skill_lv <= 0) return 0;
 	if (skill_id > 0 && !skill_lv)
@@ -10968,8 +10974,9 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	type = status_skill2sc(skill_id);
 	sce = (sc && type != -1)?sc->data[type]:NULL;
 
-	target_flag = skill_get_unit_target(skill_id);
-	target_flag2 = skill_get_unit_target2(skill_id);
+	idx = skill_get_index(skill_id);
+	target_flag = skill_db[idx]->unit_target&BCT_ALLFLAGS;
+	target_flag2 = skill_db[idx]->unit_target2&BCT_ALLFLAGS;
 
 	switch (skill_id) { //Skill effect.
 		case WZ_METEOR:
@@ -11448,7 +11455,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	case AB_EPICLESIS:
 		if( (sg = skill_unitsetting(src, skill_id, skill_lv, x, y, 0)) ) {
 			i = sg->unit->range;
-			map_foreachinarea(skill_area_sub, src->m, x - i, y - i, x + i, y + i, BL_CHAR, src, ALL_RESURRECTION, 1, tick, flag|target_flag|1,skill_castend_nodamage_id);
+			map_foreachinarea(skill_area_sub, src->m, x - i, y - i, x + i, y + i, BL_CHAR, src, ALL_RESURRECTION, 1, tick, flag|target_flag2|1,skill_castend_nodamage_id);
 		}
 		break;
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -266,7 +266,8 @@ int skill_get_type( uint16 skill_id )                              { skill_get  
 int skill_get_unit_id ( uint16 skill_id, int flag )                { skill_get  (skill_id, skill_db[skill_id]->unit_id[flag]); }
 int skill_get_unit_interval( uint16 skill_id )                     { skill_get  (skill_id, skill_db[skill_id]->unit_interval); }
 int skill_get_unit_range( uint16 skill_id, uint16 skill_lv )       { skill_get2 (skill_id, skill_lv, skill_db[skill_id]->unit_range); }
-int skill_get_unit_target( uint16 skill_id )                       { skill_get  (skill_id, skill_db[skill_id]->unit_target&BCT_ALL); }
+int skill_get_unit_target( uint16 skill_id )                       { skill_get  (skill_id, skill_db[skill_id]->unit_target&BCT_ALLFLAGS); }
+int skill_get_unit_target2( uint16 skill_id )                      { skill_get  (skill_id, skill_db[skill_id]->unit_target2&BCT_ALLFLAGS); }
 int skill_get_unit_bl_target( uint16 skill_id )                    { skill_get  (skill_id, skill_db[skill_id]->unit_target&BL_ALL); }
 int skill_get_unit_flag( uint16 skill_id )                         { skill_get  (skill_id, skill_db[skill_id]->unit_flag); }
 int skill_get_unit_layout_type( uint16 skill_id ,uint16 skill_lv ) { skill_get2 (skill_id, skill_lv, skill_db[skill_id]->unit_layout_type); }
@@ -3722,13 +3723,15 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 	struct block_list *src = map_id2bl(id),*target;
 	struct unit_data *ud = unit_bl2ud(src);
 	struct skill_timerskill *skl;
-	int range;
+	int range, target_flag = BCT_NOONE, target_flag2 = BCT_NOONE;
 
 	nullpo_ret(src);
 	nullpo_ret(ud);
 	skl = ud->skilltimerskill[data];
 	nullpo_ret(skl);
 	ud->skilltimerskill[data] = NULL;
+	target_flag = skill_get_unit_target(skl->skill_id);
+	target_flag2 = skill_get_unit_target2(skl->skill_id);
 
 	do {
 		if(src->prev == NULL)
@@ -3784,10 +3787,10 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 				case NPC_EARTHQUAKE:
 					if( skl->type > 1 )
 						skill_addtimerskill(src,tick+250,src->id,0,0,skl->skill_id,skl->skill_lv,skl->type-1,skl->flag);
-					skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skl->skill_id, skl->skill_lv), BL_CHAR, src, skl->skill_id, skl->skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+					skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skl->skill_id, skl->skill_lv), BL_CHAR, src, skl->skill_id, skl->skill_lv, tick, target_flag2, skill_area_sub_count);
 					skill_area_temp[1] = src->id;
 					skill_area_temp[2] = 0;
-					map_foreachinrange(skill_area_sub, src, skill_get_splash(skl->skill_id, skl->skill_lv), splash_target(src), src, skl->skill_id, skl->skill_lv, tick, skl->flag, skill_castend_damage_id);
+					map_foreachinrange(skill_area_sub, src, skill_get_splash(skl->skill_id, skl->skill_lv), splash_target(src), src, skl->skill_id, skl->skill_lv, tick, skl->flag|target_flag2, skill_castend_damage_id);
 					break;
 				case WZ_WATERBALL:
 					skill_toggle_magicpower(src, skl->skill_id); // only the first hit will be amplify
@@ -3889,7 +3892,7 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 					break;
 				case GN_SPORE_EXPLOSION:
 					map_foreachinrange(skill_area_sub, target, skill_get_splash(skl->skill_id, skl->skill_lv), BL_CHAR,
-									   src, skl->skill_id, skl->skill_lv, 0, skl->flag|1|BCT_ENEMY, skill_castend_damage_id);
+									   src, skl->skill_id, skl->skill_lv, 0, skl->flag|1|target_flag2, skill_castend_damage_id);
 					break;
 				case CH_PALMSTRIKE:
 					{
@@ -3962,7 +3965,7 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 						struct s_skill_nounit_layout *layout = skill_get_nounit_layout(skl->skill_id,skl->skill_lv,src,x,y,dir);
 
 						for( i = 0; i < layout->count; i++ )
-							map_foreachincell(skill_area_sub,src->m,x+layout->dx[i],y+layout->dy[i],BL_CHAR,src,skl->skill_id,skl->skill_lv,tick,skl->flag|BCT_ENEMY|SD_ANIMATION|1,skill_castend_damage_id);
+							map_foreachincell(skill_area_sub,src->m,x+layout->dx[i],y+layout->dy[i],BL_CHAR,src,skl->skill_id,skl->skill_lv,tick,skl->flag|target_flag2|SD_ANIMATION|1,skill_castend_damage_id);
 					}
 					break;
 				case RL_FIRE_RAIN: {
@@ -4082,6 +4085,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	struct map_session_data *sd = NULL;
 	struct status_data *tstatus;
 	struct status_change *sc, *tsc;
+	int target_flag = BCT_NOONE;
+	int target_flag2 = BCT_NOONE;
 
 	if (skill_id > 0 && !skill_lv) return 0;
 
@@ -4116,6 +4121,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		tsc = NULL;
 
 	tstatus = status_get_status_data(bl);
+	target_flag = skill_get_unit_target(skill_id);
+	target_flag2 = skill_get_unit_target2(skill_id);
 
 	map_freeblock_lock();
 
@@ -4268,7 +4275,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		{	//Becomes a splash attack when Soul Linked.
 			map_foreachinrange(skill_area_sub, bl,
 				skill_get_splash(skill_id, skill_lv),splash_target(src),
-				src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1,
+				src,skill_id,skill_lv,tick, flag|target_flag2|1,
 				skill_castend_damage_id);
 		} else
 			skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
@@ -4279,7 +4286,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		skill_area_temp[1] = 0;
 		map_foreachinrange(skill_attack_area, src,
 			skill_get_splash(skill_id, skill_lv), splash_target(src),
-			BF_WEAPON, src, src, skill_id, skill_lv, tick, flag, BCT_ENEMY);
+			BF_WEAPON, src, src, skill_id, skill_lv, tick, flag, target_flag);
 		break;
 
 	case KN_CHARGEATK:
@@ -4316,7 +4323,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		skill_area_temp[1] = bl->id;
 		map_foreachinpath (skill_attack_area,src->m,src->x,src->y,bl->x,bl->y,
 			skill_get_splash(skill_id, skill_lv),skill_get_maxcount(skill_id,skill_lv), splash_target(src),
-			skill_get_type(skill_id),src,src,skill_id,skill_lv,tick,flag,BCT_ENEMY);
+			skill_get_type(skill_id),src,src,skill_id,skill_lv,tick,flag,target_flag);
 		break;
 
 	case NPC_ACIDBREATH:
@@ -4327,7 +4334,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		skill_area_temp[1] = bl->id;
 		map_foreachinpath(skill_attack_area,src->m,src->x,src->y,bl->x,bl->y,
 			skill_get_splash(skill_id, skill_lv),skill_get_maxcount(skill_id,skill_lv), splash_target(src),
-			skill_get_type(skill_id),src,src,skill_id,skill_lv,tick,flag,BCT_ENEMY);
+			skill_get_type(skill_id),src,src,skill_id,skill_lv,tick,flag,target_flag);
 		break;
 
 	case MO_INVESTIGATE:
@@ -4516,10 +4523,10 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			//SD_LEVEL -> Forced splash damage for Auto Blitz-Beat -> count targets
 			//special case: Venom Splasher uses a different range for searching than for splashing
 			if( flag&SD_LEVEL || skill_get_nk(skill_id)&NK_SPLASHSPLIT )
-				skill_area_temp[0] = map_foreachinrange(skill_area_sub, bl, (skill_id == AS_SPLASHER)?1:skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+				skill_area_temp[0] = map_foreachinrange(skill_area_sub, bl, (skill_id == AS_SPLASHER)?1:skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
 
 			// recursive invocation of skill_castend_damage_id() with flag|1
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 			if( skill_id == AS_SPLASHER ) {
 				map_freeblock_unlock(); // Don't consume a second gemstone.
 				return 0;
@@ -4609,9 +4616,9 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				// Splash around target cell, but only cells inside area; we first have to check the area is not negative
 				if((max(min_x,tx-1) <= min(max_x,tx+1)) &&
 					(max(min_y,ty-1) <= min(max_y,ty+1)) &&
-					(map_foreachinarea(skill_area_sub, bl->m, max(min_x,tx-1), max(min_y,ty-1), min(max_x,tx+1), min(max_y,ty+1), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY, skill_area_sub_count))) {
+					(map_foreachinarea(skill_area_sub, bl->m, max(min_x,tx-1), max(min_y,ty-1), min(max_x,tx+1), min(max_y,ty+1), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2, skill_area_sub_count))) {
 					// Recursive call
-					map_foreachinarea(skill_area_sub, bl->m, max(min_x,tx-1), max(min_y,ty-1), min(max_x,tx+1), min(max_y,ty+1), splash_target(src), src, skill_id, skill_lv, tick, (flag|BCT_ENEMY)+1, skill_castend_damage_id);
+					map_foreachinarea(skill_area_sub, bl->m, max(min_x,tx-1), max(min_y,ty-1), min(max_x,tx+1), min(max_y,ty+1), splash_target(src), src, skill_id, skill_lv, tick, (flag|target_flag2)+1, skill_castend_damage_id);
 					// Self-collision
 					if(bl->x >= min_x && bl->x <= max_x && bl->y >= min_y && bl->y <= max_y)
 						skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,(flag&0xFFF)>0?SD_ANIMATION:0);
@@ -4639,7 +4646,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				skill_blown(src,bl,skill_area_temp[2],-1,0);
 			for (i=0;i<4;i++) {
 				map_foreachincell(skill_area_sub,bl->m,x,y,BL_CHAR,
-					src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+					src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 				x += dirx[dir];
 				y += diry[dir];
 			}
@@ -4653,7 +4660,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		if (skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag))
 			map_foreachinrange(skill_area_sub,bl,
 				skill_get_splash(skill_id, skill_lv),BL_CHAR,
-				src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,
+				src,skill_id,skill_lv,tick,flag|target_flag|1,
 				skill_castend_nodamage_id);
 	}
 		break;
@@ -4910,7 +4917,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
 		else {
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
-			map_foreachinrange(skill_area_sub, bl,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1,skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, bl,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick, flag|target_flag|1,skill_castend_nodamage_id);
 		}
 		break;
 	case GC_DARKILLUSION:
@@ -5192,7 +5199,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		}
 		else
 		{
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 			clif_skill_damage(src,src,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 			if( sd ) pc_overheat(sd,1);
 		}
@@ -5212,7 +5219,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			// Destination area
 			skill_area_temp[4] = x;
 			skill_area_temp[5] = y;
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|1, skill_castend_damage_id);
 			skill_addtimerskill(src,tick + 800,src->id,x,y,skill_id,skill_lv,0,flag); // To teleport Self
 			clif_skill_damage(src,src,tick,status_get_amotion(src),0,-30000,1,skill_id,skill_lv,6);
 		}
@@ -5276,7 +5283,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			status_change_end(bl, SC_HIDING, INVALID_TIMER);
 			status_change_end(bl, SC_CLOAKINGEXCEED, INVALID_TIMER);
 		} else {
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 			clif_skill_damage(src, src, tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 		}
 		break;
@@ -5292,7 +5299,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 					clif_skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
 				break;
 			}
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|1, skill_castend_damage_id);
 		}
 		break;
 
@@ -5357,7 +5364,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			clif_skill_nodamage(src,battle_get_master(src),skill_id,skill_lv,1);
 			clif_skill_damage(src, bl, tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 			if( rnd()%100 < 30 )
-				map_foreachinrange(skill_area_sub,bl,i,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+				map_foreachinrange(skill_area_sub,bl,i,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 			else
 				skill_attack(skill_get_type(skill_id),src,src,bl,skill_id,skill_lv,tick,flag);
 		}
@@ -5380,7 +5387,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			clif_skill_nodamage(src,battle_get_master(src),skill_id,skill_lv,1);
 			clif_skill_damage(src, src, tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 			if( rnd()%100 < 30 )
-				map_foreachinrange(skill_area_sub,bl,i,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+				map_foreachinrange(skill_area_sub,bl,i,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 			else
 				skill_attack(skill_get_type(skill_id),src,src,bl,skill_id,skill_lv,tick,flag);
 		}
@@ -5427,7 +5434,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag);
 		}
 		else
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag | BCT_ENEMY | SD_SPLASH | 1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag | target_flag2 | SD_SPLASH | 1, skill_castend_damage_id);
 		break;
 
 	case MH_STAHL_HORN:
@@ -5474,7 +5481,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			if (sd && sd->flicker && tsc && tsc->data[SC_H_MINE] && tsc->data[SC_H_MINE]->val2 == src->id) {
 				// Splash damage around it!
 				map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src),
-					src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+					src, skill_id, skill_lv, tick, flag|target_flag2|1, skill_castend_damage_id);
 				flag |= 1; // Don't consume requirement
 				tsc->data[SC_H_MINE]->val3 = 1; // Mark the SC end because not expired
 				status_change_end(bl, SC_H_MINE, INVALID_TIMER);
@@ -5497,7 +5504,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			// First attack. If target is marked by SC_C_MARKER, do another splash damage!
 			if (tsc && tsc->data[SC_C_MARKER] && tsc->data[SC_C_MARKER]->val2 == src->id) {
 				map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src),
-					src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+					src, skill_id, skill_lv, tick, flag|target_flag2|1, skill_castend_damage_id);
 				status_change_end(bl, SC_C_MARKER, INVALID_TIMER);
 			}
 		}
@@ -5582,6 +5589,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	struct status_change *tsc;
 	struct status_change_entry *tsce;
 	int chorusbonus = 0;
+	int target_flag = BCT_NOONE;
+	int target_flag2 = BCT_NOONE;
 
 	int i = 0;
 	enum sc_type type;
@@ -5621,6 +5630,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	tstatus = status_get_status_data(bl);
 	sstatus = status_get_status_data(src);
+
+	target_flag = skill_get_unit_target(skill_id);
+	target_flag2 = skill_get_unit_target2(skill_id);
 
 	// Minstrel/Wanderer number check for chorus skills.
 	// Bonus remains 0 unless 3 or more Minstrels/Wanderers are in the party.
@@ -5766,9 +5778,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				break;
 			}
 			skill_area_temp[0] = 0;
-			party_foreachsamemap(skill_area_sub,
-				sd,skill_get_splash(skill_id, skill_lv),
-				src,skill_id,skill_lv,tick, flag|BCT_PARTY|1,
+			map_foreachinrange(skill_area_sub,
+				src,skill_get_splash(skill_id, skill_lv),
+				BL_PC,skill_id,skill_lv,tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 			if (skill_area_temp[0] == 0) {
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
@@ -5847,7 +5859,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			sc_start(src,bl,type, 23+skill_lv*4 +status_get_lv(src) -status_get_lv(bl), skill_lv,skill_get_time(skill_id,skill_lv));
 		else {
 			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR,
-				src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+				src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
 		}
 		break;
@@ -6137,7 +6149,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case MS_MAGNUM:
 		skill_area_temp[1] = 0;
 		map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_SKILL|BL_CHAR,
-			src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+			src,skill_id,skill_lv,tick, flag|target_flag2|1, skill_castend_damage_id);
 		clif_skill_nodamage (src,src,skill_id,skill_lv,1);
 		// Initiate 20% of your damage becomes fire element.
 		sc_start4(src,src,SC_WATK_ELEMENT,100,3,20,0,0,skill_get_time2(skill_id, skill_lv));
@@ -6302,7 +6314,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		{
 			map_foreachinrange(skill_area_sub, bl,
 				skill_get_splash(skill_id, skill_lv), BL_PC,
-				src, skill_id, skill_lv, tick, flag|BCT_ALL|1,
+				src, skill_id, skill_lv, tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
@@ -6551,7 +6563,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		map_foreachinrange(skill_area_sub, bl,
 			skill_get_splash(skill_id, skill_lv), splash_target(src),
-			src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1,
+			src,skill_id,skill_lv,tick, flag|target_flag2|1,
 			skill_castend_damage_id);
 		status_change_end(src, SC_HIDING, INVALID_TIMER);
 		break;
@@ -6572,10 +6584,10 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		if (battle_config.skill_wall_check)
 			i = map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src),
-				src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+				src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 		else
 			i = map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src),
-				src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+				src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 		if( !i && ( skill_id == NC_AXETORNADO || skill_id == SR_SKYNETBLOW || skill_id == KO_HAPPOKUNAI ) )
 			clif_skill_damage(src,src,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 		break;
@@ -6609,7 +6621,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		map_foreachinrange(skill_area_sub,src,
 			skill_get_splash(skill_id, skill_lv),BL_CHAR|BL_SKILL,
-			src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1,
+			src,skill_id,skill_lv,tick, flag|target_flag2|1,
 			skill_castend_damage_id);
 		break;
 
@@ -6620,7 +6632,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		skill_area_temp[1] = 0;
 		map_foreachinrange(skill_attack_area, src,
 			skill_get_splash(skill_id, skill_lv), splash_target(src),
-			BF_MAGIC, src, src, skill_id, skill_lv, tick, flag, BCT_ENEMY);
+			BF_MAGIC, src, src, skill_id, skill_lv, tick, flag, target_flag);
 		break;
 
 	case HVAN_EXPLOSION:	//[orn]
@@ -6628,7 +6640,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		//Self Destruction hits everyone in range (allies+enemies)
 		//Except for Summoned Marine spheres on non-versus maps, where it's just enemy.
 		i = ((!md || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m))?
-			BCT_ENEMY:BCT_ALL;
+			target_flag2:target_flag;
 		clif_skill_nodamage(src, src, skill_id, -1, 1);
 		map_delblock(src); //Required to prevent chain-self-destructions hitting back.
 		map_foreachinrange(skill_area_sub, bl,
@@ -6651,14 +6663,14 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		if( sd == NULL || sd->status.party_id == 0 || (flag & 1) )
 			clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
 		else if( sd )
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 	case MER_MAGNIFICAT:
 		if( mer != NULL )
 		{
 			clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
 			if( mer->master && mer->master->status.party_id != 0 && !(flag&1) )
-				party_foreachsamemap(skill_area_sub, mer->master, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			else if( mer->master && !(flag&1) )
 				clif_skill_nodamage(src, &mer->master->bl, skill_id, skill_lv, sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
 		}
@@ -6672,9 +6684,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(bl,bl,skill_id,skill_lv,
 				sc_start2(src,bl,type,100,skill_lv,(src == bl)? 1:0,skill_get_time(skill_id,skill_lv)));
 		} else if (sd) {
-			party_foreachsamemap(skill_area_sub,
-				sd,skill_get_splash(skill_id, skill_lv),
-				src,skill_id,skill_lv,tick, flag|BCT_PARTY|1,
+			map_foreachinrange(skill_area_sub,
+				src,skill_get_splash(skill_id, skill_lv),
+				BL_PC,skill_id,skill_lv,tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 		}
 		break;
@@ -8226,7 +8238,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, src,
 				skill_get_splash(skill_id, skill_lv), BL_PC,
-				src,skill_id,skill_lv,tick, flag|BCT_GUILD|1,
+				src,skill_id,skill_lv,tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 			if (sd)
 				guild_block_skill(sd,skill_get_time2(skill_id,skill_lv));
@@ -8240,7 +8252,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, src,
 				skill_get_splash(skill_id, skill_lv), BL_PC,
-				src,skill_id,skill_lv,tick, flag|BCT_GUILD|1,
+				src,skill_id,skill_lv,tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 			if (sd)
 				guild_block_skill(sd,skill_get_time2(skill_id,skill_lv));
@@ -8254,7 +8266,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, src,
 				skill_get_splash(skill_id, skill_lv), BL_PC,
-				src,skill_id,skill_lv,tick, flag|BCT_GUILD|1,
+				src,skill_id,skill_lv,tick, flag|target_flag|1,
 				skill_castend_nodamage_id);
 			if (sd)
 				guild_block_skill(sd,skill_get_time2(skill_id,skill_lv));
@@ -8452,7 +8464,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, bl,
 				skill_get_splash(skill_id, skill_lv),BL_CHAR,
-				src,skill_id,skill_lv,tick, flag|BCT_ENEMY|SD_PREAMBLE|1,
+				src,skill_id,skill_lv,tick, flag|target_flag|SD_PREAMBLE|1,
 				skill_castend_nodamage_id);
 		}
 		break;
@@ -8464,7 +8476,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, bl,
 				skill_get_splash(skill_id, skill_lv),BL_CHAR,
-				src,skill_id,skill_lv,tick, flag|BCT_ENEMY|SD_PREAMBLE|1,
+				src,skill_id,skill_lv,tick, flag|target_flag|SD_PREAMBLE|1,
 				skill_castend_nodamage_id);
 		}
 		break;
@@ -8476,7 +8488,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				break;
 			}
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		}
 		else
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
@@ -8506,7 +8518,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			map_foreachinrange(skill_area_sub, src,
 				skill_get_splash(skill_id,skill_lv),BL_CHAR,
-				src,skill_id,skill_lv,tick,flag|BCT_ENEMY|SD_PREAMBLE|1,
+				src,skill_id,skill_lv,tick,flag|target_flag|SD_PREAMBLE|1,
 				skill_castend_nodamage_id);
 		}
 		break;
@@ -8519,7 +8531,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				map_foreachinarea(skill_cell_overlap, src->m, src->x-i, src->y-i, src->x+i, src->y+i, BL_SKILL, LG_EARTHDRIVE, &dummy, src);
 			}
 			map_foreachinrange(skill_area_sub, bl,i,BL_CHAR,
-				src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+				src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		break;
 	case RK_STONEHARDSKIN:
 		if( sd && pc_checkskill(sd,RK_RUNEMASTERY) >= 4 )
@@ -8581,11 +8593,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 					sc_start(src,bl,type,100,skill_area_temp[3],skill_area_temp[4]);
 			} else {
 				if( sd && sd->status.party_id ) {
-					skill_area_temp[0] = party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,BCT_PARTY,skill_area_sub_count);
+					skill_area_temp[0] = map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,skill_id,skill_lv,tick,target_flag,skill_area_sub_count);
 					skill_area_temp[1] = src->id;
 					skill_area_temp[3] = 7 * skill_area_temp[0] / 4;
 					skill_area_temp[4] = skill_get_time(skill_id,skill_lv);
-					party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,flag|BCT_PARTY|1,skill_castend_nodamage_id);
+					map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 				}
 				else
 					sc_start2(src,bl,type,100,7,4 * ((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : skill_get_max(RK_RUNEMASTERY)),skill_get_time(skill_id,skill_lv));
@@ -8644,7 +8656,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				if( tsc->data[SC_ABUNDANCE] ) skill_area_temp[5] |= 0x200;
 			}
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
-			party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,flag|BCT_PARTY|1,skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 		}
 	break;
 
@@ -8707,7 +8719,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_damage(src,bl,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_CHAR,
-			src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+			src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		break;
 
 	case GC_HALLUCINATIONWALK:
@@ -8742,7 +8754,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start(src,bl,type,100,
 					(skill_id == AB_CLEMENTIA)? bless_lv : (skill_id == AB_CANTO)? agi_lv : skill_lv, skill_get_time(skill_id,skill_lv)));
 			else if( sd )
-				party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		}
 		break;
 
@@ -8750,7 +8762,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		if( sd == NULL || sd->status.party_id == 0 || flag&1 )
 			clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start4(src, bl, type, 100, skill_lv, 0, 0, ( sd->status.party_id ? party_foreachsamemap(party_sub_count, sd, 0) : 1 ), skill_get_time(skill_id, skill_lv)));
 		else if( sd )
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 
 	case AB_CHEAL:
@@ -8772,7 +8784,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			}
 		}
 		else if( sd )
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 
 	case AB_ORATIO:
@@ -8781,7 +8793,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		else
 		{
 			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR,
-				src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+				src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
 		}
 		break;
@@ -8802,8 +8814,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_nodamage(bl, bl, skill_id, skill_lv,
 					sc_start(src,bl, type, 100, skill_lv, skill_get_time(skill_id, skill_lv)));
 		} else if( sd )
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv),
-				src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv),
+				BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 
 	case AB_LAUDARAMUS:
@@ -8820,8 +8832,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_nodamage(bl, bl, skill_id, skill_lv,
 					sc_start(src,bl, type, 100, skill_lv, skill_get_time(skill_id, skill_lv)));
 		} else if( sd )
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv),
-				src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv),
+				BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 
 	case AB_CLEARANCE:
@@ -8927,7 +8939,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case AB_SILENTIUM:
 		// Should the level of Lex Divina be equivalent to the level of Silentium or should the highest level learned be used? [LimitLine]
 		map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR,
-			src, PR_LEXDIVINA, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+			src, PR_LEXDIVINA, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
 		break;
 
@@ -8937,9 +8949,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		else
 		{
 			if (battle_config.skill_wall_check)
-				map_foreachinshootrange(skill_area_sub,src,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,(map_flag_vs(src->m)?BCT_ALL:BCT_ENEMY|BCT_SELF)|flag|1,skill_castend_nodamage_id);
+				map_foreachinshootrange(skill_area_sub,src,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,(map_flag_vs(src->m)?target_flag:target_flag2)|flag|1,skill_castend_nodamage_id);
 			else
-				map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,(map_flag_vs(src->m)?BCT_ALL:BCT_ENEMY|BCT_SELF)|flag|1,skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id, skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,(map_flag_vs(src->m)?target_flag:target_flag2)|flag|1,skill_castend_nodamage_id);
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
 		}
 		break;
@@ -8981,15 +8993,15 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case WL_FROSTMISTY:
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
-		map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|BCT_ENEMY,skill_castend_damage_id);
+		map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|target_flag2,skill_castend_damage_id);
 		break;
 
 	case WL_JACKFROST:
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		if (battle_config.skill_wall_check)
-			map_foreachinshootrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+			map_foreachinshootrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		else
-			map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		break;
 
 	case WL_MARSHOFABYSS:
@@ -9023,7 +9035,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 				if( rate ) {
 					skill_area_temp[1] = bl->id;
-					map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_nodamage_id);
+					map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 				}
 				// Doesn't send failure packet if it fails on defense.
 			}
@@ -9130,7 +9142,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case RA_SENSITIVEKEEN:
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		clif_skill_damage(src,src,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
-		map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|BCT_ENEMY,skill_castend_damage_id);
+		map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_CHAR|BL_SKILL,src,skill_id,skill_lv,tick,flag|target_flag2,skill_castend_damage_id);
 		break;
 
 	case NC_F_SIDESLIDE:
@@ -9148,7 +9160,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				pc_setmadogear(sd, 0);
 			skill_area_temp[1] = 0;
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 			status_set_sp(src, 0, 0);
 			skill_clear_unitgroup(src);
 		}
@@ -9164,7 +9176,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case NC_MAGNETICFIELD:
 		if( (i = sc_start2(src,bl,type,100,skill_lv,src->id,skill_get_time(skill_id,skill_lv))) )
 		{
-			map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),splash_target(src),src,skill_id,skill_lv,tick,flag|BCT_ENEMY|SD_SPLASH|1,skill_castend_damage_id);
+			map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),splash_target(src),src,skill_id,skill_lv,tick,flag|target_flag2|SD_SPLASH|1,skill_castend_damage_id);
 			clif_skill_damage(src,src,tick,status_get_amotion(src),0,-30000,1,skill_id,skill_lv,6);
 			if (sd) pc_overheat(sd,1);
 		}
@@ -9235,7 +9247,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		} else {
 			clif_skill_nodamage(src, bl, skill_id, 0, 1);
 			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR,
-				src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+				src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		}
 		break;
 
@@ -9338,7 +9350,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 							case 1: // Splash AoE ATK
 								sc_start(src,bl,SC_SHIELDSPELL_DEF,100,opt,INVALID_TIMER);
 								clif_skill_damage(src,src,tick,status_get_amotion(src),0,-30000,1,skill_id,skill_lv,6);
-								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 								status_change_end(bl,SC_SHIELDSPELL_DEF,INVALID_TIMER);
 								break;
 							case 2: // % Damage Reflecting Increase
@@ -9372,13 +9384,13 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 							case 1: // Splash AoE MATK
 								sc_start(src,bl,SC_SHIELDSPELL_MDEF,100,opt,INVALID_TIMER);
 								clif_skill_damage(src,src,tick,status_get_amotion(src),0,-30000,1,skill_id,skill_lv,6);
-								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 								status_change_end(bl,SC_SHIELDSPELL_MDEF,INVALID_TIMER);
 								break;
 							case 2: // Splash AoE Lex Divina
 								sc_start(src,bl,SC_SHIELDSPELL_MDEF,100,opt,shield_mdef * 2000);
 								clif_skill_damage(src,src,tick,status_get_amotion(src),0,-30000,1,skill_id,skill_lv,6);
-								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_nodamage_id);
+								map_foreachinrange(skill_area_sub,src,splashrange,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 								break;
 							case 3: // Casts Magnificat.
 								if (sc_start(src,bl,SC_SHIELDSPELL_MDEF,100,opt,shield_mdef * 30000))
@@ -9418,7 +9430,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv));
 		else {
 			skill_area_temp[2] = 0;
-			map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_PC,src,skill_id,skill_lv,tick,flag|SD_PREAMBLE|BCT_PARTY|BCT_SELF|1,skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_PC,src,skill_id,skill_lv,tick,flag|SD_PREAMBLE|target_flag|1,skill_castend_nodamage_id);
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
 		break;
@@ -9448,7 +9460,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			int count = 0;
 			clif_skill_damage(src, bl, tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
 			count = map_forcountinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv), (sd)?sd->spiritball_old:15, // Assume 15 spiritballs in non-charactors
-				BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+				BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			if( sd ) pc_delspiritball(sd, count, 0);
 			clif_skill_nodamage(src, src, skill_id, skill_lv,
 				sc_start2(src,src, SC_CURSEDCIRCLE_ATKER, 100, skill_lv, count, skill_get_time(skill_id,skill_lv)));
@@ -9477,7 +9489,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, i ? 1:0);
 		} else {
 			clif_skill_damage(src,bl,tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, 6);
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|BCT_SELF|SD_SPLASH|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag|SD_SPLASH|1, skill_castend_nodamage_id);
 		}
 		break;
 
@@ -9540,7 +9552,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			sc_start2(src,bl,type,100,skill_lv,((sd) ? pc_checkskill(sd,WM_LESSON) : skill_get_max(WM_LESSON)),skill_get_time(skill_id,skill_lv));
 		} else if( sd ) {
-			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag|BCT_PARTY|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_PC, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			sc_start2(src,bl,type,100,skill_lv,((sd) ? pc_checkskill(sd,WM_LESSON) : skill_get_max(WM_LESSON)),skill_get_time(skill_id,skill_lv));
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
@@ -9574,7 +9586,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		if( flag&1 )
 			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv));
 		else {
-			map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,src,skill_id,skill_lv,tick,flag|BCT_ALL|1,skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,src,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
 		break;
@@ -9586,7 +9598,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			// Success chance: (Skill Level x 6) + (Voice Lesson Skill Level x 2) + (Caster’s Job Level / 2) %
 			skill_area_temp[5] = skill_lv * 6 + ((sd) ? pc_checkskill(sd, WM_LESSON) : skill_get_max(WM_LESSON)) * 2 + (sd ? sd->status.job_level : 50) / 2;
 			skill_area_temp[6] = skill_get_time(skill_id,skill_lv);
-			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv), BL_CHAR|BL_SKILL, src, skill_id, skill_lv, tick, flag|BCT_ALL|BCT_WOS|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv), BL_CHAR|BL_SKILL, src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
 		break;
@@ -9617,11 +9629,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				break;
 			}
 			if( map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id,skill_lv),
-					BL_PC, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count) > 7 )
+					BL_PC, src, skill_id, skill_lv, tick, target_flag, skill_area_sub_count) > 7 )
 				flag |= 2;
 			else
 				flag |= 1;
-			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),BL_PC, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|BCT_SELF, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),BL_PC, src, skill_id, skill_lv, tick, flag|target_flag|BCT_SELF, skill_castend_nodamage_id);
 			clif_skill_nodamage(src, bl, skill_id, skill_lv,
 				sc_start(src,src,SC_STOP,100,skill_lv,skill_get_time2(skill_id,skill_lv)));
 			if( flag&2 ) // Dealed here to prevent conflicts
@@ -9639,7 +9651,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			}
 		} else if( sd ) {
 			if( sc_start2(src,bl,type,100,skill_lv,chorusbonus,skill_get_time(skill_id,skill_lv)) )
-				party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,flag|BCT_PARTY|1,skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub,src,skill_get_splash(skill_id,skill_lv),BL_PC,skill_id,skill_lv,tick,flag|target_flag|1,skill_castend_nodamage_id);
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 		}
 		break;
@@ -9650,7 +9662,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			sc_start2(src,bl,type,100,skill_lv,chorusbonus,skill_get_time(skill_id,skill_lv));
 		} else {	// These affect to all targets arround the caster.
 			if( rnd()%100 < 15 + 5 * skill_lv * 5 * chorusbonus ) {
-				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),BL_PC, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),BL_PC, src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 				clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			}
 		}
@@ -9817,7 +9829,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			skill_area_temp[5] = (4 * skill_lv * 1000) + ((sd) ? pc_checkskill(sd,WM_LESSON) : skill_get_max(WM_LESSON)) * 2000 + (status_get_lv(src) * 1000 / 15) + (sd ? sd->status.job_level * 200 : 0);
 			skill_area_temp[6] = skill_get_time(skill_id,skill_lv);
 			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ALL|BCT_WOS|1, skill_castend_nodamage_id);
+			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		}
 		break;
 
@@ -9939,7 +9951,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				status_zap(bl, 0, status_get_max_sp(bl) * (25 + 5 * skill_lv) / 100);
 		} else
 			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR,
-							   src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+							   src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 	case GN_SLINGITEM:
 		if( sd ) {
@@ -9954,7 +9966,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( itemdb_is_GNbomb(ammo_id) ) {
 				if(battle_check_target(src,bl,BCT_ENEMY) > 0) {// Only attack if the target is an enemy.
 					if( ammo_id == ITEMID_PINEAPPLE_BOMB )
-						map_foreachincell(skill_area_sub,bl->m,bl->x,bl->y,BL_CHAR,src,GN_SLINGITEM_RANGEMELEEATK,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+						map_foreachincell(skill_area_sub,bl->m,bl->x,bl->y,BL_CHAR,src,GN_SLINGITEM_RANGEMELEEATK,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 					else
 						skill_attack(BF_WEAPON,src,src,bl,GN_SLINGITEM_RANGEMELEEATK,skill_lv,tick,flag);
 				} else //Otherwise, it fails, shows animation and removes items.
@@ -10160,9 +10172,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		}else{
 			skill_area_temp[2] = 0;
 			if (battle_config.skill_wall_check)
-				map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_nodamage_id);
+				map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag|SD_SPLASH|1, skill_castend_nodamage_id);
 			else
-				map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_nodamage_id);
+				map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag|SD_SPLASH|1, skill_castend_nodamage_id);
 		}
 		break;
 
@@ -10315,43 +10327,47 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case RL_D_TAIL:
 		if (sd) {
 			if (battle_config.skill_wall_check)
-				skill_area_temp[0] = map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+				skill_area_temp[0] = map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
 			else
-				skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+				skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
 			if (!skill_area_temp[0]) {
 				clif_skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
 				break;
 			}
 		}
-		if (battle_config.skill_wall_check)
-			map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|SD_ANIMATION|1, skill_castend_damage_id);
-		else
-			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|SD_ANIMATION|1, skill_castend_damage_id);
+		else {
+			if (battle_config.skill_wall_check)
+				map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|SD_ANIMATION|1, skill_castend_damage_id);
+			else
+				map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|SD_ANIMATION|1, skill_castend_damage_id);
+		}
 		skill_area_temp[0] = 0;
 		break;
 	case RL_QD_SHOT:
 		if (sd) {
 			skill_area_temp[1] = bl->id;
 			// Check surrounding
-			if (battle_config.skill_wall_check)
-				skill_area_temp[0] = map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
-			else
-				skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
-			if (skill_area_temp[0])
-				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+			if (battle_config.skill_wall_check) {
+				skill_area_temp[0] = map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
+				map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
+			}
+			else {
+				skill_area_temp[0] = map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
+				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
+			}
 
 			// Main target always receives damage
 			clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
-			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_LEVEL);
+			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag|target_flag|SD_LEVEL);
 			if (tsc && tsc->data[SC_C_MARKER])
 				status_change_end(bl, SC_C_MARKER, INVALID_TIMER);
 		}
 		else {
 			clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
 			if (battle_config.skill_wall_check)
-				map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+				map_foreachinshootrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 			else
-				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
+				map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|1, skill_castend_damage_id);
 		}
 		skill_area_temp[0] = 0;
 		skill_area_temp[1] = 0;
@@ -10368,7 +10384,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			}
 			// Detonate RL_H_MINE
 			if ((i = pc_checkskill(sd, RL_H_MINE)))
-				map_foreachinrange(skill_area_sub, src, splash, BL_CHAR, src, RL_H_MINE, i, tick, flag|BCT_ENEMY|SD_SPLASH, skill_castend_damage_id);
+				map_foreachinrange(skill_area_sub, src, splash, BL_CHAR, src, RL_H_MINE, i, tick, flag|skill_get_unit_target2(RL_H_MINE)|SD_SPLASH, skill_castend_damage_id);
 			sd->flicker = false;
 		}
 		break;
@@ -10935,10 +10951,11 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	struct status_change_entry *sce;
 	struct skill_unit_group* sg;
 	enum sc_type type;
-	int i;
+	int i, target_flag = BCT_NOONE, target_flag2 = BCT_NOONE;
 
 	//if(skill_lv <= 0) return 0;
-	if(skill_id > 0 && !skill_lv) return 0;	// celest
+	if (skill_id > 0 && !skill_lv)
+		return 0;	// celest
 
 	nullpo_ret(src);
 
@@ -10950,6 +10967,9 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	sc = status_get_sc(src);
 	type = status_skill2sc(skill_id);
 	sce = (sc && type != -1)?sc->data[type]:NULL;
+
+	target_flag = skill_get_unit_target(skill_id);
+	target_flag2 = skill_get_unit_target2(skill_id);
 
 	switch (skill_id) { //Skill effect.
 		case WZ_METEOR:
@@ -10978,11 +10998,11 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 		i = skill_get_splash(skill_id, skill_lv);
 		map_foreachinarea(skill_area_sub,
 			src->m, x-i, y-i, x+i, y+i, BL_PC,
-			src, skill_id, skill_lv, tick, flag|BCT_ALL|1,
+			src, skill_id, skill_lv, tick, flag|target_flag|1,
 			skill_castend_nodamage_id);
 		map_foreachinarea(skill_area_sub,
 			src->m, x-i, y-i, x+i, y+i, BL_CHAR,
-			src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1,
+			src, skill_id, skill_lv, tick, flag|target_flag2|1,
 			skill_castend_damage_id);
 		break;
 
@@ -10990,7 +11010,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 		i = skill_get_splash(skill_id, skill_lv);
 		map_foreachinarea (skill_area_sub,
 			src->m, x-i, y-i, x+i, y+i, BL_CHAR,
-			src, skill_id, skill_lv, tick, flag|BCT_ENEMY|2,
+			src, skill_id, skill_lv, tick, flag|target_flag|2,
 			skill_castend_nodamage_id);
 		break;
 
@@ -11007,7 +11027,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	case SR_RIDEINLIGHTNING:
 		i = skill_get_splash(skill_id, skill_lv);
 		map_foreachinarea(skill_area_sub, src->m, x-i, y-i, x+i, y+i, BL_CHAR,
-			src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
+			src, skill_id, skill_lv, tick, flag|target_flag2|1, skill_castend_damage_id);
 		break;
 
 	case SA_VOLCANO:
@@ -11286,7 +11306,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 				i_lv = skill_get_splash(skill_id, skill_lv);
 				map_foreachinarea(skill_area_sub,
 					src->m,x-i_lv,y-i_lv,x+i_lv,y+i_lv,BL_CHAR,
-					src,skill_id,skill_lv,tick,flag|BCT_PARTY|BCT_GUILD|1,
+					src,skill_id,skill_lv,tick,flag|target_flag|1,
 					skill_castend_nodamage_id);
 			}
 		} else {
@@ -11307,7 +11327,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 				id = skill_get_splash(skill_id, skill_lv);
 				map_foreachinarea(skill_area_sub,
 					src->m,x-id,y-id,x+id,y+id,BL_CHAR,
-					src,skill_id,skill_lv,tick,flag|BCT_PARTY|BCT_GUILD|1,
+					src,skill_id,skill_lv,tick,flag|target_flag|1,
 						skill_castend_nodamage_id);
 			}
 		}
@@ -11406,13 +11426,13 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	case RK_DRAGONBREATH_WATER:
 		i = skill_get_splash(skill_id,skill_lv);
 		map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,splash_target(src),
-			src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+			src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		break;
 
 	case SO_ARRULLO:
 		i = skill_get_splash(skill_id,skill_lv);
 		map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,splash_target(src),
-			src, skill_id, skill_lv, tick, flag|BCT_ENEMY|1, skill_castend_nodamage_id);
+			src, skill_id, skill_lv, tick, flag|target_flag|1, skill_castend_nodamage_id);
 		break;
 
 	case GC_POISONSMOKE:
@@ -11428,7 +11448,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	case AB_EPICLESIS:
 		if( (sg = skill_unitsetting(src, skill_id, skill_lv, x, y, 0)) ) {
 			i = sg->unit->range;
-			map_foreachinarea(skill_area_sub, src->m, x - i, y - i, x + i, y + i, BL_CHAR, src, ALL_RESURRECTION, 1, tick, flag|BCT_NOENEMY|1,skill_castend_nodamage_id);
+			map_foreachinarea(skill_area_sub, src->m, x - i, y - i, x + i, y + i, BL_CHAR, src, ALL_RESURRECTION, 1, tick, flag|target_flag|1,skill_castend_nodamage_id);
 		}
 		break;
 
@@ -11438,7 +11458,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 			sc->comet_y = y;
 		}
 		i = skill_get_splash(skill_id,skill_lv);
-		map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,splash_target(src),src,skill_id,skill_lv,tick,flag|BCT_ENEMY|SD_ANIMATION|1,skill_castend_damage_id);
+		map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,splash_target(src),src,skill_id,skill_lv,tick,flag|target_flag2|SD_ANIMATION|1,skill_castend_damage_id);
 		break;
 
 	case WL_EARTHSTRAIN:
@@ -11516,7 +11536,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 			struct s_skill_nounit_layout *layout = skill_get_nounit_layout(skill_id,skill_lv,src,sx,sy,dir);
 
 			for( i = 0; i < layout->count; i++ )
-				map_foreachincell(skill_area_sub,src->m,sx+layout->dx[i],sy+layout->dy[i],BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|SD_ANIMATION|1,skill_castend_damage_id);
+				map_foreachincell(skill_area_sub,src->m,sx+layout->dx[i],sy+layout->dy[i],BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|SD_ANIMATION|1,skill_castend_damage_id);
 			skill_addtimerskill(src,gettick() + status_get_amotion(src),0,x,y,LG_OVERBRAND_BRANDISH,skill_lv,dir,flag);
 		}
 		break;
@@ -11535,7 +11555,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 		if( status_charge(src,status_get_max_hp(src)*3*skill_lv / 100,0) ) {
 			i = skill_get_splash(skill_id,skill_lv);
 			map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,splash_target(src),
-				src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+				src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		} else if( sd )
 			clif_skill_fail(sd,skill_id,USESKILL_FAIL,0);
 		break;
@@ -11547,7 +11567,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 
 	case WM_GREAT_ECHO:
 		flag|=1; // Should counsume 1 item per skill usage.
-		map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),splash_target(src), src, skill_id, skill_lv, tick, flag|BCT_ENEMY, skill_castend_damage_id);
+		map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id,skill_lv),splash_target(src), src, skill_id, skill_lv, tick, flag|target_flag2, skill_castend_damage_id);
 		break;
 
 	case WM_SEVERE_RAINSTORM:
@@ -11584,7 +11604,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 						map_foreachinarea(skill_area_sub,src->m,
 							ud->skillunit[i_su]->unit->bl.x - 2,ud->skillunit[i_su]->unit->bl.y - 2,
 							ud->skillunit[i_su]->unit->bl.x + 2,ud->skillunit[i_su]->unit->bl.y + 2, BL_CHAR,
-							src, GN_DEMONIC_FIRE, skill_lv + 20, tick, flag|BCT_ENEMY|SD_LEVEL|1, skill_castend_damage_id);
+							src, GN_DEMONIC_FIRE, skill_lv + 20, tick, flag|target_flag2|SD_LEVEL|1, skill_castend_damage_id);
 						skill_delunit(ud->skillunit[i_su]->unit);
 						break;
 					case 3:
@@ -11604,7 +11624,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 						map_foreachinarea(skill_area_sub, src->m,
 										  ud->skillunit[i_su]->unit->bl.x - 2, ud->skillunit[i_su]->unit->bl.y - 2,
 										  ud->skillunit[i_su]->unit->bl.x + 2, ud->skillunit[i_su]->unit->bl.y + 2, BL_CHAR,
-										  src, GN_FIRE_EXPANSION_ACID, acid_lv, tick, flag|BCT_ENEMY|SD_LEVEL|1, skill_castend_damage_id);
+										  src, GN_FIRE_EXPANSION_ACID, acid_lv, tick, flag|target_flag2|SD_LEVEL|1, skill_castend_damage_id);
 						skill_delunit(ud->skillunit[i_su]->unit);
 						}
 						break;
@@ -11638,9 +11658,9 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 			rate = (100 - (1000 / (sstatus->dex + sstatus->luk) * 5)) * (skill_lv / 2 + 5) / 10;
 			if( rate < 0 )
 				rate = 0;
-			skill_area_temp[0] = map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,BL_CHAR,src,skill_id,skill_lv,tick,BCT_ENEMY,skill_area_sub_count);
+			skill_area_temp[0] = map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,BL_CHAR,src,skill_id,skill_lv,tick,target_flag2,skill_area_sub_count);
 			if( rnd()%100 < rate )
-				map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_damage_id);
+				map_foreachinarea(skill_area_sub,src->m,x-i,y-i,x+i,y+i,BL_CHAR,src,skill_id,skill_lv,tick,flag|target_flag2|1,skill_castend_damage_id);
 		}
 		break;
 
@@ -11665,7 +11685,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 		{
 			i = skill_get_splash(skill_id, skill_lv);
 			if (sd) {
-				skill_area_temp[0] = map_foreachinarea(skill_area_sub, src->m, x-i, y-i, x+i, y+i, BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+				skill_area_temp[0] = map_foreachinarea(skill_area_sub, src->m, x-i, y-i, x+i, y+i, BL_CHAR, src, skill_id, skill_lv, tick, target_flag2, skill_area_sub_count);
 				if (!skill_area_temp[0]) {
 					// This skill doesn't have area effect, apply self? :P
 					//clif_skill_poseffect(src, skill_id, skill_lv, x, y, tick+500);
@@ -11673,7 +11693,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 					break;
 				}
 			}
-			map_foreachinarea(skill_area_sub, src->m, x-i, y-i, x+i, y+i, BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|SD_ANIMATION|8, skill_castend_damage_id);
+			map_foreachinarea(skill_area_sub, src->m, x-i, y-i, x+i, y+i, BL_CHAR, src, skill_id, skill_lv, tick, flag|target_flag2|SD_SPLASH|SD_ANIMATION|8, skill_castend_damage_id);
 			skill_area_temp[0] = 0;
 			break;
 		}
@@ -15966,6 +15986,8 @@ void skill_brandishspear(struct block_list* src, struct block_list* bl, uint16 s
 	uint8 dir = map_calc_dir(src,bl->x,bl->y);
 	struct square tc;
 	int x=bl->x,y=bl->y;
+	int target_flag2 = skill_get_unit_target2(skill_id);
+
 	skill_brandishspear_first(&tc,dir,x,y);
 	skill_brandishspear_dir(&tc,dir,4);
 	skill_area_temp[1] = bl->id;
@@ -15974,7 +15996,7 @@ void skill_brandishspear(struct block_list* src, struct block_list* bl, uint16 s
 		for(c=1;c<4;c++){
 			map_foreachincell(skill_area_sub,
 				bl->m,tc.val1[c],tc.val2[c],BL_CHAR,
-				src,skill_id,skill_lv,tick, flag|BCT_ENEMY|n,
+				src,skill_id,skill_lv,tick, flag|target_flag2|n,
 				skill_castend_damage_id);
 		}
 	}
@@ -15990,7 +16012,7 @@ void skill_brandishspear(struct block_list* src, struct block_list* bl, uint16 s
 		for(c=0;c<5;c++){
 			map_foreachincell(skill_area_sub,
 				bl->m,tc.val1[c],tc.val2[c],BL_CHAR,
-				src,skill_id,skill_lv,tick, flag|BCT_ENEMY|n,
+				src,skill_id,skill_lv,tick, flag|target_flag2|n,
 				skill_castend_damage_id);
 			if(skill_lv > 6 && n==3 && c==4){
 				skill_brandishspear_dir(&tc,dir,-1);
@@ -16002,7 +16024,7 @@ void skill_brandishspear(struct block_list* src, struct block_list* bl, uint16 s
 		if(c==0||c==5) skill_brandishspear_dir(&tc,dir,-1);
 		map_foreachincell(skill_area_sub,
 			bl->m,tc.val1[c%5],tc.val2[c%5],BL_CHAR,
-			src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1,
+			src,skill_id,skill_lv,tick, flag|target_flag2|1,
 			skill_castend_damage_id);
 	}
 }
@@ -16375,6 +16397,9 @@ int skill_attack_area(struct block_list *bl, va_list ap)
 
 	if (skill_area_temp[1] == bl->id) //This is the target of the skill, do a full attack and skip target checks.
 		return (int)skill_attack(atk_type,src,dsrc,bl,skill_id,skill_lv,tick,flag);
+
+	if (flag&BCT_WOS && src == bl)
+		return 0;
 
 	if(battle_check_target(dsrc,bl,type) <= 0 ||
 		!status_check_skilluse(NULL, bl, skill_id, 2))
@@ -17605,7 +17630,7 @@ static int skill_unit_timer_sub(DBKey key, DBData *data, va_list ap)
 				struct block_list *src = map_id2bl(group->src_id);
 				struct status_change *sc;
 				if (src && (sc = status_get_sc(src)) != NULL && sc->data[SC__FEINTBOMB]) { // Copycat explodes if caster is still hidden.
-					map_foreachinrange(skill_area_sub, &group->unit->bl, unit->range, splash_target(src), src, SC_FEINTBOMB, group->skill_lv, tick, BCT_ENEMY|SD_ANIMATION|1, skill_castend_damage_id);
+					map_foreachinrange(skill_area_sub, &group->unit->bl, unit->range, splash_target(src), src, SC_FEINTBOMB, group->skill_lv, tick, group->target_flag|SD_ANIMATION|1, skill_castend_damage_id);
 					status_change_end(bl, SC__FEINTBOMB, INVALID_TIMER);
 				}
 				skill_delunit(unit);
@@ -20141,12 +20166,30 @@ static bool skill_parse_row_nocastdb(char* split[], int columns, int current)
 	return true;
 }
 
+static void skill_parse_unit_target(uint32 *target, const char *str) {
+	if      (strncmpi(str,"noenemy",7) == 0)     *target = BCT_NOENEMY;
+	else if (strncmpi(str,"friend",6) == 0)      *target = BCT_NOENEMY;
+	else if (strncmpi(str,"party",5) == 0)       *target = BCT_PARTY;
+	else if (strncmpi(str,"ally",4) == 0)        *target = BCT_PARTY|BCT_GUILD;
+	else if (strncmpi(str,"guild",5) == 0)       *target = BCT_GUILD;
+	else if (strncmpi(str,"all",3) == 0)         *target = BCT_ALL;
+	else if (strncmpi(str,"enemy",5) == 0)       *target = BCT_ENEMY;
+	else if (strncmpi(str,"self",4) == 0)        *target = BCT_SELF;
+	else if (strncmpi(str,"sameguild",9) == 0)   *target = BCT_GUILD|BCT_SAMEGUILD;
+	else if (strncmpi(str,"noone",6) == 0)       *target = BCT_NOONE;
+	else                                         *target = strtol(str,NULL,16);
+
+	if (strstr(str,"wos") != 0)
+		*target |= BCT_WOS;
+}
+
 /** Reads skill unit db
  * Structure: ID,unit ID,unit ID 2,layout,range,interval,target,flag
  */
-static bool skill_parse_row_unitdb(char* split[], int columns, int current)
-{
+static bool skill_parse_row_unitdb(char* split[], int columns, int current) {
 	uint16 idx = skill_db_isset(atoi(split[0]), __FUNCTION__);
+	char *p = NULL, *target[2];
+	uint8 i = 0;
 
 	skill_db[idx]->unit_id[0] = (uint16)strtol(split[1],NULL,16);
 	skill_db[idx]->unit_id[1] = (uint16)strtol(split[2],NULL,16);
@@ -20154,17 +20197,18 @@ static bool skill_parse_row_unitdb(char* split[], int columns, int current)
 	skill_split_atoi(split[4],skill_db[idx]->unit_range);
 	skill_db[idx]->unit_interval = atoi(split[5]);
 
-	if( strcmpi(split[6],"noenemy")==0 ) skill_db[idx]->unit_target = BCT_NOENEMY;
-	else if( strcmpi(split[6],"friend")==0 ) skill_db[idx]->unit_target = BCT_NOENEMY;
-	else if( strcmpi(split[6],"party")==0 ) skill_db[idx]->unit_target = BCT_PARTY;
-	else if( strcmpi(split[6],"ally")==0 ) skill_db[idx]->unit_target = BCT_PARTY|BCT_GUILD;
-	else if( strcmpi(split[6],"guild")==0 ) skill_db[idx]->unit_target = BCT_GUILD;
-	else if( strcmpi(split[6],"all")==0 ) skill_db[idx]->unit_target = BCT_ALL;
-	else if( strcmpi(split[6],"enemy")==0 ) skill_db[idx]->unit_target = BCT_ENEMY;
-	else if( strcmpi(split[6],"self")==0 ) skill_db[idx]->unit_target = BCT_SELF;
-	else if( strcmpi(split[6],"sameguild")==0 ) skill_db[idx]->unit_target = BCT_GUILD|BCT_SAMEGUILD;
-	else if( strcmpi(split[6],"noone")==0 ) skill_db[idx]->unit_target = BCT_NOONE;
-	else skill_db[idx]->unit_target = strtol(split[6],NULL,16);
+	p = strtok(split[6], ":");
+	for (i = 0; i < 2 && p != NULL; i++) {
+		trim(p);
+		target[i] = p;
+		p = strtok(NULL, ":");
+	}
+
+	skill_parse_unit_target(&skill_db[idx]->unit_target, target[0]);
+	if (i > 1)
+		skill_parse_unit_target(&skill_db[idx]->unit_target2, target[1]);
+	else
+		skill_db[idx]->unit_target2 = skill_db[idx]->unit_target;
 
 	skill_db[idx]->unit_flag = strtol(split[7],NULL,16);
 

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -188,7 +188,8 @@ struct s_skill_db {
 	int unit_layout_type[MAX_SKILL_LEVEL];		 ///< Layout type. -1 is special layout, others are square with lenght*width: (val*2+1)^2
 	int unit_range[MAX_SKILL_LEVEL];			 ///< Unit cell effect range
 	int16 unit_interval;						 ///< Interval
-	uint32 unit_target;							 ///< Unit target. @see enum e_battle_check_target
+	uint32 unit_target;							 ///< Unit target. @see enum e_battle_check_target and enum bl_type
+	uint32 unit_target2;						 ///< Unit target. @see enum e_battle_check_target and enum bl_type
 	uint32 unit_flag;							 ///< Unit flags. @see enum e_skill_unit_flag
 
 	// skill_cast_db.txt
@@ -385,6 +386,7 @@ int skill_get_maxcount( uint16 skill_id ,uint16 skill_lv );
 int skill_get_blewcount( uint16 skill_id ,uint16 skill_lv );
 int skill_get_unit_flag( uint16 skill_id );
 int skill_get_unit_target( uint16 skill_id );
+int skill_get_unit_target2( uint16 skill_id );
 int skill_get_inf3( uint16 skill_id );
 // Accessor for skill requirements
 int skill_get_hp( uint16 skill_id ,uint16 skill_lv );


### PR DESCRIPTION
* Moved (almost?) all hardcoded `BCT_` flags for recursive/area skill effect to `Target1:Target2` in skill_unit_db.txt. Those `BCT_` flags are used in `skill_area_sub` and `skill_attack_area` to check skill target.
* Added `*wos` -without self- value for `Target1:Target2`

Signed-off-by: Cydh Ramdh <cydh@pservero.com>