### PR TITLE
Aqua Benedicta/Water Ball official behavior. Fixes #1119

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -15367,12 +15367,6 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 				return false;
 			}
 			break;
-		case AL_HOLYWATER:
-			if (map_getcell(sd->bl.m, sd->bl.x, sd->bl.y, CELL_CHKLANDPROTECTOR)) {
-				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
-				return false; // Aqua Benedicta will not cast on LP [secretdataz]
-			}
-			break;
 	}
 
 	/* check state required */
@@ -15425,7 +15419,7 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 		case ST_WATER:
 			if (sc && (sc->data[SC_DELUGE] || sc->data[SC_SUITON]))
 				break;
-			if (map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKWATER))
+			if (map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKWATER) && !map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKLANDPROTECTOR))
 				break;
 			clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 			return false;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -7347,8 +7347,12 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case AL_HOLYWATER:
 		if(sd) {
-			if (skill_produce_mix(sd, skill_id, ITEMID_HOLY_WATER, 0, 0, 0, 1, -1))
-				clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
+			if (skill_produce_mix(sd, skill_id, ITEMID_HOLY_WATER, 0, 0, 0, 1, -1)) {
+				struct skill_unit* su;
+				if ((su = map_find_skill_unit_oncell(bl, bl->x, bl->y, NJ_SUITON, NULL, 0)) != NULL)
+					skill_delunit(su);
+				clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
+			}
 			else
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 		}
@@ -15361,6 +15365,12 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 			if (sd->spiritcharm_type == CHARM_TYPE_NONE || sd->spiritcharm <= 0) {
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_SUMMON_NONE,0);
 				return false;
+			}
+			break;
+		case AL_HOLYWATER:
+			if (map_getcell(sd->bl.m, sd->bl.x, sd->bl.y, CELL_CHKLANDPROTECTOR)) {
+				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+				return false; // Aqua Benedicta will not cast on LP [secretdataz]
 			}
 			break;
 	}


### PR DESCRIPTION
This PR corrects Aqua Benedicta and Water Ball's behavior.
- Both skills will fail if casted on Land Protector cell.
- Aqua Benedicta will consume a Watery Evasion cell on castend.  
Thanks to @Playtester for advices