### PR TITLE
Fixing sql upgrade 2014 06 12 losing data when having negative values in card columns

### DIFF
--- a/sql-files/upgrades/upgrade_20140612.sql
+++ b/sql-files/upgrades/upgrade_20140612.sql
@@ -5,35 +5,29 @@ UPDATE `inventory` SET `card0` = 256 WHERE `card0` = -256;
 UPDATE `mail` SET `card0` = 256 WHERE `card0` = -256;
 UPDATE `storage` SET `card0` = 256 WHERE `card0` = -256;
 
-UPDATE `auction` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `auction` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `auction` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `auction` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `auction` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `auction` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `auction` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
-UPDATE `cart_inventory` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `cart_inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `cart_inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `cart_inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `cart_inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `cart_inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `cart_inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
-UPDATE `guild_storage` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `guild_storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `guild_storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `guild_storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `guild_storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `guild_storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `guild_storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
-UPDATE `inventory` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
-UPDATE `mail` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `mail` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `mail` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `mail` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `mail` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `mail` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `mail` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
-UPDATE `storage` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+UPDATE `storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
 ALTER TABLE `auction` MODIFY `nameid` smallint(5) unsigned NOT NULL default '0';
 ALTER TABLE `auction` MODIFY `card0` smallint(5) unsigned NOT NULL default '0';

--- a/sql-files/upgrades/upgrade_20140612.sql
+++ b/sql-files/upgrades/upgrade_20140612.sql
@@ -5,6 +5,36 @@ UPDATE `inventory` SET `card0` = 256 WHERE `card0` = -256;
 UPDATE `mail` SET `card0` = 256 WHERE `card0` = -256;
 UPDATE `storage` SET `card0` = 256 WHERE `card0` = -256;
 
+UPDATE `auction` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `auction` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `auction` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `auction` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `cart_inventory` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `cart_inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `cart_inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `cart_inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `guild_storage` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `guild_storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `guild_storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `guild_storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `inventory` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `inventory` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `inventory` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `inventory` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `mail` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `mail` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `mail` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `mail` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `storage` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `storage` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `storage` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `storage` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
 ALTER TABLE `auction` MODIFY `nameid` smallint(5) unsigned NOT NULL default '0';
 ALTER TABLE `auction` MODIFY `card0` smallint(5) unsigned NOT NULL default '0';
 ALTER TABLE `auction` MODIFY `card1` smallint(5) unsigned NOT NULL default '0';

--- a/sql-files/upgrades/upgrade_20140612_log.sql
+++ b/sql-files/upgrades/upgrade_20140612_log.sql
@@ -1,8 +1,8 @@
 UPDATE `picklog` SET `card0` = 256 WHERE `card0` = -256;
-UPDATE `picklog` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
-UPDATE `picklog` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
-UPDATE `picklog` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
-UPDATE `picklog` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
+
+UPDATE `picklog` SET `card1` = (65536 + `card1`) WHERE `card1` < 0 AND `card0` IN(254,255);
+UPDATE `picklog` SET `card2` = (65536 + `card2`) WHERE `card2` < 0 AND `card0` IN(254,255);
+UPDATE `picklog` SET `card3` = (65536 + `card3`) WHERE `card3` < 0 AND `card0` IN(254,255);
 
 ALTER TABLE `picklog` MODIFY `nameid` smallint(5) unsigned NOT NULL default '0';
 ALTER TABLE `picklog` MODIFY `card0` smallint(5) unsigned NOT NULL default '0';

--- a/sql-files/upgrades/upgrade_20140612_log.sql
+++ b/sql-files/upgrades/upgrade_20140612_log.sql
@@ -1,4 +1,8 @@
 UPDATE `picklog` SET `card0` = 256 WHERE `card0` = -256;
+UPDATE `picklog` SET `card0` = (65536 + `card0`) WHERE `card0` < 0;
+UPDATE `picklog` SET `card1` = (65536 + `card1`) WHERE `card1` < 0;
+UPDATE `picklog` SET `card2` = (65536 + `card2`) WHERE `card2` < 0;
+UPDATE `picklog` SET `card3` = (65536 + `card3`) WHERE `card3` < 0;
 
 ALTER TABLE `picklog` MODIFY `nameid` smallint(5) unsigned NOT NULL default '0';
 ALTER TABLE `picklog` MODIFY `card0` smallint(5) unsigned NOT NULL default '0';


### PR DESCRIPTION
Fixing sql upgrade 2014 06 12 losing data when having negative data (e.g. char ids) in card slots. Easiest way to reproduce is on a Named Wedding Ring. After the upgrade, names were not recognized and the item showed as Unnamed.
This was caused by commits 42b29ee and 7cd82d0.