### PR TITLE
Randomized Start Point

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -111,8 +111,8 @@ save_log: yes
 // Format: <map_name>,<x>,<y>{:<map_name>,<x>,<y>...}
 // Max number of start points is MAX_STARTPOINT in char.h (default 5)
 // Location is randomly picked on character creation.
-start_point: iz_int,97,90,iz_int01,97,90,iz_int02,97,90,iz_int03,97,90,iz_int04,97,90
-start_point_pre: new_1-1,53,111,new_2-1,53,111,new_3-1,53,111,new_4-1,53,111,new_5-1,53,111
+start_point: iz_int,97,90:iz_int01,97,90:iz_int02,97,90:iz_int03,97,90:iz_int04,97,90
+start_point_pre: new_1-1,53,111:new_2-1,53,111:new_3-1,53,111:new_4-1,53,111:new_5-1,53,111
 
 // Starting items for new characters
 // Max number of items is MAX_STARTITEM in char.c (default 32)

--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -108,9 +108,11 @@ autosave_time: 60
 save_log: yes
 
 // Starting point for new characters
-// Format: <map_name>,<x>,<y>
-start_point: iz_int,97,90
-start_point_pre: new_1-1,53,111
+// Format: <map_name>,<x>,<y>{:<map_name>,<x>,<y>...}
+// Max number of start points is MAX_STARTPOINT in char.h (default 5)
+// Location is randomly picked on character creation.
+start_point: iz_int,97,90,iz_int01,97,90,iz_int02,97,90,iz_int03,97,90,iz_int04,97,90
+start_point_pre: new_1-1,53,111,new_2-1,53,111,new_3-1,53,111,new_4-1,53,111,new_5-1,53,111
 
 // Starting items for new characters
 // Max number of items is MAX_STARTITEM in char.c (default 32)

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -2670,6 +2670,8 @@ static void char_config_split_startpoint(char *w2_value)
 #endif
 
 	fields = (char **)aMalloc(fields_length * sizeof(char *));
+	if (fields == NULL)
+		return; // Failed to allocate memory.
 	lineitem = strtok(w2_value, ":");
 
 	while (lineitem != NULL) {
@@ -2715,6 +2717,8 @@ static void char_config_split_startitem(char *w2_value)
 	strcat(config_name, "start_items");
 
 	fields = (char **)aMalloc(fields_length * sizeof(char *));
+	if (fields == NULL)
+		return; // Failed to allocate memory.
 	lineitem = strtok(w2_value, ":");
 
 	while (lineitem != NULL) {

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -15,6 +15,8 @@
 extern int login_fd; //login file descriptor
 extern int char_fd; //char file descriptor
 
+#define MAX_STARTPOINT 5
+
 enum E_CHARSERVER_ST {
 	CHARSERVER_ST_RUNNING = CORE_ST_LAST,
 	CHARSERVER_ST_STARTING,
@@ -142,7 +144,8 @@ struct CharServ_Config {
 	int log_inter;	// loggin inter or not [devil]
 	int char_check_db;	///cheking sql-table at begining ?
 
-	struct point start_point; // Initial position the player will spawn on server
+	struct point start_point[MAX_STARTPOINT]; // Initial position the player will spawn on server
+	short start_point_count;
 	int console;
 	int max_connect_user;
 	int gm_allow_group;

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -16,6 +16,7 @@ extern int login_fd; //login file descriptor
 extern int char_fd; //char file descriptor
 
 #define MAX_STARTPOINT 5
+#define MAX_STARTITEM 32
 
 enum E_CHARSERVER_ST {
 	CHARSERVER_ST_RUNNING = CORE_ST_LAST,
@@ -144,8 +145,9 @@ struct CharServ_Config {
 	int log_inter;	// loggin inter or not [devil]
 	int char_check_db;	///cheking sql-table at begining ?
 
-	struct point start_point[MAX_STARTPOINT]; // Initial position the player will spawn on server
-	short start_point_count;
+	struct point start_point[MAX_STARTPOINT]; // Initial position the player will spawn on the server
+	short start_point_count; // Number of positions read
+	struct startitem start_items[MAX_STARTITEM]; // Initial items the player with spawn with on the server
 	int console;
 	int max_connect_user;
 	int gm_allow_group;

--- a/src/common/mapindex.h
+++ b/src/common/mapindex.h
@@ -4,6 +4,8 @@
 #ifndef _MAPINDEX_H_
 #define _MAPINDEX_H_
 
+#include "../config/renewal.h"
+
 #define MAX_MAPINDEX 2000
 
 //Some definitions for the mayor city maps.
@@ -31,7 +33,11 @@
 #define MAP_RACHEL "rachel"
 #define MAP_VEINS "veins"
 #define MAP_JAIL "sec_pri"
-#define MAP_NOVICE "new_1-1"
+#ifdef RENEWAL
+	#define MAP_NOVICE "iz_int"
+#else
+	#define MAP_NOVICE "new_1-1"
+#endif
 #define MAP_MOSCOVIA "moscovia"
 #define MAP_MIDCAMP "mid_camp"
 #define MAP_MANUK "manuk"

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -219,6 +219,11 @@ struct point {
 	short x,y;
 };
 
+struct startitem {
+	unsigned short nameid, amount;
+	short pos;
+};
+
 enum e_skill_flag
 {
 	SKILL_FLAG_PERMANENT,

--- a/src/config/const.h
+++ b/src/config/const.h
@@ -103,7 +103,7 @@
     #define MAP_DEFAULT_X 97
     #define MAP_DEFAULT_Y 90
 #else
-    #define MAP_DEFAULT_NAME "new_zone01"
+    #define MAP_DEFAULT_NAME "new_1-1"
     #define MAP_DEFAULT_X 53
     #define MAP_DEFAULT_Y 111
 #endif

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -1840,7 +1840,11 @@ ACMD_FUNC(go)
 		{ MAP_UMBALA,       89, 157 }, // 12=Umbala
 		{ MAP_NIFLHEIM,     21, 153 }, // 13=Niflheim
 		{ MAP_LOUYANG,     217,  40 }, // 14=Louyang
+#ifdef RENEWAL
+		{ MAP_NOVICE,       97, 90  }, // 15=Training Grounds (Renewal)
+#else
 		{ MAP_NOVICE,       53, 111 }, // 15=Training Grounds
+#endif
 		{ MAP_JAIL,         23,  61 }, // 16=Prison
 		{ MAP_JAWAII,      249, 127 }, // 17=Jawaii
 		{ MAP_AYOTHAYA,    151, 117 }, // 18=Ayothaya


### PR DESCRIPTION
* Fixes #805
* Character's will follow somewhat of the official method of a 'random' start point at their first login.
* Official servers use load balancing for setting the start point dynamically according to user count, whereas we at rAthena wanted to stay simple since we don't believe you guys will need this kind of load balancing for new characters.