### PR TITLE
Changed the regeneration timer to not run, if a BL is dead.

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2101,7 +2101,7 @@ void map_foreachnpc(int (*func)(struct npc_data* nd, va_list args), ...)
 
 /// Applies func to everything in the db.
 /// Stops iterating if func returns -1.
-void map_foreachregen(int (*func)(struct block_list* bl, va_list args), ...)
+void map_foreachregen(int (*func)(struct block_list* bl), ...)
 {
 	DBIterator* iter;
 	struct block_list* bl;
@@ -2109,14 +2109,12 @@ void map_foreachregen(int (*func)(struct block_list* bl, va_list args), ...)
 	iter = db_iterator(regen_db);
 	for( bl = (struct block_list*)dbi_first(iter); dbi_exists(iter); bl = (struct block_list*)dbi_next(iter) )
 	{
-		va_list args;
-		int ret;
-
-		va_start(args, func);
-		ret = func(bl, args);
-		va_end(args);
-		if( ret == -1 )
-			break;// stop iterating
+		// Dead BLs don't regenerate
+		// TODO: BLs other than PC should issue a warning/error since they might refer to bad code(not removed bls)
+		if( !status_isdead(bl) ){
+			if( func(bl) == -1 )
+				break;// stop iterating
+		}
 	}
 	dbi_destroy(iter);
 }

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -2099,9 +2099,8 @@ void map_foreachnpc(int (*func)(struct npc_data* nd, va_list args), ...)
 	dbi_destroy(iter);
 }
 
-/// Applies func to everything in the db.
-/// Stops iterating if func returns -1.
-void map_foreachregen(int (*func)(struct block_list* bl), ...)
+/// Applies func to everything in the regen db.
+void map_foreachregen(void (*func)(struct block_list* bl))
 {
 	DBIterator* iter;
 	struct block_list* bl;
@@ -2110,10 +2109,8 @@ void map_foreachregen(int (*func)(struct block_list* bl), ...)
 	for( bl = (struct block_list*)dbi_first(iter); dbi_exists(iter); bl = (struct block_list*)dbi_next(iter) )
 	{
 		// Dead BLs don't regenerate
-		// TODO: BLs other than PC should issue a warning/error since they might refer to bad code(not removed bls)
 		if( !status_isdead(bl) ){
-			if( func(bl) == -1 )
-				break;// stop iterating
+			func(bl);
 		}
 	}
 	dbi_destroy(iter);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -871,7 +871,7 @@ void map_deliddb(struct block_list *bl);
 void map_foreachpc(int (*func)(struct map_session_data* sd, va_list args), ...);
 void map_foreachmob(int (*func)(struct mob_data* md, va_list args), ...);
 void map_foreachnpc(int (*func)(struct npc_data* nd, va_list args), ...);
-void map_foreachregen(int (*func)(struct block_list* bl), ...);
+void map_foreachregen(void (*func)(struct block_list* bl));
 void map_foreachiddb(int (*func)(struct block_list* bl, va_list args), ...);
 struct map_session_data * map_nick2sd(const char*);
 struct mob_data * map_getmob_boss(int16 m);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -871,7 +871,7 @@ void map_deliddb(struct block_list *bl);
 void map_foreachpc(int (*func)(struct map_session_data* sd, va_list args), ...);
 void map_foreachmob(int (*func)(struct mob_data* md, va_list args), ...);
 void map_foreachnpc(int (*func)(struct npc_data* nd, va_list args), ...);
-void map_foreachregen(int (*func)(struct block_list* bl, va_list args), ...);
+void map_foreachregen(int (*func)(struct block_list* bl), ...);
 void map_foreachiddb(int (*func)(struct block_list* bl, va_list args), ...);
 struct map_session_data * map_nick2sd(const char*);
 struct mob_data * map_getmob_boss(int16 m);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -12930,13 +12930,11 @@ int status_change_spread(struct block_list *src, struct block_list *bl, bool typ
 
 /**
  * Applying natural heal bonuses (sit, skill, homun, etc...)
- * TODO: the va_list doesn't seem to be used, safe to remove?
  * @param bl: Object applying bonuses to [PC|HOM|MER|ELEM]
- * @param args: va_list arguments
  * @return which regeneration bonuses have been applied (flag)
  */
 static unsigned int natural_heal_prev_tick,natural_heal_diff_tick;
-static int status_natural_heal(struct block_list* bl, va_list args)
+static int status_natural_heal(struct block_list* bl)
 {
 	struct regen_data *regen;
 	struct status_data *status;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -12934,7 +12934,7 @@ int status_change_spread(struct block_list *src, struct block_list *bl, bool typ
  * @return which regeneration bonuses have been applied (flag)
  */
 static unsigned int natural_heal_prev_tick,natural_heal_diff_tick;
-static int status_natural_heal(struct block_list* bl)
+static void status_natural_heal(struct block_list* bl)
 {
 	struct regen_data *regen;
 	struct status_data *status;
@@ -12947,7 +12947,7 @@ static int status_natural_heal(struct block_list* bl)
 
 	regen = status_get_regen_data(bl);
 	if (!regen)
-		return 0;
+		return;
 	status = status_get_status_data(bl);
 	sc = status_get_sc(bl);
 	if (sc && !sc->count)
@@ -13017,7 +13017,7 @@ static int status_natural_heal(struct block_list* bl)
 	}
 
 	if (!flag)
-		return 0;
+		return;
 
 	if (flag&(RGN_HP|RGN_SP)) {
 		if(!vd)
@@ -13075,7 +13075,7 @@ static int status_natural_heal(struct block_list* bl)
 	}
 
 	if (!regen->sregen)
-		return flag;
+		return;
 
 	// Skill regen
 	sregen = regen->sregen;
@@ -13113,7 +13113,6 @@ static int status_natural_heal(struct block_list* bl)
 				break; // Full
 		}
 	}
-	return flag;
 }
 
 /**


### PR DESCRIPTION
Also removed an unused parameter at the same time.
