### PR TITLE
Fix chat related issue on 2015-10-29 clients. Fixes #1000.

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -9803,7 +9803,10 @@ static bool clif_process_message(struct map_session_data* sd, int format, char**
 	}
 
 #if PACKETVER >= 20151001
-	message[messagelen++] = '\0';
+	if (message[messagelen-1] != '\0')
+	{
+		message[messagelen++] = '\0';
+	}
 #endif
 
 	// the declared length must match real length


### PR DESCRIPTION
Some special chat messages e.g. Frost Joke are already null-terminated. We don't have to add more null byte.

Fix last letter in party chat get cut.