### PR TITLE
Trap Settings

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -119,11 +119,11 @@ skill_nofootset: 1
 // Default on official servers: 1 (for players)
 gvg_traps_target_all: 1
 
-// Hunter's traps visibility setting:
-// 1: (Official) Many of Hunter's traps are invisible at all times.
-//    But any player who see the Hunter laying the trap will be able to see the trap until they move out of sight of it.
-//    Although, invisible traps can be revealed through Hunter's Detecting skill.
-traps_setting: 1
+// Traps visibility setting (trap with UF_HIDDEN_TRAP flag):
+// 0 = Always visible
+// 1 = Enable invisibility in versus maps (GVG/PVP/BG)
+// 2 = Enable invisibility in all maps
+traps_setting: 0
 
 // Restrictions applied to the Alchemist's Summon Flora skill (add as necessary)
 // 1: Enable players to damage the floras outside of versus grounds.

--- a/db/pre-re/skill_unit_db.txt
+++ b/db/pre-re/skill_unit_db.txt
@@ -23,6 +23,7 @@
 //      0x04000(UF_REM_CRAZYWEED)		Removed if be overlapped by GN_CRAZYWEED
 //      0x08000(UF_REM_FIRERAIN)		Removed if be overlapped by RL_FIRE_RAIN
 //      0x10000(UF_KNOCKBACK_GROUP) 	Knock back a whole skill group (by default, skill unit is knocked back each unit)
+//      0x20000(UF_HIDDEN_TRAP) 		Hidden trap, see 'traps_setting' skill config to enable this flag
 // 	Example: 0x006 = 0x002+0x004 -> Cannot be stacked nor cast near targets
 //
 // Notes:

--- a/db/re/skill_unit_db.txt
+++ b/db/re/skill_unit_db.txt
@@ -23,6 +23,7 @@
 //      0x04000(UF_REM_CRAZYWEED)		Removed if be overlapped by GN_CRAZYWEED
 //      0x08000(UF_REM_FIRERAIN)		Removed if be overlapped by RL_FIRE_RAIN
 //      0x10000(UF_KNOCKBACK_GROUP) 	Knock back a whole skill group (by default, skill unit is knocked back each unit)
+//      0x20000(UF_HIDDEN_TRAP) 		Hidden trap, see 'traps_setting' skill config to enable this flag
 // 	Example: 0x006 = 0x002+0x004 -> Cannot be stacked nor cast near targets
 //
 // Notes:
@@ -47,16 +48,16 @@
  89,0x86,    ,  4, 1, 450,enemy, 0x018	//WZ_STORMGUST
  91,0x86,    ,  2, 0,1000,enemy, 0x010	//WZ_HEAVENDRIVE
  92,0x8e,    ,  2, 0,  -1,enemy, 0x8010	//WZ_QUAGMIRE
-115,0x90,    ,  0, 1,1000,enemy, 0x8006	//HT_SKIDTRAP
-116,0x93,    ,  0, 1,1000,enemy, 0x8006	//HT_LANDMINE
-117,0x91,    ,  0, 1,1000,enemy, 0x9006	//HT_ANKLESNARE
-118,0x94,    ,  0, 1,1000,enemy, 0x8006	//HT_SHOCKWAVE
-119,0x95,    ,  0, 1,1000,enemy, 0x8006	//HT_SANDMAN
-120,0x96,    ,  0, 1,1000,enemy, 0x8006	//HT_FLASHER
-121,0x97,    ,  0, 1,1000,enemy, 0x8006	//HT_FREEZINGTRAP
+115,0x90,    ,  0, 1,1000,enemy, 0x28006	//HT_SKIDTRAP
+116,0x93,    ,  0, 1,1000,enemy, 0x28006	//HT_LANDMINE
+117,0x91,    ,  0, 1,1000,enemy, 0x29006	//HT_ANKLESNARE
+118,0x94,    ,  0, 1,1000,enemy, 0x28006	//HT_SHOCKWAVE
+119,0x95,    ,  0, 1,1000,enemy, 0x28006	//HT_SANDMAN
+120,0x96,    ,  0, 1,1000,enemy, 0x28006	//HT_FLASHER
+121,0x97,    ,  0, 1,1000,enemy, 0x28006	//HT_FREEZINGTRAP
 122,0x8f,    ,  0, 1,1000,enemy, 0x8006	//HT_BLASTMINE
 123,0x98,    ,  0, 1,1000,enemy, 0x8006	//HT_CLAYMORETRAP
-125,0x99,    ,  0, 1,1000,all,   0x8000	//HT_TALKIEBOX
+125,0x99,    ,  0, 1,1000,all,   0x28000	//HT_TALKIEBOX
 140,0x92,    , -1, 1,1000,enemy, 0x8000	//AS_VENOMDUST
 220,0xb0,    ,  0, 0,  -1,all,   0x8002	//RG_GRAFFITI
 229,0xb1,    ,  0, 1, 500,enemy, 0x006	//AM_DEMONSTRATION

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -7747,7 +7747,7 @@ static const struct _battle_data {
 	{ "player_damage_delay_rate",           &battle_config.pc_damage_delay_rate,            100,    0,      INT_MAX,        },
 	{ "defunit_not_enemy",                  &battle_config.defnotenemy,                     0,      0,      1,              },
 	{ "gvg_traps_target_all",               &battle_config.vs_traps_bctall,                 BL_PC,  BL_NUL, BL_ALL,         },
-	{ "traps_setting",                      &battle_config.traps_setting,                   0,      0,      1,              },
+	{ "traps_setting",                      &battle_config.traps_setting,                   0,      0,      2,              },
 	{ "summon_flora_setting",               &battle_config.summon_flora,                    1|2,    0,      1|2,            },
 	{ "clear_skills_on_death",              &battle_config.clear_unit_ondeath,              BL_NUL, BL_NUL, BL_ALL,         },
 	{ "clear_skills_on_warp",               &battle_config.clear_unit_onwarp,               BL_ALL, BL_NUL, BL_ALL,         },

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -613,7 +613,7 @@ void clif_cooking_list(struct map_session_data *sd, int trigger, uint16 skill_id
 
 void clif_produceeffect(struct map_session_data* sd,int flag, unsigned short nameid);
 
-void clif_getareachar_skillunit(struct block_list *bl, struct skill_unit *unit, enum send_target target, uint8 flag);
+void clif_getareachar_skillunit(struct block_list *bl, struct skill_unit *unit, enum send_target target, bool visible);
 void clif_skill_delunit(struct skill_unit *unit);
 void clif_skillunit_update(struct block_list* bl);
 

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -4229,9 +4229,11 @@ static int skill_reveal_trap(struct block_list *bl, va_list ap)
  * @param range Affected range
  * @param x
  * @param y
- * TODO: Remove this hardcodes
+ * TODO: Remove hardcode usages for this function
  **/
 void skill_reveal_trap_inarea(struct block_list *src, int range, int x, int y) {
+	if (!battle_config.traps_setting)
+		return;
 	nullpo_retv(src);
 	map_foreachinarea(skill_reveal_trap, src->m, x-range, y-range, x+range, y+range, BL_SKILL);
 }

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -291,7 +291,9 @@ struct skill_unit {
 	struct skill_unit_group *group; /// Skill group reference
 	int limit;
 	int val1, val2;
-	short alive, range;
+	short range;
+	unsigned alive : 1;
+	unsigned hidden : 1;
 };
 
 #define MAX_SKILLUNITGROUPTICKSET 25
@@ -319,6 +321,7 @@ enum e_skill_unit_flag {
 	UF_REM_CRAZYWEED    = 0x04000,	// removed by Crazyweed
 	UF_REM_FIRERAIN     = 0x08000,	// removed by Fire Rain
 	UF_KNOCKBACK_GROUP  = 0x10000,	// knockback skill unit with its group instead of single unit
+	UF_HIDDEN_TRAP      = 0x20000,	// Hidden trap [Cydh]
 };
 
 /// Create Database item
@@ -431,7 +434,7 @@ int skill_strip_equip(struct block_list *src,struct block_list *bl, unsigned sho
 // Skills unit
 struct skill_unit_group *skill_id2group(int group_id);
 struct skill_unit_group *skill_unitsetting(struct block_list* src, uint16 skill_id, uint16 skill_lv, short x, short y, int flag);
-struct skill_unit *skill_initunit (struct skill_unit_group *group, int idx, int x, int y, int val1, int val2);
+struct skill_unit *skill_initunit (struct skill_unit_group *group, int idx, int x, int y, int val1, int val2, bool hidden);
 int skill_delunit(struct skill_unit *unit);
 struct skill_unit_group *skill_initunitgroup(struct block_list* src, int count, uint16 skill_id, uint16 skill_lv, int unit_id, int limit, int interval);
 int skill_delunitgroup_(struct skill_unit_group *group, const char* file, int line, const char* func);
@@ -440,6 +443,10 @@ void skill_clear_unitgroup(struct block_list *src);
 int skill_clear_group(struct block_list *bl, int flag);
 void ext_skill_unit_onplace(struct skill_unit *unit, struct block_list *bl, unsigned int tick);
 int64 skill_unit_ondamaged(struct skill_unit *unit,int64 damage);
+
+// Skill unit visibility [Cydh]
+void skill_getareachar_skillunit_visibilty(struct skill_unit *su, enum send_target target);
+void skill_getareachar_skillunit_visibilty_single(struct skill_unit *su, struct block_list *bl);
 
 int skill_castfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv);
 int skill_castfix_sc(struct block_list *bl, double time, uint8 flag);

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -2080,6 +2080,8 @@ bool skill_is_combo(uint16 skill_id);
 void skill_combo_toogle_inf(struct block_list* bl, uint16 skill_id, int inf);
 void skill_combo(struct block_list* src,struct block_list *dsrc, struct block_list *bl, uint16 skill_id, uint16 skill_lv, int tick);
 
+void skill_reveal_trap_inarea(struct block_list *src, int range, int x, int y);
+
 #ifdef ADJUST_SKILL_DAMAGE
 /// Skill Damage target
 enum e_skill_damage_caster {

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -11812,8 +11812,10 @@ int status_change_timer(int tid, unsigned int tick, int id, intptr_t data)
 			if(sce->val4%2)
 				sce->val4--;
 			map_foreachinrange( status_change_timer_sub, bl, sce->val3, BL_CHAR|BL_SKILL, bl, sce, type, tick);
-		} else
+		} else {
 			map_foreachinrange( status_change_timer_sub, bl, sce->val3, BL_CHAR, bl, sce, type, tick);
+			skill_reveal_trap_inarea(bl, sce->val3, bl->x, bl->y);
+		}
 
 		if( --(sce->val2)>0 ) {
 			sce->val4 += 20; // Use for Shadow Form 2 seconds checking.


### PR DESCRIPTION
* Changed `traps_setting` config values.
  * 0 = Always visible (default)
  * 1 = Enable invisibility in versus maps (GVG/PVP/BG)
  * 2 = Enable invisibility in all maps
* Added skill unit flag `UF_HIDDEN_TRAP 0x20000` for trap invisibilty.
* Added some skills and effects that can reveal hidden traps. Sight, Ruwach, and Improve Concentration can reveal hidden traps.