### PR TITLE
Implementation of Hat Effect

### DIFF
--- a/db/packet_db.txt
+++ b/db/packet_db.txt
@@ -2469,7 +2469,7 @@ packet_keys: 0x62C86D09,0x75944F17,0x112C133D // [YomRawr]
 0x0923,36,storagepassword,2:4:20
 
 // New Packets
-0xA3B,-1		// ZC_HAT_EFFECT
+0x0A3B,-1,ZC_HAT_EFFECT,2:4:8:9
 
 // RODEX Mail system
 0x09E7,3		// ZC_NOTIFY_UNREADMAIL
@@ -2498,6 +2498,7 @@ packet_keys: 0x62C86D09,0x75944F17,0x112C133D // [YomRawr]
 0x0A32,2		// ZC_OPEN_RODEX_THROUGH_NPC_ONLY
 0x0A13,26,dull,0	// CZ_CHECK_RECEIVE_CHARACTER_NAME
 0x0A14,10		// ZC_CHECK_RECEIVE_CHARACTER_NAME
+0x0A3B,-1,ZC_HAT_EFFECT,2:4:8:9
 
 // New EquipPackets Support
 0x0A09,45	// ZC_ADD_EXCHANGE_ITEM3
@@ -2559,6 +2560,7 @@ packet_keys: 0x17F83A19,0x116944F4,0x1CC541E9 // [Napster]
 0x089E,26,friendslistadd,2
 0x0960,5,hommenu,2:4
 0x0941,36,storagepassword,2:4:20
+0x0A3B,-1,ZC_HAT_EFFECT,2:4:8:9
 
 // New Packet
 0x097F,-1		// ZC_SELECTCART
@@ -2596,6 +2598,7 @@ packet_keys: 0x45B945B9,0x45B945B9,0x45B945B9	// [Dastgir]
 0x023b,26,friendslistadd,2
 0x0361,5,hommenu,2:4
 0x0860,36,storagepassword,2:4:20
+0x0A3B,-1,ZC_HAT_EFFECT,2:4:8:9
 
 //2015-11-04aRagexe
 packet_ver: 55
@@ -2629,6 +2632,7 @@ packet_keys: 0x4C17382A,0x7ED174C9,0x29961E4F // [Winnie]
 0x07EC,26,friendslistadd,2
 0x088D,5,hommenu,2:4
 0x0940,36,storagepassword,2:4:20
+0x0A3B,-1,ZC_HAT_EFFECT,2:4:8:9
 
 //Add new packets here
 //packet_ver: 56

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9171,5 +9171,15 @@ Requires client 2015-05-13aRagEXE or newer.
 
 ---------------------------------------
 
+*hateffect(<Hat Effect ID>,<State>{,<GID>});
+
+This will set a Hat Effect onto the player. The state field allows you to
+enable (true) or disable (false) the effect on the player.
+The Hat Effect constants can be found in db/const.txt starting with HAT_EF_*.
+
+Requires client 2015-05-13aRagEXE or newer. 
+
+---------------------------------------
+
 Whew.
 That's about all of them.

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -53,6 +53,7 @@ enum e_packet_ack {
 	ZC_MERGE_ITEM_OPEN,
 	ZC_ACK_MERGE_ITEM,
 	ZC_BROADCASTING_SPECIAL_ITEM_OBTAIN,
+	ZC_HAT_EFFECT,
 	//add other here
 	MAX_ACK_FUNC //auto upd len
 };
@@ -994,5 +995,7 @@ void clif_broadcast_obtain_special_item(const char *char_name, unsigned short na
 void clif_dressing_room(struct map_session_data *sd, int flag);
 void clif_navigateTo(struct map_session_data *sd, const char* mapname, uint16 x, uint16 y, uint8 flag, bool hideWindow, uint16 mob_id );
 void clif_SelectCart(struct map_session_data *sd);
+void clif_hateffect(struct map_session_data *src, struct block_list *bl, enum send_target target);
+void clif_hateffect_single(struct block_list *bl, enum send_target target, unsigned short HatEFID, bool show);
 
 #endif /* _CLIF_H_ */

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1269,6 +1269,9 @@ bool pc_authok(struct map_session_data *sd, uint32 login_id2, time_t expiration_
 	sd->bonus_script.head = NULL;
 	sd->bonus_script.count = 0;
 
+	sd->hat_effect.HatEFIDs = NULL;
+	sd->hat_effect.count = 0;
+
 	// Check EXP overflow, since in previous revision EXP on Max Level can be more than 'official' Max EXP
 	if (pc_is_maxbaselv(sd) && sd->status.base_exp > MAX_LEVEL_BASE_EXP) {
 		sd->status.base_exp = MAX_LEVEL_BASE_EXP;

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -193,6 +193,7 @@ struct map_session_data {
 	struct view_data vd;
 	struct status_data base_status, battle_status;
 	struct status_change sc;
+	struct hat_effect hat_effect;
 	struct regen_data regen;
 	struct regen_data_sub sregen, ssregen;
 	//NOTE: When deciding to add a flag to state or special_state, take into consideration that state is preserved in

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2117,6 +2117,11 @@ struct status_change {
 	struct status_change_entry *data[SC_MAX];
 };
 
+struct hat_effect {
+	uint16 *HatEFIDs;
+	uint8 count;
+};
+
 // for looking up associated data
 sc_type status_skill2sc(int skill);
 int status_sc2skill(sc_type sc);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -3211,6 +3211,12 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 			}
 			sd->qi_count = 0;
 
+			if (sd->hat_effect.count) {
+				aFree(sd->hat_effect.HatEFIDs);
+				sd->hat_effect.HatEFIDs = NULL;
+			}
+			sd->hat_effect.count = 0;
+
 			// Clearing...
 			if (sd->bonus_script.head)
 				pc_bonus_script_clear(sd, BSF_REM_ALL);


### PR DESCRIPTION
* Follow 5da49b87b5a2ae77852d1f697b62f5bfea7bcde8
* Added a new script command `hateffect(<Hat Effect ID>,<State>{,<GID>});`


I don't what other good guys planning @rathena/rathena-core-developers @rathena/rathena-script-db-developers 

Just do some adjustments from last @Lemongrass3110 commit and what I tried recently.
Because sc_start can be dangerous, changed the plan to make new array.

----

TODO:
* [ ] Implement `hateffect` script to the items
* Makes `hateffect` script can be work for other object than `PC`
  * [ ] Support for BL_NPC
  * [ ] Support for BL_MOB
  * [ ] Support for BL_HOM, BL_MER, BL_ELEM, BL_PET (necessary?)
* [ ] Add battle config to make effect is removed while player is invisible, in official, the effects are lasting even player is invisible.

----

Only tested using custom items
> packet_db_ver: 53 // 2015-09-16

```
2220,Hat,Hat,4,1000,,200,,2,,0,0xFFFFFFFF,63,2,256,,0,1,16,{ hateffect HAT_EF_BLOSSOM_FLUTTERING,1; },{},{ hateffect HAT_EF_BLOSSOM_FLUTTERING,0; }
2269,Centimental_Flower,Romantic Flower,4,20,,100,,0,,0,0xFFFFFFFE,63,2,1,,0,0,56,{ hateffect HAT_EF_RL_BANISHING_BUSTER,1; },{},{ hateffect HAT_EF_RL_BANISHING_BUSTER,0; }
18599,Black_Devil_Mask,Black Devil Mask,4,20,,100,,0,,0,0xFFFFFFFF,63,2,512,,0,0,760,{ hateffect HAT_EF_FLUTTER_BUTTERFLY,1; },{},{ hateffect HAT_EF_FLUTTER_BUTTERFLY,0; }
```

![screenchyraro480](https://cloud.githubusercontent.com/assets/4016864/17268019/baafdec4-5645-11e6-9e0b-bfe39bab90b4.jpg)
![screenchyraro482](https://cloud.githubusercontent.com/assets/4016864/17268018/ba981848-5645-11e6-9a28-1771af65659f.jpg)

