### PR TITLE
Updated Manhole skill behavior

### DIFF
--- a/db/pre-re/skill_db.txt
+++ b/db/pre-re/skill_db.txt
@@ -1087,7 +1087,7 @@
 2295,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_LAZINESS,Masquerade - Laziness
 2296,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_UNLUCKY,Masquerade - Unlucky
 2297,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_WEAKNESS,Masquerade - Weakness
-2298,3,6,1,0,0x1,0,5,1,yes,0,0,0,none,0,0x8000,	SC_STRIPACCESSARY,Strip Accessory
+2298,3,6,1,0,0x1,0,5,1,yes,0,0,0,none,0,0x0,	SC_STRIPACCESSARY,Strip Accessory
 2299,7,6,2,0,0x1,0,3,1,yes,0,0,3,magic,0,0x0,	SC_MANHOLE,Man Hole
 2300,7,6,2,0,0x1,0,3,1,yes,0,0,1,magic,0,0x0,	SC_DIMENSIONDOOR,Dimension Door
 2301,7,6,2,0,0x1,0,3,1,yes,0,0x20000,0,magic,0,0x0,	SC_CHAOSPANIC,Chaos Panic

--- a/db/re/skill_db.txt
+++ b/db/re/skill_db.txt
@@ -1087,7 +1087,7 @@
 2295,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_LAZINESS,Masquerade - Laziness
 2296,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_UNLUCKY,Masquerade - Unlucky
 2297,3,6,1,0,0x1,0,3,1,yes,0,0,0,none,0,0x0,	SC_WEAKNESS,Masquerade - Weakness
-2298,3,6,1,0,0x1,0,5,1,yes,0,0,0,none,0,0x8000,	SC_STRIPACCESSARY,Strip Accessory
+2298,3,6,1,0,0x1,0,5,1,yes,0,0,0,none,0,0x0,	SC_STRIPACCESSARY,Strip Accessory
 2299,7,6,2,0,0x1,0,3,1,yes,0,0,3,magic,0,0x0,	SC_MANHOLE,Man Hole
 2300,7,6,2,0,0x1,0,3,1,yes,0,0,1,magic,0,0x0,	SC_DIMENSIONDOOR,Dimension Door
 2301,7,6,2,0,0x1,0,3,1,yes,0,0x20000,0,magic,0,0x0,	SC_CHAOSPANIC,Chaos Panic

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2014,6 +2014,10 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 				&& (src->type != BL_PC || ((TBL_PC*)src)->skillitem != skill_id))
 				return false;
 			break;
+		case SC_MANHOLE:
+			// Skill is disabled against special racial grouped monsters(GvG and Battleground)
+			if (status_get_race2(target) == RC2_GVG || status_get_race2(target) == RC2_BATTLEFIELD)
+				return false;
 		default:
 			break;
 	}
@@ -2187,14 +2191,6 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 			if( tsc ) {
 				if( tsc->option&hide_flag && !status_has_mode(status,MD_DETECTOR))
 					return false;
-			}
-			if (status_get_race2(target) == RC2_GVG || status_get_race2(target) == RC2_BATTLEFIELD) { // Skills disabled in GvG and Battleground against special racial grouped monsters
-				switch (skill_id) {
-					case SC_MANHOLE:
-						return false;
-					default:
-						break;
-				}
 			}
 	}
 	return true;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2188,6 +2188,14 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 				if( tsc->option&hide_flag && !status_has_mode(status,MD_DETECTOR))
 					return false;
 			}
+			if (status_get_race2(target) == RC2_GVG || status_get_race2(target) == RC2_BATTLEFIELD) { // Skills disabled in GvG and Battleground against special racial grouped monsters
+				switch (skill_id) {
+					case SC_MANHOLE:
+						return false;
+					default:
+						break;
+				}
+			}
 	}
 	return true;
 }


### PR DESCRIPTION
* Fixes #1601
* GvG and Battleground monster objects are not able to be targeted by Manhole.
* Removed the usage of Strip Accessory on targets who are affected by Manhole.
Thanks to @ignizh!