### PR TITLE
Adjusted the temporary ban check

### DIFF
--- a/src/login/loginclif.c
+++ b/src/login/loginclif.c
@@ -197,7 +197,7 @@ static void logclif_auth_failed(struct login_session_data* sd, int result) {
 		    login_log(ip, sd->userid, result, msg_txt(22)); //unknow error
 	}
 
-	if( result == 1 && login_config.dynamic_pass_failure_ban )
+	if( (result == 0 || result == 1) && login_config.dynamic_pass_failure_ban )
 		ipban_log(ip); // log failed password attempt
 
 //#if PACKETVER >= 20120000 /* not sure when this started */

--- a/src/login/loginlog.c
+++ b/src/login/loginlog.c
@@ -47,7 +47,7 @@ unsigned long loginlog_failedattempts(uint32 ip, unsigned int minutes) {
 	if( !enabled )
 		return 0;
 
-	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT count(*) FROM `%s` WHERE `ip` = '%s' AND `rcode` = '1' AND `time` > NOW() - INTERVAL %d MINUTE",
+	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT count(*) FROM `%s` WHERE `ip` = '%s' AND (`rcode` = '0' OR `rcode` = '1') AND `time` > NOW() - INTERVAL %d MINUTE",
 		log_login_db, ip2str(ip,NULL), minutes) )// how many times failed account? in one ip.
 		Sql_ShowDebug(sql_handle);
 


### PR DESCRIPTION
* Temporarily ban players who attempt to login to too many unregistered accounts.
* This makes it tougher for people who have access to server data and attempt to use that data on other servers.

Thanks to @Tokeiburu!