### PR TITLE
Fixing quest objectives being shown by client incorrectly on monster kill.

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -15948,7 +15948,7 @@ void clif_quest_delete(struct map_session_data *sd, int quest_id)
 
 /// Notification of an update to the hunting mission counter (ZC_UPDATE_MISSION_HUNT).
 /// 02b5 <packet len>.W <mobs>.W { <quest id>.L <mob id>.L <total count>.W <current count>.W }*3
-void clif_quest_update_objective(struct map_session_data *sd, struct quest *qd)
+void clif_quest_update_objective(struct map_session_data *sd, struct quest *qd, int mobid)
 {
 	int fd = sd->fd;
 	int i;
@@ -15961,10 +15961,12 @@ void clif_quest_update_objective(struct map_session_data *sd, struct quest *qd)
 	WFIFOW(fd, 4) = qi->objectives_count;
 
 	for (i = 0; i < qi->objectives_count; i++) {
-		WFIFOL(fd, i*12+6) = qd->quest_id;
-		WFIFOL(fd, i*12+10) = qi->objectives[i].mob;
-		WFIFOW(fd, i*12+14) = qi->objectives[i].count;
-		WFIFOW(fd, i*12+16) = qd->count[i];
+		if (mobid == 0 || mobid == qi->objectives[i].mob) {
+			WFIFOL(fd, i * 12 + 6) = qd->quest_id;
+			WFIFOL(fd, i * 12 + 10) = qi->objectives[i].mob;
+			WFIFOW(fd, i * 12 + 14) = qi->objectives[i].count;
+			WFIFOW(fd, i * 12 + 16) = qd->count[i];
+		}
 	}
 
 	WFIFOSET(fd, len);

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -813,7 +813,7 @@ void clif_quest_send_mission(struct map_session_data * sd);
 void clif_quest_add(struct map_session_data * sd, struct quest * qd);
 void clif_quest_delete(struct map_session_data * sd, int quest_id);
 void clif_quest_update_status(struct map_session_data * sd, int quest_id, bool active);
-void clif_quest_update_objective(struct map_session_data * sd, struct quest * qd);
+void clif_quest_update_objective(struct map_session_data * sd, struct quest * qd, int mobid);
 void clif_quest_show_event(struct map_session_data *sd, struct block_list *bl, short state, short color);
 void clif_displayexp(struct map_session_data *sd, unsigned int exp, char type, bool quest);
 

--- a/src/map/quest.c
+++ b/src/map/quest.c
@@ -56,7 +56,7 @@ int quest_pc_login(TBL_PC *sd)
 
 	//@TODO[Haru]: Is this necessary? Does quest_send_mission not take care of this?
 	for( i = 0; i < sd->avail_quests; i++ )
-		clif_quest_update_objective(sd, &sd->quest_log[i]);
+		clif_quest_update_objective(sd, &sd->quest_log[i], 0);
 #endif
 
 	return 0;
@@ -104,7 +104,7 @@ int quest_add(TBL_PC *sd, int quest_id)
 	sd->save_quest = true;
 
 	clif_quest_add(sd, &sd->quest_log[n]);
-	clif_quest_update_objective(sd, &sd->quest_log[n]);
+	clif_quest_update_objective(sd, &sd->quest_log[n], 0);
 
 	if( save_settings&CHARSAVE_QUEST )
 		chrif_save(sd,0);
@@ -157,7 +157,7 @@ int quest_change(TBL_PC *sd, int qid1, int qid2)
 
 	clif_quest_delete(sd, qid1);
 	clif_quest_add(sd, &sd->quest_log[i]);
-	clif_quest_update_objective(sd, &sd->quest_log[i]);
+	clif_quest_update_objective(sd, &sd->quest_log[i], 0);
 
 	if( save_settings&CHARSAVE_QUEST )
 		chrif_save(sd,0);
@@ -253,7 +253,7 @@ void quest_update_objective(TBL_PC *sd, int mob_id)
 			if( qi->objectives[j].mob == mob_id && sd->quest_log[i].count[j] < qi->objectives[j].count )  {
 				sd->quest_log[i].count[j]++;
 				sd->save_quest = true;
-				clif_quest_update_objective(sd, &sd->quest_log[i]);
+				clif_quest_update_objective(sd, &sd->quest_log[i], mob_id);
 			}
 		}
 


### PR DESCRIPTION
Fixing quest objectives being shown by client incorrectly on monster kill. Client only shows the first monster received, but we want to show the killed monster. This is just a recreated PR instead of PR#787.