### PR TITLE
Corrected 'VIP' personal info notification

### DIFF
--- a/doc/packet_interserv.txt
+++ b/doc/packet_interserv.txt
@@ -468,7 +468,7 @@ Currently the max packet size is 0xFFFF (see 'WFIFOSET()' in 'src/common/socket.
 
 0x2743:
 	Type: AH
-	Structure: <cmd>.W <aid>.L <vip_time>.L <flag>.B <groupid>.L <mapfd>.B
+	Structure: <cmd>.W <aid>.L <vip_time>.L <flag>.B <groupid>.L <mapfd>.L
 	index: 0,2,6,10,11,15
 	len: 19
 	parameter:

--- a/doc/packet_interserv.txt
+++ b/doc/packet_interserv.txt
@@ -454,13 +454,13 @@ Currently the max packet size is 0xFFFF (see 'WFIFOSET()' in 'src/common/socket.
 
 0x2742:
 	Type: HA
-	Structure: <cmd>.W <aid>.L <type>.B <timediff>.L <mapfd>.L
+	Structure: <cmd>.W <aid>.L <flag>.B <timediff>.L <mapfd>.L
 	index: 0,2,6,7,11
 	len: 15
 	parameter:
 		- cmd : packet identification (0x2742)
 		- aid: account identification
-		- type: &1 ack vip data to char-serv, &2 add duration
+		- flag: 0x1 ack vip data to char-serv, 0x2 add duration, 0x8 First request on player login
 		- timediff: tick to add to viptime
 		- mapfd: map-serv link to ack if type&1
 	desc:
@@ -468,16 +468,15 @@ Currently the max packet size is 0xFFFF (see 'WFIFOSET()' in 'src/common/socket.
 
 0x2743:
 	Type: AH
-	Structure: <cmd>.W <aid>.L <vip_time>.L <isvip>.B <groupid>.L <isgm>.L <mapfd>.B
-	index: 0,2,6,10,11,15,16
-	len: 20
+	Structure: <cmd>.W <aid>.L <vip_time>.L <flag>.B <groupid>.L <mapfd>.B
+	index: 0,2,6,10,11,15
+	len: 19
 	parameter:
 		- cmd : packet identification (0x2743)
 		- aid: account identification
 		- vip_time: timestamp of vip_time if he is vip
-		- isvip: is this account in vip mode atm
+		- flag: 0x1: isvip, is this account in vip mode atm, 0x2: isgm, 0x4: show rates on player
 		- groupid: group id of account
-		- isgm: is he a gm
 		- mapfd: map-serv link to ack
 	desc:
 		- Transmit vip specific data to char-serv (will be transfered to mapserv)
@@ -2501,16 +2500,15 @@ Currently the max packet size is 0xFFFF (see 'WFIFOSET()' in 'src/common/socket.
 
 0x2b2b
 	Type: AZ
-	Structure: <cmd>.W <aid>.L <vip_time>.L <isvip>.B <isgm>.B <groupid>.L
-	index: 0,2,6,10,11,12
-	len: 16
+	Structure: <cmd>.W <aid>.L <vip_time>.L <groupid>.L <flag>.B
+	index: 0,2,6,10,11
+	len: 15
 	parameter:
 		- cmd : packet identification (0x2b2b)
 		- aid
 		- vip_time
-		- isvip
-		- isgm
 		- groupid
+		- flag : 0x1: isvip, is this account in vip mode atm, 0x2: isgm, 0x4: show rates on player
 	desc:
 		- Received vip-data from char-serv, fill map-serv data
 

--- a/src/char/char_logif.c
+++ b/src/char/char_logif.c
@@ -621,38 +621,37 @@ int chlogif_parse_updip(int fd, struct char_session_data* sd){
  */
 int chlogif_parse_vipack(int fd) {
 #ifdef VIP_ENABLE
-	if (RFIFOREST(fd) < 20)
+	if (RFIFOREST(fd) < 19)
 		return 0;
 	else {
 		uint32 aid = RFIFOL(fd,2); //aid
 		uint32 vip_time = RFIFOL(fd,6); //vip_time
-		uint8 isvip = RFIFOB(fd,10); //isvip
+		uint8 flag = RFIFOB(fd,10);
 		uint32 groupid = RFIFOL(fd,11); //new group id
-		uint8 isgm = RFIFOB(fd,15); //isgm
-		int mapfd = RFIFOL(fd,16); //link to mapserv for ack
-		RFIFOSKIP(fd,20);
-		chmapif_vipack(mapfd,aid,vip_time,isvip,isgm,groupid);
+		int mapfd = RFIFOL(fd,15); //link to mapserv for ack
+		RFIFOSKIP(fd,19);
+		chmapif_vipack(mapfd,aid,vip_time,groupid,flag);
 	}
 #endif
 	return 1;
 }
 
 /**
- * HZ 0x2b2b
- * Request vip data from loginserv
+ * HA 0x2742
+ * Request vip data to loginserv
  * @param aid : account_id to request the vip data
- * @param type : &2 define new duration, &1 load info
+ * @param flag : 0x1 Select info and update old_groupid, 0x2 VIP duration is changed by atcommand or script, 0x8 First request on player login
  * @param add_vip_time : tick to add to vip timestamp
  * @param mapfd: link to mapserv for ack
  * @return 0 if success
  */
-int chlogif_reqvipdata(uint32 aid, uint8 type, int32 timediff, int mapfd) {
+int chlogif_reqvipdata(uint32 aid, uint8 flag, int32 timediff, int mapfd) {
 	loginif_check(-1);
 #ifdef VIP_ENABLE
 	WFIFOHEAD(login_fd,15);
 	WFIFOW(login_fd,0) = 0x2742;
 	WFIFOL(login_fd,2) = aid; //aid
-	WFIFOB(login_fd,6) = type; //type
+	WFIFOB(login_fd,6) = flag; //flag
 	WFIFOL(login_fd,7) = timediff; //req_inc_duration
 	WFIFOL(login_fd,11) = mapfd; //req_inc_duration
 	WFIFOSET(login_fd,15);

--- a/src/char/char_logif.h
+++ b/src/char/char_logif.h
@@ -44,7 +44,7 @@ int chlogif_parse_askkick(int fd, struct char_session_data* sd);
 int chlogif_parse_updip(int fd, struct char_session_data* sd);
 
 int chlogif_parse_vipack(int fd);
-int chlogif_reqvipdata(uint32 aid, uint8 type, int32 timediff, int mapfd);
+int chlogif_reqvipdata(uint32 aid, uint8 flag, int32 timediff, int mapfd);
 int chlogif_req_accinfo(int fd, int u_fd, int u_aid, int u_group, int account_id, int8 type);
 
 int chlogif_parse(int fd);

--- a/src/char/char_mapif.c
+++ b/src/char/char_mapif.c
@@ -1206,16 +1206,15 @@ int chmapif_parse_updfamelist(int fd){
  * HZ 0x2b2b
  * Transmist vip data to mapserv
  */
-int chmapif_vipack(int mapfd, uint32 aid, uint32 vip_time, uint8 isvip, uint8 isgm, uint32 groupid) {
+int chmapif_vipack(int mapfd, uint32 aid, uint32 vip_time, uint32 groupid, uint8 flag) {
 #ifdef VIP_ENABLE
-	uint8 buf[16];
+	uint8 buf[15];
 	WBUFW(buf,0) = 0x2b2b;
 	WBUFL(buf,2) = aid;
 	WBUFL(buf,6) = vip_time;
-	WBUFB(buf,10) = isvip;
-	WBUFB(buf,11) = isgm;
-	WBUFL(buf,12) = groupid;
-	chmapif_send(mapfd,buf,16);  // inform the mapserv back
+	WBUFL(buf,10) = groupid;
+	WBUFB(buf,14) = flag;
+	chmapif_send(mapfd,buf,15);  // inform the mapserv back
 #endif
 	return 0;
 }

--- a/src/char/char_mapif.h
+++ b/src/char/char_mapif.h
@@ -47,7 +47,7 @@ int chmapif_parse_reqauth(int fd, int id);
 int chmapif_parse_updmapip(int fd, int id);
 int chmapif_parse_fw_configstats(int fd);
 
-int chmapif_vipack(int mapfd, uint32 aid, uint32 vip_time, uint8 isvip, uint8 isgm, uint32 groupid);
+int chmapif_vipack(int mapfd, uint32 aid, uint32 vip_time, uint32 groupid, uint8 flag);
 int chmapif_parse_reqcharban(int fd);
 int chmapif_parse_reqcharunban(int fd);
 int chmapif_bonus_script_get(int fd);

--- a/src/login/loginchrif.c
+++ b/src/login/loginchrif.c
@@ -206,18 +206,21 @@ int logchrif_send_accdata(int fd, uint32 aid) {
 
 /**
  * Transmit vip specific data to char-serv (will be transfered to mapserv)
+ * @param fd
+ * @param acc
+ * @param flag 0x1: VIP, 0x2: GM, 0x4: Show rates on player
+ * @param mapfd
  */
-int logchrif_sendvipdata(int fd, struct mmo_account acc, char isvip, char isgm, int mapfd) {
+int logchrif_sendvipdata(int fd, struct mmo_account acc, unsigned char flag, int mapfd) {
 #ifdef VIP_ENABLE
 	WFIFOHEAD(fd,19);
 	WFIFOW(fd,0) = 0x2743;
 	WFIFOL(fd,2) = acc.account_id;
 	WFIFOL(fd,6) = (int)acc.vip_time;
-	WFIFOB(fd,10) = isvip;
+	WFIFOB(fd,10) = flag;
 	WFIFOL(fd,11) = acc.group_id; //new group id
-	WFIFOL(fd,15) = isgm;
-	WFIFOL(fd,16) = mapfd; //link to mapserv
-	WFIFOSET(fd,20);
+	WFIFOL(fd,15) = mapfd; //link to mapserv
+	WFIFOSET(fd,19);
 	logchrif_send_accdata(fd,acc.account_id); //refresh char with new setting
 #endif
 	return 1;
@@ -649,8 +652,9 @@ int logchrif_parse_pincode_authfail(int fd){
 /**
  * Received a vip data reqest from char
  * type is the query to perform
- *  &1 : Select info and update old_groupid
- *  &2 : Update vip time
+ *  0x1 : Select info and update old_groupid
+ *  0x2 : VIP duration is changed by atcommand or script
+ *  0x8 : First request on player login
  * @param fd link to charserv
  * @return 0 missing data, 1 succeeded
  */
@@ -662,7 +666,7 @@ int logchrif_parse_reqvipdata(int fd) {
 		struct mmo_account acc;
 		AccountDB* accounts = login_get_accounts_db();
 		int aid = RFIFOL(fd,2);
-		int8 type = RFIFOB(fd,6);
+		int8 flag = RFIFOB(fd,6);
 		int32 timediff = RFIFOL(fd,7);
 		int mapfd = RFIFOL(fd,11);
 		RFIFOSKIP(fd,15);
@@ -673,10 +677,10 @@ int logchrif_parse_reqvipdata(int fd) {
 			bool isvip = false;
 
 			if( acc.group_id > login_config.vip_sys.group ) { //Don't change group if it's higher.
-				logchrif_sendvipdata(fd,acc,false,true,mapfd);
+				logchrif_sendvipdata(fd,acc,0x2|((flag&0x8)?0x4:0),mapfd);
 				return 1;
 			}
-			if( type&2 ) {
+			if( flag&2 ) {
 				if(!vip_time)
 					vip_time = now; //new entry
 				vip_time += timediff; // set new duration
@@ -696,8 +700,8 @@ int logchrif_parse_reqvipdata(int fd) {
 			}
 			acc.vip_time = vip_time;
 			accounts->save(accounts,&acc);
-			if( type&1 )
-				logchrif_sendvipdata(fd,acc,isvip,false,mapfd);
+			if( flag&1 )
+				logchrif_sendvipdata(fd,acc,((isvip)?0x1:0)|((flag&0x8)?0x4:0),mapfd);
 		}
 	}
 #endif

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -9549,8 +9549,6 @@ ACMD_FUNC(vip) {
 	pl_sd->vip.time += vipdifftime; //increase or reduce VIP duration
 	
 	if (pl_sd->vip.time <= now) {
-		pl_sd->vip.time = 0;
-		pl_sd->vip.enabled = 0;
 		clif_displaymessage(pl_sd->fd, msg_txt(pl_sd,703)); // GM has removed your VIP time.
 		clif_displaymessage(fd, msg_txt(sd,704)); // Player is no longer VIP.
 	} else {

--- a/src/map/chrif.c
+++ b/src/map/chrif.c
@@ -39,7 +39,7 @@ static const int packet_len_table[0x3d] = { // U - used, F - free
 	11,10,10, 0,11, -1,266,10,	// 2b10-2b17: U->2b10, U->2b11, U->2b12, F->2b13, U->2b14, U->2b15, U->2b16, U->2b17
 	 2,10, 2,-1,-1,-1, 2, 7,	// 2b18-2b1f: U->2b18, U->2b19, U->2b1a, U->2b1b, U->2b1c, U->2b1d, U->2b1e, U->2b1f
 	-1,10, 8, 2, 2,14,19,19,	// 2b20-2b27: U->2b20, U->2b21, U->2b22, U->2b23, U->2b24, U->2b25, U->2b26, U->2b27
-	-1, 0, 6,16, 0, 6,-1,-1,	// 2b28-2b2f: U->2b28, F->2b29, U->2b2a, U->2b2b, F->2b2c, U->2b2d, U->2b2e, U->2b2f
+	-1, 0, 6,15, 0, 6,-1,-1,	// 2b28-2b2f: U->2b28, F->2b29, U->2b2a, U->2b2b, F->2b2c, U->2b2d, U->2b2e, U->2b2f
  };
 
 //Used Packets:
@@ -849,6 +849,10 @@ int chrif_changeemail(int id, const char *actual_email, const char *new_email) {
  * @operation_type : see chrif_req_op
  * @timediff : tick to add or remove to unixtimestamp
  * @val1 : extra data value to transfer for operation
+ *		   CHRIF_OP_LOGIN_VIP: 0x1 : Select info and update old_groupid
+ *							   0x2 : VIP duration is changed by atcommand or script
+ *							   0x4 : Show status reply by char-server through 0x2b0f
+ *							   0x8 : First request on player login
  * @val2 : extra data value to transfer for operation
  */
 int chrif_req_login_operation(int aid, const char* character_name, enum chrif_req_op operation_type, int32 timediff, int val1, int val2) {
@@ -1575,38 +1579,44 @@ void chrif_parse_ack_vipActive(int fd) {
 #ifdef VIP_ENABLE
 	int aid = RFIFOL(fd,2);
 	uint32 vip_time = RFIFOL(fd,6);
-	bool isvip = RFIFOB(fd,10);
-	bool isgm = RFIFOB(fd,11);
-	uint32 groupid = RFIFOL(fd,12);
+	uint32 groupid = RFIFOL(fd,10);
+	uint8 flag = RFIFOB(fd,14);
 	TBL_PC *sd = map_id2sd(aid);
+	bool changed = false;
 
 	if(sd == NULL) return;
 
 	sd->group_id = groupid;
 	pc_group_pc_load(sd);
 
-	if(isgm) {
+	if ((flag&0x2)) //isgm
 		clif_displaymessage(sd->fd,msg_txt(sd,437));
-		return;
-	}
-	if(isvip) {
-		sd->vip.enabled = 1;
-		sd->vip.time = vip_time;
-		// Increase storage size for VIP.
-		sd->storage_size = battle_config.vip_storage_increase + MIN_STORAGE;
-		if (sd->storage_size > MAX_STORAGE) {
-			ShowError("intif_parse_ack_vipActive: Storage size for player %s (%d:%d) is larger than MAX_STORAGE. Storage size has been set to MAX_STORAGE.\n", sd->status.name, sd->status.account_id, sd->status.char_id);
-			sd->storage_size = MAX_STORAGE;
+	else {
+		changed = (sd->vip.enabled != (flag&0x1));
+		if((flag&0x1)) { //isvip
+			sd->vip.enabled = 1;
+			sd->vip.time = vip_time;
+			// Increase storage size for VIP.
+			sd->storage_size = battle_config.vip_storage_increase + MIN_STORAGE;
+			if (sd->storage_size > MAX_STORAGE) {
+				ShowError("intif_parse_ack_vipActive: Storage size for player %s (%d:%d) is larger than MAX_STORAGE. Storage size has been set to MAX_STORAGE.\n", sd->status.name, sd->status.account_id, sd->status.char_id);
+				sd->storage_size = MAX_STORAGE;
+			}
+			// Magic Stone requirement avoidance for VIP.
+			if (battle_config.vip_gemstone)
+				sd->special_state.no_gemstone = 2; // need to be done after status_calc_bl(bl,first);
+		} else if (sd->vip.enabled) {
+			sd->vip.enabled = 0;
+			sd->vip.time = 0;
+			sd->storage_size = MIN_STORAGE;
+			sd->special_state.no_gemstone = 0;
+			clif_displaymessage(sd->fd,msg_txt(sd,438));
 		}
-		// Magic Stone requirement avoidance for VIP.
-		if (battle_config.vip_gemstone)
-			sd->special_state.no_gemstone = 2; // need to be done after status_calc_bl(bl,first);
-	} else if (sd->vip.enabled) {
-		sd->vip.enabled = 0;
-		sd->vip.time = 0;
-		sd->storage_size = MIN_STORAGE;
-		sd->special_state.no_gemstone = 0;
-		clif_displaymessage(sd->fd,msg_txt(sd,438));
+	}
+	// Show info if status changed
+	if (((flag&0x4) || changed) && !sd->vip.disableshowrate) {
+		clif_display_pinfo(sd,ZC_PERSONAL_INFOMATION);
+		//clif_vip_display_info(sd,ZC_PERSONAL_INFOMATION_CHN);
 	}
 #endif
 }

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10303,12 +10303,6 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 		clif_partyinvitationstate(sd);
 		clif_equipcheckbox(sd);
 #endif
-#ifdef VIP_ENABLE
-		if (!sd->vip.disableshowrate) {
-			clif_display_pinfo(sd,ZC_PERSONAL_INFOMATION);
-			//clif_vip_display_info(sd,ZC_PERSONAL_INFOMATION_CHN);
-		}
-#endif
 
 		if (sd->guild && battle_config.guild_notice_changemap == 1)
 			clif_guild_notice(sd, sd->guild); // Displays after VIP

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10232,7 +10232,6 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 	if(sd->state.connect_new) {
 		int lv;
 		guild_notice = true;
-		sd->state.connect_new = 0;
 		clif_skillinfoblock(sd);
 		clif_hotkeys_send(sd);
 		clif_updatestatus(sd,SP_BASEEXP);
@@ -10347,7 +10346,18 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 		status_change_clear_onChangeMap(&sd->bl, &sd->sc);
 		map_iwall_get(sd); // Updates Walls Info on this Map to Client
 		status_calc_pc(sd, SCO_NONE); // Some conditions are map-dependent so we must recalculate
-		sd->state.changemap = false;
+
+#ifdef VIP_ENABLE
+		if (!sd->state.connect_new &&
+			!sd->vip.disableshowrate &&
+			sd->state.pmap != sd->bl.m &&
+			map[sd->state.pmap].adjust.bexp != map[sd->bl.m].adjust.bexp
+			)
+		{
+			clif_display_pinfo(sd,ZC_PERSONAL_INFOMATION);
+			//clif_vip_display_info(sd,ZC_PERSONAL_INFOMATION_CHN);
+		}
+#endif
 
 		// Instances do not need their own channels
 		if( channel_config.map_enable && channel_config.map_autojoin && !map[sd->bl.m].flag.chmautojoin && !map[sd->bl.m].instance_id )
@@ -10414,6 +10424,9 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 
 	pc_show_questinfo_reinit(sd);
 	pc_show_questinfo(sd);
+
+	sd->state.connect_new = 0;
+	sd->state.changemap = false;
 }
 
 

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -1443,7 +1443,7 @@ void pc_reg_received(struct map_session_data *sd)
 #ifdef VIP_ENABLE
 	sd->vip.time = 0;
 	sd->vip.enabled = 0;
-	chrif_req_login_operation(sd->status.account_id, sd->status.name, CHRIF_OP_LOGIN_VIP, 0, 1, 0);  // request VIP information
+	chrif_req_login_operation(sd->status.account_id, sd->status.name, CHRIF_OP_LOGIN_VIP, 0, 1|8, 0);  // request VIP information
 #endif
 	intif_Mail_requestinbox(sd->status.char_id, 0); // MAIL SYSTEM - Request Mail Inbox
 	intif_request_questlog(sd);


### PR DESCRIPTION
* Only displayed when map-server is changed, should not when map changed/warped
* Updated some packet that related with VIP and its doc.

Signed-off-by: Cydh Ramdh <cydh@pservero.com>

---
TODO:
* [x] Show notification if the map has base/job exp rate modified by `bexp` and `jexp` mapflag?