### PR TITLE
Battleground script command expansion

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8466,11 +8466,10 @@ Mark Color:
 ============================
 ---------------------------------------
 
-*waitingroom2bg_single(<battle group>,"<map name>",<x>,<y>,"<npc name>");
+*waitingroom2bg_single(<battle group>,{"<map name>",<x>,<y>{,"<npc name>"}});
 
-Adds the first waiting player from the chat room of the given NPC to an
-existing battleground group and warps it to the specified coordinates on
-the given map.
+Adds the first waiting player from the chat room of the given NPC to an existing battleground group.
+The player will also be warped to the default spawn point of the battle group or to the specified coordinates <x> and <y> on the given <map>.
 
 ---------------------------------------
 
@@ -8494,7 +8493,7 @@ Example:
 
 *bg_create("<map name>",<x>,<y>{,"<On Quit Event>","<On Death Event>"});
 
-Creates an instance of battleground battle group that can be used in other battleground commands.
+Creates an instance of battleground battle group that can be used with other battleground commands.
 
 <map name>,<x>,<y> refer to where the "respawn" base is, where the player group will respawn when they die.
 <On Quit Event> refers to an NPC label that attaches to the character and is run when they relog. (Optional)
@@ -8504,10 +8503,9 @@ Returns battle group ID on success. Returns 0 on failure.
 
 ---------------------------------------
 
-*bg_join(<battle group>,"<map name>",<x>,<y>{,<char id>});
+*bg_join(<battle group>,{"<map name>",{<x>,<y>{,<char id>}});
 
-Adds attached player or <char id> (if specified) to an existing battleground group and warps it to the specified coordinates
-<x> and <y> on the given map.
+Adds an attached player or <char id> if specified to an existing battleground group. The player will also be warped to the default spawn point of the battle group or to the specified coordinates <x> and <y> on the given <map>.
 
 Returns true on success. Returns false on failure.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8474,11 +8474,11 @@ the given map.
 
 ---------------------------------------
 
-*waitingroom2bg("<map name>",<x>,<y>,"<On Quit Event>","<On Death Event>"{,"<NPC Name>"});
+*waitingroom2bg("<map name>",<x>,<y>,{"<On Quit Event>","<On Death Event>"{,"<NPC Name>"}});
 
 <map name>,<x>,<y> refer to where the "respawn" base is, where the player group will respawn when they die.
-<On Quit Event> refers to an NPC label that attaches to the character and is run when they relog.
-<On Death Event> refers to an NPC label that attaches to the character and is run when they die. Can be "" for empty.
+<On Quit Event> refers to an NPC label that attaches to the character and is run when they relog. (Optional)
+<On Death Event> refers to an NPC label that attaches to the character and is run when they die. (Optional)
 
 Unlike the prior command, the latter will attach a GROUP in a waiting room to the battleground, and 
 sets the array $@arenamembers[0] where 0 holds the IDs of the first group, and 1 holds the IDs of the second.
@@ -8492,13 +8492,13 @@ Example:
 
 ---------------------------------------
 
-*bg_create("<map name>",<x>,<y>,"<On Quit Event>","<On Death Event>");
+*bg_create("<map name>",<x>,<y>{,"<On Quit Event>","<On Death Event>"});
 
 Creates an instance of battleground battle group that can be used in other battleground commands.
 
 <map name>,<x>,<y> refer to where the "respawn" base is, where the player group will respawn when they die.
-<On Quit Event> refers to an NPC label that attaches to the character and is run when they relog.
-<On Death Event> refers to an NPC label that attaches to the character and is run when they die. Can be "" for empty.
+<On Quit Event> refers to an NPC label that attaches to the character and is run when they relog. (Optional)
+<On Death Event> refers to an NPC label that attaches to the character and is run when they die. (Optional)
 
 Returns battle group ID on success. Returns 0 on failure.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8492,6 +8492,27 @@ Example:
 
 ---------------------------------------
 
+*bg_create("<map name>",<x>,<y>,"<On Quit Event>","<On Death Event>");
+
+Creates an instance of battleground battle group that can be used in other battleground commands.
+
+<map name>,<x>,<y> refer to where the "respawn" base is, where the player group will respawn when they die.
+<On Quit Event> refers to an NPC label that attaches to the character and is run when they relog.
+<On Death Event> refers to an NPC label that attaches to the character and is run when they die. Can be "" for empty.
+
+Returns battle group ID on success. Returns 0 on failure.
+
+---------------------------------------
+
+*bg_join(<battle group>,"<map name>",<x>,<y>{,<char id>});
+
+Adds attached player or <char id> (if specified) to an existing battleground group and warps it to the specified coordinates
+<x> and <y> on the given map.
+
+Returns 1 on success. Returns 0 on failure.
+
+---------------------------------------
+
 *bg_team_setxy <Battle Group ID>,<x>,<y>;
 
 Updates the respawn point of the given Battle Group to x,y on the same map. <Battle Group ID> can be retrieved using getcharid(4).

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8509,7 +8509,7 @@ Returns battle group ID on success. Returns 0 on failure.
 Adds attached player or <char id> (if specified) to an existing battleground group and warps it to the specified coordinates
 <x> and <y> on the given map.
 
-Returns 1 on success. Returns 0 on failure.
+Returns true on success. Returns false on failure.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18772,10 +18772,10 @@ BUILDIN_FUNC(bg_join) {
 
 	if (bg_team_join(bg_id, sd) && pc_setpos(sd, mapindex, x, y, CLR_TELEPORT) == SETPOS_OK)
 	{
-		script_pushint(st, 1);
+		script_pushint(st, true);
 	}
 	else
-		script_pushint(st, 0);
+		script_pushint(st, false);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -22275,7 +22275,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(agitend2,""),
 	BUILDIN_DEF(agitcheck2,""),
 	// BattleGround
-	BUILDIN_DEF(waitingroom2bg,"siiss?"),
+	BUILDIN_DEF(waitingroom2bg,"sii???"),
 	BUILDIN_DEF(waitingroom2bg_single,"isiis"),
 	BUILDIN_DEF(bg_team_setxy,"iii"),
 	BUILDIN_DEF(bg_warp,"isii"),
@@ -22288,7 +22288,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(bg_getareausers,"isiiii"),
 	BUILDIN_DEF(bg_updatescore,"sii"),
 	BUILDIN_DEF(bg_join,"isii?"),
-	BUILDIN_DEF(bg_create,"siiss"),
+	BUILDIN_DEF(bg_create,"sii??"),
 
 	// Instancing
 	BUILDIN_DEF(instance_create,"s??"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18668,12 +18668,17 @@ BUILDIN_FUNC(waitingroom2bg)
 	ev = script_getstr(st,5); // Logout Event
 	dev = script_getstr(st,6); // Die Event
 
+	if (ev[0] != '\0')
+		check_event(st, ev);
+	if (dev[0] != '\0')
+		check_event(st, dev);
+
 	if( (bg_id = bg_create(mapindex, x, y, ev, dev)) == 0 )
 	{ // Creation failed
 		script_pushint(st,0);
 		return SCRIPT_CMD_SUCCESS;
 	}
-
+	
         
 	for (i = 0; i < cd->users; i++) { // Only add those who are in the chat room
 		struct map_session_data *sd;
@@ -18745,6 +18750,11 @@ BUILDIN_FUNC(bg_create) {
 	y = script_getnum(st, 4);
 	ev = script_getstr(st, 5); // Logout Event
 	dev = script_getstr(st, 6); // Die Event
+
+	if (ev[0] != '\0')
+		check_event(st, ev);
+	if (dev[0] != '\0')
+		check_event(st, dev);
 
 	if ((bg_id = bg_create(mapindex, x, y, ev, dev)) == 0)
 	{ // Creation failed

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18704,8 +18704,10 @@ BUILDIN_FUNC(waitingroom2bg_single)
 	}
 	if (script_hasdata(st, 3)) {
 		map_name = script_getstr(st, 3);
-		if ((mapindex = mapindex_name2id(map_name)) == 0)
+		if ((mapindex = mapindex_name2id(map_name)) == 0) {
+			script_pushint(st, false);
 			return SCRIPT_CMD_SUCCESS; // Invalid Map
+		}
 		x = script_getnum(st, 4);
 		y = script_getnum(st, 5);
 	}
@@ -18744,8 +18746,8 @@ BUILDIN_FUNC(bg_create) {
 	map_name = script_getstr(st, 2);
 	if (strcmp(map_name, "-") != 0 && (mapindex = mapindex_name2id(map_name)) == 0)
 	{ // Invalid Map
-			script_pushint(st, 0);
-			return SCRIPT_CMD_SUCCESS;
+		script_pushint(st, 0);
+		return SCRIPT_CMD_SUCCESS;
 	}
 
 	x = script_getnum(st, 3);
@@ -18780,8 +18782,10 @@ BUILDIN_FUNC(bg_join) {
 	}
 	if (script_hasdata(st, 3)) {
 		map_name = script_getstr(st, 3);
-		if ((mapindex = mapindex_name2id(map_name)) == 0)
+		if ((mapindex = mapindex_name2id(map_name)) == 0) {
+			script_pushint(st, false);
 			return SCRIPT_CMD_SUCCESS; // Invalid Map
+		}
 		x = script_getnum(st, 4);
 		y = script_getnum(st, 5);
 	} else {

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18794,7 +18794,7 @@ BUILDIN_FUNC(bg_join) {
 		y = bg->y;
 	}
 
-	if ((sd = script_charid2sd(6, sd)) == NULL) {
+	if ((script_charid2sd(6, sd)) == NULL) {
 		script_pushint(st, false);
 		return SCRIPT_CMD_FAILURE;
 	}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18747,6 +18747,12 @@ BUILDIN_FUNC(bg_create) {
 	check_event(st, ev);
 	check_event(st, dev);
 
+	if ((bg_id = bg_create(mapindex, x, y, ev, dev)) == 0)
+	{ // Creation failed
+		script_pushint(st, 0);
+		return SCRIPT_CMD_SUCCESS;
+	}
+
 	script_pushint(st, bg_id);
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18653,14 +18653,10 @@ BUILDIN_FUNC(waitingroom2bg)
 	}
 
 	map_name = script_getstr(st,2);
-	if( strcmp(map_name,"-") != 0 )
-	{
-		mapindex = mapindex_name2id(map_name);
-		if( mapindex == 0 )
-		{ // Invalid Map
-			script_pushint(st,0);
-			return SCRIPT_CMD_SUCCESS;
-		}
+	if (strcmp(map_name, "-") != 0 && (mapindex = mapindex_name2id(map_name)) == 0)
+	{ // Invalid Map
+		script_pushint(st, 0);
+		return SCRIPT_CMD_SUCCESS;
 	}
 
 	x = script_getnum(st,3);
@@ -18670,10 +18666,8 @@ BUILDIN_FUNC(waitingroom2bg)
 	if(script_hasdata(st,6))
 		dev = script_getstr(st,6); // Die Event
 
-	if (ev[0] != '\0')
-		check_event(st, ev);
-	if (dev[0] != '\0')
-		check_event(st, dev);
+	check_event(st, ev);
+	check_event(st, dev);
 
 	if( (bg_id = bg_create(mapindex, x, y, ev, dev)) == 0 )
 	{ // Creation failed
@@ -18737,14 +18731,10 @@ BUILDIN_FUNC(bg_create) {
 	int x, y, mapindex = 0, bg_id;
 
 	map_name = script_getstr(st, 2);
-	if (strcmp(map_name, "-") != 0)
-	{
-		mapindex = mapindex_name2id(map_name);
-		if (mapindex == 0)
-		{ // Invalid Map
+	if (strcmp(map_name, "-") != 0 && (mapindex = mapindex_name2id(map_name)) == 0)
+	{ // Invalid Map
 			script_pushint(st, 0);
 			return SCRIPT_CMD_SUCCESS;
-		}
 	}
 
 	x = script_getnum(st, 3);
@@ -18754,16 +18744,8 @@ BUILDIN_FUNC(bg_create) {
 	if(script_hasdata(st, 6))
 		dev = script_getstr(st, 6); // Die Event
 
-	if (ev[0] != '\0')
-		check_event(st, ev);
-	if (dev[0] != '\0')
-		check_event(st, dev);
-
-	if ((bg_id = bg_create(mapindex, x, y, ev, dev)) == 0)
-	{ // Creation failed
-		script_pushint(st, 0);
-		return SCRIPT_CMD_SUCCESS;
-	}
+	check_event(st, ev);
+	check_event(st, dev);
 
 	script_pushint(st, bg_id);
 	return SCRIPT_CMD_SUCCESS;
@@ -18788,9 +18770,8 @@ BUILDIN_FUNC(bg_join) {
 	y = script_getnum(st, 5);
 	sd = script_charid2sd(6, sd);
 
-	if (bg_team_join(bg_id, sd))
+	if (bg_team_join(bg_id, sd) && pc_setpos(sd, mapindex, x, y, CLR_TELEPORT) == SETPOS_OK)
 	{
-		pc_setpos(sd, mapindex, x, y, CLR_TELEPORT);
 		script_pushint(st, 1);
 	}
 	else

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18681,7 +18681,6 @@ BUILDIN_FUNC(waitingroom2bg)
 		return SCRIPT_CMD_SUCCESS;
 	}
 	
-        
 	for (i = 0; i < cd->users; i++) { // Only add those who are in the chat room
 		struct map_session_data *sd;
 		if( (sd = cd->usersd[i]) != NULL && bg_team_join(bg_id, sd) ){

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18794,7 +18794,7 @@ BUILDIN_FUNC(bg_join) {
 		y = bg->y;
 	}
 
-	if ((script_charid2sd(6, sd)) == NULL) {
+	if (!script_charid2sd(6, sd)) {
 		script_pushint(st, false);
 		return SCRIPT_CMD_FAILURE;
 	}

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18694,15 +18694,27 @@ BUILDIN_FUNC(waitingroom2bg_single)
 	struct npc_data *nd;
 	struct chat_data *cd;
 	struct map_session_data *sd;
+	struct battleground_data *bg;
 	int x, y, mapindex, bg_id;
 
 	bg_id = script_getnum(st,2);
-	map_name = script_getstr(st,3);
-	if( (mapindex = mapindex_name2id(map_name)) == 0 )
-		return SCRIPT_CMD_SUCCESS; // Invalid Map
+	if ((bg = bg_team_search(bg_id)) == NULL) {
+		script_pushint(st, false);
+		return SCRIPT_CMD_SUCCESS;
+	}
+	if (script_hasdata(st, 3)) {
+		map_name = script_getstr(st, 3);
+		if ((mapindex = mapindex_name2id(map_name)) == 0)
+			return SCRIPT_CMD_SUCCESS; // Invalid Map
+		x = script_getnum(st, 4);
+		y = script_getnum(st, 5);
+	}
+	else {
+		mapindex = bg->mapindex;
+		x = bg->x;
+		y = bg->y;
+	}
 
-	x = script_getnum(st,4);
-	y = script_getnum(st,5);
 	nd = npc_name2id(script_getstr(st,6));
 
 	if( nd == NULL || (cd = (struct chat_data *)map_id2bl(nd->chat_id)) == NULL || cd->users <= 0 )
@@ -18711,13 +18723,12 @@ BUILDIN_FUNC(waitingroom2bg_single)
 	if( (sd = cd->usersd[0]) == NULL )
 		return SCRIPT_CMD_SUCCESS;
 
-	if( bg_team_join(bg_id, sd) )
+	if( bg_team_join(bg_id, sd) && pc_setpos(sd, mapindex, x, y, CLR_TELEPORT) == SETPOS_OK)
 	{
-		pc_setpos(sd, mapindex, x, y, CLR_TELEPORT);
-		script_pushint(st,1);
+		script_pushint(st, true);
 	}
 	else
-		script_pushint(st,0);
+		script_pushint(st, false);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -18754,21 +18765,35 @@ BUILDIN_FUNC(bg_create) {
 /// Adds attached player or <char id> (if specified) to an existing 
 /// battleground group and warps it to the specified coordinates on
 /// the given map.
-/// bg_join(<battle group>,"<map name>",<x>,<y>{,<char id>});
+/// bg_join(<battle group>,{"<map name>",<x>,<y>{,<char id>}});
 /// @author [secretdataz]
 BUILDIN_FUNC(bg_join) {
 	const char* map_name;
 	struct map_session_data *sd;
+	struct battleground_data *bg;
 	int x, y, bg_id, mapindex;
 
 	bg_id = script_getnum(st, 2);
-	map_name = script_getstr(st, 3);
-	if ((mapindex = mapindex_name2id(map_name)) == 0)
-		return SCRIPT_CMD_SUCCESS; // Invalid Map
+	if ((bg = bg_team_search(bg_id)) == NULL) {
+		script_pushint(st, false);
+		return SCRIPT_CMD_SUCCESS;
+	}
+	if (script_hasdata(st, 3)) {
+		map_name = script_getstr(st, 3);
+		if ((mapindex = mapindex_name2id(map_name)) == 0)
+			return SCRIPT_CMD_SUCCESS; // Invalid Map
+		x = script_getnum(st, 4);
+		y = script_getnum(st, 5);
+	} else {
+		mapindex = bg->mapindex;
+		x = bg->x;
+		y = bg->y;
+	}
 
-	x = script_getnum(st, 4);
-	y = script_getnum(st, 5);
-	sd = script_charid2sd(6, sd);
+	if ((sd = script_charid2sd(6, sd)) == NULL) {
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
+	}
 
 	if (bg_team_join(bg_id, sd) && pc_setpos(sd, mapindex, x, y, CLR_TELEPORT) == SETPOS_OK)
 	{
@@ -22276,7 +22301,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(agitcheck2,""),
 	// BattleGround
 	BUILDIN_DEF(waitingroom2bg,"sii???"),
-	BUILDIN_DEF(waitingroom2bg_single,"isiis"),
+	BUILDIN_DEF(waitingroom2bg_single,"i????"),
 	BUILDIN_DEF(bg_team_setxy,"iii"),
 	BUILDIN_DEF(bg_warp,"isii"),
 	BUILDIN_DEF(bg_monster,"isiisi?"),
@@ -22287,7 +22312,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(bg_get_data,"ii"),
 	BUILDIN_DEF(bg_getareausers,"isiiii"),
 	BUILDIN_DEF(bg_updatescore,"sii"),
-	BUILDIN_DEF(bg_join,"isii?"),
+	BUILDIN_DEF(bg_join,"i????"),
 	BUILDIN_DEF(bg_create,"sii??"),
 
 	// Instancing

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18665,8 +18665,10 @@ BUILDIN_FUNC(waitingroom2bg)
 
 	x = script_getnum(st,3);
 	y = script_getnum(st,4);
-	ev = script_getstr(st,5); // Logout Event
-	dev = script_getstr(st,6); // Die Event
+	if(script_hasdata(st,5))
+		ev = script_getstr(st,5); // Logout Event
+	if(script_hasdata(st,6))
+		dev = script_getstr(st,6); // Die Event
 
 	if (ev[0] != '\0')
 		check_event(st, ev);
@@ -18729,7 +18731,7 @@ BUILDIN_FUNC(waitingroom2bg_single)
 
 
 /// Creates an instance of battleground battle group.
-/// *bg_create("<map name>",<x>,<y>,"<On Quit Event>","<On Death Event>");
+/// *bg_create("<map name>",<x>,<y>{,"<On Quit Event>","<On Death Event>"});
 /// @author [secretdataz]
 BUILDIN_FUNC(bg_create) {
 	const char *map_name, *ev = "", *dev = "";
@@ -18748,8 +18750,10 @@ BUILDIN_FUNC(bg_create) {
 
 	x = script_getnum(st, 3);
 	y = script_getnum(st, 4);
-	ev = script_getstr(st, 5); // Logout Event
-	dev = script_getstr(st, 6); // Die Event
+	if(script_hasdata(st, 5))
+		ev = script_getstr(st, 5); // Logout Event
+	if(script_hasdata(st, 6))
+		dev = script_getstr(st, 6); // Die Event
 
 	if (ev[0] != '\0')
 		check_event(st, ev);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18728,7 +18728,7 @@ BUILDIN_FUNC(waitingroom2bg_single)
 /// @author [secretdataz]
 BUILDIN_FUNC(bg_create) {
 	const char *map_name, *ev = "", *dev = "";
-	int x, y, mapindex = 0, bg_id;
+	int x, y, mapindex = 0;
 
 	map_name = script_getstr(st, 2);
 	if (strcmp(map_name, "-") != 0 && (mapindex = mapindex_name2id(map_name)) == 0)
@@ -18747,13 +18747,7 @@ BUILDIN_FUNC(bg_create) {
 	check_event(st, ev);
 	check_event(st, dev);
 
-	if ((bg_id = bg_create(mapindex, x, y, ev, dev)) == 0)
-	{ // Creation failed
-		script_pushint(st, 0);
-		return SCRIPT_CMD_SUCCESS;
-	}
-
-	script_pushint(st, bg_id);
+	script_pushint(st, bg_create(mapindex, x, y, ev, dev));
 	return SCRIPT_CMD_SUCCESS;
 }
 


### PR DESCRIPTION
This PR allows the script engine to create an instance of battleground group and attach a player to a battleground group without depending on chat room.
I think this will open possibilities for many ideas.