### PR TITLE
Fix to NPC [Larissa#mos_01] in script [npc/quests/quests_moscovia.txt]

### DIFF
--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -4001,7 +4001,7 @@ mosk_in,211,259,5	script	Larissa#mos_01	4_F_RUSWOMAN2,{
 				}
 				setarray .@di[0],7031,1,519,2,504,2,548,1,1019,1,518,1;
 				for (.@i = 0; .@i < getarraysize(.@di); .@i += 2)
-					delitem .@n[.@i],.@n[.@i+1];
+					delitem .@di[.@i],.@di[.@i+1];
 				getitem .@n[0],.@n[1];
 				close;
 			}


### PR DESCRIPTION
Fix to NPC [Larissa#mos_01] in script [npc/quests/quests_moscovia.txt] from [Help Mikhail] Quest.

delitem script uses ".@di" array instead of ".@n" array.