### PR TITLE
Init SC Blocking Database. …

### DIFF
--- a/db/status_disabled.txt
+++ b/db/status_disabled.txt
@@ -1,0 +1,29 @@
+// Status Change Restriction Database
+//
+// Defines restrictions of status changes (SC).
+// Disabled SC will always be removed or fail to be inflicted on this map.
+//
+// Structure of Database:
+// SCType,Flag
+//
+// Legend for 'Flag' field (bitmask):
+// 1    - restricted in normal maps
+// 2    - restricted in PVP
+// 4    - restricted in GVG
+// 8    - restricted in Battlegrounds
+// Restricted zones - configured by 'restricted <number>' mapflag
+// 32   - restricted in zone 1
+// 64   - restricted in zone 2
+// 128  - restricted in zone 3
+// 256  - restricted in zone 4
+// 512  - restricted in zone 5
+// 1024 - restricted in zone 6
+// 2048 - restricted in zone 7
+//
+// Examples:
+// SC_ENDURE,4   // Endure status always be removed when player enter GvG and WoE Castles and new effect cannot be inflicted.
+
+//----------------------------------------------------------------------------
+// GVG
+//----------------------------------------------------------------------------
+SC_ENDURE,4

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10032,6 +10032,8 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 			sd->state.hpmeter_visible = 1;
 		}
 
+		status_change_clear_onChangeMap(&sd->bl, &sd->sc);
+
 		map_iwall_get(sd); // Updates Walls Info on this Map to Client
 		status_calc_pc(sd, SCO_NONE); // Some conditions are map-dependent so we must recalculate
 		sd->state.changemap = false;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -41,6 +41,8 @@ static struct {
 
 static int atkmods[3][MAX_WEAPON_TYPE];	/// ATK weapon modification for size (size_fix.txt)
 
+unsigned int SCDisabled[SC_MAX]; ///< List of disabled SC on map zones. [Cydh]
+
 static struct eri *sc_data_ers; /// For sc_data entries
 static struct status_data dummy_status;
 
@@ -84,6 +86,9 @@ static unsigned short status_calc_ematk(struct block_list *,struct status_change
 static int status_get_hpbonus(struct block_list *bl, enum e_status_bonus type);
 static int status_get_spbonus(struct block_list *bl, enum e_status_bonus type);
 static unsigned int status_calc_maxhpsp_pc(struct map_session_data* sd, unsigned int stat, bool isHP);
+
+static bool status_change_isDisabledOnMap_(sc_type type, bool mapIsVS, bool mapIsPVP, bool mapIsGVG, bool mapIsBG, unsigned int mapZone);
+#define status_change_isDisabledOnMap(type,m) ( status_change_isDisabledOnMap_((type),map_flag_vs((m)),map[(m)].flag.pvp,map_flag_gvg((m)),map[(m)].flag.battleground,8*map[(m)].zone) )
 
 /**
  * Returns the status change associated with a skill.
@@ -199,6 +204,7 @@ void initChangeTables(void)
 	memset(StatusChangeFlagTable, 0, sizeof(StatusChangeFlagTable));
 	memset(StatusChangeStateTable, 0, sizeof(StatusChangeStateTable));
 	memset(StatusDisplayType, 0, sizeof(StatusDisplayType));
+	memset(SCDisabled, 0, sizeof(SCDisabled));
 
 
 	/* First we define the skill for common ailments. These are used in skill_additional_effect through sc cards. [Skotlex] */
@@ -7720,6 +7726,9 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	if( status_isdead(bl) && type != SC_NOCHAT ) // SC_NOCHAT should work even on dead characters
 		return 0;
 
+	if (status_change_isDisabledOnMap(type, bl->m))
+		return 0;
+
 	if( bl->type == BL_MOB) {
 		struct mob_data *md = BL_CAST(BL_MOB,bl);
 		if(md && (md->mob_id == MOBID_EMPERIUM || mob_is_battleground(md)) && type != SC_SAFETYWALL && type != SC_PNEUMA)
@@ -13235,6 +13244,76 @@ static bool status_readdb_attrfix(const char *basedir,bool silent)
 }
 
 /**
+ * Check if status is disabled on a map
+ * @param bl
+ * @param sc
+ **/
+static bool status_change_isDisabledOnMap_(sc_type type, bool mapIsVS, bool mapIsPVP, bool mapIsGVG, bool mapIsBG, unsigned int mapZone) {
+	if (type <= SC_NONE || type >= SC_MAX)
+		return true;
+
+	if ((!mapIsVS && SCDisabled[type]&1) ||
+		(mapIsPVP && SCDisabled[type]&2) ||
+		(mapIsGVG && SCDisabled[type]&4) ||
+		(mapIsBG && SCDisabled[type]&8) ||
+		(SCDisabled[type]&(mapZone))) 
+	{
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Check if status is disabled on a map
+ * @param bl
+ * @param sc
+ **/
+void status_change_clear_onChangeMap(struct block_list *bl, struct status_change *sc) {
+	nullpo_retv(bl);
+
+	if (sc && sc->count) {
+		unsigned short i;
+		bool mapIsVS = map_flag_vs(bl->m);
+		bool mapIsPVP = map[bl->m].flag.pvp;
+		bool mapIsGVG = map_flag_gvg(bl->m);
+		bool mapIsBG = map[bl->m].flag.battleground;
+		unsigned int mapZone = map[bl->m].zone*8;
+
+		for (i = 0; i < SC_MAX; i++) {
+			if (!sc->data[i] || !SCDisabled[i])
+				continue;
+
+			if (status_change_isDisabledOnMap_((sc_type)i, mapIsVS, mapIsPVP, mapIsGVG, mapIsBG, mapZone))
+				status_change_end(bl, (sc_type)i, INVALID_TIMER);
+		}
+	}
+}
+
+/**
+ * Read status_disabled.txt file
+ **/
+static bool status_readdb_disabled(char **str, int columns, int current) {
+	int type = SC_NONE;
+
+	if (ISDIGIT(str[0][0])) {
+		type = atoi(str[0]);
+	}
+	else {
+		if (!script_get_constant(str[0],&type))
+			type = SC_NONE;
+	}
+
+	if (type <= SC_NONE || type >= SC_MAX) {
+		ShowError("status_readdb_disabled: Invalid SC with type %s.\n", str[0]);
+		return false;
+	}
+
+	SCDisabled[type] = (unsigned int)atol(str[1]);
+	return true;
+}
+
+/**
  * Sets defaults in tables and starts read db functions
  * sv_readdb reads the file, outputting the information line-by-line to
  * previous functions above, separating information by delimiter
@@ -13273,6 +13352,8 @@ int status_readdb(void)
 			for(k=0;k<ELE_ALL;k++)
 				attr_fix_table[i][j][k]=100;
 
+	memset(SCDisabled, 0, sizeof(SCDisabled));
+
 	// read databases
 	// path,filename,separator,mincol,maxcol,maxrow,func_parsor
 	for(i=0; i<ARRAYLENGTH(dbsubpath); i++){
@@ -13292,6 +13373,7 @@ int status_readdb(void)
 		
 		status_readdb_attrfix(dbsubpath2,i); // !TODO use sv_readdb ?
 		sv_readdb(dbsubpath1, "size_fix.txt",',',MAX_WEAPON_TYPE,MAX_WEAPON_TYPE,ARRAYLENGTH(atkmods),&status_readdb_sizefix, i);
+		sv_readdb(dbsubpath1, "status_disabled.txt",',',2,2,-1,&status_readdb_disabled, i);
 		sv_readdb(dbsubpath2, "refine_db.txt", ',', 4+MAX_REFINE, 4+MAX_REFINE, ARRAYLENGTH(refine_info), &status_readdb_refine, i);
 		aFree(dbsubpath1);
 		aFree(dbsubpath2);

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2196,6 +2196,7 @@ int status_change_spread(struct block_list *src, struct block_list *bl, bool typ
 #endif
 
 unsigned short status_base_atk(const struct block_list *bl, const struct status_data *status);
+void status_change_clear_onChangeMap(struct block_list *bl, struct status_change *sc);
 
 void initChangeTables(void);
 int status_readdb(void);


### PR DESCRIPTION
* This database contains status (SC) that will be disabled/blocked on certain map.
* The specified map for SC is determined by map type or zone.
* The disabled SC will be removed if player has the SC from previous map and will be fail to activated.

Signed-off-by: Cydh Ramdh <cydh@pservero.com>