### PR TITLE
Updated default PACKETVER

### DIFF
--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -23,7 +23,7 @@ feature.atcommand_suggestions: off
 // Feature became unstable on clients 2012 onwards (exact date not known),
 // it has been fixed on clients 2013-05-15 onwards however.
 // Feature was removed again on clients 2014-11-12 and later.
-feature.auction: on
+feature.auction: off
 
 // Warp suggestions (Note 1)
 // Show suggestions when attempting to @warp to a non-existent map?

--- a/src/common/mmo.h
+++ b/src/common/mmo.h
@@ -21,7 +21,7 @@
 // see conf/battle/client.conf for other version
 
 #ifndef PACKETVER
-	#define PACKETVER 20130807
+	#define PACKETVER 20151104
 	//#define PACKETVER 20120410
 #endif
 


### PR DESCRIPTION
It makes no sense to use 20130807 as the default PACKETVER when we use 55 (20151104) as the default packet_ver in /db/packet_db.txt

Signed-off-by: Akkarinage akkarin@rathena.org
