### PR TITLE
Mora Enchants: Arch Bishop Rings should be exchangeable by ABs since …

### DIFF
--- a/npc/re/merchants/enchan_mora.txt
+++ b/npc/re/merchants/enchan_mora.txt
@@ -106,15 +106,15 @@ mora,88,89,5	script	Keeper of Secrets#pa082	495,{
 		mes "You have obtained ^aa00aa"+getitemname(.@item)+"^000000. May the Blessing of the Light be with you.";
 		close;
 	case 3:
-		if (Class == Job_Arch_Bishop || Class == Job_Arch_Bishop_T || Class == Job_Baby_Bishop) {
+		if (Class != Job_Arch_Bishop && Class != Job_Arch_Bishop_T && Class != Job_Baby_Bishop) {
 			mes "[Artifice]";
-			mes "We exchange rings into coins for those who cannot control the ring.";
+			mes "We exchange rings into coins for those who can control the ring.";
 			next;
 			mes "[Artifice]";
-			mes "It seems that you have power to control the ring so I cannot exchange it into coins.";
+			mes "It seems that you have no power to control the ring so I cannot exchange it into coins.";
 			close;
 		}
-		     if (countitem(2864)) set .@item,2864; //Light_Of_Cure
+		if (countitem(2864)) set .@item,2864; //Light_Of_Cure
 		else if (countitem(2865)) set .@item,2865; //Seal_Of_Cathedral
 		else if (countitem(2866)) set .@item,2866; //Ring_Of_Archbishop
 		else {


### PR DESCRIPTION
…they can only bought by them.

This is a suggestion! It's not possible to exchange the rings currently.

http://irowiki.org/wiki/Mora_Enchants

> Only an Arch Bishop can trade in Mora Coins for the gear with the Keeper of Secrets. Enchanting with the Master of Relics has a chance of breaking the gear.

> The Master of Relics is located near the middle of town by the lake (mora 96, 74). Any of the gears may be purchased from the Keeper of Secrets (88, 89) at a cost of 10 Mora Coins each; however, the player is only allowed to select which equipment type they desire (shoes, armor, weapon, accessory), and they are given one of the 2 or 3 possibilities at random. However, you are not allowed to purchase an accessory when you already have one or more in your inventory. Also, it's possible to trade any of the three accessories in to obtain 10 Mora coins, to do so choose the third option from the Keeper of Secrets. 

Anyway even with this change it sounds strange to me. Why do you get a random accessory, when it's possible to exchange them for the same buying price?

(needs official information)