### PR TITLE
correct bad npc name format in buwaya cave instance

### DIFF
--- a/npc/re/instances/BuwayaCave.txt
+++ b/npc/re/instances/BuwayaCave.txt
@@ -156,20 +156,20 @@ OnTouch:
 
 // Instance Scripts :: buwaya_in
 //============================================================
-1@ma_c,33,112,0	script	#damage	139,7,7,{
+1@ma_c,33,112,0	script	damage	139,7,7,{
 	end;
 OnInstanceInit:
 	initnpctimer;
-	disablenpc instance_npcname("#damage");
+	disablenpc instance_npcname("damage");
 	end;
 OnTimer1000:
-	enablenpc instance_npcname("#damage");
+	enablenpc instance_npcname("damage");
 	specialeffect EF_POISONHIT;
 	end;
 OnTimer2000:
 	stopnpctimer;
 	initnpctimer;
-	disablenpc instance_npcname("#damage");
+	disablenpc instance_npcname("damage");
 	end;
 OnTouch:
 	percentheal -10,-10;
@@ -190,7 +190,7 @@ OnTouch:
 		mes "We don't have enough power to destroy it but Buwaya has a weakness.";
 		mes "Look at the wall over there.";
 		mes "If you knock there, Buywaya will feel pain and spit you out.";
-		donpcevent instance_npcname("#box_mob_call")+"::OnEnable";
+		donpcevent instance_npcname("box_mob_call")+"::OnEnable";
 		close2;
 		disablenpc instance_npcname("Kidnapped People#1");
 		end;
@@ -206,7 +206,7 @@ OnInstanceInit:
 	end;
 OnEnable:
 	enablenpc instance_npcname("Kidnapped People#1");
-	donpcevent instance_npcname("#box_mob_call")+"::OnDisable";
+	donpcevent instance_npcname("box_mob_call")+"::OnDisable";
 	end;
 }
 
@@ -244,36 +244,36 @@ OnEnable:
 	end;
 }
 
-1@ma_c,3,3,0	script	#box_mob_call	139,1,1,{
+1@ma_c,3,3,0	script	box_mob_call	139,1,1,{
 	end;
 OnInstanceInit:
 	setcell instance_mapname("1@ma_c"),30,118,35,118,cell_shootable,1; //custom
-	disablenpc instance_npcname("#box_mob_call");
+	disablenpc instance_npcname("box_mob_call");
 	end;
 OnEnable:
-	enablenpc instance_npcname("#box_mob_call");
-	set .@label$, instance_npcname("#box_mob_call")+"::OnMyMobDead";
+	enablenpc instance_npcname("box_mob_call");
+	set .@label$, instance_npcname("box_mob_call")+"::OnMyMobDead";
 	set .@map$, instance_mapname("1@ma_c");
 	monster .@map$,30,118,"Buwaya's Weakness",2333,1,.@label$;
 	monster .@map$,35,118,"Buwaya's Weakness",2333,1,.@label$;
 	end;
 OnDisable:
-	killmonster instance_mapname("1@ma_c"),instance_npcname("#box_mob_call")+"::OnMyMobDead";
-	disablenpc instance_npcname("#box_mob_call");
+	killmonster instance_mapname("1@ma_c"),instance_npcname("box_mob_call")+"::OnMyMobDead";
+	disablenpc instance_npcname("box_mob_call");
 	end;
 OnMyMobDead:
-	if (mobcount(instance_mapname("1@ma_c"),instance_npcname("#box_mob_call")+"::OnMyMobDead") < 1)
-		donpcevent instance_npcname("#box_out")+"::OnEnable";
+	if (mobcount(instance_mapname("1@ma_c"),instance_npcname("box_mob_call")+"::OnMyMobDead") < 1)
+		donpcevent instance_npcname("box_out")+"::OnEnable";
 	end;
 }
 
-1@ma_c,33,118,0	script	#box_out	45,2,2,{
+1@ma_c,33,118,0	script	box_out	45,2,2,{
 OnInstanceInit:
 OnDisable:
-	disablenpc instance_npcname("#box_out");
+	disablenpc instance_npcname("box_out");
 	end;
 OnEnable:
-	enablenpc instance_npcname("#box_out");
+	enablenpc instance_npcname("box_out");
 	end;
 OnTouch:
 	set .@x, rand(1,20) + 97;
@@ -282,31 +282,31 @@ OnTouch:
 	end;
 }
 
-1@ma_c,97,74,0	script	#box_call	139,50,50,{
+1@ma_c,97,74,0	script	box_call	139,50,50,{
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname("#box_call");
+	disablenpc instance_npcname("box_call");
 	initnpctimer;
 	end;
 OnTimer30000:
 	mapannounce instance_mapname("1@ma_c"),"Buwaya : I will put you in my treasure box!",bc_map,"0x00ff99"; //FW_NORMAL 12 0 0
 	// Should execute OnTimer33000, but client doesn't render the effect fast enough.
 	for(set .@i,1; .@i<=9; set .@i,.@i+1)
-		donpcevent instance_npcname("#yunobi"+.@i)+"::OnEnable";
+		donpcevent instance_npcname("yunobi"+.@i)+"::OnEnable";
 	end;
 OnTimer33000:
-	donpcevent instance_npcname("#box_out")+"::OnDisable";
-	donpcevent instance_npcname("#box_mob_call")+"::OnDisable";
+	donpcevent instance_npcname("box_out")+"::OnDisable";
+	donpcevent instance_npcname("box_mob_call")+"::OnDisable";
 	donpcevent instance_npcname("Kidnapped People#1")+"::OnEnable";
 	donpcevent instance_npcname("Kidnapped People#2")+"::OnEnable";
 	end;
 OnTimer34000:
-	enablenpc instance_npcname("#box_call");
+	enablenpc instance_npcname("box_call");
 	end;
 OnTimer35000:
 	stopnpctimer;
 	initnpctimer;
-	disablenpc instance_npcname("#box_call");
+	disablenpc instance_npcname("box_call");
 	end;
 OnTouch_:
 	specialeffect2 EF_GUIDEDATTACK;
@@ -314,11 +314,11 @@ OnTouch_:
 	end;
 OnDisable:
 	stopnpctimer;
-	disablenpc instance_npcname("#box_call");
+	disablenpc instance_npcname("box_call");
 	end;
 }
 
-1@ma_c,97,74,0	script	#yunobi1	139,{
+1@ma_c,97,74,0	script	yunobi1	139,{
 	end;
 OnInstanceInit:
 	hideonnpc instance_npcname(strnpcinfo(0));
@@ -327,16 +327,16 @@ OnEnable:
 	specialeffect EF_MAPPILLAR2;
 	end;
 }
-1@ma_c,97,94,0	duplicate(#yunobi1)	#yunobi2	139
-1@ma_c,117,94,0	duplicate(#yunobi1)	#yunobi3	139
-1@ma_c,117,74,0	duplicate(#yunobi1)	#yunobi4	139
-1@ma_c,117,54,0	duplicate(#yunobi1)	#yunobi5	139
-1@ma_c,97,54,0	duplicate(#yunobi1)	#yunobi6	139
-1@ma_c,77,54,0	duplicate(#yunobi1)	#yunobi7	139
-1@ma_c,77,74,0	duplicate(#yunobi1)	#yunobi8	139
-1@ma_c,77,94,0	duplicate(#yunobi1)	#yunobi9	139
+1@ma_c,97,94,0	duplicate(yunobi1)	yunobi2	139
+1@ma_c,117,94,0	duplicate(yunobi1)	yunobi3	139
+1@ma_c,117,74,0	duplicate(yunobi1)	yunobi4	139
+1@ma_c,117,54,0	duplicate(yunobi1)	yunobi5	139
+1@ma_c,97,54,0	duplicate(yunobi1)	yunobi6	139
+1@ma_c,77,54,0	duplicate(yunobi1)	yunobi7	139
+1@ma_c,77,74,0	duplicate(yunobi1)	yunobi8	139
+1@ma_c,77,94,0	duplicate(yunobi1)	yunobi9	139
 
-1@ma_c,1,1,0	script	#bunshin	139,{
+1@ma_c,1,1,0	script	bunshin	139,{
 	end;
 OnInstanceInit:
 	initnpctimer;
@@ -357,7 +357,7 @@ OnTimer64000:
 	mapannounce instance_mapname("1@ma_c"),"Buwaya : This is...MY...Deadly... ATTACK!",bc_map,"0x00ff99"; //FW_NORMAL 12 0 0
 	end;
 OnTimer65000:
-	set .@label$, instance_npcname("#bunshin")+"::OnMyMobDead";
+	set .@label$, instance_npcname("bunshin")+"::OnMyMobDead";
 	set .@map$, instance_mapname("1@ma_c");
 	areamonster .@map$,112,89,122,99,"Buwaya",2332,1,.@label$;
 	areamonster .@map$,112,49,122,59,"Buwaya",2332,1,.@label$;
@@ -368,47 +368,47 @@ OnTimer66000:
 	mapannounce instance_mapname("1@ma_c"),"Buwaya : Are you scared?",bc_map,"0x00ff99"; //FW_NORMAL 12 0 0
 	end;
 OnTimer105000:
-	killmonster instance_mapname("1@ma_c"),instance_npcname("#bunshin")+"::OnMyMobDead";
+	killmonster instance_mapname("1@ma_c"),instance_npcname("bunshin")+"::OnMyMobDead";
 	stopnpctimer;
 	initnpctimer;
 	end;
 OnMyMobDead:
-	if (mobcount(instance_mapname("1@ma_c"),instance_npcname("#bunshin")+"::OnMyMobDead") < 1) {
+	if (mobcount(instance_mapname("1@ma_c"),instance_npcname("bunshin")+"::OnMyMobDead") < 1) {
 		stopnpctimer;
 		initnpctimer;
 	}
 	end;
 OnDisable:
 	stopnpctimer;
-	killmonster instance_mapname("1@ma_c"),instance_npcname("#bunshin")+"::OnMyMobDead";
-	disablenpc instance_npcname("#bunshin");
+	killmonster instance_mapname("1@ma_c"),instance_npcname("bunshin")+"::OnMyMobDead";
+	disablenpc instance_npcname("bunshin");
 	end;
 }
 
-1@ma_c,2,2,0	script	#buwaya_con	139,{
+1@ma_c,2,2,0	script	buwaya_con	139,{
 	end;
 OnInstanceInit:
-	areamonster instance_mapname("1@ma_c"),90,67,104,81,"Buwaya",2319,1,instance_npcname("#buwaya_con")+"::OnMyMobDead";
+	areamonster instance_mapname("1@ma_c"),90,67,104,81,"Buwaya",2319,1,instance_npcname("buwaya_con")+"::OnMyMobDead";
 	end;
 OnMyMobDead:
 	set .@map$, instance_mapname("1@ma_c");
-	if (mobcount(.@map$,instance_npcname("#buwaya_con")+"::OnMyMobDead") < 1) {
-		donpcevent instance_npcname("#box_call")+"::OnDisable";
-		donpcevent instance_npcname("#bunshin")+"::OnDisable";
-		donpcevent instance_npcname("#exit_mob")+"::OnDisable";
-		donpcevent instance_npcname("#cave_out")+"::OnEnable";
+	if (mobcount(.@map$,instance_npcname("buwaya_con")+"::OnMyMobDead") < 1) {
+		donpcevent instance_npcname("box_call")+"::OnDisable";
+		donpcevent instance_npcname("bunshin")+"::OnDisable";
+		donpcevent instance_npcname("exit_mob")+"::OnDisable";
+		donpcevent instance_npcname("cave_out")+"::OnEnable";
 		mapannounce .@map$,"Guard : You did great work. Please hurry up and escape to the way you came in!",bc_map,"0x00ff99"; //FW_NORMAL 12 0 0
 	}
 	end;
 }
 
-1@ma_c,3,3,0	script	#exit_mob	139,{
+1@ma_c,3,3,0	script	exit_mob	139,{
 	end;
 OnInstanceInit:
 	initnpctimer;
 	end;
 OnTimer60000:
-	set .@label$, instance_npcname("#exit_mob")+"::OnMyMobDead";
+	set .@label$, instance_npcname("exit_mob")+"::OnMyMobDead";
 	set .@map$, instance_mapname("1@ma_c");
 	if (mobcount(.@map$,.@label$) < 30)
 		set .@amount,10;
@@ -421,19 +421,19 @@ OnTimer60000:
 	end;
 OnDisable:
 	stopnpctimer;
-	killmonster instance_mapname("1@ma_c"),instance_npcname("#exit_mob")+"::OnMyMobDead";
-	disablenpc instance_npcname("#exit_mob");
+	killmonster instance_mapname("1@ma_c"),instance_npcname("exit_mob")+"::OnMyMobDead";
+	disablenpc instance_npcname("exit_mob");
 	end;
 OnMyMobDead:
 	end;
 }
 
-1@ma_c,28,57,0	script	#cave_out	45,2,2,{
+1@ma_c,28,57,0	script	cave_out	45,2,2,{
 OnInstanceInit:
-	disablenpc instance_npcname("#cave_out");
+	disablenpc instance_npcname("cave_out");
 	end;
 OnEnable:
-	enablenpc instance_npcname("#cave_out");
+	enablenpc instance_npcname("cave_out");
 	end;
 OnTouch:
 	mes "Would like to go out?";
@@ -443,7 +443,7 @@ OnTouch:
 	close;
 }
 
-1@ma_c,1,1,0	script	#buwaya_spawn_mobs	-1,{
+1@ma_c,1,1,0	script	buwaya_spawn_mobs	-1,{
 OnInstanceInit:
 	set .@map$, instance_mapname("1@ma_c");
 	areamonster .@map$,73,81,93,101,"Seaweed",2331,18;


### PR DESCRIPTION
IMO. The first char of npc name should not be put in with '#' .