### PR TITLE
Hotfix/issue779

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -545,7 +545,8 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 			if( sd && !(nk&NK_NO_CARDFIX_ATK) ) {
 				cardfix = cardfix * (100 + sd->magic_addrace[tstatus->race] + sd->magic_addrace[RC_ALL]) / 100;
 				if( !(nk&NK_NO_ELEFIX) ) { // Affected by Element modifier bonuses
-					cardfix = cardfix * (100 + sd->magic_addele[tstatus->def_ele] + sd->magic_addele[ELE_ALL]) / 100;
+					cardfix = cardfix * (100 + sd->magic_addele[tstatus->def_ele] + sd->magic_addele[ELE_ALL] + 
+						sd->magic_addele_script[tstatus->def_ele] + sd->magic_addele_script[ELE_ALL]) / 100;
 					cardfix = cardfix * (100 + sd->magic_atk_ele[rh_ele] + sd->magic_atk_ele[ELE_ALL]) / 100;
 				}
 				cardfix = cardfix * (100 + sd->magic_addsize[tstatus->size] + sd->magic_addsize[SZ_ALL]) / 100;
@@ -565,7 +566,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 				cardfix = 1000; // reset var for target
 
 				if( !(nk&NK_NO_ELEFIX) ) { // Affected by Element modifier bonuses
-					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL];
+					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL] + tsd->subele_script[rh_ele] + tsd->subele_script[ELE_ALL];
 
 					for( i = 0; ARRAYLENGTH(tsd->subele2) > i && tsd->subele2[i].rate != 0; i++ ) {
 						if( tsd->subele2[i].ele != rh_ele )
@@ -748,7 +749,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 			// Affected by target DEF bonuses
 			else if( tsd && !(nk&NK_NO_CARDFIX_DEF) && !(left&2) ) {
 				if( !(nk&NK_NO_ELEFIX) ) { // Affected by Element modifier bonuses
-					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL];
+					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL] + tsd->subele_script[rh_ele] + tsd->subele_script[ELE_ALL];
 
 					for( i = 0; ARRAYLENGTH(tsd->subele2) > i && tsd->subele2[i].rate != 0; i++ ) {
 						if( tsd->subele2[i].ele != rh_ele )
@@ -762,7 +763,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 					cardfix = cardfix * (100 - ele_fix) / 100;
 
 					if( left&1 && lh_ele != rh_ele ) {
-						int ele_fix_lh = tsd->subele[lh_ele] + tsd->subele[ELE_ALL];
+						int ele_fix_lh = tsd->subele[lh_ele] + tsd->subele[ELE_ALL] + tsd->subele_script[lh_ele] + tsd->subele_script[ELE_ALL];
 
 						for( i = 0; ARRAYLENGTH(tsd->subele2) > i && tsd->subele2[i].rate != 0; i++ ) {
 							if( tsd->subele2[i].ele != lh_ele )
@@ -803,7 +804,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 			// Affected by target DEF bonuses
 			if( tsd && !(nk&NK_NO_CARDFIX_DEF) ) {
 				if( !(nk&NK_NO_ELEFIX) ) { // Affected by Element modifier bonuses
-					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL];
+					int ele_fix = tsd->subele[rh_ele] + tsd->subele[ELE_ALL] + tsd->subele_script[rh_ele] + tsd->subele_script[ELE_ALL];
 
 					for( i = 0; ARRAYLENGTH(tsd->subele2) > i && tsd->subele2[i].rate != 0; i++ ) {
 						if( tsd->subele2[i].ele != rh_ele )

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -3101,7 +3101,7 @@ void pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 	case SP_SUBELE: // bonus2 bSubEle,e,x;
 		PC_BONUS_CHK_ELEMENT(type2,SP_SUBELE);
 		if(sd->state.lr_flag != 2)
-			sd->subele[type2]+=val;
+			sd->subele_script[type2] += val;
 		break;
 	case SP_SUBRACE: // bonus2 bSubRace,r,x;
 		PC_BONUS_CHK_RACE(type2,SP_SUBRACE);
@@ -3136,7 +3136,7 @@ void pc_bonus2(struct map_session_data *sd,int type,int type2,int val)
 	case SP_MAGIC_ADDELE: // bonus2 bMagicAddEle,e,x;
 		PC_BONUS_CHK_ELEMENT(type2,SP_MAGIC_ADDELE);
 		if(sd->state.lr_flag != 2)
-			sd->magic_addele[type2]+=val;
+			sd->magic_addele_script[type2] += val;
 		break;
 	case SP_MAGIC_ADDRACE: // bonus2 bMagicAddRace,r,x;
 		PC_BONUS_CHK_RACE(type2,SP_MAGIC_ADDRACE);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -331,6 +331,7 @@ struct map_session_data {
 	// here start arrays to be globally zeroed at the beginning of status_calc_pc()
 	int param_bonus[6],param_equip[6]; //Stores card/equipment bonuses.
 	int subele[ELE_MAX];
+	int subele_script[ELE_MAX];
 	int subdefele[ELE_MAX];
 	int subrace[RC_MAX];
 	int subclass[CLASS_MAX];
@@ -349,6 +350,7 @@ struct map_session_data {
 	int arrow_addclass[CLASS_MAX];
 	int arrow_addsize[SZ_MAX];
 	int magic_addele[ELE_MAX];
+	int magic_addele_script[ELE_MAX];
 	int magic_addrace[RC_MAX];
 	int magic_addclass[CLASS_MAX];
 	int magic_addsize[SZ_MAX];

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -362,7 +362,7 @@ void initChangeTables(void)
 #endif
 	set_sc( BD_ROKISWEIL		, SC_ROKISWEIL	, SI_ROKISWEIL	, SCB_NONE );
 	set_sc( BD_INTOABYSS		, SC_INTOABYSS	, SI_INTOABYSS	, SCB_NONE );
-	set_sc( BD_SIEGFRIED		, SC_SIEGFRIED		, SI_SIEGFRIED	, SCB_ALL );
+	set_sc( BD_SIEGFRIED		, SC_SIEGFRIED		, SI_SIEGFRIED	, SCB_DEF_ELE );
 	add_sc( BA_FROSTJOKER		, SC_FREEZE		);
 	set_sc( BA_WHISTLE		, SC_WHISTLE		, SI_WHISTLE		, SCB_FLEE|SCB_FLEE2 );
 	set_sc( BA_ASSASSINCROSS	, SC_ASSNCROS		, SI_ASSASSINCROSS		, SCB_ASPD );
@@ -765,15 +765,15 @@ void initChangeTables(void)
 
 	/* Elemental spirits' status changes */
 	set_sc( EL_CIRCLE_OF_FIRE	, SC_CIRCLE_OF_FIRE_OPTION	, SI_CIRCLE_OF_FIRE_OPTION	, SCB_NONE );
-	set_sc( EL_FIRE_CLOAK		, SC_FIRE_CLOAK_OPTION		, SI_FIRE_CLOAK_OPTION		, SCB_ALL );
+	set_sc( EL_FIRE_CLOAK		, SC_FIRE_CLOAK_OPTION		, SI_FIRE_CLOAK_OPTION		, SCB_DEF_ELE );
 	set_sc( EL_WATER_SCREEN		, SC_WATER_SCREEN_OPTION	, SI_WATER_SCREEN_OPTION	, SCB_NONE );
-	set_sc( EL_WATER_DROP		, SC_WATER_DROP_OPTION		, SI_WATER_DROP_OPTION		, SCB_ALL );
+	set_sc( EL_WATER_DROP		, SC_WATER_DROP_OPTION		, SI_WATER_DROP_OPTION		, SCB_DEF_ELE );
 	set_sc( EL_WATER_BARRIER	, SC_WATER_BARRIER		, SI_WATER_BARRIER		, SCB_WATK|SCB_FLEE );
 	set_sc( EL_WIND_STEP		, SC_WIND_STEP_OPTION		, SI_WIND_STEP_OPTION		, SCB_SPEED|SCB_FLEE );
-	set_sc( EL_WIND_CURTAIN		, SC_WIND_CURTAIN_OPTION	, SI_WIND_CURTAIN_OPTION	, SCB_ALL );
+	set_sc( EL_WIND_CURTAIN		, SC_WIND_CURTAIN_OPTION	, SI_WIND_CURTAIN_OPTION	, SCB_DEF_ELE );
 	set_sc( EL_ZEPHYR		, SC_ZEPHYR			, SI_ZEPHYR			, SCB_FLEE );
 	set_sc( EL_SOLID_SKIN		, SC_SOLID_SKIN_OPTION		, SI_SOLID_SKIN_OPTION		, SCB_DEF|SCB_MAXHP );
-	set_sc( EL_STONE_SHIELD		, SC_STONE_SHIELD_OPTION	, SI_STONE_SHIELD_OPTION	, SCB_ALL );
+	set_sc( EL_STONE_SHIELD		, SC_STONE_SHIELD_OPTION	, SI_STONE_SHIELD_OPTION	, SCB_DEF_ELE );
 	set_sc( EL_POWER_OF_GAIA	, SC_POWER_OF_GAIA		, SI_POWER_OF_GAIA		, SCB_MAXHP|SCB_DEF|SCB_SPEED );
 	set_sc( EL_PYROTECHNIC		, SC_PYROTECHNIC_OPTION		, SI_PYROTECHNIC_OPTION		, SCB_WATK );
 	set_sc( EL_HEATER		, SC_HEATER_OPTION		, SI_HEATER_OPTION		, SCB_WATK );
@@ -3682,12 +3682,6 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 		sd->sprecov_rate = 0;
 
 	// Anti-element and anti-race
-	if((skill=pc_checkskill(sd,CR_TRUST))>0)
-		sd->subele[ELE_HOLY] += skill*5;
-	if((skill=pc_checkskill(sd,BS_SKINTEMPER))>0) {
-		sd->subele[ELE_NEUTRAL] += skill;
-		sd->subele[ELE_FIRE] += skill*4;
-	}
 	if((skill=pc_checkskill(sd,SA_DRAGONOLOGY))>0) {
 #ifdef RENEWAL
 		skill = skill * 2;
@@ -3701,13 +3695,9 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 	}
 	if((skill = pc_checkskill(sd, AB_EUCHARISTICA)) > 0) {
 		sd->right_weapon.addrace[RC_DEMON] += skill;
-		sd->right_weapon.addele[ELE_DARK] += skill;
 		sd->left_weapon.addrace[RC_DEMON] += skill;
-		sd->left_weapon.addele[ELE_DARK] += skill;
 		sd->magic_addrace[RC_DEMON] += skill;
-		sd->magic_addele[ELE_DARK] += skill;
 		sd->subrace[RC_DEMON] += skill;
-		sd->subele[ELE_DARK] += skill;
 	}
 
 	if(sc->count) {
@@ -3715,66 +3705,11 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 			sc->data[SC_CONCENTRATE]->val3 = sd->param_bonus[1]; // Agi
 			sc->data[SC_CONCENTRATE]->val4 = sd->param_bonus[4]; // Dex
 		}
-		if(sc->data[SC_SIEGFRIED]) {
-			i = sc->data[SC_SIEGFRIED]->val2;
-			sd->subele[ELE_WATER] += i;
-			sd->subele[ELE_EARTH] += i;
-			sd->subele[ELE_FIRE] += i;
-			sd->subele[ELE_WIND] += i;
-			sd->subele[ELE_POISON] += i;
-			sd->subele[ELE_HOLY] += i;
-			sd->subele[ELE_DARK] += i;
-			sd->subele[ELE_GHOST] += i;
-			sd->subele[ELE_UNDEAD] += i;
-		}
 		if(sc->data[SC_PROVIDENCE]) {
-			sd->subele[ELE_HOLY] += sc->data[SC_PROVIDENCE]->val2;
 			sd->subrace[RC_DEMON] += sc->data[SC_PROVIDENCE]->val2;
 		}
-		if(sc->data[SC_ARMOR_ELEMENT]) {	// This status change should grant card-type elemental resist.
-			sd->subele[ELE_WATER] += sc->data[SC_ARMOR_ELEMENT]->val1;
-			sd->subele[ELE_EARTH] += sc->data[SC_ARMOR_ELEMENT]->val2;
-			sd->subele[ELE_FIRE] += sc->data[SC_ARMOR_ELEMENT]->val3;
-			sd->subele[ELE_WIND] += sc->data[SC_ARMOR_ELEMENT]->val4;
-		}
-		if(sc->data[SC_ARMOR_RESIST]) { // Undead Scroll
-			sd->subele[ELE_WATER] += sc->data[SC_ARMOR_RESIST]->val1;
-			sd->subele[ELE_EARTH] += sc->data[SC_ARMOR_RESIST]->val2;
-			sd->subele[ELE_FIRE] += sc->data[SC_ARMOR_RESIST]->val3;
-			sd->subele[ELE_WIND] += sc->data[SC_ARMOR_RESIST]->val4;
-		}
-		if( sc->data[SC_FIRE_CLOAK_OPTION] ) {
-			i = sc->data[SC_FIRE_CLOAK_OPTION]->val2;
-			sd->subele[ELE_FIRE] += i;
-			sd->subele[ELE_WATER] -= i;
-		}
-		if( sc->data[SC_WATER_DROP_OPTION] ) {
-			i = sc->data[SC_WATER_DROP_OPTION]->val2;
-			sd->subele[ELE_WATER] += i;
-			sd->subele[ELE_WIND] -= i;
-		}
-		if( sc->data[SC_WIND_CURTAIN_OPTION] ) {
-			i = sc->data[SC_WIND_CURTAIN_OPTION]->val2;
-			sd->subele[ELE_WIND] += i;
-			sd->subele[ELE_EARTH] -= i;
-		}
-		if( sc->data[SC_STONE_SHIELD_OPTION] ) {
-			i = sc->data[SC_STONE_SHIELD_OPTION]->val2;
-			sd->subele[ELE_EARTH] += i;
-			sd->subele[ELE_FIRE] -= i;
-		}
-		if (sc->data[SC_MTF_MLEATKED] )
-			sd->subele[ELE_NEUTRAL] += sc->data[SC_MTF_MLEATKED]->val3;
 		if (sc->data[SC_MTF_CRIDAMAGE])
 			sd->bonus.crit_atk_rate += sc->data[SC_MTF_CRIDAMAGE]->val1;
-		if( sc->data[SC_FIRE_INSIGNIA] && sc->data[SC_FIRE_INSIGNIA]->val1 == 3 )
-			sd->magic_addele[ELE_FIRE] += 25;
-		if( sc->data[SC_WATER_INSIGNIA] && sc->data[SC_WATER_INSIGNIA]->val1 == 3 )
-			sd->magic_addele[ELE_WATER] += 25;
-		if( sc->data[SC_WIND_INSIGNIA] && sc->data[SC_WIND_INSIGNIA]->val1 == 3 )
-			sd->magic_addele[ELE_WIND] += 25;
-		if( sc->data[SC_EARTH_INSIGNIA] && sc->data[SC_EARTH_INSIGNIA]->val1 == 3 )
-			sd->magic_addele[ELE_EARTH] += 25;
 	}
 	status_cpy(&sd->battle_status, base_status);
 
@@ -3799,6 +3734,121 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 	calculating = 0;
 
 	return 0;
+}
+
+/**
+ * Calculate attack bonus of element attack for BL_PC.
+ * Any SC that listed here, has minimal SCB_ATK_ELE flag.
+ * @param sd
+ * @param sc
+ **/
+void status_calc_atk_ele_pc(struct map_session_data *sd, struct status_change *sc) {
+	int i = 0;
+
+	nullpo_retv(sd);
+	nullpo_retv(sc);
+	
+	memset(sd->magic_addele, 0, sizeof(sd->magic_addele));
+	memset(sd->right_weapon.addele, 0, sizeof(sd->right_weapon.addele));
+	memset(sd->left_weapon.addele, 0, sizeof(sd->left_weapon.addele));
+
+	if ((i = pc_checkskill(sd, AB_EUCHARISTICA)) > 0) {
+		sd->right_weapon.addele[ELE_DARK] += i;
+		sd->left_weapon.addele[ELE_DARK] += i;
+		sd->magic_addele[ELE_DARK] += i;
+	}
+
+	if (sc->data[SC_FIRE_INSIGNIA] && sc->data[SC_FIRE_INSIGNIA]->val1 == 3)
+		sd->magic_addele[ELE_FIRE] += 25;
+	if (sc->data[SC_WATER_INSIGNIA] && sc->data[SC_WATER_INSIGNIA]->val1 == 3)
+		sd->magic_addele[ELE_WATER] += 25;
+	if (sc->data[SC_WIND_INSIGNIA] && sc->data[SC_WIND_INSIGNIA]->val1 == 3)
+		sd->magic_addele[ELE_WIND] += 25;
+	if (sc->data[SC_EARTH_INSIGNIA] && sc->data[SC_EARTH_INSIGNIA]->val1 == 3)
+		sd->magic_addele[ELE_EARTH] += 25;
+}
+
+/**
+ * Calculate defense bonus againts element attack for BL_PC.
+ * Any SC that listed here, has minimal SCB_DEF_ELE flag.
+ * @param sd
+ * @param sc
+ **/
+void status_calc_def_ele_pc(struct map_session_data *sd, struct status_change *sc) {
+	int i = 0;
+
+	nullpo_retv(sd);
+	nullpo_retv(sc);
+
+	memset(sd->subele, 0, sizeof(sd->subele));
+
+	if ((i = pc_checkskill(sd,CR_TRUST))>0)
+		sd->subele[ELE_HOLY] += i * 5;
+
+	if ((i = pc_checkskill(sd,BS_SKINTEMPER))>0) {
+		sd->subele[ELE_NEUTRAL] += i;
+		sd->subele[ELE_FIRE] += i * 4;
+	}
+
+	if ((i = pc_checkskill(sd, AB_EUCHARISTICA)) > 0)
+		sd->subele[ELE_DARK] += i;
+
+	if (sc->data[SC_SIEGFRIED]) {
+		i = sc->data[SC_SIEGFRIED]->val2;
+		sd->subele[ELE_WATER] += i;
+		sd->subele[ELE_EARTH] += i;
+		sd->subele[ELE_FIRE] += i;
+		sd->subele[ELE_WIND] += i;
+		sd->subele[ELE_POISON] += i;
+		sd->subele[ELE_HOLY] += i;
+		sd->subele[ELE_DARK] += i;
+		sd->subele[ELE_GHOST] += i;
+		sd->subele[ELE_UNDEAD] += i;
+	}
+
+	if (sc->data[SC_PROVIDENCE])
+		sd->subele[ELE_HOLY] += sc->data[SC_PROVIDENCE]->val2;
+
+	if (sc->data[SC_ARMOR_ELEMENT]) {	// This status change should grant card-type elemental resist.
+		sd->subele[ELE_WATER] += sc->data[SC_ARMOR_ELEMENT]->val1;
+		sd->subele[ELE_EARTH] += sc->data[SC_ARMOR_ELEMENT]->val2;
+		sd->subele[ELE_FIRE] += sc->data[SC_ARMOR_ELEMENT]->val3;
+		sd->subele[ELE_WIND] += sc->data[SC_ARMOR_ELEMENT]->val4;
+	}
+
+	if (sc->data[SC_ARMOR_RESIST]) { // Undead Scroll
+		sd->subele[ELE_WATER] += sc->data[SC_ARMOR_RESIST]->val1;
+		sd->subele[ELE_EARTH] += sc->data[SC_ARMOR_RESIST]->val2;
+		sd->subele[ELE_FIRE] += sc->data[SC_ARMOR_RESIST]->val3;
+		sd->subele[ELE_WIND] += sc->data[SC_ARMOR_RESIST]->val4;
+	}
+
+	if (sc->data[SC_FIRE_CLOAK_OPTION]) {
+		i = sc->data[SC_FIRE_CLOAK_OPTION]->val2;
+		sd->subele[ELE_FIRE] += i;
+		sd->subele[ELE_WATER] -= i;
+	}
+
+	if (sc->data[SC_WATER_DROP_OPTION]) {
+		i = sc->data[SC_WATER_DROP_OPTION]->val2;
+		sd->subele[ELE_WATER] += i;
+		sd->subele[ELE_WIND] -= i;
+	}
+
+	if (sc->data[SC_WIND_CURTAIN_OPTION]) {
+		i = sc->data[SC_WIND_CURTAIN_OPTION]->val2;
+		sd->subele[ELE_WIND] += i;
+		sd->subele[ELE_EARTH] -= i;
+	}
+
+	if (sc->data[SC_STONE_SHIELD_OPTION]) {
+		i = sc->data[SC_STONE_SHIELD_OPTION]->val2;
+		sd->subele[ELE_EARTH] += i;
+		sd->subele[ELE_FIRE] -= i;
+	}
+
+	if (sc->data[SC_MTF_MLEATKED])
+		sd->subele[ELE_NEUTRAL] += sc->data[SC_MTF_MLEATKED]->val3;
 }
 
 /**
@@ -4528,14 +4578,20 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 
 	if(flag&SCB_ATK_ELE) {
 		status->rhw.ele = status_calc_attack_element(bl, sc, b_status->rhw.ele);
-		if (sd) sd->state.lr_flag = 1;
+		if (sd)
+			sd->state.lr_flag = 1;
 		status->lhw.ele = status_calc_attack_element(bl, sc, b_status->lhw.ele);
-		if (sd) sd->state.lr_flag = 0;
+		if (sd)
+			sd->state.lr_flag = 0;
+		if (sd && sc && sc->count)
+			status_calc_atk_ele_pc(sd, sc);
 	}
 
 	if(flag&SCB_DEF_ELE) {
 		status->def_ele = status_calc_element(bl, sc, b_status->def_ele);
 		status->ele_lv = status_calc_element_lv(bl, sc, b_status->ele_lv);
+		if (sd && sc && sc->count)
+			status_calc_def_ele_pc(sd, sc);
 	}
 
 	if(flag&SCB_MODE) {

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3748,19 +3748,19 @@ void status_calc_atk_ele_pc(struct map_session_data *sd, struct status_change *s
 	int i = 0;
 
 	nullpo_retv(sd);
-	
+
 	memset(sd->magic_addele, 0, sizeof(sd->magic_addele));
 	memset(sd->right_weapon.addele, 0, sizeof(sd->right_weapon.addele));
 	memset(sd->left_weapon.addele, 0, sizeof(sd->left_weapon.addele));
-
-	if (!sc || !sc->count)
-		return;
 
 	if ((i = pc_checkskill(sd, AB_EUCHARISTICA)) > 0) {
 		sd->right_weapon.addele[ELE_DARK] += i;
 		sd->left_weapon.addele[ELE_DARK] += i;
 		sd->magic_addele[ELE_DARK] += i;
 	}
+
+	if (!sc || !sc->count)
+		return;
 
 	if (sc->data[SC_FIRE_INSIGNIA] && sc->data[SC_FIRE_INSIGNIA]->val1 == 3)
 		sd->magic_addele[ELE_FIRE] += 25;
@@ -3785,9 +3785,6 @@ void status_calc_def_ele_pc(struct map_session_data *sd, struct status_change *s
 
 	memset(sd->subele, 0, sizeof(sd->subele));
 
-	if (!sc || !sc->count)
-		return;
-
 	if ((i = pc_checkskill(sd,CR_TRUST))>0)
 		sd->subele[ELE_HOLY] += i * 5;
 
@@ -3798,6 +3795,9 @@ void status_calc_def_ele_pc(struct map_session_data *sd, struct status_change *s
 
 	if ((i = pc_checkskill(sd, AB_EUCHARISTICA)) > 0)
 		sd->subele[ELE_DARK] += i;
+
+	if (!sc || !sc->count)
+		return;
 
 	if (sc->data[SC_SIEGFRIED]) {
 		i = sc->data[SC_SIEGFRIED]->val2;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3029,6 +3029,7 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 	memset (sd->param_bonus, 0, sizeof(sd->param_bonus)
 		+ sizeof(sd->param_equip)
 		+ sizeof(sd->subele)
+		+ sizeof(sd->subele_script)
 		+ sizeof(sd->subdefele)
 		+ sizeof(sd->subrace)
 		+ sizeof(sd->subclass)
@@ -3047,6 +3048,7 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 		+ sizeof(sd->arrow_addclass)
 		+ sizeof(sd->arrow_addsize)
 		+ sizeof(sd->magic_addele)
+		+ sizeof(sd->magic_addele_script)
 		+ sizeof(sd->magic_addrace)
 		+ sizeof(sd->magic_addclass)
 		+ sizeof(sd->magic_addsize)
@@ -3746,11 +3748,13 @@ void status_calc_atk_ele_pc(struct map_session_data *sd, struct status_change *s
 	int i = 0;
 
 	nullpo_retv(sd);
-	nullpo_retv(sc);
 	
 	memset(sd->magic_addele, 0, sizeof(sd->magic_addele));
 	memset(sd->right_weapon.addele, 0, sizeof(sd->right_weapon.addele));
 	memset(sd->left_weapon.addele, 0, sizeof(sd->left_weapon.addele));
+
+	if (!sc || !sc->count)
+		return;
 
 	if ((i = pc_checkskill(sd, AB_EUCHARISTICA)) > 0) {
 		sd->right_weapon.addele[ELE_DARK] += i;
@@ -3778,9 +3782,11 @@ void status_calc_def_ele_pc(struct map_session_data *sd, struct status_change *s
 	int i = 0;
 
 	nullpo_retv(sd);
-	nullpo_retv(sc);
 
 	memset(sd->subele, 0, sizeof(sd->subele));
+
+	if (!sc || !sc->count)
+		return;
 
 	if ((i = pc_checkskill(sd,CR_TRUST))>0)
 		sd->subele[ELE_HOLY] += i * 5;
@@ -4581,16 +4587,16 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 		if (sd)
 			sd->state.lr_flag = 1;
 		status->lhw.ele = status_calc_attack_element(bl, sc, b_status->lhw.ele);
-		if (sd)
+		if (sd) {
 			sd->state.lr_flag = 0;
-		if (sd && sc && sc->count)
 			status_calc_atk_ele_pc(sd, sc);
+		}
 	}
 
 	if(flag&SCB_DEF_ELE) {
 		status->def_ele = status_calc_element(bl, sc, b_status->def_ele);
 		status->ele_lv = status_calc_element_lv(bl, sc, b_status->ele_lv);
-		if (sd && sc && sc->count)
+		if (sd)
 			status_calc_def_ele_pc(sd, sc);
 	}
 


### PR DESCRIPTION
* Fixed 'Elemental Resistance Potions' doesn't work without changing any equipment.
* Moved player's Elemental resistance & attack bonus from `status_calc_pc_` that need `SCB_BASE` to `status_calc_atk_ele_pc` and `status_calc_def_ele_pc` as a child of `SCB_ATK_ELE` and `SCB_DEF_ELE` (doesn't need to calculate everything just for these points)