### PR TITLE
Revert "Fixed character deletion" - Issue 1189

### DIFF
--- a/src/char/char.c
+++ b/src/char/char.c
@@ -1804,7 +1804,7 @@ int char_mmo_char_tobuf(uint8* buffer, struct mmo_charstatus* p)
 	offset += MAP_NAME_LENGTH_EXT;
 #endif
 #if PACKETVER >= 20100803
-#if (PACKETVER > 20130000 && PACKETVER < 20141016) || (PACKETVER >= 20150826 && PACKETVER < 20151001) || PACKETVER >= 20151104
+#if (PACKETVER > 20130000 && PACKETVER < 20141016) || PACKETVER >= 20150826
 	WBUFL(buf,124) = (p->delete_date?TOL(p->delete_date-time(NULL)):0);
 #else
 	WBUFL(buf,124) = TOL(p->delete_date);


### PR DESCRIPTION
This reverts commits 7a0b628acbbf52c35831f60ed2943e6eb2d07c4d and a41ba12cf2b60bfb3d86f10934bb568da91b2f9a.

Should fix issue #1189.

Problem: Character Deletion doesn't work. (Currently only tested with 20151029!)

For more information you should definitely have a look in #1189.

I suggest to **wait with merging this pull-request** until we figured out why @niknokseyer is having this problem.