### PR TITLE
small cleanup && optimization @ skill.c / skilldb_id2idx lookup

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -57,7 +57,7 @@
 	#error GD_SKILLRANGEMAX is greater than 999
 #endif
 
-
+DBMap* skilldb_name2id = NULL;
 static DBMap *skilldb_id2idx;			 /// Skill ID to Index lookup: skill_index = skill_get_index(skill_id)
 struct s_skill_db **skill_db;			 /// Skill DB
 static uint16 skill_num;				 /// Skill count, also as last index

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -58,7 +58,7 @@
 #endif
 
 DBMap* skilldb_name2id = NULL;
-static DBMap *skilldb_id2idx;			 /// Skill ID to Index lookup: skill_index = skill_get_index(skill_id)
+static uint16 skilldb_id2idx[UINT16_MAX];/// Skill ID to Index lookup: skill_index = skill_get_index(skill_id) - [FWI] 20160423 the whole index thing should be removed.
 struct s_skill_db **skill_db;			 /// Skill DB
 static uint16 skill_num;				 /// Skill count, also as last index
 #define skill_next_idx() ( skill_num++ ) /// Macro to get&increase last skill number/index
@@ -174,7 +174,7 @@ uint16 skill_idx2id(uint16 idx) {
  * @return Skill Index or 0 if not found/unset
  **/
 int skill_get_index_( uint16 skill_id, bool silent, const char *func, const char *file, int line ) {
-	uint16 idx = (uint16)uidb_iget(skilldb_id2idx, skill_id);
+	uint16 idx = skilldb_id2idx[skill_id];
 	if (!idx && skill_id != 0 && !silent)
 		ShowError("Skill '%d' is undefined! %s:%d::%s\n", skill_id, file, line, func);
 	return idx;
@@ -17663,6 +17663,7 @@ int skill_delunit(struct skill_unit* unit)
 	return 0;
 }
 
+
 static DBMap* skillunit_group_db = NULL; /// Skill unit group DB. Key int group_id -> struct skill_unit_group*
 
 /// Returns the target skill_unit_group or NULL if not found.
@@ -21186,7 +21187,7 @@ static uint16 skill_db_create(uint16 skill_id) {
 		safestrncpy(skill_db[skill_num]->desc, "Unknown Skill", sizeof(skill_db[skill_num]->desc));
 	}
 	skill_db[skill_num]->nameid = skill_id;
-	uidb_iput(skilldb_id2idx, skill_id, skill_num);
+	skilldb_id2idx[skill_id] = skill_num;
 	return skill_next_idx();
 }
 
@@ -21226,7 +21227,8 @@ static void skill_readdb(void)
 	};
 	
 	db_clear(skilldb_name2id);
-	db_clear(skilldb_id2idx);
+	for(i = 0; i < UINT16_MAX; i++)
+		skilldb_id2idx[i] = 0;
 
 	skill_db_destroy();
 	skill_db_create(0);
@@ -21303,7 +21305,6 @@ void skill_reload (void) {
 void do_init_skill(void)
 {
 	skilldb_name2id = strdb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_DATA, 0);
-	skilldb_id2idx = uidb_alloc(DB_OPT_DUP_KEY|DB_OPT_RELEASE_DATA);
 
 	skill_readdb();
 
@@ -21329,7 +21330,6 @@ void do_init_skill(void)
 void do_final_skill(void)
 {
 	db_destroy(skilldb_name2id);
-	db_destroy(skilldb_id2idx);
 	db_destroy(skillunit_group_db);
 	db_destroy(skillunit_db);
 	db_destroy(skillusave_db);

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -26,7 +26,7 @@ struct status_change_entry;
 #define SKILL_NAME_LENGTH 31 /// Max Skill Name length
 #define SKILL_DESC_LENGTH 31 /// Max Skill Desc length
 
-DBMap* skilldb_name2id;
+extern DBMap* skilldb_name2id;
 
 /// Constants to identify a skill's nk value (damage properties)
 /// The NK value applies only to non INF_GROUND_SKILL skills


### PR DESCRIPTION
As mentioned in the commit message:
Before this change skilldb_id2idx was a DBMap (int-db)
which is quite costly for a static lookup table which has an 16-bit int as index.

Also should be noted that the lookup via id2idx is done quite often during runtime .. so this change makes sense.

Sorry for requesting this commits twice, but the first PR#1199 was'nt ANSI-C Compatible so the compiling@linux/gcc broke.