### PR TITLE
Official Random Coordinates for Savepoint

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3967,15 +3967,20 @@ normally translate to random coordinates.
 
 ---------------------------------------
 
-*savepoint "<map name>",<x>,<y>{,<char_id>};
-*save "<map name>",<x>,<y>{,<char_id>};
+*savepoint "<map name>",<x>,<y>{,{<range x>,<range y>,}<char_id>};
+*save "<map name>",<x>,<y>{,{<range x>,<range y>,}<char_id>};
 
 These commands save where the invoking character will return to upon clicking
 "Return to Save Point", after death and in some other cases. The two versions are 
 equivalent. They ignore any and all mapflags, and can make a character respawn where
 no teleportation is otherwise possible.
 
+The <range x> and <range y> optional values allow for a randomization with the
+player's save point. The values will randomly add or subtract from the given <x>
+and <y> coordinates.
+
     savepoint "place",350,75;
+	savepoint "place",350,75,2,2; // Randomly save the character between 350,75 and 352,77
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3980,7 +3980,7 @@ player's save point. The values will randomly add or subtract from the given <x>
 and <y> coordinates.
 
     savepoint "place",350,75;
-	savepoint "place",350,75,2,2; // Randomly save the character between 350,75 and 352,77
+	savepoint "place",350,75,2,2; // Randomly save the character between 348,73 and 352,77
 
 ---------------------------------------
 

--- a/npc/cities/einbroch.txt
+++ b/npc/cities/einbroch.txt
@@ -817,7 +817,7 @@ ein_in01,206,224,3	script	Hotel Employee#ein	855,{
 			mes "Thank you, and please";
 			mes "come again.";
 			close2;
-			savepoint "ein_in01",200,224;
+			savepoint "ein_in01",200,224,1,1;
 			end;
 		case 2:
 			if (Zeny > 4999) {

--- a/npc/jobs/2-1/assassin.txt
+++ b/npc/jobs/2-1/assassin.txt
@@ -99,7 +99,7 @@ in_moc_16,19,33,1	script	Guildsman#asn	55,{
 		set ASSIN_Q,0;
 		set ASSIN_Q2,0;
 		set ASSIN_Q3,0;
-		savepoint "in_moc_16",18,14;
+		savepoint "in_moc_16",18,14,1,1;
 		warp "in_moc_16",18,14;
 		end;
 	}
@@ -1460,7 +1460,7 @@ OnTouch_:
 	else
 		set ASSIN_Q,4;
 	warp "in_moc_16",87,102;
-	savepoint "in_moc_16",16,13;
+	savepoint "in_moc_16",16,13,1,1;
 	end;
 
 OnEnable:
@@ -1528,7 +1528,7 @@ OnTouch_:
 			set ASSIN_Q2,0;
 			set ASSIN_Q3,0;
 			changequest 8004,8000;
-			savepoint "in_moc_16",18,14;
+			savepoint "in_moc_16",18,14,1,1;
 			warp "in_moc_16",18,14;
 			donpcevent "Standby Room#ASNTEST::OnStart";
 			end;
@@ -1610,7 +1610,7 @@ OnTouch_:
 	}
 	else {
 		mapannounce "in_moc_16",strcharinfo(0)+" has entered 'Guildmaster's room.'",bc_map;
-		savepoint "in_moc_16",181,183;
+		savepoint "in_moc_16",181,183,1,1;
 		donpcevent "Guildmaster#ASN1::OnCast";
 		warp "in_moc_16",167,113;
 		end;
@@ -1619,7 +1619,7 @@ OnTouch_:
 
 in_moc_16,167,110,0	script	Guildmaster#ASN1	-1,3,1,{
 OnTouch_:
-	savepoint "in_moc_16",167,110;
+	savepoint "in_moc_16",167,110,1,1;
 	mes "[Guildmaster]";
 	mes "Welcome. ";
 	mes "This place is called the 'Guildmaster's room,' the deepest place in the Assassin guild.";
@@ -1641,7 +1641,7 @@ OnCast:
 in_moc_16,149,80,4	script	Guildmaster#ASN2	106,1,1,{
 	end;
 OnTouch_:
-	savepoint "morocc",100,100;
+	savepoint "morocc",100,100,1,1;
 	if (ASSIN_Q == 7 && BaseJob == Job_Thief) {
 		set ASSIN_Q,8;
 		mes "[Guildmaster]";
@@ -2128,7 +2128,7 @@ OnTouch_:
 		next;
 		mes "[Guildmaster]";
 		mes "You, " + strcharinfo(0) + ", have chosen to live as an Assassin. May you learn our ways and be an honorable example to others.";
-		savepoint "morocc",100,100;
+		savepoint "morocc",100,100,1,1;
 		getitem 1008,1; //Frozen_Heart
 		changequest 8006,8007;
 		next;

--- a/npc/jobs/2-1/hunter.txt
+++ b/npc/jobs/2-1/hunter.txt
@@ -743,7 +743,7 @@ payon_in03,131,7,3	script	Hunter#htnGM	59,{
 		mes "Wow, you came back in one piece!";
 		mes "I mean, good job. I'll give you the item which proves that you have passed the test.";
 		set HNTR_Q,17;
-		savepoint "payon",104,99;
+		savepoint "payon",104,99,1,1;
 		getitem 1007,1; //Penetration
 		changequest 4012,4013;
 		next;
@@ -935,7 +935,7 @@ payon_in02,21,31,1	script	Hunter#htnGM2	59,{
 		mes "Wow. You're back in one piece!";
 		mes "I mean, good job. Well then, I'll give you the item which serves as proof that you passed the test.";
 		set HNTR_Q,17;
-		savepoint "payon",104,99;
+		savepoint "payon",104,99,1,1;
 		getitem 1007,1; //Penetration
 		next;
 		mes "[Hunter Guildmaster]";
@@ -985,7 +985,7 @@ OnTouch_:
 		next;
 		mes "[Guide]";
 		mes "We will provide the arrows, so just make sure that you bring a bow. Well, then. Please enter when you are ready.";
-		savepoint "job_hunte",176,22;
+		savepoint "job_hunte",176,22,1,1;
 		close;
 	}
 	else if (HNTR_Q > 12 && HNTR_Q < 16) {
@@ -1011,7 +1011,7 @@ OnTouch_:
 			// donpcevent "Waiting Room#hnt::OnStart";
 			close2;
 			set HNTR_Q,13;
-			savepoint "payon",104,99;
+			savepoint "payon",104,99,1,1;
 			warp "payon_in02",21,27;
 		}
 	}
@@ -1019,7 +1019,7 @@ OnTouch_:
 		mes "[Guide]";
 		mes "You shouldn't be here. How about finding the required job change item first?";
 		close2;
-		savepoint "payon",104,99;
+		savepoint "payon",104,99,1,1;
 		warp "payon_in02",21,27;
 	}
 	end;
@@ -1258,7 +1258,7 @@ OnTouch_:
 	donpcevent "Waiting Room#hnt::OnStart";
 	set HNTR_Q,16;
 	changequest 4011,4012;
-	savepoint "payon",104,99;
+	savepoint "payon",104,99,1,1;
 	if (rand(2))
 		warp "payon_in02",21,27;
 	else

--- a/npc/jobs/2-1/priest.txt
+++ b/npc/jobs/2-1/priest.txt
@@ -1737,7 +1737,7 @@ function	script	F_FatherRub	{
 			mes "[Father Rubalkabara]";
 			mes "Well then, please head to your next destination for your pilgrimage. Be safe in your travels.";
 			close2;
-			savepoint "prt_fild03",361,255;
+			savepoint "prt_fild03",361,255,1,1;
 			set PRIEST_Q,2;
 			end;
 		}
@@ -1785,7 +1785,7 @@ function	script	F_MotherMart	{
 			mes "God for safety";
 			mes "on your journey.";
 			close2;
-			savepoint "moc_fild07",35,355;
+			savepoint "moc_fild07",35,355,1,1;
 			set PRIEST_Q,3;
 			end;
 		}
@@ -1845,7 +1845,7 @@ function	script	F_FatherYos	{
 			mes "your trials is now";
 			mes "completed.";
 			close2;
-			savepoint "prt_fild00",206,230;
+			savepoint "prt_fild00",206,230,1,1;
 			set PRIEST_Q,4;
 			end;
 		}

--- a/npc/jobs/2-1/wizard.txt
+++ b/npc/jobs/2-1/wizard.txt
@@ -837,7 +837,7 @@ gef_tower,102,24,2	script	Gloomy Wizard	735,{
 			mes "Just consider yourself a glass cannon...because the monsters are going to break you into pieces. Hahahahahahahahaha~";
 			next;
 			set WIZ_Q,6;
-			savepoint "geffen",120,107;
+			savepoint "geffen",120,107,1,1;
 			mes "[Raulel]";
 			mes "Then, as you wish. I'll send you there right now.";
 			mes "Oh, if you see a white light at the end of a tunnel, that means your pathetic cause you failed! Hahahahahah~";
@@ -871,7 +871,7 @@ gef_tower,102,24,2	script	Gloomy Wizard	735,{
 		next;
 		if (select("Continue testing.:I want to go back because I have butterflies in my stomach.") == 1) {
 			set WIZ_Q,6;
-			savepoint "geffen",120,107;
+			savepoint "geffen",120,107,1,1;
 			mes "[Raulel]";
 			mes "You are indeed, very determined. Ok! Hahahahahaha~";
 			mes "*Cough* *cough* As you wish, we shall begin the final test!";
@@ -911,7 +911,7 @@ gef_tower,102,24,2	script	Gloomy Wizard	735,{
 			mes "*Cough* Cough* Do you want to take the test again? Or did you bring the ^3355FFWorn Out Scroll^000000?";
 			next;
 			if (select("Continue the test.:Worn Out Scroll...") == 1) {
-				savepoint "geffen",120,107;
+				savepoint "geffen",120,107,1,1;
 				mes "[Raulel]";
 				mes "Hahaha~ Ok, at least you have some spirit.";
 				mes "I'll send you in again, try dying once more will yah? Hahahahahahahahaha~";

--- a/npc/jobs/valkyrie.txt
+++ b/npc/jobs/valkyrie.txt
@@ -391,7 +391,7 @@ S_WarpChar:
 	mes "[Teleporter]";
 	mes "Have a nice trip.";
 	close2;
-	savepoint getarg(0),getarg(1),getarg(2);
+	savepoint getarg(0),getarg(1),getarg(2),1,1;
 	warp getarg(0),getarg(1),getarg(2);
 	end;
 }

--- a/npc/kafras/cool_event_corp.txt
+++ b/npc/kafras/cool_event_corp.txt
@@ -39,7 +39,7 @@ function	script	F_CoolEventCorp	{
 		mes getarg(1)+".";
 		mes "Thank you for using the";
 		mes "Cool Event Corp. service~";
-		savepoint getarg(2),getarg(3),getarg(4);
+		savepoint getarg(2),getarg(3),getarg(4),1,1;
 		close2;
 		break;
 	case 2:

--- a/npc/kafras/kafras.txt
+++ b/npc/kafras/kafras.txt
@@ -43,7 +43,7 @@ aldeba_in,96,181,4	script	Kafra Service	113,{
 		mes "of the Kafra Corporation";
 		mes "Headquarters. Thank you.";
 		next;
-		savepoint "aldeba_in",96,179;
+		savepoint "aldeba_in",96,179,1,1;
 		mes "[Kafra Leilah]";
 		mes "Please make use of";
 		mes "the Kafra Services that are";
@@ -121,7 +121,7 @@ aldebaran,143,119,4	script	Kafra Employee::kaf_aldebaran	113,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,1,20,600;
-	savepoint "aldebaran",143,109;
+	savepoint "aldebaran",143,109,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Al De Baran";
 }
 
@@ -136,7 +136,7 @@ geffen,120,62,0	script	Kafra Employee::kaf_geffen	115,{
 	mes "are always on your side.";
 	mes "So how can I help you?";
 	callfunc "F_Kafra",5,0,0,30,750;
-	savepoint "geffen",119,40;
+	savepoint "geffen",119,40,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Geffen";
 }
 
@@ -151,7 +151,7 @@ geffen,203,123,2	script	Kafra Employee::geffen2	114,{
 	mes "with its excellent service. So";
 	mes "what can I do for you today?";
 	callfunc "F_Kafra",5,0,0,30,750;
-	savepoint "geffen",200,124;
+	savepoint "geffen",200,124,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Geffen";
 }
 
@@ -166,7 +166,7 @@ morocc,156,97,4	script	Kafra Employee::kaf_morocc	113,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,0,60,930;
-	savepoint "morocc",156,46;
+	savepoint "morocc",156,46,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Morroc";
 }
 
@@ -181,7 +181,7 @@ morocc,160,258,4	script	Kafra::kaf_morocc2	114,{
 	mes "with its excellent service. So";
 	mes "what can I do for you today?";
 	callfunc "F_Kafra",5,0,0,60,930;
-	savepoint "morocc",157,272;
+	savepoint "morocc",157,272,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Morroc";
 }
 
@@ -196,7 +196,7 @@ payon,181,104,4	script	Kafra Employee::kaf_payon	113,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,1,60,930;
-	savepoint "payon",160,58;
+	savepoint "payon",160,58,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Payon";
 }
 
@@ -210,7 +210,7 @@ payon,175,226,4	script	Kafra Employee::kaf_payon2	116,{
 	mes "always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,0,1,60,930;
-	savepoint "payon",257,242;
+	savepoint "payon",257,242,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Payon";
 }
 
@@ -224,7 +224,7 @@ pay_arche,55,123,0	script	Kafra Employee::kaf_payon3	4_F_KAFRA1,{
 	mes "are always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,5,1,90,1200;
-	savepoint "pay_arche",49,144;
+	savepoint "pay_arche",49,144,1,1;
 	callfunc "F_KafEnd",0,1,"at the Payon Dungeon";
 }
 
@@ -241,7 +241,7 @@ prontera,152,326,3	script	Kafra Employee::kaf_prontera	112,{
 	mes "you. So how can I be";
 	mes "of service today?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "prontera",157,327;
+	savepoint "prontera",157,327,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Prontera";
 }
 
@@ -254,7 +254,7 @@ prontera,151,29,0	script	Kafra Employee::kaf_prontera2	115,{
 	mes "are always on your side.";
 	mes "So how can I help you?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "prontera",150,33;
+	savepoint "prontera",150,33,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Prontera";
 }
 
@@ -267,7 +267,7 @@ prontera,29,207,6	script	Kafra Employee::kaf_prontera3	113,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "prontera",33,208;
+	savepoint "prontera",33,208,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Prontera";
 }
 
@@ -282,7 +282,7 @@ prontera,282,200,2	script	Kafra Employee::kaf_prontera4	114,{
 	mes "with its excellent service. So";
 	mes "what can I do for you today?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "prontera",281,203;
+	savepoint "prontera",281,203,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Prontera";
 }
 
@@ -296,7 +296,7 @@ prontera,146,89,6	script	Kafra Employee::kaf_prontera5	117,{
 	mes "are always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "prontera",116,73;
+	savepoint "prontera",116,73,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Prontera";
 }
 
@@ -311,7 +311,7 @@ yuno,152,187,4	script	Kafra Employee::kaf_yuno	860,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "yuno",158,125;
+	savepoint "yuno",158,125,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Juno";
 }
 
@@ -324,7 +324,7 @@ yuno,327,108,4	script	Kafra Employee::kaf_yuno2	860,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "yuno",328,101;
+	savepoint "yuno",328,101,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Juno";
 }
 
@@ -337,7 +337,7 @@ yuno,277,221,4	script	Kafra Employee::kaf_yuno3	861,{
 	mes "you with convenient services.";
 	mes "How may I be of assistance?";
 	callfunc "F_Kafra",5,0,0,40,800;
-	savepoint "yuno",274,229;
+	savepoint "yuno",274,229,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Juno";
 }
 
@@ -353,7 +353,7 @@ alberta,28,229,0	script	Kafra Employee::kaf_alberta	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,0,0,50,850;
-	savepoint "alberta",31,231;
+	savepoint "alberta",31,231,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Alberta";
 }
 
@@ -368,7 +368,7 @@ alberta,113,60,6	script	Kafra Employee::kaf_alberta2	112,{
 	mes "you. So how can I be";
 	mes "of service today?";
 	callfunc "F_Kafra",5,0,0,50,850;
-	savepoint "alberta",117,57;
+	savepoint "alberta",117,57,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Alberta";
 }
 
@@ -384,7 +384,7 @@ comodo,195,150,4	script	Kafra Employee::kaf_comodo	721,{
 	mes "service is always";
 	mes "on your side~";
 	callfunc "F_Kafra",5,0,1,80,1000;
-	savepoint "comodo",204,143;
+	savepoint "comodo",204,143,1,1;
 	callfunc "F_KafEnd",0,1,"in the town of Comodo";
 }
 
@@ -398,7 +398,7 @@ cmd_fild07,136,134,4	script	Kafra Employee::kaf_cmd_fild07	721,{
 	mes "service is always";
 	mes "on your side~";
 	callfunc "F_Kafra",5,0,1,80,1000;
-	savepoint "cmd_fild07",127,134;
+	savepoint "cmd_fild07",127,134,1,1;
 	callfunc "F_KafEnd",0,1,"in Pyros Lighthouse";
 }
 
@@ -417,7 +417,7 @@ cmd_fild07,136,134,4	script	Kafra Employee::kaf_cmd_fild07	721,{
 	if (checkre(0))
 		savepoint strnpcinfo(4),129,97;
 	else
-		savepoint "izlude",94,103;
+		savepoint "izlude",94,103,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Izlude";
 }
 
@@ -426,7 +426,7 @@ cmd_fild07,136,134,4	script	Kafra Employee::kaf_cmd_fild07	721,{
 moscovia,223,191,3	script	Kafra Employee::kaf_mosk	114,{
 	cutin "kafra_04",2;
 	callfunc "F_Kafra",0,3,0,80,700;
-	savepoint "moscovia",221,194;;
+	savepoint "moscovia",221,194,1,1;;
 	callfunc "F_KafEnd",0,3,"in the city of Moscovia";
 }
 
@@ -441,7 +441,7 @@ amatsu,102,149,4	script	Kafra Employee::kaf_amatsu	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,3,1,50,700;
-	savepoint "amatsu",116,94;
+	savepoint "amatsu",116,94,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Amatsu";
 }
 
@@ -456,7 +456,7 @@ ayothaya,212,169,5	script	Kafra Employee::kaf_ayothaya	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,3,1,50,700;
-	savepoint "ayothaya",149,69;
+	savepoint "ayothaya",149,69,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Ayotaya";
 }
 
@@ -470,7 +470,7 @@ einbech,181,132,5	script	Kafra Employee#ein3::kaf_einbech	860,{
 	mes "are always on your side.";
 	mes "So how can I help you?";
 	callfunc "F_Kafra",5,4,1,40,850;
-	savepoint "einbech",182,124;
+	savepoint "einbech",182,124,1,1;
 	callfunc "F_KafEnd",0,1,"in the town of Einbech";
 }
 
@@ -485,7 +485,7 @@ einbroch,242,205,5	script	Kafra Employee#ein2::kaf_einbroch	860,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,4,1,50,800;
-	savepoint "einbroch",238,198;
+	savepoint "einbroch",238,198,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Einbroch";
 }
 
@@ -498,7 +498,7 @@ einbroch,59,203,6	script	Kafra Employee#ein1::kaf_einbroch2	861,{
 	mes "are always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,4,1,50,800;
-	savepoint "einbroch",240,197;
+	savepoint "einbroch",240,197,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Einbroch";
 }
 
@@ -513,7 +513,7 @@ gonryun,159,122,4	script	Kafra Employee::kaf_gonryun	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,3,1,50,700;
-	savepoint "gonryun",160,62;
+	savepoint "gonryun",160,62,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Kunlun";
 }
 
@@ -528,7 +528,7 @@ lighthalzen,164,100,4	script	Kafra Employee::kaf_lighthalzen	860,{
 	mes "are always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,4,1,40,800;
-	savepoint "lighthalzen",158,94;
+	savepoint "lighthalzen",158,94,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Lighthalzen";
 }
 
@@ -540,7 +540,7 @@ lighthalzen,191,320,4	script	Kafra Employee::kaf_lighthalzen2	861,{
 	mes "are always on your side.";
 	mes "So how can I help you?";
 	callfunc "F_Kafra",5,4,1,40,800;
-	savepoint "lighthalzen",194,313;
+	savepoint "lighthalzen",194,313,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Lighthalzen";
 }
 
@@ -552,7 +552,7 @@ lhz_in02,237,284,4	script	Kafra Employee::kaf_lhz_in02	861,{
 	mes "are always on your side.";
 	mes "So how can I help you?";
 	callfunc "F_Kafra",5,4,1,40,800;
-	savepoint "lhz_in02",278,215;
+	savepoint "lhz_in02",278,215,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Lighthalzen";
 }
 
@@ -567,7 +567,7 @@ louyang,210,104,5	script	Kafra Employee::kaf_louyang	4_F_KAFRA2,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,3,1,50,700;
-	savepoint "louyang",217,92;
+	savepoint "louyang",217,92,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Louyang";
 }
 
@@ -583,7 +583,7 @@ umbala,87,160,4	script	Kafra Employee::kaf_umbala	721,{
 	mes "service is always";
 	mes "on your side~";
 	callfunc "F_Kafra",5,0,1,80,0;
-	savepoint "umbala",126,131;
+	savepoint "umbala",126,131,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Umbala";
 }
 
@@ -591,7 +591,7 @@ umbala,87,160,4	script	Kafra Employee::kaf_umbala	721,{
 //============================================================
 niflheim,202,180,3	script	Kafra Employee::kaf_niflheim	791,{
 	callfunc "F_Kafra",1,2,1,150,0;
-	savepoint "niflheim",192,182;
+	savepoint "niflheim",192,182,1,1;
 	callfunc "F_KafEnd",1,1,"in the city of Niflheim";
 }
 
@@ -612,7 +612,7 @@ izlu2dun,106,58,8	script	Kafra Employee::kaf_izlu2dun	4_F_KAFRA2,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,2,1,120,1200;
-	savepoint "izlu2dun",87,170;
+	savepoint "izlu2dun",87,170,1,1;
 	callfunc "F_KafEnd",0,1,"at Byalan Island";
 }
 
@@ -627,7 +627,7 @@ prt_fild05,290,224,3	script	Kafra Employee::prt_fild05	114,{
 	mes "with its excellent service. So";
 	mes "what can I do for you today?";
 	callfunc "F_Kafra",5,1,1,40,0;
-	savepoint "prt_fild05",274,243;
+	savepoint "prt_fild05",274,243,1,1;
 	callfunc "F_KafEnd",0,1, "at the Prontera Culverts";
 }
 
@@ -641,7 +641,7 @@ mjolnir_02,83,362,4	script	Kafra Employee::kaf_mjolnir_02	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,6,1,100,0;
-	savepoint "mjolnir_02",98,352;
+	savepoint "mjolnir_02",98,352,1,1;
 	callfunc "F_KafEnd",0,1,"at Mjolnir Dead Pit";
 }
 
@@ -656,7 +656,7 @@ moc_ruins,59,157,5	script	Kafra Employee::moc_ruins	114,{
 	mes "with its excellent service. So";
 	mes "what can I do for you today?";
 	callfunc "F_Kafra",5,2,1,90,1200;
-	savepoint "moc_ruins",41,141;
+	savepoint "moc_ruins",41,141,1,1;
 	callfunc "F_KafEnd",0,1," at the Pyramids";
 }
 
@@ -670,7 +670,7 @@ gef_fild10,73,340,5	script	Kafra Employee::kaf_gef_fild10	116,{
 	mes "always ready to serve you.";
 	mes "How can I help you today?";
 	callfunc "F_Kafra",5,6,1,130,0;
-	savepoint "gef_fild10",54,326;
+	savepoint "gef_fild10",54,326,1,1;
 	callfunc "F_KafEnd",0,1,"at the Orc Dungeon";
 }
 
@@ -684,6 +684,6 @@ alb2trea,59,69,5	script	Kafra Employee::kaf_alb2trea	117,{
 	mes "are always on your side.";
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,2,1,50,0;
-	savepoint "alb2trea",92,64;
+	savepoint "alb2trea",92,64,1,1;
 	callfunc "F_KafEnd",0,1,0,"at Sunken Ship";
 }

--- a/npc/kafras/kafras.txt
+++ b/npc/kafras/kafras.txt
@@ -415,7 +415,7 @@ cmd_fild07,136,134,4	script	Kafra Employee::kaf_cmd_fild07	721,{
 	mes "How may I assist you?";
 	callfunc "F_Kafra",5,0,1,40,820;
 	if (checkre(0))
-		savepoint strnpcinfo(4),129,97;
+		savepoint strnpcinfo(4),129,97,1,1;
 	else
 		savepoint "izlude",94,103,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Izlude";

--- a/npc/merchants/inn.txt
+++ b/npc/merchants/inn.txt
@@ -124,7 +124,7 @@ lhz_in02,230,284,4	script	Hotel Employee#01	86,{
 	next;
 	switch(select("Save Point:Rest - 5,000 zeny:Cancel")) {
 	case 1:
-		savepoint "lhz_in02",209,275;
+		savepoint "lhz_in02",209,275,1,1;
 		mes "[Hotel Employee]";
 		mes "Thank you, your";
 		mes "Respawn Point has";
@@ -179,7 +179,7 @@ ve_in,157,219,5	script	Inn Master#Receptionist	709,{
 		mes "Your Respawn Point";
 		mes "has been saved in Veins.";
 		mes "Enjoy your stay in town~";
-		savepoint "ve_in",157,209;
+		savepoint "ve_in",157,209,1,1;
 		close;
 	case 2:
 		mes "[Inn Master]";
@@ -219,7 +219,7 @@ function	script	F_InnMaid	{
 		mes "has been saved.";
 		mes "Thank you,";
 		mes "please come again.";
-		savepoint getarg(2),getarg(3),getarg(4);
+		savepoint getarg(2),getarg(3),getarg(4),1,1;
 		close;
 	case 2:
 		mes .@npc_name$;

--- a/npc/other/poring_war.txt
+++ b/npc/other/poring_war.txt
@@ -292,7 +292,7 @@ poring_w01,96,97,3	script	Sweet Devi#wop	738,{
 		mes "I'll send you back to your savepoint.";
 		close2;
 		if (WoP_SaveMap$ != "") {
-			savepoint WoP_SaveMap$,WoP_SaveMap_X,WoP_SaveMap_Y;
+			savepoint WoP_SaveMap$,WoP_SaveMap_X,WoP_SaveMap_Y,1,1;
 			set WoP_SaveMap$,"";
 			set WoP_SaveMap_X,0;
 			set WoP_SaveMap_Y,0;
@@ -305,7 +305,7 @@ OnPCLogoutEvent:
 	getmapxy .@map$,.@x,.@y,UNITTYPE_PC;
 	if (.@map$ == "poring_w02") {
 		if (WoP_SaveMap$ != "") {
-			savepoint WoP_SaveMap$,WoP_SaveMap_X,WoP_SaveMap_Y;
+			savepoint WoP_SaveMap$,WoP_SaveMap_X,WoP_SaveMap_Y,1,1;
 			set WoP_SaveMap$,"";
 			set WoP_SaveMap_X,0;
 			set WoP_SaveMap_Y,0;

--- a/npc/other/pvp.txt
+++ b/npc/other/pvp.txt
@@ -148,11 +148,11 @@
 		mes "Position successfully saved...";
 		mes "Thank you very much!";
 		mes "We will see you again soon.";
-		if(strnpcinfo(4) == "morocc_in") { savepoint "morocc_in",141,139; }
-		if(strnpcinfo(4) == "alberta_in") { savepoint "alberta_in",22,148; }
-		if(strnpcinfo(4) == "prt_in") { savepoint "prt_in",54,137; }
-		if(strnpcinfo(4) == "geffen_in") { savepoint "geffen_in",70,59; }
-		if(strnpcinfo(4) == "payon_in01") { savepoint "payon_in01",142,46; }
+		if(strnpcinfo(4) == "morocc_in") { savepoint "morocc_in",141,139,1,1; }
+		if(strnpcinfo(4) == "alberta_in") { savepoint "alberta_in",22,148,1,1; }
+		if(strnpcinfo(4) == "prt_in") { savepoint "prt_in",54,137,1,1; }
+		if(strnpcinfo(4) == "geffen_in") { savepoint "geffen_in",70,59,1,1; }
+		if(strnpcinfo(4) == "payon_in01") { savepoint "payon_in01",142,46,1,1; }
 		break;
 	case 5:
 		mes "[PVP Narrator]";

--- a/npc/other/turbo_track.txt
+++ b/npc/other/turbo_track.txt
@@ -3654,7 +3654,7 @@ turbo_room,130,92,3	script	Kafra Staff#tt	115,{
 	callfunc "F_Kafra",5,8,1,40,0;
 
 	M_Save:
-		savepoint "aldebaran",168,112;
+		savepoint "aldebaran",168,112,1,1;
 		callfunc "F_KafEnd",0,1,"in Al De Baran";
 
 }

--- a/npc/pre-re/jobs/1-1/acolyte.txt
+++ b/npc/pre-re/jobs/1-1/acolyte.txt
@@ -279,7 +279,7 @@ prt_fild03,365,255,2	script	Ascetic#aco	89,{
 				mes "[Father Rubalkabara]";
 				mes "Farewell.";
 				close2;
-				savepoint "prt_fild03",361,255;
+				savepoint "prt_fild03",361,255,1,1;
 				set job_acolyte_q,6;
 				end;
 			}
@@ -347,7 +347,7 @@ moc_fild07,41,355,4	script	Ascetic#2aco	95,{
 				mes "[Mother Mathilda]";
 				mes "Please return to the Prontera Sanctuary and speak to the Priest in charge.";
 				close2;
-				savepoint "moc_fild07",35,355;
+				savepoint "moc_fild07",35,355,1,1;
 				set job_acolyte_q,7;
 				end;
 			}
@@ -424,7 +424,7 @@ prt_fild00,208,218,6	script	Ascetic#3aco	98,{
 				mes "[Father Yosuke]";
 				mes "Now go back to the Santuary and finish becoming an Acolyte, kid.";
 				close2;
-				savepoint "prt_fild00",206,230;
+				savepoint "prt_fild00",206,230,1,1;
 				set job_acolyte_q,8;
 				end;
 			}

--- a/npc/pre-re/jobs/1-1/swordman.txt
+++ b/npc/pre-re/jobs/1-1/swordman.txt
@@ -110,7 +110,7 @@ izlude_in,74,172,4	script	Swordman#swd_1	119,{
 			mes "So you wish to become a proud Swordman? By all means, please sign up!";
 			next;
 			if (select("Sign up.:Cancel.") == 1) {
-				savepoint "izlude_in",65,165;
+				savepoint "izlude_in",65,165,1,1;
 				set job_sword_q,1;
 				setquest 1014;
 				mes "[Swordman]";
@@ -229,7 +229,7 @@ izlude_in,62,170,6	script	Swordman#swd_2	85,{
 		close;
 	}
 	else {
-		savepoint "izlude_in",65,165;
+		savepoint "izlude_in",65,165,1,1;
 		warp "izlude_in",39,170;
 		end;
 	}

--- a/npc/pre-re/jobs/novice/novice.txt
+++ b/npc/pre-re/jobs/novice/novice.txt
@@ -134,27 +134,27 @@ new_1-2,100,29,4	script	Receptionist#nv1	86,{
 			set nov_3_merchant,0;
 			switch(rand(6)) {
 			case 0:
-				savepoint "prontera",273,354;
+				savepoint "prontera",273,354,1,1;
 				warp "prontera",273,354;
 				break;
 			case 1:
-				savepoint "morocc",160,94;
+				savepoint "morocc",160,94,1,1;
 				warp "morocc",160,94;
 				break;
 			case 2:
-				savepoint "geffen",120,100;
+				savepoint "geffen",120,100,1,1;
 				warp "geffen",120,100;
 				break;
 			case 3:
-				savepoint "payon",70,100;
+				savepoint "payon",70,100,1,1;
 				warp "payon",70,100;
 				break;
 			case 4:
-				savepoint "alberta",116,57;
+				savepoint "alberta",116,57,1,1;
 				warp "alberta",116,57;
 				break;
 			case 5:
-				savepoint "izlude",94,103;
+				savepoint "izlude",94,103,1,1;
 				warp "izlude",94,103;
 			}
 			end;
@@ -1367,7 +1367,7 @@ new_1-2,118,108,3	script	Kafra Employee#nv1	117,{
 			set nov_3_magician,0;
 			set nov_3_acolyte,0;
 			set nov_3_merchant,0;
-			savepoint .@mapn$,.@saveX,.@saveY;
+			savepoint .@mapn$,.@saveX,.@saveY,1,1;
 			warp .@mapn$,.@warpX,.@warpY;
 			end;
 		}
@@ -1430,7 +1430,7 @@ new_1-2,118,108,3	script	Kafra Employee#nv1	117,{
 			set nov_3_magician,0;
 			set nov_3_acolyte,0;
 			set nov_3_merchant,0;
-			savepoint .@mapn$,.@saveX,.@saveY;
+			savepoint .@mapn$,.@saveX,.@saveY,1,1;
 			warp .@mapn$,.@warpX,.@warpY;
 			end;
 		}
@@ -2539,7 +2539,7 @@ new_1-2,38,182,3	script	Entrance Guard#nv	92,{
 			getitem 611,2; //Spectacles
 			getitem 569,300; //Novice_Potion
 			close2;
-			savepoint "new_1-2",23,188;
+			savepoint "new_1-2",23,188,1,1;
 			warp "new_1-3",96,21;
 			end;
 		case 2:
@@ -3372,7 +3372,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					set nov_3_magician,0;
 					set nov_3_acolyte,0;
 					set nov_3_merchant,0;
-					savepoint "izlude",93,104;
+					savepoint "izlude",93,104,1,1;
 					warp "izlude_in",74,167;
 					end;
 				case 2:
@@ -3444,7 +3444,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					set nov_3_magician,0;
 					set nov_3_acolyte,0;
 					set nov_3_merchant,0;
-					savepoint "geffen",119,37;
+					savepoint "geffen",119,37,1,1;
 					warp "geffen_in",163,98;
 					end;
 				case 2:
@@ -3515,7 +3515,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					set nov_3_magician,0;
 					set nov_3_acolyte,0;
 					set nov_3_merchant,0;
-					savepoint "alberta",30,232;
+					savepoint "alberta",30,232,1,1;
 					warp "alberta_in",62,44;
 					end;
 				case 2:
@@ -3583,7 +3583,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					mes "^A62A2A" + strcharinfo(0) + "^000000";
 					mes "and farewell.";
 					close2;
-					savepoint "morocc",150,99;
+					savepoint "morocc",150,99,1,1;
 					warp "moc_ruins",155,44;
 					end;
 				case 2:
@@ -3652,7 +3652,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					set nov_3_magician,0;
 					set nov_3_acolyte,0;
 					set nov_3_merchant,0;
-					savepoint "payon",70,100;
+					savepoint "payon",70,100,1,1;
 					warp "payon_in02",64,65;
 					end;
 				case 2:
@@ -3724,7 +3724,7 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 					set nov_3_magician,0;
 					set nov_3_acolyte,0;
 					set nov_3_merchant,0;
-					savepoint "prontera",117,72;
+					savepoint "prontera",117,72,1,1;
 					warp "prt_church",172,19;
 					end;
 				case 2:
@@ -3761,27 +3761,27 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 			set nov_3_merchant,0;
 			set .@startmap,rand(1,6);
 			if ((.@startmap > 0) && (.@startmap < 2)) {
-				savepoint "prontera",117,72;
+				savepoint "prontera",117,72,1,1;
 				warp "prt_fild08",170,371;
 			}
 			else if ((.@startmap > 1) && (.@startmap < 3)) {
-				savepoint "geffen",119,37;
+				savepoint "geffen",119,37,1,1;
 				warp "gef_fild07",327,188;
 			}
 			else if ((.@startmap > 2) && (.@startmap < 4)) {
-				savepoint "alberta",30,232;
+				savepoint "alberta",30,232,1,1;
 				warp "pay_fild03",388,70;
 			}
 			else if ((.@startmap > 3) && (.@startmap < 5)) {
-				savepoint "morocc",150,99;
+				savepoint "morocc",150,99,1,1;
 				warp "moc_fild07",198,39;
 			}
 			else if ((.@startmap > 4) && (.@startmap < 6)) {
-				savepoint "payon",256,242;
+				savepoint "payon",256,242,1,1;
 				warp "pay_fild01",334,354;
 			}
 			else if ((.@startmap > 5) && (.@startmap < 7)) {
-				savepoint "izlude",93,104;
+				savepoint "izlude",93,104,1,1;
 				warp "prt_fild08",357,212;
 			}
 			end;
@@ -3812,27 +3812,27 @@ new_1-4,100,29,1	script	Hanson#nv	46,{
 		set nov_3_merchant,0;
 		set .@startmap,rand(1,6);
 		if ((.@startmap > 0) && (.@startmap < 2)) {
-			savepoint "prontera",117,72;
+			savepoint "prontera",117,72,1,1;
 			warp "prt_fild08",170,371;
 		}
 		else if ((.@startmap > 1) && (.@startmap < 3)) {
-			savepoint "geffen",119,37;
+			savepoint "geffen",119,37,1,1;
 			warp "gef_fild07",327,188;
 		}
 		else if ((.@startmap > 2) && (.@startmap < 4)) {
-			savepoint "alberta",30,232;
+			savepoint "alberta",30,232,1,1;
 			warp "pay_fild03",388,70;
 		}
 		else if ((.@startmap > 3) && (.@startmap < 5)) {
-			savepoint "morocc",150,99;
+			savepoint "morocc",150,99,1,1;
 			warp "moc_fild07",198,39;
 		}
 		else if ((.@startmap > 4) && (.@startmap < 6)) {
-			savepoint "payon",70,100;
+			savepoint "payon",70,100,1,1;
 			warp "pay_fild01",334,354;
 		}
 		else if ((.@startmap > 5) && (.@startmap < 7)) {
-			savepoint "izlude",93,104;
+			savepoint "izlude",93,104,1,1;
 			warp "prt_fild08",357,212;
 		}
 		end;
@@ -3959,27 +3959,27 @@ S_UserJobchoice:
 	set nov_3_acolyte,0;
 	set nov_3_merchant,0;
 	if(@menu == 1) {
-		savepoint "izlude",93,104;
+		savepoint "izlude",93,104,1,1;
 		warp "izlude_in",74,167;
 	}
 	else if (@menu == 2) {
-		savepoint "geffen",119,37;
+		savepoint "geffen",119,37,1,1;
 		warp "geffen_in",163,98;
 	}
 	else if (@menu == 3) {
-		savepoint "alberta",30,232;
+		savepoint "alberta",30,232,1,1;
 		warp "alberta_in",62,44;
 	}
 	else if (@menu == 4) {
-		savepoint "morocc",150,99;
+		savepoint "morocc",150,99,1,1;
 		warp "moc_ruins",155,44;
 	}
 	else if (@menu == 5) {
-		savepoint "payon",70,100;
+		savepoint "payon",70,100,1,1;
 		warp "payon_in02",64,65;
 	}
 	else {
-		savepoint "prontera",117,72;
+		savepoint "prontera",117,72,1,1;
 		warp "prt_church",172,19;
 	}
 	return;

--- a/npc/quests/first_class/tu_acolyte.txt
+++ b/npc/quests/first_class/tu_acolyte.txt
@@ -325,7 +325,7 @@ prt_monk,230,106,3	script	Asthe#tu	1_F_PRIEST,{
 			tu_acolyte01 = 4;
 			getitem 1504,1; //Mace
 			getitem 602,1; //Wing_Of_Butterfly
-			savepoint "prt_monk",30,250;
+			savepoint "prt_monk",30,250,1,1;
 		}
 		else {
 			mes "[Asthe]";

--- a/npc/quests/first_class/tu_thief01.txt
+++ b/npc/quests/first_class/tu_thief01.txt
@@ -338,7 +338,7 @@ moc_ruins,66,164,4	script	Thief Trainer#T	4_M_02,{
 			mes "10 ^ff0000Feather of Birds^000000.";
 			mes "You can go ahead and kill Pickies to get those. It really shouldn't be that hard. Oh, and use this Wing thingee to come back.";
 			tu_thief01 = 5;
-			savepoint "moc_ruins",80,164;
+			savepoint "moc_ruins",80,164,1,1;
 			getitem 602,1; //Wing_Of_Butterfly
 			getexp 100,50;
 			specialeffect2 EF_HIT5;

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -7611,7 +7611,7 @@ function Catwarp;
 		next;
 		switch(select("Save your location:Cancel")) {
 		case 1:
-			savepoint "mid_camp",56,139;
+			savepoint "mid_camp",56,139,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -7630,7 +7630,7 @@ function Catwarp;
 		next;
 		switch(select("Save your location:Cancel")) {
 		case 1:
-			savepoint "mid_camp",56,139;
+			savepoint "mid_camp",56,139,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -7649,7 +7649,7 @@ function Catwarp;
 		next;
 		switch(select("Save your location:Use Storage:Cancel")) {
 		case 1:
-			savepoint "mid_camp",56,139;
+			savepoint "mid_camp",56,139,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -7696,7 +7696,7 @@ function Catwarp;
 		next;
 		switch(select("Save your location:Use Storage:Use Cat Warp (Midgard):Cancel")) {
 		case 1:
-			savepoint "mid_camp",56,139;
+			savepoint "mid_camp",56,139,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -7818,7 +7818,7 @@ function Catwarp;
 		next;
 		switch(select("Save your location:Use Storage:Use Cat Warp (Midgard):Use Cat Warp (Jottunheim):Cancel")) {
 		case 1:
-			savepoint "mid_camp",56,139;
+			savepoint "mid_camp",56,139,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -72,8 +72,8 @@ spl_fild02,25,211,4	script	Cat Hand Agent#spl	421,{
 		next;
 		switch(select("Save your location:Cancel")) {
 		case 1:
-			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225;
-			else savepoint "man_fild02",129,61;
+			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225,1,1;
+			else savepoint "man_fild02",129,61,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -92,8 +92,8 @@ spl_fild02,25,211,4	script	Cat Hand Agent#spl	421,{
 		next;
 		switch(select("Save your location:Use Storage:Cancel")) {
 		case 1:
-			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225;
-			else savepoint "man_fild02",129,61;
+			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225,1,1;
+			else savepoint "man_fild02",129,61,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -139,8 +139,8 @@ spl_fild02,25,211,4	script	Cat Hand Agent#spl	421,{
 		next;
 		switch(select("Save your location:Use Storage:Use Cat Warp (Midgard):Cancel")) {
 		case 1:
-			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225;
-			else savepoint "man_fild02",129,61;
+			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225,1,1;
+			else savepoint "man_fild02",129,61,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";
@@ -260,8 +260,8 @@ spl_fild02,25,211,4	script	Cat Hand Agent#spl	421,{
 		next;
 		switch(select("Save your location:Use Storage:Use Cat Warp (Midgard):Use Cat Warp (Jottunheim):Cancel")) {
 		case 1:
-			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225;
-			else savepoint "man_fild02",129,61;
+			if (strnpcinfo(2) == "spl") savepoint "spl_fild02",32,225,1,1;
+			else savepoint "man_fild02",129,61,1,1;
 			mes "[Cat Hand Agent]";
 			mes "Thank you.";
 			mes "Your location has been saved.";

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -3366,7 +3366,7 @@ mosk_in,135,191,5	script	Landlord#mos	4_F_RUSWOMAN3,{
 		mes "[Landlord]";
 		mes "Your respawn point has been saved.";
 		mes "Hope we can see you again next time hoho.";
-		savepoint "mosk_in",142,189;
+		savepoint "mosk_in",142,189,1,1;
 		close;
 	case 2:
 		if (Zeny > 4999) {

--- a/npc/re/cities/eclage.txt
+++ b/npc/re/cities/eclage.txt
@@ -33,7 +33,7 @@ ecl_in02,164,56,3	script	Receptionist#Laphine	835,{
 	case 1:
 		mes "[Receptionist}";
 		mes "Clinic has been set as your save point. Be careful though~";
-		savepoint "ecl_in02",162,50;
+		savepoint "ecl_in02",162,50,1,1;
 		close;
 	case 2:
 		mes "[Receptionist}";

--- a/npc/re/cities/izlude.txt
+++ b/npc/re/cities/izlude.txt
@@ -94,7 +94,7 @@ function	script	F_IzludeChannel	{
 	set .@i, select(getarg(0)+":Never mind");
 	if (.@i < 6) {
 		setarray .@maps$[1],"izlude","izlude_a","izlude_b","izlude_c","izlude_d";
-		savepoint .@maps$[.@i],128,98;
+		savepoint .@maps$[.@i],128,98,1,1;
 		warp .@maps$[.@i],128,98;
 		end;
 	}

--- a/npc/re/cities/malangdo.txt
+++ b/npc/re/cities/malangdo.txt
@@ -320,7 +320,7 @@ malangdo,147,117,3	script	Innkeeper#malang	554,{
 	case 2:
 		mes "[Innkeeper]";
 		mes "Location saved. We should keep company, haha~";
-		savepoint "malangdo",142,118;
+		savepoint "malangdo",142,118,1,1;
 		close;
 	case 3:
 		mes "[Innkeeper]";

--- a/npc/re/cities/malaya.txt
+++ b/npc/re/cities/malaya.txt
@@ -115,7 +115,7 @@ ma_in01,30,94,4	script	Inn Keeper#ma	583,{
 	case 1:
 		mes "[Inn Keeper]";
 		mes "Successfully stored. See you next time.";
-		savepoint "ma_in01",43,98;
+		savepoint "ma_in01",43,98,1,1;
 		close;
 	case 2:
 		if (Zeny < 5000) {

--- a/npc/re/cities/mora.txt
+++ b/npc/re/cities/mora.txt
@@ -1105,7 +1105,7 @@ mora,43,127,3	script	Innkeeper#mora_inn	522,{
 		mes "[Innkeeper]";
 		mes "You know, haste makes waste. Tsk tsk.";
 		mes "Well, the game's been saved.";
-		savepoint "mora",56,143;
+		savepoint "mora",56,143,1,1;
 		close;
 	case 2:
 		mes "[Innkeeper]";

--- a/npc/re/jobs/1-1/acolyte.txt
+++ b/npc/re/jobs/1-1/acolyte.txt
@@ -142,7 +142,7 @@ prt_fild03,365,255,2	script	Ascetic#aco	89,{
 				mes "[Father Rubalkabara]";
 				mes "Farewell.";
 				close2;
-				savepoint "prt_fild03",361,255;
+				savepoint "prt_fild03",361,255,1,1;
 				set job_acolyte_q,6;
 				end;
 			}
@@ -210,7 +210,7 @@ moc_fild07,41,355,4	script	Ascetic#2aco	95,{
 				mes "[Mother Mathilda]";
 				mes "Please return to the Prontera Sanctuary and speak to the Priest in charge.";
 				close2;
-				savepoint "moc_fild07",35,355;
+				savepoint "moc_fild07",35,355,1,1;
 				set job_acolyte_q,7;
 				end;
 			}
@@ -287,7 +287,7 @@ prt_fild00,208,218,6	script	Ascetic#3aco	98,{
 				mes "[Father Yosuke]";
 				mes "Now go back to the Santuary and finish becoming an Acolyte, kid.";
 				close2;
-				savepoint "prt_fild00",206,230;
+				savepoint "prt_fild00",206,230,1,1;
 				set job_acolyte_q,8;
 				end;
 			}

--- a/npc/re/jobs/novice/academy.txt
+++ b/npc/re/jobs/novice/academy.txt
@@ -2054,7 +2054,7 @@ iz_ac01,59,43,3	script	Therapist#ac	4_M_6THPRIN1,{
 		mes "[Therapist]";
 		mes "I see...";
 		mes "For emergency situations, in case you've fainted and want to be brought back here, I will save your current location.";
-		savepoint "iz_ac01", 45, 46;
+		savepoint "iz_ac01",45,46,1,1;
 		close;
 	}
 
@@ -5146,7 +5146,7 @@ iz_ac01,95,46,5	script	Kafra Guide Trainer#ac	4_F_KAFRA1,{
 					next;
 					mes "[Kafra Guide Trainer]";
 					mes "It's already done. Easy huh?";
-					savepoint "izlude", 128, 98;
+					savepoint "izlude",128,98,1,1;
 					next;
 					mes "[Kafra Guide Trainer]";
 					mes "Now, when you use a ^006400Butterfly Wing^000000, it will send you to the last saved location.";
@@ -9325,7 +9325,7 @@ iz_ac02,148,110,3	script	Mage Chuck#ac	4_M_JOB_WIZARD,{
 									cutin "", 255;
 									next;
 									setquest 9264;
-									savepoint "geffen", 120, 38;
+									savepoint "geffen",120,38,1,1;
 									warp "gef_fild07", 88, 205;
 									end;
 								}
@@ -14126,7 +14126,7 @@ new_1-1,53,114,3	script	Training Instructor#1a	4_F_03,{
 	} else if (strnpcinfo(4) == "new_5-1" || strnpcinfo(4) == "new_5-2" || strnpcinfo(4) == "new_5-3" || strnpcinfo(4) == "new_5-4") {
 		.@warp$ = "iz_int04";
 	}
-	savepoint .@warp$, 98, 88;
+	savepoint .@warp$,98,88,1,1;
 	warp .@warp$, 98, 88;
 	end;
 }

--- a/npc/re/jobs/novice/novice.txt
+++ b/npc/re/jobs/novice/novice.txt
@@ -151,7 +151,7 @@ new_5-1,53,114,3	duplicate(NvSprakkiA)	Sprakki#nv5a	90
 			mes "^4d4dff- You received a quest 'Novice Training Ground -1' from Sprakki.";
 			mes "Please check the Quest Info Window. -^000000";
 			close2;
-			savepoint strnpcinfo(4),100,100;
+			savepoint strnpcinfo(4),100,100,1,1;
 			warp strnpcinfo(4),100,100;
 			end;
 		case 2:
@@ -175,27 +175,27 @@ new_5-1,53,114,3	duplicate(NvSprakkiA)	Sprakki#nv5a	90
 			close2;
 			switch(.@select) {
 			case 1:
-				savepoint "prontera",273,354;
+				savepoint "prontera",273,354,1,1;
 				warp "prontera",273,354;
 				break;
 			case 2:
-				savepoint "morocc",160,94;
+				savepoint "morocc",160,94,1,1;
 				warp "morocc",160,94;
 				break;
 			case 3:
-				savepoint "geffen",120,100;
+				savepoint "geffen",120,100,1,1;
 				warp "geffen",120,100;
 				break;
 			case 4:
-				savepoint "payon",70,100;
+				savepoint "payon",70,100,1,1;
 				warp "payon",70,100;
 				break;
 			case 5:
-				savepoint "alberta",116,57;
+				savepoint "alberta",116,57,1,1;
 				warp "alberta",116,57;
 				break;
 			case 6: // Old coordinates: (94,103)
-				savepoint "izlude",128,98;
+				savepoint "izlude",128,98,1,1;
 				warp "izlude",128,98;
 				break;
 			}
@@ -206,7 +206,7 @@ new_5-1,53,114,3	duplicate(NvSprakkiA)	Sprakki#nv5a	90
 		mes "These are the Novice Training Grounds.";
 		mes "I will guide you to the Novice Training Center.";
 		close2;
-		savepoint strnpcinfo(4),100,100;
+		savepoint strnpcinfo(4),100,100,1,1;
 		warp strnpcinfo(4),100,100;
 		end;
 	}
@@ -736,7 +736,7 @@ new_5-2,115,120,3	duplicate(NvJinha)	Jinha#nv5	59
 		mes "I will send you to the Real Combat Training Field.";
 		close2;
 		set .@map$, "new_"+charat(strnpcinfo(4),4)+"-3";
-		savepoint .@map$,96,21;
+		savepoint .@map$,96,21,1,1;
 		warp .@map$,96,21;
 		end;
 	} else {
@@ -754,7 +754,7 @@ new_5-2,115,120,3	duplicate(NvJinha)	Jinha#nv5	59
 			mes "I will send you to the Real Combat Training Field.";
 			close2;
 			set .@map$, "new_"+charat(strnpcinfo(4),4)+"-3";
-			savepoint .@map$,96,21;
+			savepoint .@map$,96,21,1,1;
 			warp .@map$,96,21;
 			end;
 		}
@@ -846,7 +846,7 @@ new_5-2,33,172,4	duplicate(NvChocolat)	Chocolat#nv5	96
 				mes "May Freya bless you upon your journey.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "prontera",117,72;
+				savepoint "prontera",117,72,1,1;
 				warp "prontera",150,50;
 				end;
 			case 2:
@@ -856,7 +856,7 @@ new_5-2,33,172,4	duplicate(NvChocolat)	Chocolat#nv5	96
 				mes "Do not lose the dream in your heart right now.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "morocc",150,99;
+				savepoint "morocc",150,99,1,1;
 				warp "morocc",155,110;
 				end;
 			case 3:
@@ -866,7 +866,7 @@ new_5-2,33,172,4	duplicate(NvChocolat)	Chocolat#nv5	96
 				mes "Let Freya bless you.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "payon",70,100;
+				savepoint "payon",70,100,1,1;
 				warp "payon",166,67;
 				end;
 			case 4:
@@ -876,7 +876,7 @@ new_5-2,33,172,4	duplicate(NvChocolat)	Chocolat#nv5	96
 				mes "If you want to experience other civilizations, you have to visit Alberta first.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "alberta",30,232;
+				savepoint "alberta",30,232,1,1;
 				warp "alberta",114,58;
 				end;
 			case 5:
@@ -887,7 +887,7 @@ new_5-2,33,172,4	duplicate(NvChocolat)	Chocolat#nv5	96
 				mes "May Goddess Freya bless you!.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "geffen",119,37;
+				savepoint "geffen",119,37,1,1;
 				warp "geffen",122,65;
 				end;
 			}
@@ -1175,7 +1175,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 		set job_novice_q,13;
 		setquest 7122;
 		getitem 569,100; //Novice_Potion
-		savepoint strnpcinfo(4),96,21;
+		savepoint strnpcinfo(4),96,21,1,1;
 		next;
 		mes "^4d4dff- You've received a quest from Instructor Brade.";
 		mes "Please check the quest information window. -^000000";
@@ -1260,7 +1260,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 				mes "Take care and god bless you on your journey.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "prontera",117,72;
+				savepoint "prontera",117,72,1,1;
 				warp "prontera",150,50;
 				end;
 			case 2:
@@ -1270,7 +1270,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 				mes "Take care.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "morocc",150,99;
+				savepoint "morocc",150,99,1,1;
 				warp "morocc",155,110;
 				end;
 			case 3:
@@ -1279,7 +1279,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 				mes "God bless you.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "payon",70,100;
+				savepoint "payon",70,100,1,1;
 				warp "payon",166,67;
 				end;
 			case 4:
@@ -1290,7 +1290,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 				mes "Well then, god bless you on your soul.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "alberta",30,232;
+				savepoint "alberta",30,232,1,1;
 				warp "alberta",114,58;
 				end;
 			case 5:
@@ -1301,7 +1301,7 @@ new_5-2,36,176,4	duplicate(NvGuide)	Guide#nv5	105
 				mes "May Goddess Freya bless you.";
 				callfunc "F_NvErase";
 				close2;
-				savepoint "geffen",119,37;
+				savepoint "geffen",119,37,1,1;
 				warp "geffen",122,65;
 				end;
 			case 6:
@@ -1411,7 +1411,7 @@ new_5-3,96,30,4	duplicate(NvBradeB)	Brade#nv5b	733
 			mes "Then I'll end your training process and send you to the Swordman Guild.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "izlude",128,98; // Old coordinates: (95,104)
+			savepoint "izlude",128,98,1,1; // Old coordinates: (95,104)
 			warp "izlude_in",74,167;
 			end;
 		}
@@ -1552,7 +1552,7 @@ new_5-3,97,41,3	duplicate(NvSwordman)	Swordman Guide#nv5	728
 			mes "Then I will completely end the Training Process and send you to Prontera's Sanctuary.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "prontera",117,72;
+			savepoint "prontera",117,72,1,1;
 			warp "prt_church",172,19;
 			end;
 		}
@@ -1645,7 +1645,7 @@ new_5-3,101,41,3	duplicate(NvAcolyte)	Acolyte Guide#nv5	95
 			mes "Welcome. Then your Novice training is totally complete and you will be sent to the Thief Guild immediately.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "morocc",150,99;
+			savepoint "morocc",150,99,1,1;
 			warp "moc_prydb1",99,185;
 			end;
 		}
@@ -1783,7 +1783,7 @@ new_5-3,105,41,3	duplicate(NvThief)	Thief Guide#nv5	118
 			mes "Then I will end the Training Process and send you to the Merchant Guild's union immediately.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "alberta",30,232;
+			savepoint "alberta",30,232,1,1;
 			warp "alberta_in",62,44;
 			end;
 		}
@@ -1942,7 +1942,7 @@ new_5-3,109,41,3	duplicate(NvMerchant)	Merchant Guide#nv5	97
 			mes "Then I will completely end the Training Process and send you to the Archer Guild.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "payon",256,242;
+			savepoint "payon",256,242,1,1;
 			warp "payon_in02",64,65;
 			end;
 		}
@@ -2045,7 +2045,7 @@ new_5-3,113,41,3	duplicate(NvArcher)	Archer Guide#nv5	727
 			mes "Then I will end the Training Process and send you to the Mage Guild union in Geffen right away.";
 			callfunc "F_NvErase",1;
 			close2;
-			savepoint "geffen",119,37;
+			savepoint "geffen",119,37,1,1;
 			warp "geffen_in",163,98;
 			end;
 		}
@@ -2268,7 +2268,7 @@ new_5-3,121,41,3	duplicate(NvBruce)	Bruce#nv5	57
 S_Warp:
 	close2;
 	callfunc "F_NvErase",1;
-	savepoint getarg(0),getarg(1),getarg(2);
+	savepoint getarg(0),getarg(1),getarg(2),1,1;
 	warp getarg(0),getarg(3),getarg(4);
 	end;
 	
@@ -2435,7 +2435,7 @@ new_5-1,144,107,2	duplicate(NvGuardB)	Guard#nv5b	105
 	mes "Well, I will let you out of here.";
 	mes "Go find the instructor, Brade.";
 	close2;
-	savepoint strnpcinfo(4),100,100;
+	savepoint strnpcinfo(4),100,100,1,1;
 	warp strnpcinfo(4),100,100;
 	end;
 }
@@ -2496,7 +2496,7 @@ function	script	F_NvErase	{
 				mes "The town you will be sent to is called Izlude which is a satellite of Prontera. The Swordman Association is located in the West of town. Please remember this.";
 				next;
 				callsub L_Supplies;
-				savepoint "izlude",128,98; // Old coordinates: (95,104)
+				savepoint "izlude",128,98,1,1; // Old coordinates: (95,104)
 				warp "izlude_in",74,167;
 				end;
 			case 2:
@@ -2510,7 +2510,7 @@ function	script	F_NvErase	{
 				mes "The Prontera Sanctuary is located to the North-East in Prontera. Please remember this.";
 				next;
 				callsub L_Supplies;
-				savepoint "prontera",117,72;
+				savepoint "prontera",117,72,1,1;
 				warp "prt_church",172,19;
 				end;
 			case 3:
@@ -2524,7 +2524,7 @@ function	script	F_NvErase	{
 				mes "The Thief guild is in the underground 1st floor of a pyramid which is North-West of town. Please remember this.";
 				next;
 				callsub L_Supplies;
-				savepoint "morocc",150,99;
+				savepoint "morocc",150,99,1,1;
 				warp "moc_ruins",155,44;
 				end;
 			case 4:
@@ -2535,7 +2535,7 @@ function	script	F_NvErase	{
 				mes "the town of Alberta.";
 				next;
 				callsub L_Supplies;
-				savepoint "alberta",30,232;
+				savepoint "alberta",30,232,1,1;
 				warp "alberta_in",62,44;
 				end;
 			case 5:
@@ -2549,7 +2549,7 @@ function	script	F_NvErase	{
 				mes "The Archer Guild is located to the North-West in Payon. Please remember this.";
 				next;
 				callsub L_Supplies;
-				savepoint "payon",256,242;
+				savepoint "payon",256,242,1,1;
 				warp "payon_in02",64,65;
 				end;
 			case 6:
@@ -2563,7 +2563,7 @@ function	script	F_NvErase	{
 				mes "The Mage Academy is located in the North-West in town. Please remember this.";
 				next;
 				callsub L_Supplies;
-				savepoint "geffen",119,37;
+				savepoint "geffen",119,37,1,1;
 				warp "geffen_in",163,98;
 				end;
 			}
@@ -2624,31 +2624,31 @@ L_Warp:
 	case 1:
 		mes "I will send you to Prontera, the Capital City.";
 		close2;
-		savepoint "prontera",117,72;
+		savepoint "prontera",117,72,1,1;
 		warp "prontera",150,50;
 		end;
 	case 2:
 		mes "I will send you to Geffen, the City of Magic.";
 		close2;
-		savepoint "geffen",119,37;
+		savepoint "geffen",119,37,1,1;
 		warp "geffen",122,65;
 		end;
 	case 3:
 		mes "I will send you to Morroc, the Desert Town.";
 		close2;
-		savepoint "morocc",150,99;
+		savepoint "morocc",150,99,1,1;
 		warp "morocc",155,110;
 		end;
 	case 4:
 		mes "I will send you to Payon, the Mountain Village.";
 		close2;
-		savepoint "payon",70,100;
+		savepoint "payon",70,100,1,1;
 		warp "payon",166,67;
 		end;
 	case 5:
 		mes "I will send you to Alberta, the Port City.";
 		close2;
-		savepoint "alberta",30,232;
+		savepoint "alberta",30,232,1,1;
 		warp "alberta",114,58;
 		end;
 	case 6:
@@ -3319,7 +3319,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "izlude",128,98; // Old coordinates: (95,104)
+		savepoint "izlude",128,98,1,1; // Old coordinates: (95,104)
 		warp "izlude_in",74,167;
 		end;
 	case 2:
@@ -3329,7 +3329,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "geffen",119,37;
+		savepoint "geffen",119,37,1,1;
 		warp "geffen_in",163,98;
 		end;
 	case 3:
@@ -3339,7 +3339,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "payon",256,242;
+		savepoint "payon",256,242,1,1;
 		warp "payon_in02",64,65;
 		end;
 	case 4:
@@ -3349,7 +3349,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "alberta",30,232;
+		savepoint "alberta",30,232,1,1;
 		warp "alberta_in",62,44;
 		end;
 	case 5:
@@ -3359,7 +3359,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "morocc",150,99;
+		savepoint "morocc",150,99,1,1;
 		warp "moc_prydb1",99,185;
 		end;
 	case 6:
@@ -3369,7 +3369,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "prontera",117,72;
+		savepoint "prontera",117,72,1,1;
 		warp "prt_church",172,19;
 		end;
 	case 7:
@@ -3379,7 +3379,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "payon",164,58;
+		savepoint "payon",164,58,1,1;
 		warp "payon",163,141;
 		end;
 	case 8:
@@ -3390,7 +3390,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "izlude",128,98; // Old coordinates: (95,104)
+		savepoint "izlude",128,98,1,1; // Old coordinates: (95,104)
 		warp "izlude",128,67;
 		end;
 	case 9:
@@ -3402,7 +3402,7 @@ new_5-4,100,29,1	duplicate(NvHanson)	Final Tester#nv5	46
 		mes .@str$;
 		mes "Good bye.";
 		close2;
-		savepoint "alberta",117,56;
+		savepoint "alberta",117,56,1,1;
 		warp "alberta",171,132;
 		end;
 	default:

--- a/npc/re/kafras/kafras.txt
+++ b/npc/re/kafras/kafras.txt
@@ -32,7 +32,7 @@
 brasilis,197,221,4	script	Kafra Employee::kaf_bra	117,{
 	cutin "kafra_01",2;
 	callfunc "F_Kafra",0,3,0,80,700;
-	savepoint "brasilis",195,259;
+	savepoint "brasilis",195,259,1,1;
 	callfunc "F_KafEnd",0,1,"in the city of Brasilis";
 }
 
@@ -41,7 +41,7 @@ brasilis,197,221,4	script	Kafra Employee::kaf_bra	117,{
 dewata,202,184,6	script	Kafra Employee::kaf_dewata	117,{
 	cutin "kafra_01",2;
 	callfunc "F_Kafra",0,10,1,40,700;
-	savepoint "dewata",206,174;
+	savepoint "dewata",206,174,1,1;
 	callfunc "F_KafEnd",0,1,"on Dewata Island";
 }
 
@@ -50,7 +50,7 @@ dewata,202,184,6	script	Kafra Employee::kaf_dewata	117,{
 glast_01,200,275,5	script	Kafra Employee::kaf_glast	115,{
 	cutin "kafra_03",2;
 	callfunc "F_Kafra",0,3,2,500,700;
-	savepoint "glast_01",200,272;
+	savepoint "glast_01",200,272,1,1;
 	callfunc "F_KafEnd",0,1,"in Glast Heim";
 }
 
@@ -77,13 +77,13 @@ izlude_d,128,148,6	duplicate(kaf_izlude)	Kafra Employee#iz_d	117
 //============================================================
 malaya,71,79,4	script	Kafra Employee::kaf_malaya1	581,{
 	callfunc "F_Kafra",0,3,2,500,700;
-	savepoint "malaya",44,56;
+	savepoint "malaya",44,56,1,1;
 	callfunc "F_KafEnd",0,1,"in Port Malaya";
 }
 
 malaya,234,204,4	script	Kafra Employee::kaf_malaya2	581,{
 	callfunc "F_Kafra",0,3,2,500,700;
-	savepoint "malaya",281,212;
+	savepoint "malaya",281,212,1,1;
 	callfunc "F_KafEnd",0,1,"in Port Malaya";
 }
 

--- a/npc/re/merchants/inn.txt
+++ b/npc/re/merchants/inn.txt
@@ -32,7 +32,7 @@ bra_in01,27,24,3	script	Hotel Keeper#bra1	478,{
 		case 2:
 			mes "[Hotel Keeper]";
 			mes "Your respawn has been saved here at the hotel. I hope that you enjoy your stay here in Brasilis.";
-			savepoint "bra_in01",144,69;
+			savepoint "bra_in01",144,69,1,1;
 			close;
 		}
 	case 2:

--- a/npc/re/warps/cities/izlude.txt
+++ b/npc/re/warps/cities/izlude.txt
@@ -66,7 +66,7 @@ iz_int,96,73,0	script	iz_int_iz	WARPNPC,2,2,{
 	end;
 
 OnTouch:
-	savepoint "izlude", 128, 98;
+	savepoint "izlude",128,98,1,1;
 	warp "izlude"+strnpcinfo(2)+"", 195, 209;
 	end;
 }

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9440,22 +9440,34 @@ BUILDIN_FUNC(setmadogear)
 
 /// Sets the save point of the player.
 ///
-/// save "<map name>",<x>,<y>{,<char_id>}
-/// savepoint "<map name>",<x>,<y>{,<char_id>}
+/// save "<map name>",<x>,<y>{{<x>,<y>},<char_id>}
+/// savepoint "<map name>",<x>,<y>{{<x>,<y>},<char_id>}
 BUILDIN_FUNC(savepoint)
 {
-	int x;
-	int y;
+	int x, y, cid_pos = 5;
 	short map_idx;
 	const char* str;
 	TBL_PC* sd;
 
-	if (!script_charid2sd(5,sd))
+	if (script_lastdata(st) > 5)
+		cid_pos = 7;
+
+	if (!script_charid2sd(cid_pos,sd))
 		return SCRIPT_CMD_FAILURE;// no player attached, report source
 
 	str = script_getstr(st, 2);
 	x   = script_getnum(st,3);
 	y   = script_getnum(st,4);
+
+	if (cid_pos == 7) {
+		int dx = script_getnum(st,5), dy = script_getnum(st,6), x1 = x + dx, y1 = y + dy;
+		x -= dx;
+		y -= dy;
+		// Give random coordinates (we can't check for valid cells :P)
+		x = x + rnd()%(x1-x+1);
+		y = y + rnd()%(y1-y+1);
+	}
+
 	map_idx = mapindex_name2id(str);
 	if( map_idx )
 		pc_setsavepoint(sd, map_idx, x, y);
@@ -22209,8 +22221,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(checkwug,"?"),
 	BUILDIN_DEF(checkmadogear,"?"),
 	BUILDIN_DEF(setmadogear,"??"),
-	BUILDIN_DEF2(savepoint,"save","sii?"),
-	BUILDIN_DEF(savepoint,"sii?"),
+	BUILDIN_DEF2(savepoint,"save","sii???"),
+	BUILDIN_DEF(savepoint,"sii???"),
 	BUILDIN_DEF(gettimetick,"i"),
 	BUILDIN_DEF(gettime,"i"),
 	BUILDIN_DEF(gettimestr,"si"),

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -9440,8 +9440,8 @@ BUILDIN_FUNC(setmadogear)
 
 /// Sets the save point of the player.
 ///
-/// save "<map name>",<x>,<y>{{<x>,<y>},<char_id>}
-/// savepoint "<map name>",<x>,<y>{{<x>,<y>},<char_id>}
+/// save "<map name>",<x>,<y>{,{<range x>,<range y>,}<char_id>}
+/// savepoint "<map name>",<x>,<y>{,{<range x>,<range y>,}<char_id>}
 BUILDIN_FUNC(savepoint)
 {
 	int x, y, m, cid_pos = 5;


### PR DESCRIPTION
* Added parameters for `savepoint`.
* The new params are range for `x` and `y` for random savepoint coordinates.

---

Sample usage:
```
savepoint "prontera",33,208,1,1;
```

I didn't update the doc and NPCs.



Signed-off-by: Cydh Ramdh <cydh@pservero.com>