### PR TITLE
Added `skill_duration` mapflag.

### DIFF
--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -311,6 +311,16 @@ Notes:
 
 ---------------------------------------
 
+*skill_duration	skill_name,percentage
+
+Sets skill (trap-type) time limit to n% of original duration.
+
+// Example:
+// Makes HT_ANKLESNARE lifetime in the castle is longer 4x than normal maps.
+prtg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+
+---------------------------------------
+
 ==================
 | 3. Map Effects |
 ==================

--- a/npc/mapflag/skill_duration.txt
+++ b/npc/mapflag/skill_duration.txt
@@ -1,0 +1,549 @@
+//===== rAthena Mapflag ======================================
+//= Sets skill time limit on specified map.
+//===== Structure ============================================
+//= mapname	skill_duration	skill_name,percentage
+//============================================================
+
+//============================================================
+// Guild Event Maps
+//============================================================
+guild_vs1	mapflag	skill_duration	HT_SKIDTRAP,400
+guild_vs1	mapflag	skill_duration	HT_LANDMINE,400
+guild_vs1	mapflag	skill_duration	HT_ANKLESNARE,400
+guild_vs1	mapflag	skill_duration	HT_SHOCKWAVE,400
+guild_vs1	mapflag	skill_duration	HT_SANDMAN,400
+guild_vs1	mapflag	skill_duration	HT_FLASHER,400
+guild_vs1	mapflag	skill_duration	HT_FREEZINGTRAP,400
+guild_vs1	mapflag	skill_duration	HT_BLASTMINE,400
+guild_vs1	mapflag	skill_duration	HT_CLAYMORETRAP,400
+guild_vs1	mapflag	skill_duration	HT_TALKIEBOX,400
+
+guild_vs2	mapflag	skill_duration	HT_SKIDTRAP,400
+guild_vs2	mapflag	skill_duration	HT_LANDMINE,400
+guild_vs2	mapflag	skill_duration	HT_ANKLESNARE,400
+guild_vs2	mapflag	skill_duration	HT_SHOCKWAVE,400
+guild_vs2	mapflag	skill_duration	HT_SANDMAN,400
+guild_vs2	mapflag	skill_duration	HT_FLASHER,400
+guild_vs2	mapflag	skill_duration	HT_FREEZINGTRAP,400
+guild_vs2	mapflag	skill_duration	HT_BLASTMINE,400
+guild_vs2	mapflag	skill_duration	HT_CLAYMORETRAP,400
+guild_vs2	mapflag	skill_duration	HT_TALKIEBOX,400
+
+guild_vs3	mapflag	skill_duration	HT_SKIDTRAP,400
+guild_vs3	mapflag	skill_duration	HT_LANDMINE,400
+guild_vs3	mapflag	skill_duration	HT_ANKLESNARE,400
+guild_vs3	mapflag	skill_duration	HT_SHOCKWAVE,400
+guild_vs3	mapflag	skill_duration	HT_SANDMAN,400
+guild_vs3	mapflag	skill_duration	HT_FLASHER,400
+guild_vs3	mapflag	skill_duration	HT_FREEZINGTRAP,400
+guild_vs3	mapflag	skill_duration	HT_BLASTMINE,400
+guild_vs3	mapflag	skill_duration	HT_CLAYMORETRAP,400
+guild_vs3	mapflag	skill_duration	HT_TALKIEBOX,400
+
+guild_vs4	mapflag	skill_duration	HT_SKIDTRAP,400
+guild_vs4	mapflag	skill_duration	HT_LANDMINE,400
+guild_vs4	mapflag	skill_duration	HT_ANKLESNARE,400
+guild_vs4	mapflag	skill_duration	HT_SHOCKWAVE,400
+guild_vs4	mapflag	skill_duration	HT_SANDMAN,400
+guild_vs4	mapflag	skill_duration	HT_FLASHER,400
+guild_vs4	mapflag	skill_duration	HT_FREEZINGTRAP,400
+guild_vs4	mapflag	skill_duration	HT_BLASTMINE,400
+guild_vs4	mapflag	skill_duration	HT_CLAYMORETRAP,400
+guild_vs4	mapflag	skill_duration	HT_TALKIEBOX,400
+
+guild_vs5	mapflag	skill_duration	HT_SKIDTRAP,400
+guild_vs5	mapflag	skill_duration	HT_LANDMINE,400
+guild_vs5	mapflag	skill_duration	HT_ANKLESNARE,400
+guild_vs5	mapflag	skill_duration	HT_SHOCKWAVE,400
+guild_vs5	mapflag	skill_duration	HT_SANDMAN,400
+guild_vs5	mapflag	skill_duration	HT_FLASHER,400
+guild_vs5	mapflag	skill_duration	HT_FREEZINGTRAP,400
+guild_vs5	mapflag	skill_duration	HT_BLASTMINE,400
+guild_vs5	mapflag	skill_duration	HT_CLAYMORETRAP,400
+guild_vs5	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Luina Castles
+//============================================================
+aldeg_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+aldeg_cas01	mapflag	skill_duration	HT_LANDMINE,400
+aldeg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+aldeg_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+aldeg_cas01	mapflag	skill_duration	HT_SANDMAN,400
+aldeg_cas01	mapflag	skill_duration	HT_FLASHER,400
+aldeg_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+aldeg_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+aldeg_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+aldeg_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+aldeg_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+aldeg_cas02	mapflag	skill_duration	HT_LANDMINE,400
+aldeg_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+aldeg_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+aldeg_cas02	mapflag	skill_duration	HT_SANDMAN,400
+aldeg_cas02	mapflag	skill_duration	HT_FLASHER,400
+aldeg_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+aldeg_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+aldeg_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+aldeg_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+aldeg_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+aldeg_cas03	mapflag	skill_duration	HT_LANDMINE,400
+aldeg_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+aldeg_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+aldeg_cas03	mapflag	skill_duration	HT_SANDMAN,400
+aldeg_cas03	mapflag	skill_duration	HT_FLASHER,400
+aldeg_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+aldeg_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+aldeg_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+aldeg_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+aldeg_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+aldeg_cas04	mapflag	skill_duration	HT_LANDMINE,400
+aldeg_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+aldeg_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+aldeg_cas04	mapflag	skill_duration	HT_SANDMAN,400
+aldeg_cas04	mapflag	skill_duration	HT_FLASHER,400
+aldeg_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+aldeg_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+aldeg_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+aldeg_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+aldeg_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+aldeg_cas05	mapflag	skill_duration	HT_LANDMINE,400
+aldeg_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+aldeg_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+aldeg_cas05	mapflag	skill_duration	HT_SANDMAN,400
+aldeg_cas05	mapflag	skill_duration	HT_FLASHER,400
+aldeg_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+aldeg_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+aldeg_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+aldeg_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Britoniah Castles
+//============================================================
+gefg_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+gefg_cas01	mapflag	skill_duration	HT_LANDMINE,400
+gefg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+gefg_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+gefg_cas01	mapflag	skill_duration	HT_SANDMAN,400
+gefg_cas01	mapflag	skill_duration	HT_FLASHER,400
+gefg_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+gefg_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+gefg_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+gefg_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+gefg_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+gefg_cas02	mapflag	skill_duration	HT_LANDMINE,400
+gefg_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+gefg_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+gefg_cas02	mapflag	skill_duration	HT_SANDMAN,400
+gefg_cas02	mapflag	skill_duration	HT_FLASHER,400
+gefg_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+gefg_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+gefg_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+gefg_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+gefg_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+gefg_cas03	mapflag	skill_duration	HT_LANDMINE,400
+gefg_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+gefg_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+gefg_cas03	mapflag	skill_duration	HT_SANDMAN,400
+gefg_cas03	mapflag	skill_duration	HT_FLASHER,400
+gefg_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+gefg_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+gefg_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+gefg_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+gefg_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+gefg_cas04	mapflag	skill_duration	HT_LANDMINE,400
+gefg_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+gefg_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+gefg_cas04	mapflag	skill_duration	HT_SANDMAN,400
+gefg_cas04	mapflag	skill_duration	HT_FLASHER,400
+gefg_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+gefg_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+gefg_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+gefg_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+gefg_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+gefg_cas05	mapflag	skill_duration	HT_LANDMINE,400
+gefg_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+gefg_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+gefg_cas05	mapflag	skill_duration	HT_SANDMAN,400
+gefg_cas05	mapflag	skill_duration	HT_FLASHER,400
+gefg_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+gefg_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+gefg_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+gefg_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Greenwood Castles
+//============================================================
+payg_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+payg_cas01	mapflag	skill_duration	HT_LANDMINE,400
+payg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+payg_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+payg_cas01	mapflag	skill_duration	HT_SANDMAN,400
+payg_cas01	mapflag	skill_duration	HT_FLASHER,400
+payg_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+payg_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+payg_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+payg_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+payg_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+payg_cas02	mapflag	skill_duration	HT_LANDMINE,400
+payg_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+payg_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+payg_cas02	mapflag	skill_duration	HT_SANDMAN,400
+payg_cas02	mapflag	skill_duration	HT_FLASHER,400
+payg_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+payg_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+payg_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+payg_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+payg_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+payg_cas03	mapflag	skill_duration	HT_LANDMINE,400
+payg_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+payg_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+payg_cas03	mapflag	skill_duration	HT_SANDMAN,400
+payg_cas03	mapflag	skill_duration	HT_FLASHER,400
+payg_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+payg_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+payg_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+payg_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+payg_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+payg_cas04	mapflag	skill_duration	HT_LANDMINE,400
+payg_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+payg_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+payg_cas04	mapflag	skill_duration	HT_SANDMAN,400
+payg_cas04	mapflag	skill_duration	HT_FLASHER,400
+payg_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+payg_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+payg_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+payg_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+payg_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+payg_cas05	mapflag	skill_duration	HT_LANDMINE,400
+payg_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+payg_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+payg_cas05	mapflag	skill_duration	HT_SANDMAN,400
+payg_cas05	mapflag	skill_duration	HT_FLASHER,400
+payg_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+payg_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+payg_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+payg_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Valkyrie Castles
+//============================================================
+prtg_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+prtg_cas01	mapflag	skill_duration	HT_LANDMINE,400
+prtg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+prtg_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+prtg_cas01	mapflag	skill_duration	HT_SANDMAN,400
+prtg_cas01	mapflag	skill_duration	HT_FLASHER,400
+prtg_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+prtg_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+prtg_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+prtg_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+prtg_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+prtg_cas02	mapflag	skill_duration	HT_LANDMINE,400
+prtg_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+prtg_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+prtg_cas02	mapflag	skill_duration	HT_SANDMAN,400
+prtg_cas02	mapflag	skill_duration	HT_FLASHER,400
+prtg_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+prtg_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+prtg_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+prtg_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+prtg_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+prtg_cas03	mapflag	skill_duration	HT_LANDMINE,400
+prtg_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+prtg_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+prtg_cas03	mapflag	skill_duration	HT_SANDMAN,400
+prtg_cas03	mapflag	skill_duration	HT_FLASHER,400
+prtg_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+prtg_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+prtg_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+prtg_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+prtg_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+prtg_cas04	mapflag	skill_duration	HT_LANDMINE,400
+prtg_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+prtg_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+prtg_cas04	mapflag	skill_duration	HT_SANDMAN,400
+prtg_cas04	mapflag	skill_duration	HT_FLASHER,400
+prtg_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+prtg_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+prtg_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+prtg_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+prtg_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+prtg_cas05	mapflag	skill_duration	HT_LANDMINE,400
+prtg_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+prtg_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+prtg_cas05	mapflag	skill_duration	HT_SANDMAN,400
+prtg_cas05	mapflag	skill_duration	HT_FLASHER,400
+prtg_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+prtg_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+prtg_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+prtg_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Schwarzwald Castles
+//============================================================
+schg_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+schg_cas01	mapflag	skill_duration	HT_LANDMINE,400
+schg_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+schg_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+schg_cas01	mapflag	skill_duration	HT_SANDMAN,400
+schg_cas01	mapflag	skill_duration	HT_FLASHER,400
+schg_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+schg_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+schg_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+schg_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+schg_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+schg_cas02	mapflag	skill_duration	HT_LANDMINE,400
+schg_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+schg_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+schg_cas02	mapflag	skill_duration	HT_SANDMAN,400
+schg_cas02	mapflag	skill_duration	HT_FLASHER,400
+schg_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+schg_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+schg_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+schg_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+schg_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+schg_cas03	mapflag	skill_duration	HT_LANDMINE,400
+schg_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+schg_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+schg_cas03	mapflag	skill_duration	HT_SANDMAN,400
+schg_cas03	mapflag	skill_duration	HT_FLASHER,400
+schg_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+schg_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+schg_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+schg_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+schg_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+schg_cas04	mapflag	skill_duration	HT_LANDMINE,400
+schg_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+schg_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+schg_cas04	mapflag	skill_duration	HT_SANDMAN,400
+schg_cas04	mapflag	skill_duration	HT_FLASHER,400
+schg_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+schg_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+schg_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+schg_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+schg_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+schg_cas05	mapflag	skill_duration	HT_LANDMINE,400
+schg_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+schg_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+schg_cas05	mapflag	skill_duration	HT_SANDMAN,400
+schg_cas05	mapflag	skill_duration	HT_FLASHER,400
+schg_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+schg_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+schg_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+schg_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Arunafeltz Castles
+//============================================================
+arug_cas01	mapflag	skill_duration	HT_SKIDTRAP,400
+arug_cas01	mapflag	skill_duration	HT_LANDMINE,400
+arug_cas01	mapflag	skill_duration	HT_ANKLESNARE,400
+arug_cas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+arug_cas01	mapflag	skill_duration	HT_SANDMAN,400
+arug_cas01	mapflag	skill_duration	HT_FLASHER,400
+arug_cas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+arug_cas01	mapflag	skill_duration	HT_BLASTMINE,400
+arug_cas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+arug_cas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+arug_cas02	mapflag	skill_duration	HT_SKIDTRAP,400
+arug_cas02	mapflag	skill_duration	HT_LANDMINE,400
+arug_cas02	mapflag	skill_duration	HT_ANKLESNARE,400
+arug_cas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+arug_cas02	mapflag	skill_duration	HT_SANDMAN,400
+arug_cas02	mapflag	skill_duration	HT_FLASHER,400
+arug_cas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+arug_cas02	mapflag	skill_duration	HT_BLASTMINE,400
+arug_cas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+arug_cas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+arug_cas03	mapflag	skill_duration	HT_SKIDTRAP,400
+arug_cas03	mapflag	skill_duration	HT_LANDMINE,400
+arug_cas03	mapflag	skill_duration	HT_ANKLESNARE,400
+arug_cas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+arug_cas03	mapflag	skill_duration	HT_SANDMAN,400
+arug_cas03	mapflag	skill_duration	HT_FLASHER,400
+arug_cas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+arug_cas03	mapflag	skill_duration	HT_BLASTMINE,400
+arug_cas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+arug_cas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+arug_cas04	mapflag	skill_duration	HT_SKIDTRAP,400
+arug_cas04	mapflag	skill_duration	HT_LANDMINE,400
+arug_cas04	mapflag	skill_duration	HT_ANKLESNARE,400
+arug_cas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+arug_cas04	mapflag	skill_duration	HT_SANDMAN,400
+arug_cas04	mapflag	skill_duration	HT_FLASHER,400
+arug_cas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+arug_cas04	mapflag	skill_duration	HT_BLASTMINE,400
+arug_cas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+arug_cas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+arug_cas05	mapflag	skill_duration	HT_SKIDTRAP,400
+arug_cas05	mapflag	skill_duration	HT_LANDMINE,400
+arug_cas05	mapflag	skill_duration	HT_ANKLESNARE,400
+arug_cas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+arug_cas05	mapflag	skill_duration	HT_SANDMAN,400
+arug_cas05	mapflag	skill_duration	HT_FLASHER,400
+arug_cas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+arug_cas05	mapflag	skill_duration	HT_BLASTMINE,400
+arug_cas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+arug_cas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Novice Guild Castles
+//============================================================
+n_castle	mapflag	skill_duration	HT_SKIDTRAP,400
+n_castle	mapflag	skill_duration	HT_LANDMINE,400
+n_castle	mapflag	skill_duration	HT_ANKLESNARE,400
+n_castle	mapflag	skill_duration	HT_SHOCKWAVE,400
+n_castle	mapflag	skill_duration	HT_SANDMAN,400
+n_castle	mapflag	skill_duration	HT_FLASHER,400
+n_castle	mapflag	skill_duration	HT_FREEZINGTRAP,400
+n_castle	mapflag	skill_duration	HT_BLASTMINE,400
+n_castle	mapflag	skill_duration	HT_CLAYMORETRAP,400
+n_castle	mapflag	skill_duration	HT_TALKIEBOX,400
+
+nguild_alde	mapflag	skill_duration	HT_SKIDTRAP,400
+nguild_alde	mapflag	skill_duration	HT_LANDMINE,400
+nguild_alde	mapflag	skill_duration	HT_ANKLESNARE,400
+nguild_alde	mapflag	skill_duration	HT_SHOCKWAVE,400
+nguild_alde	mapflag	skill_duration	HT_SANDMAN,400
+nguild_alde	mapflag	skill_duration	HT_FLASHER,400
+nguild_alde	mapflag	skill_duration	HT_FREEZINGTRAP,400
+nguild_alde	mapflag	skill_duration	HT_BLASTMINE,400
+nguild_alde	mapflag	skill_duration	HT_CLAYMORETRAP,400
+nguild_alde	mapflag	skill_duration	HT_TALKIEBOX,400
+
+nguild_gef	mapflag	skill_duration	HT_SKIDTRAP,400
+nguild_gef	mapflag	skill_duration	HT_LANDMINE,400
+nguild_gef	mapflag	skill_duration	HT_ANKLESNARE,400
+nguild_gef	mapflag	skill_duration	HT_SHOCKWAVE,400
+nguild_gef	mapflag	skill_duration	HT_SANDMAN,400
+nguild_gef	mapflag	skill_duration	HT_FLASHER,400
+nguild_gef	mapflag	skill_duration	HT_FREEZINGTRAP,400
+nguild_gef	mapflag	skill_duration	HT_BLASTMINE,400
+nguild_gef	mapflag	skill_duration	HT_CLAYMORETRAP,400
+nguild_gef	mapflag	skill_duration	HT_TALKIEBOX,400
+
+nguild_pay	mapflag	skill_duration	HT_SKIDTRAP,400
+nguild_pay	mapflag	skill_duration	HT_LANDMINE,400
+nguild_pay	mapflag	skill_duration	HT_ANKLESNARE,400
+nguild_pay	mapflag	skill_duration	HT_SHOCKWAVE,400
+nguild_pay	mapflag	skill_duration	HT_SANDMAN,400
+nguild_pay	mapflag	skill_duration	HT_FLASHER,400
+nguild_pay	mapflag	skill_duration	HT_FREEZINGTRAP,400
+nguild_pay	mapflag	skill_duration	HT_BLASTMINE,400
+nguild_pay	mapflag	skill_duration	HT_CLAYMORETRAP,400
+nguild_pay	mapflag	skill_duration	HT_TALKIEBOX,400
+
+nguild_prt	mapflag	skill_duration	HT_SKIDTRAP,400
+nguild_prt	mapflag	skill_duration	HT_LANDMINE,400
+nguild_prt	mapflag	skill_duration	HT_ANKLESNARE,400
+nguild_prt	mapflag	skill_duration	HT_SHOCKWAVE,400
+nguild_prt	mapflag	skill_duration	HT_SANDMAN,400
+nguild_prt	mapflag	skill_duration	HT_FLASHER,400
+nguild_prt	mapflag	skill_duration	HT_FREEZINGTRAP,400
+nguild_prt	mapflag	skill_duration	HT_BLASTMINE,400
+nguild_prt	mapflag	skill_duration	HT_CLAYMORETRAP,400
+nguild_prt	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Battlegrounds
+//============================================================
+bat_a01	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_a01	mapflag	skill_duration	HT_LANDMINE,400
+bat_a01	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_a01	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_a01	mapflag	skill_duration	HT_SANDMAN,400
+bat_a01	mapflag	skill_duration	HT_FLASHER,400
+bat_a01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_a01	mapflag	skill_duration	HT_BLASTMINE,400
+bat_a01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_a01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_a02	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_a02	mapflag	skill_duration	HT_LANDMINE,400
+bat_a02	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_a02	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_a02	mapflag	skill_duration	HT_SANDMAN,400
+bat_a02	mapflag	skill_duration	HT_FLASHER,400
+bat_a02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_a02	mapflag	skill_duration	HT_BLASTMINE,400
+bat_a02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_a02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_b01	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_b01	mapflag	skill_duration	HT_LANDMINE,400
+bat_b01	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_b01	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_b01	mapflag	skill_duration	HT_SANDMAN,400
+bat_b01	mapflag	skill_duration	HT_FLASHER,400
+bat_b01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_b01	mapflag	skill_duration	HT_BLASTMINE,400
+bat_b01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_b01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_b02	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_b02	mapflag	skill_duration	HT_LANDMINE,400
+bat_b02	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_b02	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_b02	mapflag	skill_duration	HT_SANDMAN,400
+bat_b02	mapflag	skill_duration	HT_FLASHER,400
+bat_b02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_b02	mapflag	skill_duration	HT_BLASTMINE,400
+bat_b02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_b02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_c01	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_c01	mapflag	skill_duration	HT_LANDMINE,400
+bat_c01	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_c01	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_c01	mapflag	skill_duration	HT_SANDMAN,400
+bat_c01	mapflag	skill_duration	HT_FLASHER,400
+bat_c01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_c01	mapflag	skill_duration	HT_BLASTMINE,400
+bat_c01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_c01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_c02	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_c02	mapflag	skill_duration	HT_LANDMINE,400
+bat_c02	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_c02	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_c02	mapflag	skill_duration	HT_SANDMAN,400
+bat_c02	mapflag	skill_duration	HT_FLASHER,400
+bat_c02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_c02	mapflag	skill_duration	HT_BLASTMINE,400
+bat_c02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_c02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+bat_c03	mapflag	skill_duration	HT_SKIDTRAP,400
+bat_c03	mapflag	skill_duration	HT_LANDMINE,400
+bat_c03	mapflag	skill_duration	HT_ANKLESNARE,400
+bat_c03	mapflag	skill_duration	HT_SHOCKWAVE,400
+bat_c03	mapflag	skill_duration	HT_SANDMAN,400
+bat_c03	mapflag	skill_duration	HT_FLASHER,400
+bat_c03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+bat_c03	mapflag	skill_duration	HT_BLASTMINE,400
+bat_c03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+bat_c03	mapflag	skill_duration	HT_TALKIEBOX,400

--- a/npc/re/mapflag/skill_duration.txt
+++ b/npc/re/mapflag/skill_duration.txt
@@ -1,0 +1,121 @@
+//===== rAthena Mapflag ======================================
+//= Sets skill time limit on specified map.
+//===== Structure ============================================
+//= mapname	skill_duration	skill_name,percentage
+//============================================================
+
+//============================================================
+// Gloria Castles
+//============================================================
+te_prtcas01	mapflag	skill_duration	HT_SKIDTRAP,400
+te_prtcas01	mapflag	skill_duration	HT_LANDMINE,400
+te_prtcas01	mapflag	skill_duration	HT_ANKLESNARE,400
+te_prtcas01	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_prtcas01	mapflag	skill_duration	HT_SANDMAN,400
+te_prtcas01	mapflag	skill_duration	HT_FLASHER,400
+te_prtcas01	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_prtcas01	mapflag	skill_duration	HT_BLASTMINE,400
+te_prtcas01	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_prtcas01	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_prtcas02	mapflag	skill_duration	HT_SKIDTRAP,400
+te_prtcas02	mapflag	skill_duration	HT_LANDMINE,400
+te_prtcas02	mapflag	skill_duration	HT_ANKLESNARE,400
+te_prtcas02	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_prtcas02	mapflag	skill_duration	HT_SANDMAN,400
+te_prtcas02	mapflag	skill_duration	HT_FLASHER,400
+te_prtcas02	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_prtcas02	mapflag	skill_duration	HT_BLASTMINE,400
+te_prtcas02	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_prtcas02	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_prtcas03	mapflag	skill_duration	HT_SKIDTRAP,400
+te_prtcas03	mapflag	skill_duration	HT_LANDMINE,400
+te_prtcas03	mapflag	skill_duration	HT_ANKLESNARE,400
+te_prtcas03	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_prtcas03	mapflag	skill_duration	HT_SANDMAN,400
+te_prtcas03	mapflag	skill_duration	HT_FLASHER,400
+te_prtcas03	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_prtcas03	mapflag	skill_duration	HT_BLASTMINE,400
+te_prtcas03	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_prtcas03	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_prtcas04	mapflag	skill_duration	HT_SKIDTRAP,400
+te_prtcas04	mapflag	skill_duration	HT_LANDMINE,400
+te_prtcas04	mapflag	skill_duration	HT_ANKLESNARE,400
+te_prtcas04	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_prtcas04	mapflag	skill_duration	HT_SANDMAN,400
+te_prtcas04	mapflag	skill_duration	HT_FLASHER,400
+te_prtcas04	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_prtcas04	mapflag	skill_duration	HT_BLASTMINE,400
+te_prtcas04	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_prtcas04	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_prtcas05	mapflag	skill_duration	HT_SKIDTRAP,400
+te_prtcas05	mapflag	skill_duration	HT_LANDMINE,400
+te_prtcas05	mapflag	skill_duration	HT_ANKLESNARE,400
+te_prtcas05	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_prtcas05	mapflag	skill_duration	HT_SANDMAN,400
+te_prtcas05	mapflag	skill_duration	HT_FLASHER,400
+te_prtcas05	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_prtcas05	mapflag	skill_duration	HT_BLASTMINE,400
+te_prtcas05	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_prtcas05	mapflag	skill_duration	HT_TALKIEBOX,400
+
+//============================================================
+// Kafragaten Castles
+//============================================================
+te_aldecas1	mapflag	skill_duration	HT_SKIDTRAP,400
+te_aldecas1	mapflag	skill_duration	HT_LANDMINE,400
+te_aldecas1	mapflag	skill_duration	HT_ANKLESNARE,400
+te_aldecas1	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_aldecas1	mapflag	skill_duration	HT_SANDMAN,400
+te_aldecas1	mapflag	skill_duration	HT_FLASHER,400
+te_aldecas1	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_aldecas1	mapflag	skill_duration	HT_BLASTMINE,400
+te_aldecas1	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_aldecas1	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_aldecas2	mapflag	skill_duration	HT_SKIDTRAP,400
+te_aldecas2	mapflag	skill_duration	HT_LANDMINE,400
+te_aldecas2	mapflag	skill_duration	HT_ANKLESNARE,400
+te_aldecas2	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_aldecas2	mapflag	skill_duration	HT_SANDMAN,400
+te_aldecas2	mapflag	skill_duration	HT_FLASHER,400
+te_aldecas2	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_aldecas2	mapflag	skill_duration	HT_BLASTMINE,400
+te_aldecas2	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_aldecas2	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_aldecas3	mapflag	skill_duration	HT_SKIDTRAP,400
+te_aldecas3	mapflag	skill_duration	HT_LANDMINE,400
+te_aldecas3	mapflag	skill_duration	HT_ANKLESNARE,400
+te_aldecas3	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_aldecas3	mapflag	skill_duration	HT_SANDMAN,400
+te_aldecas3	mapflag	skill_duration	HT_FLASHER,400
+te_aldecas3	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_aldecas3	mapflag	skill_duration	HT_BLASTMINE,400
+te_aldecas3	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_aldecas3	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_aldecas4	mapflag	skill_duration	HT_SKIDTRAP,400
+te_aldecas4	mapflag	skill_duration	HT_LANDMINE,400
+te_aldecas4	mapflag	skill_duration	HT_ANKLESNARE,400
+te_aldecas4	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_aldecas4	mapflag	skill_duration	HT_SANDMAN,400
+te_aldecas4	mapflag	skill_duration	HT_FLASHER,400
+te_aldecas4	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_aldecas4	mapflag	skill_duration	HT_BLASTMINE,400
+te_aldecas4	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_aldecas4	mapflag	skill_duration	HT_TALKIEBOX,400
+
+te_aldecas5	mapflag	skill_duration	HT_SKIDTRAP,400
+te_aldecas5	mapflag	skill_duration	HT_LANDMINE,400
+te_aldecas5	mapflag	skill_duration	HT_ANKLESNARE,400
+te_aldecas5	mapflag	skill_duration	HT_SHOCKWAVE,400
+te_aldecas5	mapflag	skill_duration	HT_SANDMAN,400
+te_aldecas5	mapflag	skill_duration	HT_FLASHER,400
+te_aldecas5	mapflag	skill_duration	HT_FREEZINGTRAP,400
+te_aldecas5	mapflag	skill_duration	HT_BLASTMINE,400
+te_aldecas5	mapflag	skill_duration	HT_CLAYMORETRAP,400
+te_aldecas5	mapflag	skill_duration	HT_TALKIEBOX,400

--- a/npc/re/scripts_mapflags.conf
+++ b/npc/re/scripts_mapflags.conf
@@ -15,3 +15,4 @@ npc: npc/re/mapflag/night.txt
 npc: npc/re/mapflag/restricted.txt
 npc: npc/re/mapflag/town.txt
 npc: npc/re/mapflag/reset.txt
+npc: npc/re/mapflag/skill_duration.txt

--- a/npc/scripts_mapflags.conf
+++ b/npc/scripts_mapflags.conf
@@ -26,3 +26,4 @@ npc: npc/mapflag/battleground.txt
 npc: npc/mapflag/skill_damage.txt
 npc: npc/mapflag/town.txt
 npc: npc/mapflag/nocostume.txt
+npc: npc/mapflag/skill_duration.txt

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3489,6 +3489,7 @@ void map_flags_init(void)
 			map[i].flag.pvp = 1; // make all maps pvp for pk_mode [Valaris]
 
 		map_free_questinfo(i);
+		map_skill_duration_free(&map[i]);
 	}
 }
 
@@ -4341,6 +4342,61 @@ void map_skill_damage_add(struct map_data *m, uint16 skill_id, int pc, int mob, 
 #endif
 
 /**
+ * Add skill_duration to a map.
+ * @param map Pointer to specified map.
+ * @param skill_id Skill ID.
+ * @param per Skill duration adjustment value in percent.
+ * @return True:Success, False:Failed
+ **/
+bool map_skill_duration_add(struct map_data *map, uint16 skill_id, uint16 per) {
+
+	if (!map || !skill_get_index(skill_id))
+		return false;
+	else {
+		uint16 i;
+		struct s_skill_duration *entry = NULL;
+
+		for (i = 0; i < map->skill_duration.count; i++) {
+			if (map->skill_duration.entries[i] && map->skill_duration.entries[i]->skill_id == skill_id) {// Replace
+				map->skill_duration.entries[i]->per = per;
+				return true;
+			}
+		}
+
+		RECREATE(map->skill_duration.entries, struct s_skill_duration *, map->skill_duration.count+1);
+		CREATE(map->skill_duration.entries[map->skill_duration.count], struct s_skill_duration, 1);
+		map->skill_duration.entries[map->skill_duration.count]->skill_id = skill_id;
+		map->skill_duration.entries[map->skill_duration.count]->per = per;
+		map->skill_duration.count++;
+	}
+
+	return true;
+}
+
+/**
+ * Clear skill_duration adjustment from a map.
+ * @param map Pointer to specified map.
+ **/
+void map_skill_duration_free(struct map_data *map) {
+	uint16 i;
+
+	if (!map)
+		return;
+
+	if (map->skill_duration.entries) {
+		for (i = 0; i < map->skill_duration.count; i++) {
+			if (map->skill_duration.entries[i]) {
+				aFree(map->skill_duration.entries[i]);
+				map->skill_duration.entries[i] = NULL;
+			}
+		}
+		aFree(map->skill_duration.entries);
+	}
+	map->skill_duration.entries = NULL;
+	map->skill_duration.count = 0;
+}
+
+/**
  * @see DBApply
  */
 static int cleanup_db_sub(DBKey key, DBData *data, va_list va)
@@ -4426,6 +4482,7 @@ void do_final(void)
 				if (map[i].moblist[j]) aFree(map[i].moblist[j]);
 		}
 		map_free_questinfo(i);
+		map_skill_duration_free(&map[i]);
 #ifdef ADJUST_SKILL_DAMAGE
 		if (map[i].skill_damage.count)
 			map_skill_damage_free(&map[i]);

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -575,6 +575,11 @@ struct s_skill_damage {
 struct eri *map_skill_damage_ers;
 #endif
 
+struct s_skill_duration {
+	uint16 skill_id;
+	uint16 per;
+};
+
 struct questinfo_req {
 	unsigned int quest_id;
 	unsigned state : 2; // 0: Doesn't have, 1: Inactive, 2: Active, 3: Complete //! TODO: CONFIRM ME!!
@@ -692,6 +697,11 @@ struct map_data {
 		uint8 count;
 	} skill_damage;
 #endif
+	struct {
+		struct s_skill_duration **entries;
+		uint16 count;
+	} skill_duration;
+
 	// Instance Variables
 	unsigned short instance_id;
 	int instance_src_map;
@@ -896,6 +906,9 @@ void map_removemapdb(struct map_data *m);
 void map_skill_damage_free(struct map_data *m);
 void map_skill_damage_add(struct map_data *m, uint16 skill_id, int pc, int mob, int boss, int other, uint8 caster);
 #endif
+
+bool map_skill_duration_add(struct map_data *map, uint16 skill_id, uint16 per);
+void map_skill_duration_free(struct map_data *map);
 
 #define CHK_ELEMENT(ele) ((ele) > ELE_NONE && (ele) < ELE_MAX) /// Check valid Element
 #define CHK_ELEMENT_LEVEL(lv) ((lv) >= 1 && (lv) <= MAX_ELE_LEVEL) /// Check valid element level

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -4091,6 +4091,19 @@ static const char* npc_parse_mapflag(char* w1, char* w2, char* w3, char* w4, con
 		map[m].flag.notomb = state;
 	else if (!strcmpi(w3,"nocostume"))
 		map[m].flag.nocostume = state;
+	else if (!strcmpi(w3, "skill_duration")) {
+		if (!state && map[m].skill_duration.count)
+			map_skill_duration_free(&map[m]);
+		else {
+			char skill_name[SKILL_NAME_LENGTH];
+			uint16 per = 0;
+			if (sscanf(w4, "%30[^,],%5hu[^\n]", skill_name, &per) == 2) {
+				uint16 skill_id = skill_name2id(skill_name);
+				if (!skill_id || !map_skill_duration_add(&map[m], skill_id, per))
+					ShowError("npc_parse_mapflag: skill_duration: Skipping (file '%s', line '%d')\n", filepath, strline(buffer,start-buffer));
+			}
+		}
+	}
 	else if (!strcmpi(w3,"skill_damage")) {
 #ifdef ADJUST_SKILL_DAMAGE
 		char skill[SKILL_NAME_LENGTH];

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -12619,8 +12619,6 @@ struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16 skill_
 			ARR_FIND(0, MAX_SKILL_ITEM_REQUIRE, i, req.itemid[i] && (req.itemid[i] == ITEMID_TRAP || req.itemid[i] == ITEMID_TRAP_ALLOY));
 			if( i != MAX_SKILL_ITEM_REQUIRE && req.itemid[i] )
 				req_item = req.itemid[i];
-			if( map_flag_gvg(src->m) || map[src->m].flag.battleground )
-				limit *= 4; // longer trap times in WOE [celest]
 			if( battle_config.vs_traps_bctall && map_flag_vs(src->m) && (src->type&battle_config.vs_traps_bctall) )
 				target = BCT_ALL;
 		}

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -12515,7 +12515,7 @@ struct skill_unit_group *skill_unitsetting(struct block_list *src, uint16 skill_
 
 	nullpo_retr(NULL, src);
 
-	limit = skill_get_time(skill_id,skill_lv);
+	limit = skill_get_time3(skill_id,skill_lv,src);
 	range = skill_get_unit_range(skill_id,skill_lv);
 	interval = skill_get_unit_interval(skill_id);
 	target = skill_get_unit_target(skill_id);
@@ -20526,6 +20526,30 @@ static bool skill_check_unit_movepos(uint8 check_flag, struct block_list *bl, sh
 		return false;
 
 	return unit_movepos(bl, dst_x, dst_y, easy, checkpath);
+}
+
+/**
+ * Get skill duration after adjustments by skill_duration mapflag.
+ * @param skill_id Skill ID.
+ * @param skill_lv Skill level.
+ * @param src Source BL to map location.
+ * @return Adjusted skill duration.
+ **/
+int skill_get_time3(uint16 skill_id, uint16 skill_lv, struct block_list *src) {
+	int time = 0;
+
+	if (!skill_get_index(skill_id) || !(time = skill_get_time(skill_id, skill_lv)))
+		return 0;
+	if (src && map[src->m].skill_duration.count && map[src->m].skill_duration.entries) {
+		struct s_skill_duration *entry = NULL;
+		uint16 i;
+
+		for (i = 0; i < map[src->m].skill_duration.count; i++) {
+			if ((entry = map[src->m].skill_duration.entries[i]) && entry->skill_id == skill_id)
+				return time * entry->per / 100;
+		}
+	}
+	return time;
 }
 
 /*==========================================

--- a/src/map/skill.h
+++ b/src/map/skill.h
@@ -2135,6 +2135,7 @@ void skill_combo_toogle_inf(struct block_list* bl, uint16 skill_id, int inf);
 void skill_combo(struct block_list* src,struct block_list *dsrc, struct block_list *bl, uint16 skill_id, uint16 skill_lv, int tick);
 
 void skill_reveal_trap_inarea(struct block_list *src, int range, int x, int y);
+int skill_get_time3(uint16 skill_id, uint16 skill_lv, struct block_list *src);
 
 #ifdef ADJUST_SKILL_DAMAGE
 /// Skill Damage target


### PR DESCRIPTION
- This mapflag to set skill unit time limit to `n%` of original duration.
- Implemented mapflags for Hunter's Traps in GVG, BG, and Novice Guild maps.

Signed-off-by: Cydh Ramdh cydh@pservero.com
