### PR TITLE
Refresh client-side stats when equipping items with {script} instead of {OnEquip} Fix for issue #131

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -3801,6 +3801,14 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 		clif_updatestatus(sd,SP_CARTINFO);
 	}
 
+        //FIX FOR {SCRIPT} giving haywired stats on weapons/armors when using sc_start[Ninja]
+        clif_updatestatus(sd,SP_STR);
+        clif_updatestatus(sd,SP_AGI);
+        clif_updatestatus(sd,SP_VIT);
+        clif_updatestatus(sd,SP_INT);
+        clif_updatestatus(sd,SP_DEX);
+        clif_updatestatus(sd,SP_LUK);
+
 	calculating = 0;
 
 	return 0;


### PR DESCRIPTION
Problem tested, reproduced and confirmed.
Mostly client-sided and does not affect anything stat-related. Can be worked around by using @refresh command in-game.