### PR TITLE
Refactored the EQI constants

### DIFF
--- a/db/const.txt
+++ b/db/const.txt
@@ -14,30 +14,6 @@
 //                  in field Value. Depending on the implementation values assigned by scripts to parameters will affect
 //                  runtime values, such as Zeny, as well (see pc_readparam/pc_setparam).
 
-// These EQI_ constants do not match with the source EQI_ constants
-// Do not migrate into script_constants.h right now [Lemongrass]
-EQI_HEAD_TOP	1
-EQI_ARMOR	2
-EQI_HAND_L	3
-EQI_HAND_R	4
-EQI_GARMENT	5
-EQI_SHOES	6
-EQI_ACC_L	7
-EQI_ACC_R	8
-EQI_HEAD_MID	9
-EQI_HEAD_LOW	10
-EQI_COSTUME_HEAD_LOW	11
-EQI_COSTUME_HEAD_MID	12
-EQI_COSTUME_HEAD_TOP	13
-EQI_COSTUME_GARMENT	14
-EQI_AMMO	15
-EQI_SHADOW_ARMOR  16
-EQI_SHADOW_WEAPON  17
-EQI_SHADOW_SHIELD  18
-EQI_SHADOW_SHOES  19
-EQI_SHADOW_ACC_R  20
-EQI_SHADOW_ACC_L  21
-
 //Item Group ID
 IG_BlueBox	1
 IG_VioletBox	2

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -60,8 +60,6 @@ struct fame_list smith_fame_list[MAX_FAME_LIST];
 struct fame_list chemist_fame_list[MAX_FAME_LIST];
 struct fame_list taekwon_fame_list[MAX_FAME_LIST];
 
-static unsigned int equip_pos[EQI_MAX]={EQP_ACC_L,EQP_ACC_R,EQP_SHOES,EQP_GARMENT,EQP_HEAD_LOW,EQP_HEAD_MID,EQP_HEAD_TOP,EQP_ARMOR,EQP_HAND_L,EQP_HAND_R,EQP_COSTUME_HEAD_TOP,EQP_COSTUME_HEAD_MID,EQP_COSTUME_HEAD_LOW,EQP_COSTUME_GARMENT,EQP_AMMO,EQP_SHADOW_ARMOR,EQP_SHADOW_WEAPON,EQP_SHADOW_SHIELD,EQP_SHADOW_SHOES,EQP_SHADOW_ACC_R,EQP_SHADOW_ACC_L};
-
 #define MOTD_LINE_SIZE 128
 static char motd_text[MOTD_LINE_SIZE][CHAT_SIZE_MAX]; // Message of the day buffer [Valaris]
 
@@ -716,7 +714,7 @@ void pc_setequipindex(struct map_session_data *sd)
 		if (sd->status.inventory[i].equip) {
 			uint8 j;
 			for (j = 0; j < EQI_MAX; j++)
-				if (sd->status.inventory[i].equip & equip_pos[j])
+				if (sd->status.inventory[i].equip & equip_bitmask[j])
 					sd->equip_index[j] = i;
 
 			if (sd->status.inventory[i].equip & EQP_HAND_R) {
@@ -5581,7 +5579,7 @@ short pc_checkequip(struct map_session_data *sd,int pos)
 	nullpo_retr(-1, sd);
 
 	for(i=0;i<EQI_MAX;i++){
-		if(pos & equip_pos[i])
+		if(pos & equip_bitmask[i])
 			return sd->equip_index[i];
 	}
 
@@ -5601,7 +5599,7 @@ bool pc_checkequip2(struct map_session_data *sd, unsigned short nameid, int min,
 	int i;
 
 	for(i = min; i < max; i++) {
-		if(equip_pos[i]) {
+		if(equip_bitmask[i]) {
 			int idx = sd->equip_index[i];
 
 			if (sd->status.inventory[idx].nameid == nameid)
@@ -9475,7 +9473,7 @@ bool pc_equipitem(struct map_session_data *sd,short n,int req_pos)
 	}
 
 	for(i=0;i<EQI_MAX;i++) {
-		if(pos & equip_pos[i]) {
+		if(pos & equip_bitmask[i]) {
 			if(sd->equip_index[i] >= 0) //Slot taken, remove item from there.
 				pc_unequipitem(sd,sd->equip_index[i],2);
 
@@ -9659,7 +9657,7 @@ bool pc_unequipitem(struct map_session_data *sd, int n, int flag) {
 		ShowInfo("unequip %d %x:%x\n",n,pc_equippoint(sd,n),sd->status.inventory[n].equip);
 
 	for(i = 0; i < EQI_MAX; i++) {
-		if (sd->status.inventory[n].equip & equip_pos[i])
+		if (sd->status.inventory[n].equip & equip_bitmask[i])
 			sd->equip_index[i] = -1;
 	}
 

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -68,6 +68,35 @@ enum equip_index {
 	EQI_MAX
 };
 
+/**
+ * Translation table from athena equip index to aegis bitmask
+*/
+static unsigned int equip_bitmask[EQI_MAX] = {
+	EQP_ACC_L,				// EQI_ACC_L
+	EQP_ACC_R,				// EQI_ACC_R
+	EQP_SHOES,				// EQI_SHOES
+	EQP_GARMENT,			// EQI_GARMENT
+	EQP_HEAD_LOW,			// EQI_HEAD_LOW
+	EQP_HEAD_MID,			// EQI_HEAD_MID
+	EQP_HEAD_TOP,			// EQI_HEAD_TOP
+	EQP_ARMOR,				// EQI_ARMOR
+	EQP_HAND_L,				// EQI_HAND_L
+	EQP_HAND_R,				// EQI_HAND_R
+	EQP_COSTUME_HEAD_TOP,	// EQI_COSTUME_HEAD_TOP
+	EQP_COSTUME_HEAD_MID,	// EQI_COSTUME_HEAD_MID
+	EQP_COSTUME_HEAD_LOW,	// EQI_COSTUME_HEAD_LOW
+	EQP_COSTUME_GARMENT,	// EQI_COSTUME_GARMENT
+	EQP_AMMO,				// EQI_AMMO
+	EQP_SHADOW_ARMOR,		// EQI_SHADOW_ARMOR
+	EQP_SHADOW_WEAPON,		// EQI_SHADOW_WEAPON
+	EQP_SHADOW_SHIELD,		// EQI_SHADOW_SHIELD
+	EQP_SHADOW_SHOES,		// EQI_SHADOW_SHOES
+	EQP_SHADOW_ACC_R,		// EQI_SHADOW_ACC_R
+	EQP_SHADOW_ACC_L		// EQI_SHADOW_ACC_L
+};
+
+#define equip_index_check(i) ( (i) >= EQI_ACC_L && (i) < EQI_MAX )
+
 struct weapon_data {
 	int atkmods[3];
 	// all the variables except atkmods get zero'ed in each call of status_calc_pc

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -8066,33 +8066,6 @@ BUILDIN_FUNC(strnpcinfo)
 	return SCRIPT_CMD_SUCCESS;
 }
 
-
-/// aegis->athena slot position conversion table
-/// Index is used by EQI_ in db/const.txt
-static unsigned int equip[] = {
-	EQP_HEAD_TOP,
-	EQP_ARMOR,
-	EQP_HAND_L,
-	EQP_HAND_R,
-	EQP_GARMENT,
-	EQP_SHOES,
-	EQP_ACC_L,
-	EQP_ACC_R,
-	EQP_HEAD_MID,
-	EQP_HEAD_LOW,
-	EQP_COSTUME_HEAD_LOW,
-	EQP_COSTUME_HEAD_MID,
-	EQP_COSTUME_HEAD_TOP,
-	EQP_COSTUME_GARMENT,
-	EQP_AMMO,
-	EQP_SHADOW_ARMOR,
-	EQP_SHADOW_WEAPON,
-	EQP_SHADOW_SHIELD,
-	EQP_SHADOW_SHOES,
-	EQP_SHADOW_ACC_R,
-	EQP_SHADOW_ACC_L
-};
-
 /**
  * getequipid(<equipment slot>{,<char_id>})
  **/
@@ -8107,15 +8080,15 @@ BUILDIN_FUNC(getequipid)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	num = script_getnum(st,2) - 1;
-	if( num < 0 || num >= ARRAYLENGTH(equip) )
+	num = script_getnum(st,2);
+	if( !equip_index_check(num) )
 	{
 		script_pushint(st,-1);
 		return SCRIPT_CMD_FAILURE;
 	}
 
 	// get inventory position of item
-	i = pc_checkequip(sd,equip[num]);
+	i = pc_checkequip(sd,equip_bitmask[num]);
 	if( i < 0 )
 	{
 		script_pushint(st,-1);
@@ -8145,14 +8118,14 @@ BUILDIN_FUNC(getequipuniqueid)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	num = script_getnum(st,2) - 1;
-	if (num < 0 || num >= ARRAYLENGTH(equip)) {
+	num = script_getnum(st,2);
+	if ( !equip_index_check(num) ) {
 		script_pushconststr(st, "");
 		return SCRIPT_CMD_FAILURE;
 	}
 
 	// get inventory position of item
-	i = pc_checkequip(sd,equip[num]);
+	i = pc_checkequip(sd,equip_bitmask[num]);
 	if (i < 0) {
 		script_pushconststr(st, "");
 		return SCRIPT_CMD_FAILURE;
@@ -8189,15 +8162,15 @@ BUILDIN_FUNC(getequipname)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	num = script_getnum(st,2) - 1;
-	if( num < 0 || num >= ARRAYLENGTH(equip) )
+	num = script_getnum(st,2);
+	if( !equip_index_check(num) )
 	{
 		script_pushconststr(st,"");
 		return SCRIPT_CMD_SUCCESS;
 	}
 
 	// get inventory position of item
-	i = pc_checkequip(sd,equip[num]);
+	i = pc_checkequip(sd,equip_bitmask[num]);
 	if( i < 0 )
 	{
 		script_pushconststr(st,"");
@@ -8317,8 +8290,8 @@ BUILDIN_FUNC(getequipisequiped)
 	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (num >= EQI_ACC_L && num < EQI_MAX)
+		i=pc_checkequip(sd,num);
 
 	if(i >= 0)
 		script_pushint(st,1);
@@ -8347,8 +8320,8 @@ BUILDIN_FUNC(getequipisenableref)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if( num > 0 && num <= ARRAYLENGTH(equip) )
-		i = pc_checkequip(sd,equip[num-1]);
+	if( equip_index_check(num) )
+		i = pc_checkequip(sd,equip_bitmask[num]);
 	if( i >= 0 && sd->inventory_data[i] && !sd->inventory_data[i]->flag.no_refine && !sd->status.inventory[i].expire_time )
 		script_pushint(st,1);
 	else
@@ -8376,8 +8349,8 @@ BUILDIN_FUNC(getequiprefinerycnt)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 	if(i >= 0)
 		script_pushint(st,sd->status.inventory[i].refine);
 	else
@@ -8406,8 +8379,8 @@ BUILDIN_FUNC(getequipweaponlv)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 	if(i >= 0 && sd->inventory_data[i])
 		script_pushint(st,sd->inventory_data[i]->wlv);
 	else
@@ -8435,8 +8408,8 @@ BUILDIN_FUNC(getequippercentrefinery)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i = pc_checkequip(sd,equip_bitmask[num]);
 	if(i >= 0 && sd->status.inventory[i].nameid && sd->status.inventory[i].refine < MAX_REFINE)
 		script_pushint(st,status_get_refine_chance((enum refine_type)itemdb_wlv(sd->status.inventory[i].nameid), (int)sd->status.inventory[i].refine));
 	else
@@ -8464,8 +8437,8 @@ BUILDIN_FUNC(successrefitem) {
 	if (script_hasdata(st, 3))
 		up = script_getnum(st, 3);
 
-	if (pos > 0 && pos <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos))
+		i = pc_checkequip(sd,equip_bitmask[pos]);
 	if (i >= 0) {
 		unsigned int ep = sd->status.inventory[i].equip;
 
@@ -8531,8 +8504,8 @@ BUILDIN_FUNC(failedrefitem) {
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (pos > 0 && pos <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos))
+		i = pc_checkequip(sd,equip_bitmask[pos]);
 	if (i >= 0) {
 		sd->status.inventory[i].refine = 0;
 		pc_unequipitem(sd,i,3); //recalculate bonus
@@ -8566,8 +8539,8 @@ BUILDIN_FUNC(downrefitem) {
 	if (script_hasdata(st, 3))
 		down = script_getnum(st, 3);
 
-	if (pos > 0 && pos <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos))
+		i = pc_checkequip(sd,equip_bitmask[pos]);
 	if (i >= 0) {
 		unsigned int ep = sd->status.inventory[i].equip;
 
@@ -8612,8 +8585,8 @@ BUILDIN_FUNC(delequip) {
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (pos > 0 && pos <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos))
+		i = pc_checkequip(sd,equip_bitmask[pos]);
 	if (i >= 0) {
 		pc_unequipitem(sd,i,3); //recalculate bonus
 		ret = !(pc_delitem(sd,i,1,0,2,LOG_TYPE_SCRIPT));
@@ -8641,8 +8614,8 @@ BUILDIN_FUNC(breakequip) {
 	if (!script_charid2sd(3,sd))
 		return SCRIPT_CMD_FAILURE;
 
-	if (pos > 0 && pos <= ARRAYLENGTH(equip))
-		i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos))
+		i = pc_checkequip(sd,equip_bitmask[pos]);
 	if (i >= 0) {
 		sd->status.inventory[i].attribute = 1;
 		pc_unequipitem(sd,i,3);
@@ -12441,8 +12414,8 @@ BUILDIN_FUNC(getequipcardcnt)
 
 	num=script_getnum(st,2);
 	sd=script_rid2sd(st);
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 
 	if (i < 0 || !sd->inventory_data[i]) {
 		script_pushint(st,0);
@@ -12473,8 +12446,8 @@ BUILDIN_FUNC(successremovecards) {
 	TBL_PC* sd = script_rid2sd(st);
 	int num = script_getnum(st,2);
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 
 	if (i < 0 || !sd->inventory_data[i]) {
 		return SCRIPT_CMD_SUCCESS;
@@ -12538,8 +12511,8 @@ BUILDIN_FUNC(failedremovecards) {
 	int num = script_getnum(st,2);
 	int typefail = script_getnum(st,3);
 
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 
 	if (i < 0 || !sd->inventory_data[i])
 		return SCRIPT_CMD_SUCCESS;
@@ -13158,8 +13131,8 @@ BUILDIN_FUNC(getequipcardid)
 	num=script_getnum(st,2);
 	slot=script_getnum(st,3);
 	sd=script_rid2sd(st);
-	if (num > 0 && num <= ARRAYLENGTH(equip))
-		i=pc_checkequip(sd,equip[num-1]);
+	if (equip_index_check(num))
+		i=pc_checkequip(sd,equip_bitmask[num]);
 	if(i >= 0 && slot>=0 && slot<4)
 		script_pushint(st,sd->status.inventory[i].card[slot]);
 	else
@@ -14867,8 +14840,8 @@ BUILDIN_FUNC(unequip) {
 		return SCRIPT_CMD_FAILURE;
 
 	pos = script_getnum(st,2);
-	if (pos >= 1 && pos <= ARRAYLENGTH(equip)) {
-		short i = pc_checkequip(sd,equip[pos-1]);
+	if (equip_index_check(pos)) {
+		short i = pc_checkequip(sd,equip_bitmask[pos]);
 		if (i >= 0) {
 			pc_unequipitem(sd,i,1|2);
 			script_pushint(st, 1);

--- a/src/map/script_constants.h
+++ b/src/map/script_constants.h
@@ -652,10 +652,8 @@
 	script_set_constant("bSubDefEle",SP_SUBDEF_ELE,false);
 	script_set_constant("bStateNoRecoverRace",SP_STATE_NORECOVER_RACE,false);
 	script_set_constant("bCriticalLong",SP_CRITICAL_RANGEATK,false);
-
+	
 	/* equip positions */
-	// Disabled as long as we did not clean the EQI_/EQP_ mess up [Lemongrass]
-	/*
 	export_constant(EQI_HEAD_TOP);
 	export_constant(EQI_ARMOR);
 	export_constant(EQI_HAND_L);
@@ -677,7 +675,6 @@
 	export_constant(EQI_SHADOW_SHOES);
 	export_constant(EQI_SHADOW_ACC_R);
 	export_constant(EQI_SHADOW_ACC_L);
-	*/
 
 	/* looks */
 	export_constant(LOOK_BASE);


### PR DESCRIPTION
The EQI constants of the constants database did not match the ones used in the source up to now.
For whatever reason long long ago an array was created which mapped the const_db EQI constants to the source's EQP constant(aegis bitmasks).
With this commit we now use the already existing array from pc.h(which was moved from pc.c to be accessible).