### PR TITLE
Updated .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,14 @@
-*        text=auto
-*.c      diff=cpp
-*.sln    merge=union
-*.vcproj merge=union
-*.vcxproj merge=union
-*.sln text eol=crlf
-*.bat text eol=crlf
-configure text eol=lf
+*            text=auto
+*.c          diff=cpp eol=crlf
+*.h          diff=cpp eol=crlf
+*.sln        merge=union
+*.vcproj     merge=union
+*.vcxproj    merge=union
+*.sln text   eol=crlf
+*.bat text   eol=crlf
+configure    text eol=lf
 configure.in text eol=lf
-Makefile text eol=lf
-Makefile.in text eol=lf
-*.sh text eol=lf
+Makefile     text eol=lf
+Makefile.in  text eol=lf
+*.sh         text eol=lf
+*.sql        text eol=crlf


### PR DESCRIPTION
Updated for:
* `*.c          diff=cpp eol=crlf`
* `*.h          diff=cpp eol=crlf`
* `*.sql        text eol=crlf`

Set .sql end-line to CRLF (since it always be like that) and to prevent any future ugly changes.
Happened twice already, by @Playtester and @rAthenaAPI.