### PR TITLE
Waiting room utils:

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6447,6 +6447,20 @@ example.
 
 ---------------------------------------
 
+*waitingroomkick "<NPC object name>" , "<character name>";
+
+This command kicks the given character from the waiting room attached to the given NPC.
+
+---------------------------------------
+
+*getwaitingroomusers "<NPC object name>";
+
+This command get all the characters in the waiting room of the given NPC and stores
+their gids in the array .@waitingroom_users[]. Also, stores the the number of characters
+in the variable .@waitingroom_usercount
+
+---------------------------------------
+
 *kickwaitingroomall {"<NPC object name>"};
 
 This command kicks everybody out of a specified waiting room chat.

--- a/src/map/chat.c
+++ b/src/map/chat.c
@@ -323,6 +323,24 @@ int chat_changechatstatus(struct map_session_data* sd, const char* title, const 
 }
 
 /**
+ * Kicks a user from the chat room.
+ * @param cd : chat to be kicked from
+ * @param kickusername : player name to be kicked
+ * @retur 1:success, 0:failure
+ */
+int chat_npckickchat(struct chat_data* cd, const char* kickusername)
+{
+	int i;
+	nullpo_ret(cd);
+
+	ARR_FIND( 0, cd->users, i, strncmp(cd->usersd[i]->status.name, kickusername, NAME_LENGTH) == 0 );
+	if( i == cd->users )
+		return -1;
+	chat_leavechat(cd->usersd[i],1);
+	return 0;
+}
+
+/**
  * Kick a member from a chat room.
  * @param sd : player requesting
  * @param kickusername : player name to be kicked

--- a/src/map/chat.h
+++ b/src/map/chat.h
@@ -45,6 +45,8 @@ int chat_enableevent(struct chat_data* cd);
 int chat_disableevent(struct chat_data* cd);
 int chat_npckickall(struct chat_data* cd);
 
+int chat_npckickchat(struct chat_data* cd, const char* kickusername);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -11093,6 +11093,49 @@ BUILDIN_FUNC(delwaitingroom)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/// Kick the specified player from the waiting room of the target npc.
+///
+/// waitingroomkick "<npc_name>", <kickusername>;
+BUILDIN_FUNC(waitingroomkick)
+{
+	struct npc_data* nd;
+	struct chat_data* cd;
+	const char* kickusername;
+	
+	nd = npc_name2id(script_getstr(st,2));
+	kickusername = script_getstr(st,3);
+
+	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL )
+		chat_npckickchat(cd, kickusername);
+	return 0;
+}
+
+/// Get Users in waiting room and stores gids in .@waitingroom_users[]
+/// Num users stored in .@waitingroom_usercount
+///
+/// getwaitingroomusers "<npc_name>";
+BUILDIN_FUNC(getwaitingroomusers)
+{
+	struct npc_data* nd;
+	struct chat_data* cd;
+
+	int i, j=0;
+
+	if( script_hasdata(st,2) )
+		nd = npc_name2id(script_getstr(st, 2));
+	else
+		nd = (struct npc_data *)map_id2bl(st->oid);
+	
+	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL ) {
+		for(i = 0; i < cd->users; ++i) {
+			setd_sub(st, NULL, ".@waitingroom_users", j, (void *)cd->usersd[i]->status.account_id, NULL);
+			j++;
+		}
+		setd_sub(st, NULL, ".@waitingroom_usercount", 0, (void *)j, NULL);
+	}
+	return 0;
+}
+
 /// Kicks all the players from the waiting room of the current or target npc.
 ///
 /// kickwaitingroomall "<npc_name>";
@@ -20517,6 +20560,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(changecharsex,"?"),
 	BUILDIN_DEF(waitingroom,"si?????"),
 	BUILDIN_DEF(delwaitingroom,"?"),
+	BUILDIN_DEF(waitingroomkick,"ss"),
+	BUILDIN_DEF(getwaitingroomusers, "?"),
 	BUILDIN_DEF2(waitingroomkickall,"kickwaitingroomall","?"),
 	BUILDIN_DEF(enablewaitingroomevent,"?"),
 	BUILDIN_DEF(disablewaitingroomevent,"?"),


### PR DESCRIPTION
Two script commands to be used in scripts, that bring a bit more of flexibility when scripting.


    * waitingroomkick "<NPC object name>" , "<character name>"; Kicks one player, there was just a method for several players
    * getwaitingroomusers "<NPC object name>"; get the mumber of players inside a waitingroom and their rids.

The original code was taken form here: http://herc.ws/board/topic/9876-help-my-old-3ceam-src-to-latest-hercules/#entry58710