### PR TITLE
Refactored hardcoded npc event names

### DIFF
--- a/db/pre-re/item_db.txt
+++ b/db/pre-re/item_db.txt
@@ -2608,7 +2608,7 @@
 5429,Bogy_Cap,Bogy Cap,4,20,,100,,2,,1,0xFFFFFFFF,7,2,256,,0,1,430,{ bonus bHPrecovRate, 5; bonus bSPrecovRate, 5; },{},{}
 5430,Sacred_Torch_Coronet,Torch Cap,4,20,,0,,3,,0,0xFFFFFFFF,7,2,256,,0,0,431,{ bonus2 bSubEle,Ele_Fire,20; skill "MG_FIREBOLT",5; },{},{}
 5431,Chicken_Hat,Chicken Hat,4,20,,1000,,0,,1,0xFFFFFFFF,7,2,256,,30,1,432,{ bonus3 bAutoSpell,"MC_LOUD",1,30; bonus bAspdRate,5; },{},{}
-5432,Brazil_Baseball_Cap,bRO 4th Anniversary Hat,4,20,,100,,0,,0,0xFFFFFFFF,7,2,256,,0,1,433,{ if(gettime(6)==9&&gettime(5)>=10&&gettime(5)<=24) bonus bAllStats, 4; },{},{}
+5432,Brazil_Baseball_Cap,bRO 4th Anniversary Hat,4,20,,100,,0,,0,0xFFFFFFFF,7,2,256,,0,1,433,{ if(gettime(DT_MONTH)==SEPTEMBER&&gettime(DT_DAYOFMONTH)>=10&&gettime(DT_DAYOFMONTH)<=24) bonus bAllStats, 4; },{},{}
 5433,Golden_Wreath,Golden Laurel,4,20,,100,,0,,0,0xFFFFFFFF,7,2,256,,0,1,434,{},{},{}
 //5434,Cola_Can,Cola Can,4,20,,100,,2,,1,0xFFFFFFFF,7,2,256,,0,1,435,{},{},{}
 5435,Coke_Hat,Red Minstrel Hat,4,20,,100,,1,,1,0xFFFFFFFF,7,2,256,,40,1,436,{ bonus bInt,1; bonus bMaxSP,80; bonus bMdef,3; if(getrefine()>5) { bonus bMdef,getrefine()-5; bonus bMaxSP,(getrefine()-5)*10; } },{},{}
@@ -4696,7 +4696,7 @@
 12130,Cookie_Bag,Cookie Bag,2,2,,70,,,,,0xFFFFFFFF,7,2,,,,,,{ getrandgroupitem(IG_CookieBag),1; getrandgroupitem(IG_CookieBag),1; getrandgroupitem(IG_CookieBag),1; },{},{}
 12131,Lucky_Potion,Lucky Potion,0,2,,100,,,,,0xFFFFFFFF,7,2,,,,,,{},{},{}
 12132,Red_Bag,Santa's Bag,2,0,,200,,,,,0xFFFFFFFF,7,2,,,,,,{ sc_start SC_Xmas,600000,0; },{},{}
-12133,Ice_Cream_,McDonald's Ice Cone,0,0,,80,,,,,0xFFFFFFFF,7,2,,,,,,{ if(gettime(5)!=MDiceCone) { set MDiceCone,gettime(5); percentheal 50,50; } },{},{}
+12133,Ice_Cream_,McDonald's Ice Cone,0,0,,80,,,,,0xFFFFFFFF,7,2,,,,,,{ if(gettime(DT_DAYOFMONTH)!=MDiceCone) { set MDiceCone,gettime(DT_DAYOFMONTH); percentheal 50,50; } },{},{}
 12134,Red_Envelope,Red Envelope,2,1,,10,,,,,0xFFFFFFFF,7,2,,,,,,{ set Zeny,Zeny+rand(1000,10000); },{},{}
 12135,Green_Ale,Green Ale,2,20,,30,,,,,0xFFFFFFFF,7,2,,,,,,{ percentheal 50,50; sc_start SC_Confusion,10000,0,1000,0; },{},{}
 12136,Women's_Bundle,Women's Bundle,2,0,,100,,,,,0xFFFFFFFF,7,2,,,,,,{ getitem callfunc("F_Rand",558,529,2668,7518),1; },{},{}

--- a/db/re/item_db.txt
+++ b/db/re/item_db.txt
@@ -3549,7 +3549,7 @@
 5429,Bogy_Cap,Bogy Cap,4,20,,100,,4,,1,0xFFFFFFFF,63,2,256,,0,1,430,{ bonus bHPrecovRate,5; bonus bSPrecovRate,5; },{},{}
 5430,Sacred_Torch_Coronet,Torch Cap,4,20,,0,,6,,0,0xFFFFFFFF,63,2,256,,0,0,431,{ bonus2 bSubEle,Ele_Fire,20; skill "MG_FIREBOLT",5; },{},{}
 5431,Chicken_Hat,Chicken Hat,4,20,,1000,,0,,1,0xFFFFFFFF,63,2,256,,30,1,432,{ bonus3 bAutoSpell,"MC_LOUD",1,30; bonus bAspdRate,5; },{},{}
-5432,Brazil_Baseball_Cap,bRO 4th Anniversary Hat,4,20,,100,,0,,0,0xFFFFFFFF,63,2,256,,0,1,433,{ if(gettime(6)==9&&gettime(5)>=10&&gettime(5)<=24) bonus bAllStats,4; },{},{}
+5432,Brazil_Baseball_Cap,bRO 4th Anniversary Hat,4,20,,100,,0,,0,0xFFFFFFFF,63,2,256,,0,1,433,{ if(gettime(DT_MONTH)==SEPTEMBER&&gettime(DT_DAYOFMONTH)>=10&&gettime(DT_DAYOFMONTH)<=24) bonus bAllStats,4; },{},{}
 5433,Golden_Wreath,Golden Laurel,4,20,,100,,0,,0,0xFFFFFFFF,63,2,256,,0,1,434,{},{},{}
 5434,Cola_Can,Cola Can,4,20,,100,,3,,1,0xFFFFFFFF,63,2,256,,0,1,435,{},{},{}
 5435,Coke_Hat,Red Minstrel Hat,4,20,,100,,2,,1,0xFFFFFFFF,63,2,256,,40,1,436,{ bonus bInt,1; bonus bMaxSP,80; bonus bMdef,3; .@r = getrefine(); if(.@r>5) { bonus bMdef,.@r-5; bonus bMaxSP,(.@r-5)*10; } },{},{}
@@ -6263,7 +6263,7 @@
 12130,Cookie_Bag,Cookie Bag,2,2,,70,,,,,0xFFFFFFFF,63,2,,,,,,{ getrandgroupitem(IG_CookieBag,1); getrandgroupitem(IG_CookieBag,1); getrandgroupitem(IG_CookieBag,1); },{},{}
 12131,Lucky_Potion,Lucky Potion,0,2,,100,,,,,0xFFFFFFFF,63,2,,,,,,{ /* sc_start SC_LUKFOOD,180000,15; */ },{},{}
 12132,Red_Bag,Santa's Bag,2,0,,200,,,,,0xFFFFFFFF,63,2,,,,,,{ sc_start SC_XMAS,600000,0; sc_start SC_SPEEDUP0,600000,25; },{},{}
-12133,Ice_Cream_,McDonald's Ice Cone,0,0,,80,,,,,0xFFFFFFFF,63,2,,,,,,{ if(gettime(5)!=MDiceCone) { MDiceCone = gettime(5); percentheal 50,50; } },{},{}
+12133,Ice_Cream_,McDonald's Ice Cone,0,0,,80,,,,,0xFFFFFFFF,63,2,,,,,,{ if(gettime(DT_DAYOFMONTH)!=MDiceCone) { MDiceCone = gettime(DT_DAYOFMONTH); percentheal 50,50; } },{},{}
 12134,Red_Envelope,Red Envelope,2,1,,10,,,,,0xFFFFFFFF,63,2,,,,,,{ Zeny += rand(1000,10000); },{},{}
 12135,Green_Ale,Green Ale,2,20,,30,,,,,0xFFFFFFFF,63,2,,,,,,{ percentheal 50,50; sc_start SC_CONFUSION,10000,0,1000,0; },{},{}
 12136,Women's_Bundle,Women's Bundle,2,0,,100,,,,,0xFFFFFFFF,63,2,,,,,,{ getitem callfunc("F_Rand",558,529,2668,7518),1; },{},{}

--- a/doc/sample/npc_test_time.txt
+++ b/doc/sample/npc_test_time.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20070315
+//= 20161206
 //===== Description: ========================================= 
 //= Demonstrates time commands.
 //============================================================
@@ -12,14 +12,15 @@ prontera,157,181,6	script	Time Sample	105,{
 	mes "[Time Sample]";
 	mes "System Tick : " + gettimetick(0);
 	mes "  Time Tick : " + gettimetick(1);
-	mes " GetTime(0) : " + gettime(0);
-	mes " GetTime(1) : " + gettime(1) + " (Sec)";
-	mes " GetTime(2) : " + gettime(2) + " (Min)";
-	mes " GetTime(3) : " + gettime(3) + " (Hour)";
-	mes " GetTime(4) : " + gettime(4) + " (WeekDay)";
-	mes " GetTime(5) : " + gettime(5) + " (MonthDay)";
-	mes " GetTime(6) : " + gettime(6) + " (Month)";
-	mes " GetTime(7) : " + gettime(7) + " (Year)";
+	mes "  Unix Tick : " + gettimetick(2);
+	mes " GetTime(DT_SECOND) : " + gettime(DT_SECOND) + " (Sec)";
+	mes " GetTime(DT_MINUTE) : " + gettime(DT_MINUTE) + " (Min)";
+	mes " GetTime(DT_HOUR) : " + gettime(DT_HOUR) + " (Hour)";
+	mes " GetTime(DT_DAYOFWEEK) : " + gettime(DT_DAYOFWEEK) + " (Day of week)";
+	mes " GetTime(DT_DAYOFMONTH) : " + gettime(DT_DAYOFMONTH) + " (Day of month)";
+	mes " GetTime(DT_MONTH) : " + gettime(DT_MONTH) + " (Month)";
+	mes " GetTime(DT_YEAR) : " + gettime(DT_YEAR) + " (Year)";
+	mes " GetTime(DT_DAYOFYEAR) : " + gettime(DT_DAYOFYEAR) + " (Day of year)";
 	mes " GetTimeStr : " + gettimestr("%Y-%m/%d %H:%M:%S",19);
 	close;
 }

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6060,6 +6060,8 @@ A debug message also shows on the console when no events are triggered.
 This is simply "donpcevent <npc name>::OnCommand<command>".
 It is an approximation of official server script language's 'cmdothernpc'.
 
+Returns true if the command was executed on the other NPC successfully, false if not.
+
 ---------------------------------------
 
 *npctalk "<message>"{,"<NPC name>"};

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20160523
+//= 20161206
 //===== Description: =========================================
 //= A reference manual for the rAthena scripting language.
 //= Commands are sorted depending on their functionality.
@@ -3004,18 +3004,18 @@ This function will return a tick depending on <tick type>:
 
 This function will return specified information about the current system time.
 
-1 - Seconds (of a minute)
-2 - Minutes (of an hour)
-3 - Hour (of a day)
-4 - Week day (0 for Sunday, 6 is Saturday)
-5 - Day of the month.
-6 - Number of the month.
-7 - Year.
-8 - Day of the year.
+DT_SECOND - Seconds (of the current minute)
+DT_MINUTE - Minutes (of the current hour)
+DT_HOUR - Hour (of the current day)
+DT_DAYOFWEEK - Week day (constants for MONDAY to SUNDAY are available)
+DT_DAYOFMONTH - Day of the current month
+DT_MONTH - Month (constants for JANUARY to DECEMBER are available)
+DT_YEAR - Year
+DT_DAYOFYEAR - Day of the year
 
-It will only return numbers.
+It will only return numbers. If another type is supplied -1 will be returned.
 
-    if (gettime(4)==6) mes "It's a Saturday. I don't work on Saturdays.";
+	if (gettime(DT_DAYOFWEEK)==SATURDAY) mes "It's a Saturday. I don't work on Saturdays.";
 
 ---------------------------------------
 
@@ -7684,7 +7684,7 @@ OnClock0600:
 	end;
 OnInit:
 	// setting correct mode upon server start-up
-	if(gettime(3)>=6 && gettime(3)<18) end;
+	if(gettime(DT_HOUR)>=6 && gettime(DT_HOUR)<18) end;
 OnClock1800:
 	night;
 	end;

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -900,6 +900,13 @@ This label will be executed when an instance is created and initialized through
 the 'instance_create' command. It will run again if @reloadscript is used while
 an instance is in progress.
 
+OnInstanceDestroy:
+
+This label will be executed when an instance is destroyed by a timeout, exceeding
+the keepalive time or through the 'instance_destroy' command. It will be called
+exactly before the instance will be destroyed and all other NPCs of the instance
+will still be available at this point of time.
+
 OnTouch:
 
 This label will be executed if a trigger area is defined for the NPC object it's 
@@ -8274,7 +8281,8 @@ Destroys instance with the ID <instance id>. If no ID is specified, the instance
 the script is attached to is used. If the script is not attached to an instance,
 the instance of the currently attached player is used (if it is a character, party,
 or guild mode). If it is not owned by anyone, no player needs to be attached. If
-that fails, the script will come to a halt.
+that fails, the script will come to a halt. This will also trigger the "OnInstanceDestroy"
+label in all NPCs inside the instance.
 
 ---------------------------------------
 

--- a/doc/woe_time_explanation.txt
+++ b/doc/woe_time_explanation.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= erKURITA
 //===== Last Updated: ========================================
-//= 20120717
+//= 20161206
 //===== Description: =========================================
 //= Details on the behavior of the default WoE controller.
 //============================================================
@@ -18,14 +18,14 @@ OnClock2350: would run at 23:50, server time.
 gettime(<type>) is a function that checks for certain
 information regarding time. The types are:
 
-	1 - Seconds (of a minute)
-	2 - Minutes (of an hour)
-	3 - Hour (of a day), ranging from 0 to 23
-	4 - Weekday, ranging from 0 (Sunday) to 6 (Saturday)
-	5 - Day of the month
-	6 - Number of the month
-	7 - Year
-	8 - Day of the year
+	DT_SECOND - Seconds (of the current minute)
+	DT_MINUTE - Minutes (of the current hour)
+	DT_HOUR - Hour (of the current day)
+	DT_DAYOFWEEK - Week day (constants for MONDAY to SUNDAY are available)
+	DT_DAYOFMONTH - Day of the current month
+	DT_MONTH - Month (constants for JANUARY to DECEMBER are available)
+	DT_YEAR - Year
+	DT_DAYOFYEAR - Day of the year
 
 This way, we can check for a desired minute, hour, day, month, etc.
 
@@ -33,28 +33,28 @@ This way, we can check for a desired minute, hour, day, month, etc.
 
 Now the structure:
 
-	OnClock2100:	// Start time for Tues(2), Thurs(4)
-	OnClock2300:	// End time for Tues(2), Thurs(4)
-	OnClock1600:	// Start time for Sat(6)
-	OnClock1800:	// End time for Sat(6)
+	OnClock2100:	// Start time for Tuesday and Thursday
+	OnClock2300:	// End time for Tuesday and Thursday
+	OnClock1600:	// Start time for Saturday
+	OnClock1800:	// End time for Saturday
 
 These 4 labels will run one after the other, reaching the next check:
 
-	if((gettime(4)==2) && (gettime(3)>=21 && gettime(3)<23)) goto L_Start;
-	if((gettime(4)==4) && (gettime(3)>=21 && gettime(3)<23)) goto L_Start;
-	if((gettime(4)==6) && (gettime(3)>=16 && gettime(3)<18)) goto L_Start;
+	if((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)>=21 && gettime(DT_HOUR)<23)) goto L_Start;
+	if((gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)>=21 && gettime(DT_HOUR)<23)) goto L_Start;
+	if((gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)>=16 && gettime(DT_HOUR)<18)) goto L_Start;
 
 This part will check for the times. Since both Start and End times run
 through the same chain of commands, these are important checks to ensure
 it's the right time. Let's take the following example:
 
-	if((gettime(4)==2) && (gettime(3)>=21 && gettime(3)<23))
+	if((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)>=21 && gettime(DT_HOUR)<23))
 
-The first gettime() is checking for a type 4, the day of the week, and it's
-comparing it to the one desired, which is 2 (Tuesday). The function will
-return either 1 (true) or 0 (false).
+The first gettime() is checking for a type DT_DAYOFWEEK, the day of the week, and it's
+comparing it to the one desired, which is TUESDAY. The function will
+return either true or false.
 
-The second gettime is checking type 3, the hour, and it's comparing
+The second gettime is checking type DT_HOUR, the hour, and it's comparing
 it to 21. If the first part is greater than or equal to (>=) the second part,
 the comparison will return 1.
 
@@ -75,9 +75,9 @@ It's saying that if X and G are true, the condition is met, thus proceeding to L
 
 Now, the last part of the script, regarding the end of WoE time:
 
-	if((gettime(4)==2) && (gettime(3)==23)) goto L_End;
-	if((gettime(4)==4) && (gettime(3)==23)) goto L_End;
-	if((gettime(4)==6) && (gettime(3)==18)) goto L_End;
+	if((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)==23)) goto L_End;
+	if((gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)==23)) goto L_End;
+	if((gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)==18)) goto L_End;
 	end;
 
 This is the same as before, but it's checking for the day in the first gettime() and
@@ -97,6 +97,6 @@ An example of how to set the WoE so it starts on Monday, at 4 pm and ends up at 
 
 	OnAgitInit: // This can only be written once: put OnClock above and the checks below.
 
-	if ((gettime(4)==1) && (gettime(3)>=16 && gettime(3)<22)) goto L_Start;
-	if ((gettime(4)==1) && (gettime(3)==22) goto L_End;
+	if ((gettime(DT_DAYOFWEEK)==MONDAY) && (gettime(DT_HOUR)>=16 && gettime(DT_HOUR)<22)) goto L_Start;
+	if ((gettime(DT_DAYOFWEEK)==MONDAY) && (gettime(DT_HOUR)==22) goto L_End;
 	end; // Don't forget this!

--- a/npc/airports/airships.txt
+++ b/npc/airports/airships.txt
@@ -1139,18 +1139,18 @@ airplane_01,32,61,4	script	Nils#ein	49,1,1,{
 		mes .@line1_1$[.@wordtest];
 		mes .@line1_2$[.@wordtest];
 		mes .@line1_3$[.@wordtest];
-		set .@start_time, gettime(3)*60*60 + gettime(2)*60 + gettime(1);
+		set .@start_time, gettimetick(1);
 		next;
 		input .@save1$;
-		set .@end_time, gettime(3)*60*60 + gettime(2)*60 + gettime(1);
+		set .@end_time, gettimetick(1);
 		set .@total_time, .@end_time - .@start_time;
 		mes "[Nils]";
 		mes .@line2_1$[.@wordtest];
 		mes .@line2_2$[.@wordtest];
-		set .@start_time, gettime(3)*60*60 + gettime(2)*60 + gettime(1);
+		set .@start_time, gettimetick(1);
 		next;
 		input .@save2$;
-		set .@end_time, gettime(3)*60*60 + gettime(2)*60 + gettime(1);
+		set .@end_time, gettimetick(1);
 		set .@total_time, .@total_time + (.@start_time - .@end_time);
 		set .@tasoo, (.@letters[.@wordtest] / .@total_time) * 6;
 		if ((.@save1$ == .@word1$[.@wordtest]) && (.@save2$ == .@word2$[.@wordtest])) {

--- a/npc/custom/etc/airplane.txt
+++ b/npc/custom/etc/airplane.txt
@@ -387,7 +387,7 @@ function	script	F_Itin	{
 
 seta:
 	set @tempo, @tempo + 1;
-	set @time, gettime(3);
+	set @time, gettime(DT_HOUR);
 	set @minutes, 5 * @tempo - 5;
 	set @minutess, 5 * @tempo - 2;
 	if(@minutes<10)set @minutes$, "0" + @minutes;
@@ -408,7 +408,7 @@ seta:
 setb:
 	if($@currenttime - 1==@tempo)goto setc;
 	set @tempo, @tempo + 1;
-	set @time, gettime(3) + 1;
+	set @time, gettime(DT_HOUR) + 1;
 	set @minutes, 5 * @tempo - 5;
 	set @minutess, 5 * @tempo - 2;
 	if(@minutes<10)set @minutes$, "0" + @minutes;

--- a/npc/custom/etc/bank_kafra.txt
+++ b/npc/custom/etc/bank_kafra.txt
@@ -24,7 +24,7 @@
 	mes"[Maniss]";
 	mes strcharinfo(0)+", welcome to the 2nd Bank of Prontera!";
 
-	set @kb_int,(gettime(6)*31)+gettime(5); //today's number
+	set @kb_int,(gettime(DT_MONTH)*31)+gettime(DT_DAYOFMONTH); //today's number
 	set @income,0;
 	//calculate %
 	if (#kafrabank<=0 || #kb_int>=@kb_int) goto L_NoIncomeToday;

--- a/npc/custom/events/holiday/valentinesdayexp.txt
+++ b/npc/custom/events/holiday/valentinesdayexp.txt
@@ -21,7 +21,7 @@ prontera,156,172,4	script	Tine	58,{
 //	mes "@dsv: "+@dsv;
 //	mes "ispartneron()=="+ispartneron();
 //	mes "Sex == "+Sex;
-//	if(@dsv == gettime(3)+1) mes "@dsv == gettime(3)+1";
+//	if(@dsv == gettime(DT_HOUR)+1) mes "@dsv == gettime(DT_HOUR)+1";
 
 	mes "[Tine]";
 	mes "The legend says that on 14th February... on the Day of Saint Valentine...";
@@ -62,14 +62,14 @@ M_INFO:
 
 OnInit:
 	//559,Hand-made_Chocolate
-	setitemscript 559,"{ itemheal 50,50; if(Sex==SEX_FEMALE || @dsv == gettime(3)+1 || ispartneron()==0)end; set @dsv,gettime(3)+1; misceffect 113; }";
+	setitemscript 559,"{ itemheal 50,50; if(Sex==SEX_FEMALE || @dsv == gettime(DT_HOUR)+1 || ispartneron()==0)end; set @dsv,gettime(DT_HOUR)+1; misceffect 113; }";
 	//560,Hand-made_White_Chocolate
-	setitemscript 560,"{ itemheal 50,50; if(Sex==SEX_MALE || @dsv == gettime(3)+1 || ispartneron()==0)end; set @dsv,gettime(3)+1; misceffect 113; }";
+	setitemscript 560,"{ itemheal 50,50; if(Sex==SEX_MALE || @dsv == gettime(DT_HOUR)+1 || ispartneron()==0)end; set @dsv,gettime(DT_HOUR)+1; misceffect 113; }";
 
 	//2634,Wedding_Ring_M,Wedding Ring,5,,10,0,,0,,0,127918079,7,1,136,,0,0,0,{ skill 334,1; skill 335,1; skill 336,1; }
-	setitemscript 2634,"{ skill 334,1; skill 335,1; skill 336,1; if(@dsv == gettime(3)+1 && ispartneron()){ bonus2 bExpAddRace,5,50; bonus2 bExpAddRace,6,50; bonus2 bExpAddRace,7,50; bonus2 bExpAddRace,8,50; bonus2 bExpAddRace,1,50; } }";
+	setitemscript 2634,"{ skill 334,1; skill 335,1; skill 336,1; if(@dsv == gettime(DT_HOUR)+1 && ispartneron()){ bonus2 bExpAddRace,5,50; bonus2 bExpAddRace,6,50; bonus2 bExpAddRace,7,50; bonus2 bExpAddRace,8,50; bonus2 bExpAddRace,1,50; } }";
 	//2635,Wedding_Ring_F,Wedding Ring,5,,10,0,,0,,0,127918079,7,0,136,,0,0,0,{ skill 334,1; skill 335,1; skill 336,1; }
-	setitemscript 2635,"{ skill 334,1; skill 335,1; skill 336,1; if(@dsv == gettime(3)+1 && ispartneron()){ bonus2 bExpAddRace,0,50; bonus2 bExpAddRace,9,50; bonus2 bExpAddRace,2,50; bonus2 bExpAddRace,3,50; bonus2 bExpAddRace,4,50; } }";
+	setitemscript 2635,"{ skill 334,1; skill 335,1; skill 336,1; if(@dsv == gettime(DT_HOUR)+1 && ispartneron()){ bonus2 bExpAddRace,0,50; bonus2 bExpAddRace,9,50; bonus2 bExpAddRace,2,50; bonus2 bExpAddRace,3,50; bonus2 bExpAddRace,4,50; } }";
 	end;
 }
 

--- a/npc/custom/events/holiday/xmas_rings_event.txt
+++ b/npc/custom/events/holiday/xmas_rings_event.txt
@@ -91,7 +91,7 @@ M_QUEST:
 
 OnInit:
 //Santa's Hat
-	setitemscript 2236,"{ bonus bMdef,1; bonus bLuk,1; if(isequipped(2636,2637)){if(@xmr == gettime(2))end; set @xmr,gettime(2); misceffect 410; end;} if(isequipped(2636)){if(@xmr == gettime(2))end; set @xmr,gettime(2); misceffect 72;} if(isequipped(2637)){if(@xmr == gettime(2))end; set @xmr,gettime(2); misceffect 338;}}";
+	setitemscript 2236,"{ bonus bMdef,1; bonus bLuk,1; if(isequipped(2636,2637)){if(@xmr == gettime(DT_MINUTE))end; set @xmr,gettime(DT_MINUTE); misceffect 410; end;} if(isequipped(2636)){if(@xmr == gettime(DT_MINUTE))end; set @xmr,gettime(DT_MINUTE); misceffect 72;} if(isequipped(2637)){if(@xmr == gettime(DT_MINUTE))end; set @xmr,gettime(DT_MINUTE); misceffect 338;}}";
 //Gold Xmas Ring
 	setitemscript 2636,"{ bonus bLoseSPWhenUnequip,30; if(isequipped(2236)==0)end; if(getskilllv(\"AL_HEAL\")){skill \"TF_HIDING\",4+isequipped(2637);}else{skill \"AL_HEAL\",1+4*isequipped(2637);} }";
 //Silver Xmas Ring

--- a/npc/custom/quests/thq/THQS_QuestNPC.txt
+++ b/npc/custom/quests/thq/THQS_QuestNPC.txt
@@ -46,7 +46,7 @@ N_PayZeny:
 	set On_Quest, 0;
 	set Zeny,Zeny-2500;
 	//add time delay penalty. You can get another quest after 2 - 3 hours. [Lupus]
-	set #THQ_DELAY, (GetTime(7)*12*31*24+GetTime(6)*31*24+GetTime(5)*24+GetTime(3)+rand(2,3));
+	set #THQ_DELAY, (GetTime(DT_YEAR)*12*31*24+GetTime(DT_MONTH)*31*24+GetTime(DT_DAYOFMONTH)*24+GetTime(DT_HOUR)+rand(2,3));
 	mes "[Guy]";
 	mes "Its sad to see someone give a quest up...";
 	mes "Shame on you.";
@@ -61,7 +61,7 @@ N_ZenyFail:
 N_NewQuest:
 	if (Event_THQS == 0) goto N_Signup;
 	//checking if time penalty is over [Lupus]
-	if (#THQ_DELAY > (GetTime(7)*12*31*24 + GetTime(6)*31*24 + GetTime(5)*24 + GetTime(3)) ) goto L_NoQuestsForYet;
+	if (#THQ_DELAY > (GetTime(DT_YEAR)*12*31*24 + GetTime(DT_MONTH)*31*24 + GetTime(DT_DAYOFMONTH)*24 + GetTime(DT_HOUR)) ) goto L_NoQuestsForYet;
 	mes "[Guy]";
 	mes "Ahh welcome fellow Treasure Hunter.";
 	mes "You currently have ^FF0000"+#Treasure_Token+"^000000 treasure tokens!!!";
@@ -73,7 +73,7 @@ N_NewQuest:
 	mes "Ok lets see what quest we can give you today.";
 	mes "The quest names in ^FF0000This Colour^000000 mean that they are more challanging then the rest, but have better rewards.";
 	next;
-	set #THQ_DELAY,(GetTime(7)*12*31*24+GetTime(6)*31*24+GetTime(5)*24+GetTime(3) + 1); //you can get another quest after 1 hour [Lupus]
+	set #THQ_DELAY,(GetTime(DT_YEAR)*12*31*24+GetTime(DT_MONTH)*31*24+GetTime(DT_DAYOFMONTH)*24+GetTime(DT_HOUR) + 1); //you can get another quest after 1 hour [Lupus]
 	emotion e_no1;
 	if(@treasure_job==0) set @treasure_job,rand(1,10); //doesn't allow cheaters to pick any quest they want
 	if(@treasure_job==2) goto N_JobList2;
@@ -102,7 +102,7 @@ N_Signup:
 L_NoQuestsForYet:
 	mes "[Guy]";
 	mes "I'm afraid there aren't any Quests for you yet.";
-	mes "Call in "+ (#THQ_DELAY - (GetTime(7)*12*31*24+GetTime(6)*31*24+GetTime(5)*24+GetTime(3)) )+" hours later.";
+	mes "Call in "+ (#THQ_DELAY - (GetTime(DT_YEAR)*12*31*24+GetTime(DT_MONTH)*31*24+GetTime(DT_DAYOFMONTH)*24+GetTime(DT_HOUR)) )+" hours later.";
 	emotion e_sry;
 	close;
 

--- a/npc/custom/woe_controller.txt
+++ b/npc/custom/woe_controller.txt
@@ -104,7 +104,7 @@ OnMinute00:
 	freeloop(1);
 	if (agitcheck() || agitcheck2()) {
 		for(set .@i,0; .@i<.Size; set .@i,.@i+4)
-			if (gettime(4) == $WOE_CONTROL[.@i] && gettime(3) == $WOE_CONTROL[.@i+2]) {
+			if (gettime(DT_DAYOFWEEK) == $WOE_CONTROL[.@i] && gettime(DT_HOUR) == $WOE_CONTROL[.@i+2]) {
 			OnWOEEnd:
 				announce "The War Of Emperium is over!",bc_all|bc_woe;
 				AgitEnd; AgitEnd2;
@@ -122,7 +122,7 @@ OnMinute00:
 	if ((!agitcheck() && !agitcheck2()) || .Init) {
 		if (!agitcheck() && !agitcheck2()) set .Init,0;
 		for(set .@i,0; .@i<.Size; set .@i,.@i+4)
-			if (gettime(4) == $WOE_CONTROL[.@i] && gettime(3) >= $WOE_CONTROL[.@i+1] && gettime(3) < $WOE_CONTROL[.@i+2]) {
+			if (gettime(DT_DAYOFWEEK) == $WOE_CONTROL[.@i] && gettime(DT_HOUR) >= $WOE_CONTROL[.@i+1] && gettime(DT_HOUR) < $WOE_CONTROL[.@i+2]) {
 				deletearray .Active[0],2;
 				set .Active[0], $WOE_CONTROL[.@i+3];
 				if (.Init) { AgitEnd; AgitEnd2; }
@@ -210,7 +210,7 @@ while(1) {
 	if (agitcheck() || agitcheck2()) {
 		if (.Active[0]) {
 			for(set .@i,0; .@i<.Size; set .@i,.@i+4)
-				if (gettime(4) == $WOE_CONTROL[.@i] && gettime(3) >= $WOE_CONTROL[.@i+1] && gettime(3) < $WOE_CONTROL[.@i+2]) {
+				if (gettime(DT_DAYOFWEEK) == $WOE_CONTROL[.@i] && gettime(DT_HOUR) >= $WOE_CONTROL[.@i+1] && gettime(DT_HOUR) < $WOE_CONTROL[.@i+2]) {
 					set .@i, $WOE_CONTROL[.@i+2];
 					break;
 				}
@@ -222,7 +222,7 @@ while(1) {
 			mes "The War of Emperium is ^0055FFactive^000000.";
 	} else {
 		for(set .@i,0; .@i<.Size; set .@i,.@i+4)
-			if ((gettime(4) == $WOE_CONTROL[.@i] && gettime(3) <= $WOE_CONTROL[.@i+1]) || gettime(4) < $WOE_CONTROL[.@i]) {
+			if ((gettime(DT_DAYOFWEEK) == $WOE_CONTROL[.@i] && gettime(DT_HOUR) <= $WOE_CONTROL[.@i+1]) || gettime(DT_DAYOFWEEK) < $WOE_CONTROL[.@i]) {
 				setarray .@time[0],$WOE_CONTROL[.@i],$WOE_CONTROL[.@i+1];
 				break;
 			}

--- a/npc/events/idul_fitri.txt
+++ b/npc/events/idul_fitri.txt
@@ -14,7 +14,7 @@
 
 prontera,146,92,3	script	Cellerb	58,{
 	mes "[Staff Idul Fitri]";
-	if((gettime(6)==10 && (gettime(5)==24 || gettime(5)==25))==0) {
+	if((gettime(DT_MONTH)==OCTOBER && (gettime(DT_DAYOFMONTH)==24 || gettime(DT_DAYOFMONTH)==25))==0) {
 		mes "Congratulation! Celebrate Feast Day Of Ramadan Idul Fitri 1427 H.";
 		specialeffect EF_SANDMAN;
 		close;

--- a/npc/guild/agit_controller.txt
+++ b/npc/guild/agit_controller.txt
@@ -33,16 +33,16 @@
 -	script	Agit_Event	-1,{
 	end;
 
-OnClock2100:	//start time for Tues(2), Thurs(4)
-OnClock2300:	//end time for Tues(2), Thurs(4)
-OnClock1600:	//start time for Sat(6)
-OnClock1800:	//end time for Sat(6)
+OnClock2100:	//start time for Tuesday and Thursday
+OnClock2300:	//end time for Tuesday and Thursday
+OnClock1600:	//start time for Saturday
+OnClock1800:	//end time for Saturday
 
 OnAgitInit:
 	// starting time checks
-	if((gettime(4)==2) && (gettime(3)>=21 && gettime(3)<23) ||
-	   (gettime(4)==4) && (gettime(3)>=21 && gettime(3)<23) ||
-	   (gettime(4)==6) && (gettime(3)>=16 && gettime(3)<18)) {
+	if((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)>=21 && gettime(DT_HOUR)<23) ||
+	   (gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)>=21 && gettime(DT_HOUR)<23) ||
+	   (gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)>=16 && gettime(DT_HOUR)<18)) {
 		if (!agitcheck()) {
 			AgitStart;
 			callsub S_DisplayOwners;
@@ -51,9 +51,9 @@ OnAgitInit:
 	}
 
 	// end time checks
-	if ((gettime(4)==2) && (gettime(3)==23) ||
-	    (gettime(4)==4) && (gettime(3)==23) ||
-	    (gettime(4)==6) && (gettime(3)==18)) { 
+	if ((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)==23) ||
+	    (gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)==23) ||
+	    (gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)==18)) { 
 		if (agitcheck()) {
 			AgitEnd;
 			callsub S_DisplayOwners;

--- a/npc/guild2/agit_start_se.txt
+++ b/npc/guild2/agit_start_se.txt
@@ -16,16 +16,16 @@
 -	script	Agit2_Event	-1,{
 	end;
 
-OnClock1800:	//start time for Tues(2), Thurs(4)
-OnClock2000:	//end time for Tues(2), Thurs(4)
-OnClock2100:	//start time for Sat(6)
-OnClock2300:	//end time for Sat(6)
+OnClock1800:	//start time for Tuesday and Thursday
+OnClock2000:	//end time for Tuesday and Thursday
+OnClock2100:	//start time for Saturday
+OnClock2300:	//end time for Saturday
 
 OnAgitInit2:
 	// starting time checks
-	if((gettime(4)==2) && (gettime(3)>=18 && gettime(3)<21) ||
-	   (gettime(4)==4) && (gettime(3)>=18 && gettime(3)<21) ||
-	   (gettime(4)==6) && (gettime(3)>=22 && gettime(3)<23)) {
+	if((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)>=18 && gettime(DT_HOUR)<21) ||
+	   (gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)>=18 && gettime(DT_HOUR)<21) ||
+	   (gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)>=22 && gettime(DT_HOUR)<23)) {
 		if (!agitcheck2()) {
 			AgitStart2;
 		}
@@ -33,9 +33,9 @@ OnAgitInit2:
 	}
 
 	// end time checks
-	if ((gettime(4)==2) && (gettime(3)==21) ||
-	    (gettime(4)==4) && (gettime(3)==21) ||
-	    (gettime(4)==6) && (gettime(3)==23)) { 
+	if ((gettime(DT_DAYOFWEEK)==TUESDAY) && (gettime(DT_HOUR)==21) ||
+	    (gettime(DT_DAYOFWEEK)==THURSDAY) && (gettime(DT_HOUR)==21) ||
+	    (gettime(DT_DAYOFWEEK)==SATURDAY) && (gettime(DT_HOUR)==23)) { 
 		if (agitcheck2()) {
 			AgitEnd2;
 		}

--- a/npc/other/arena/arena_lvl50.txt
+++ b/npc/other/arena/arena_lvl50.txt
@@ -39,8 +39,8 @@ force_1-1,99,20,4	script	Heel and Toe#arena	124,{
 
 OnStart:
 	initnpctimer;
-	set $arena_min50st,gettime(2);
-	set $arena_sec50st,gettime(1);
+	set $arena_min50st,gettime(DT_MINUTE);
+	set $arena_sec50st,gettime(DT_SECOND);
 	end;
 
 OnTimer3000:
@@ -776,8 +776,8 @@ OnMyMobDead:
 		donpcevent "Heel and Toe#arena::On09_End";
 		donpcevent "arena#50::OnReset_09";
 		donpcevent "arena#50::OnReset_All";
-		set $arena_min50end,gettime(2);
-		set $arena_sec50end,gettime(1);
+		set $arena_min50end,gettime(DT_MINUTE);
+		set $arena_sec50end,gettime(DT_SECOND);
 	}
 	end;
 }

--- a/npc/other/arena/arena_lvl60.txt
+++ b/npc/other/arena/arena_lvl60.txt
@@ -40,8 +40,8 @@ force_2-1,99,20,4	script	Minilover#arena	124,{
 
 OnStart:
 	initnpctimer;
-	set $arena_min60st,gettime(2);
-	set $arena_sec60st,gettime(1);
+	set $arena_min60st,gettime(DT_MINUTE);
+	set $arena_sec60st,gettime(DT_SECOND);
 	end;
 
 OnTimer3000:
@@ -786,8 +786,8 @@ OnMyMobDead:
 		donpcevent "Minilover#arena::On09_End";
 		donpcevent "arena#60::OnReset_09";
 		donpcevent "arena#60::OnReset_All";
-		set $arena_min60end,gettime(2);
-		set $arena_sec60end,gettime(1);
+		set $arena_min60end,gettime(DT_MINUTE);
+		set $arena_sec60end,gettime(DT_SECOND);
 	}
 	end;
 }

--- a/npc/other/arena/arena_lvl70.txt
+++ b/npc/other/arena/arena_lvl70.txt
@@ -39,8 +39,8 @@ force_3-1,99,20,4	script	Cadillac#arena	124,{
 
 OnStart:
 	initnpctimer;
-	set $arena_min70st,gettime(2);
-	set $arena_sec70st,gettime(1);
+	set $arena_min70st,gettime(DT_MINUTE);
+	set $arena_sec70st,gettime(DT_SECOND);
 	end;
 
 OnTimer3000:
@@ -751,8 +751,8 @@ OnMyMobDead:
 		donpcevent "Cadillac#arena::On09_End";
 		donpcevent "arena#70::OnReset_09";
 		donpcevent "arena#70::OnReset_All";
-		set $arena_min70end,gettime(2);
-		set $arena_sec70end,gettime(1);
+		set $arena_min70end,gettime(DT_MINUTE);
+		set $arena_sec70end,gettime(DT_SECOND);
 	}
 	end;
 }

--- a/npc/other/arena/arena_lvl80.txt
+++ b/npc/other/arena/arena_lvl80.txt
@@ -39,8 +39,8 @@ force_4-1,99,20,4	script	Octus#arena	124,{
 
 OnStart:
 	initnpctimer;
-	set $arena_min80st,gettime(2);
-	set $arena_sec80st,gettime(1);
+	set $arena_min80st,gettime(DT_MINUTE);
+	set $arena_sec80st,gettime(DT_SECOND);
 	end;
 
 OnTimer3000:
@@ -732,8 +732,8 @@ OnMyMobDead:
 		donpcevent "Octus#arena::On09_End";
 		donpcevent "arena#80::OnReset_09";
 		donpcevent "arena#80::OnReset_All";
-		set $arena_min80end,gettime(2);
-		set $arena_sec80end,gettime(1);
+		set $arena_min80end,gettime(DT_MINUTE);
+		set $arena_sec80end,gettime(DT_SECOND);
 	}
 	end;
 }

--- a/npc/other/arena/arena_party.txt
+++ b/npc/other/arena/arena_party.txt
@@ -149,8 +149,8 @@ OnTouch_:
 force_1-2,99,31,4	script	Slipslowrun#party	124,{
 OnStart:
 	initnpctimer;
-	set $arena_minptst,gettime(2);
-	set $arena_secptst,gettime(1);
+	set $arena_minptst,gettime(DT_MINUTE);
+	set $arena_secptst,gettime(DT_SECOND);
 	end;
 
 OnTimer2000:
@@ -414,8 +414,8 @@ OnReset:
 
 force_1-2,95,187,0	script	force_09_exit	45,1,1,{
 OnTouch_:
-	set $arena_minptend,gettime(2);
-	set $arena_secptend,gettime(1);
+	set $arena_minptend,gettime(DT_MINUTE);
+	set $arena_secptend,gettime(DT_SECOND);
 	warp "prt_are_in",73,139;
 	donpcevent "#arn_timer_pt::OnEnter";
 	donpcevent "arena_p::OnReset";

--- a/npc/quests/first_class/tu_archer.txt
+++ b/npc/quests/first_class/tu_archer.txt
@@ -1381,7 +1381,7 @@ pay_arche,76,135,3	script	#Target	HIDDEN_NPC,{ end; }
 -	script	::Acolyte_Tu	-1,{
 	mes "[Acolyte]";
 	if(tu_archer01 == 14){
-		if(gettime(3) >= 18 && gettime(3) < 22){
+		if(gettime(DT_HOUR) >= 18 && gettime(DT_HOUR) < 22){
 			mes "H-hello!";
 			mes "Umm, umm...";
 			mes "Are you R-Reidin Corse's";
@@ -1479,7 +1479,7 @@ pay_arche,76,135,3	script	#Target	HIDDEN_NPC,{ end; }
 		}
 	}
 	else if(tu_archer01 == 15){
-		if((gettime(3) >= 18) && (gettime(3) < 22)){
+		if((gettime(DT_HOUR) >= 18) && (gettime(DT_HOUR) < 22)){
 			mes "^666666Zzzzz...^000000";
 			mes "Wh-wha...?";
 			mes "Who are you?";

--- a/npc/quests/guildrelay.txt
+++ b/npc/quests/guildrelay.txt
@@ -72,7 +72,7 @@
 		if (strcharinfo(0) == getguildmaster(.@GID)) {
 			if (guildrelay_q == 100) {
 				if (guildtime > 22) {
-					if ((gettime(3) > 1) && (gettime(3) < guildtime)) {
+					if ((gettime(DT_HOUR) > 1) && (gettime(DT_HOUR) < guildtime)) {
 						mes "[" + .@name$ + "]";
 						mes "Oh, you're back. So did you";
 						mes "rest up enough? I'm sure the";
@@ -129,7 +129,7 @@
 					}
 				}
 				else if (guildtime > 22) {
-					if ((gettime(3) > 0) && (gettime(3) < guildtime)) {
+					if ((gettime(DT_HOUR) > 0) && (gettime(DT_HOUR) < guildtime)) {
 						mes "[" + .@name$ + "]";
 						mes "Oh, you're back. So did you";
 						mes "rest up enough? I'm sure the";
@@ -185,7 +185,7 @@
 						close;
 					}
 				}
-				else if ((gettime(3) - guildtime) > 2) {
+				else if ((gettime(DT_HOUR) - guildtime) > 2) {
 					mes "[" + .@name$ + "]";
 					mes "Oh, you're back. So did you";
 					mes "rest up enough? I'm sure the";
@@ -242,7 +242,7 @@
 				}
 			}
 			else if (guildrelay_q == 150) {
-				if (((guildtime > 22) && (gettime(3) > 1) && (gettime(3) < guildtime)) || ((guildtime > 21) && (gettime(3) > 0) && (gettime(3) < guildtime)) || ((gettime(3) - guildtime) > 2)) {
+				if (((guildtime > 22) && (gettime(DT_HOUR) > 1) && (gettime(DT_HOUR) < guildtime)) || ((guildtime > 21) && (gettime(DT_HOUR) > 0) && (gettime(DT_HOUR) < guildtime)) || ((gettime(DT_HOUR) - guildtime) > 2)) {
 					mes "[" + .@name$ + "]";
 					mes "Ah, you look well rested,";
 					mes "master. It is now time for";
@@ -306,12 +306,12 @@
 				}
 			}
 			else if (guildrelay_q == 25) {
-				if (((guildtime > 22) && ((gettime(3) > 4) && (gettime(3) < guildtime)))
-				|| ((guildtime > 21) && ((gettime(3) > 3) && (gettime(3) < guildtime)))
-				|| ((guildtime > 20) && ((gettime(3) > 2) && (gettime(3) < guildtime)))
-				|| ((guildtime > 19) && ((gettime(3) > 1) && (gettime(3) < guildtime)))
-				|| ((guildtime > 18) && ((gettime(3) > 0) && (gettime(3) < guildtime)))
-				|| ((gettime(3) - guildtime) > 5)) {
+				if (((guildtime > 22) && ((gettime(DT_HOUR) > 4) && (gettime(DT_HOUR) < guildtime)))
+				|| ((guildtime > 21) && ((gettime(DT_HOUR) > 3) && (gettime(DT_HOUR) < guildtime)))
+				|| ((guildtime > 20) && ((gettime(DT_HOUR) > 2) && (gettime(DT_HOUR) < guildtime)))
+				|| ((guildtime > 19) && ((gettime(DT_HOUR) > 1) && (gettime(DT_HOUR) < guildtime)))
+				|| ((guildtime > 18) && ((gettime(DT_HOUR) > 0) && (gettime(DT_HOUR) < guildtime)))
+				|| ((gettime(DT_HOUR) - guildtime) > 5)) {
 					mes "[" + .@name$ + "]";
 					mes "Ah, have you rested well,";
 					mes "master? Please excuse my";
@@ -415,7 +415,7 @@
 					mes "Hand me the spirit, and allow";
 					mes "me to give you your guild's reward.";
 					delitem 7239,1; //Soul_Of_Proceeding
-					set guildtime,gettime(3);
+					set guildtime,gettime(DT_HOUR);
 					set guildrelay_q,100;
 					set .@incen_item,rand(1,100);
 					if ((.@incen_item > 0) && (.@incen_item < 25)) {
@@ -483,7 +483,7 @@
 					mes "challenges that you will all";
 					mes "face together. Good work!";
 					delitem 7245,1; //Soul_Of_Friendship
-					set guildtime,gettime(3);
+					set guildtime,gettime(DT_HOUR);
 					set guildrelay_q,150;
 					set .@incen_item,rand(1,100);
 					if ((.@incen_item > 0) && (.@incen_item < 16)) {
@@ -576,7 +576,7 @@
 					mes "Tristan III, and share it with";
 					mes "guild. Once again, good work.";
 					delitem 7251,1; //Soul_Of_Victory
-					set guildtime,gettime(3);
+					set guildtime,gettime(DT_HOUR);
 					set guildrelay_q,25;
 					set .@incen_item,rand(1,100);
 					if ((.@incen_item > 0) && (.@incen_item < 26)) {
@@ -1411,11 +1411,11 @@
 				mes "don't you worry about it.";
 				delitem 7235,1; //Soul_Of_Courage
 				set guildrelay_q,4;
-				set guildtime,gettime(3);
+				set guildtime,gettime(DT_HOUR);
 				close;
 			}
 			if ((guildtime > 22) && (guildrelay_q == 4) && (BaseJob == Job_Blacksmith)) {
-				if ((gettime(3) > 2) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 2) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "I guess enough time";
 					mes "has passed. You ready";
@@ -1429,7 +1429,7 @@
 				}
 			}
 			if ((guildtime > 21) && (guildrelay_q == 4) && (BaseJob == Job_Blacksmith)) {
-				if ((gettime(3) > 0101) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 0101) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "I guess enough time";
 					mes "has passed. You ready";
@@ -1443,7 +1443,7 @@
 				}
 			}
 			if ((guildtime > 20) && (guildrelay_q == 4) && (BaseJob == Job_Blacksmith)) {
-				if ((gettime(3) > 0001) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 0001) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "I guess enough time";
 					mes "has passed. You ready";
@@ -1456,7 +1456,7 @@
 					close;
 				}
 			}
-			if ((gettime(3) - guildtime > 0300) && (guildrelay_q == 4) && (BaseJob == Job_Blacksmith)) {
+			if ((gettime(DT_HOUR) - guildtime > 0300) && (guildrelay_q == 4) && (BaseJob == Job_Blacksmith)) {
 				mes "[" + .@name$ + "]";
 				mes "I guess enough time";
 				mes "has passed. You ready";
@@ -1797,11 +1797,11 @@
 				mes "in order to be successful.";
 				delitem 7240,1; //Soul_Of_Confidence
 				set guildrelay_q,9;
-				set guildtime,gettime(3);
+				set guildtime,gettime(DT_HOUR);
 				close;
 			}
 			if ((guildtime > 22) && (guildrelay_q == 9) && (BaseJob == Job_Sage)) {
-				if ((gettime(3) > 02) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 02) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "So did you spend some";
 					mes "quality time with your";
@@ -1832,7 +1832,7 @@
 				}
 			}
 			else if ((guildtime > 21) && (guildrelay_q == 9) && (BaseJob == Job_Sage)) {
-				if ((gettime(3) > 01) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 01) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "So did you spend some";
 					mes "quality time with your";
@@ -1863,7 +1863,7 @@
 				}
 			}
 			else if ((guildtime > 20) && (guildrelay_q == 9) && (BaseJob == Job_Sage)) {
-				if ((gettime(3) > 0) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 0) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "So did you spend some";
 					mes "quality time with your";
@@ -1893,7 +1893,7 @@
 					close;
 				}
 			}
-			else if ((gettime(3) - guildtime > 3) && (guildrelay_q == 9) && (BaseJob == Job_Sage)) {
+			else if ((gettime(DT_HOUR) - guildtime > 3) && (guildrelay_q == 9) && (BaseJob == Job_Sage)) {
 				mes "[" + .@name$ + "]";
 				mes "So did you spend some";
 				mes "quality time with your";
@@ -2767,11 +2767,11 @@
 				mes "to your feelings this time...";
 				delitem 7249,1; //Soul_Of_Service
 				set guildrelay_q,21;
-				set guildtime,gettime(3);
+				set guildtime,gettime(DT_HOUR);
 				close;
 			}
 			if ((guildtime > 22) && (guildrelay_q == 21) && (BaseJob == Job_Crusader)) {
-				if ((gettime(3) > 2) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 2) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "Yes. You've come at just";
 					mes "the right time. Remember";
@@ -2793,7 +2793,7 @@
 				}
 			}
 			if ((guildtime > 21) && (guildrelay_q == 21) && (BaseJob == Job_Crusader)) {
-				if ((gettime(3) > 1) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 1) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "Yes. You've come at just";
 					mes "the right time. Remember";
@@ -2815,7 +2815,7 @@
 				}
 			}
 			if ((guildtime > 20) && (guildrelay_q == 21) && (BaseJob == Job_Crusader)) {
-				if ((gettime(3) > 0) && (gettime(3) < guildtime)) {
+				if ((gettime(DT_HOUR) > 0) && (gettime(DT_HOUR) < guildtime)) {
 					mes "[" + .@name$ + "]";
 					mes "Yes. You've come at just";
 					mes "the right time. Remember";
@@ -2836,7 +2836,7 @@
 					close;
 				}
 			}
-			if ((gettime(3) - guildtime > 3) && (guildrelay_q == 21) && (BaseJob == Job_Crusader)) {
+			if ((gettime(DT_HOUR) - guildtime > 3) && (guildrelay_q == 21) && (BaseJob == Job_Crusader)) {
 				mes "[" + .@name$ + "]";
 				mes "Yes. You've come at just";
 				mes "the right time. Remember";

--- a/npc/quests/partyrelay.txt
+++ b/npc/quests/partyrelay.txt
@@ -403,7 +403,7 @@ payon,83,327,3	script	Gatan#payon::RelayGatan	86,{
 		mes "instructions, didn't you?";
 		close;
 	}
-	set .@relaytime,gettime(3);
+	set .@relaytime,gettime(DT_HOUR);
 	if (party_relay == 28) {
 		mes "[Gatan]";
 		mes "Say, I don't think it's";
@@ -1839,7 +1839,7 @@ payon,204,221,3	script	Bafhail#payon::RelayBafhail	731,{
 		mes "with any of the other guys?";
 		close;
 	}
-	set .@relaytime,gettime(3);
+	set .@relaytime,gettime(DT_HOUR);
 	if (party_relay == 30) {
 		mes "[Bafhail]";
 		mes "Did you give that ticket";
@@ -2473,7 +2473,7 @@ payon,168,314,3	script	Lospii#payon::RelayLospii	706,{
 		mes "have to meet either, but...";
 		close;
 	}
-	set .@relaytime,gettime(3);
+	set .@relaytime,gettime(DT_HOUR);
 	getmapxy(.@m$,.@x,.@y,UNITTYPE_NPC,strnpcinfo(3));
 	set .@juwi,getareausers(.@m$,.@x-8,.@y-8,.@x+8,.@y+8);
 	if (party_relay == 32) {

--- a/npc/quests/quests_ein.txt
+++ b/npc/quests/quests_ein.txt
@@ -5698,7 +5698,7 @@ OnTouch_:
 			mes "Failure to do so will result";
 			mes "in lockout. Please wait.";
 			next;
-			set .@startseconds,gettime(3)*60*60+gettime(2)*60+gettime(1);
+			set .@startseconds,gettimetick(1);
 			mes "[Security System]";
 			switch(rand(1,7)) {
 			case 1:
@@ -5767,7 +5767,7 @@ OnTouch_:
 			}
 			next;
 			input .@input2$;
-			set .@endtime,gettime(3)*60*60+gettime(2)*60+gettime(1);
+			set .@endtime,gettimetick(1);
 			set .@time,.@endtime-.@startseconds;
 			mes "[Security System]";
 			if ((.@input1$ == .@word1$) && (.@input2$ == .@word2$)) {

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -81,7 +81,7 @@ lighthalzen,267,200,3	script	Guard#lhz01	868,{
 		set $@Lhz_Gangster_Alert, 100;
 		close;
 	}
-	if (gettime(3) >= 22 || gettime(3) < 2) {
+	if (gettime(DT_HOUR) >= 22 || gettime(DT_HOUR) < 2) {
 		mes "[Guard]";
 		mes "Zzzz... Zzz...";
 		mes "ZZZzzzzzzzzzz...";
@@ -148,7 +148,7 @@ lighthalzen,294,223,7	script	Guard#lhz02	868,{
 		set $@Lhz_Gangster_Alert, 100;
 		close;
 	}
-	if (gettime(3) >= 22 || gettime(3) < 2) {
+	if (gettime(DT_HOUR) >= 22 || gettime(DT_HOUR) < 2) {
 		mes "[Guard]";
 		mes "Zzzz... Zzz...";
 		mes "ZZZzzzzzzzzzz...";
@@ -7288,7 +7288,7 @@ yuno_pre,69,20,4	script	Secretary#1	862,{
 					mes "Membership Card.^000000";
 					close;
 				}
-				if(((gettime(3) > 10) && (gettime(3) < 15)) || ((gettime(3) > 19) && (gettime(3) <= 23)))
+				if(((gettime(DT_HOUR) > 10) && (gettime(DT_HOUR) < 15)) || ((gettime(DT_HOUR) > 19) && (gettime(DT_HOUR) <= 23)))
 				{
 					mes "^3355FFYou suavely flash";
 					mes "your ''Secret Wing''";

--- a/npc/quests/quests_louyang.txt
+++ b/npc/quests/quests_louyang.txt
@@ -40,7 +40,7 @@
 // Soup Quest :: lou_tre
 //============================================================
 lou_in02,53,174,7	script	Employee#1	822,6,62,{
-	if (gettime(3) >= 10 && gettime(3) < 22) {
+	if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 22) {
 		mes "[Chang Pai]";
 		mes "Welcome, welcome!";
 		mes "We are ready to serve you~!";
@@ -53,7 +53,7 @@ lou_in02,53,174,7	script	Employee#1	822,6,62,{
 
 OnTouch_:
 	if (ch_tre == 2 || ch_tre == 3) {
-		if (gettime(3) >= 10 && gettime(3) < 14) {
+		if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 			if (rand(1,10) < 9) {
 				mes "[Chang Pai]";
 				mes "Wait, who are you?!";
@@ -66,7 +66,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 14 && gettime(3) < 17) {
+		else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 			if (rand(1,10) < 10) {
 				mes "[Chang Pai]";
 				mes "Wait, who are you?!";
@@ -79,7 +79,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 17 && gettime(3) < 21) {
+		else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 21) {
 			if (rand(1,10) < 6) {
 				mes "[Chang Pai]";
 				mes "Wait, who are you?!";
@@ -115,7 +115,7 @@ OnTouch_:
 }
 
 lou_in02,76,181,3	script	Employee#2	822,2,2,{
-	if (gettime(3) >= 10 && gettime(3) < 22) {
+	if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 22) {
 		mes "[Huang Jia Xian]";
 		mes "Welcome~";
 		mes "Sorry for making you wait. If you wish to rest, please go upstairs.";
@@ -140,7 +140,7 @@ lou_in02,76,181,3	script	Employee#2	822,2,2,{
 
 OnTouch_:
 	if (ch_tre == 2 || ch_tre == 3) {
-		if (gettime(3) >= 10 && gettime(3) < 14) {
+		if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 			if (rand(1,10) < 9) {
 				mes "[Huang Jia Xian]";
 				mes "What the...?";
@@ -154,7 +154,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 14 && gettime(3) < 17) {
+		else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 			if (rand(1,10) < 10) {
 				mes "[Huang Jia Xian]";
 				mes "What the...?";
@@ -168,7 +168,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 17 && gettime(3) < 22) {
+		else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 			if (rand(1,10) < 6) {
 				mes "[Huang Jia Xian]";
 				mes "What the...?";
@@ -205,7 +205,7 @@ OnTouch_:
 }
 
 lou_in02,61,175,3	script	Employee#3	818,2,2,{
-	if (gettime(3) >= 10 && gettime(3) < 22) {
+	if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 22) {
 		if (ch_tre == 5) {
 			mes "[Ya Hua]";
 			mes "Welcome, welcome!";
@@ -236,7 +236,7 @@ lou_in02,61,175,3	script	Employee#3	818,2,2,{
 
 OnTouch_:
 	if (ch_tre == 2 || ch_tre == 3) {
-		if (gettime(3) >= 10 && gettime(3) < 14) {
+		if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 			if (rand(1,10) < 9) {
 				mes "[Ya Hua]";
 				mes "What do you think";
@@ -250,7 +250,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 14 && gettime(3) < 17) {
+		else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 			if (rand(1,10) < 10) {
 				mes "[Ya Hua]";
 				mes "What do you think";
@@ -264,7 +264,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 17 && gettime(3) < 22) {
+		else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 			if (rand(1,10) < 6) {
 				mes "[Ya Hua]";
 				mes "What do you think";
@@ -369,7 +369,7 @@ lou_in02,62,183,3	script	Chef#1-2	820,2,2,{
 
 OnTouch_:
 	if (ch_tre == 2 || ch_tre == 3) {
-		if (gettime(3) >= 10 && gettime(3) < 14) {
+		if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 			if (rand(1,10) < 9) {
 				mes "[Wang Shi Long]";
 				mes "Hey, what do you";
@@ -384,7 +384,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 14 && gettime(3) < 17) {
+		else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 			if (rand(1,10) < 10) {
 				mes "[Wang Shi Long]";
 				mes "Hey, what do you";
@@ -399,7 +399,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 17 && gettime(3) < 22) {
+		else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 			if (rand(1,10) < 6) {
 				mes "[Wang Shi Long]";
 				mes "Hey, what do you";
@@ -722,16 +722,16 @@ lou_in02,50,185,5	script	Pot#1	111,{
 			mes "^3131FFYou take a careful look around.";
 			mes "It wouldn't be wise to steal this now if anyone is watching.^000000";
 			next;
-			if (gettime(3) >= 10 && gettime(3) < 14) {
+			if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 				mes "^3131FFThe restaurant doesn't seem busy right now, so there's only a few employees and customers.^000000";
 			}
-			else if (gettime(3) >= 14 && gettime(3) < 17) {
+			else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 				mes "^3131FFOnly the restaurant";
 				mes "employees are around,";
 				mes "and they busy chatting";
 				mes "amongst each other.^000000";
 			}
-			else if (gettime(3) >= 17 && gettime(3) < 22) {
+			else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 				mes "^3131FFThe restaurant is filled";
 				mes "with customers, and the";
 				mes "hustle and bustle of the";
@@ -772,7 +772,7 @@ lou_in02,50,185,5	script	Pot#1	111,{
 		mes "^3131FFHowever, it's empty.^000000";
 		close;
 	}
-	if (gettime(3) >= 10 && gettime(3) < 22) {
+	if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 22) {
 		mes "[Chef]";
 		mes "Ah...!";
 		mes "Please, do not";
@@ -794,16 +794,16 @@ lou_in02,49,185,5	script	Pot#2	111,{
 			mes "^3131FFYou take a careful look around.";
 			mes "It wouldn't be wise to steal this now if anyone is watching.^000000";
 			next;
-			if (gettime(3) >= 10 && gettime(3) < 14) {
+			if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 				mes "^3131FFThe restaurant doesn't seem busy right now, so there's only a few employees and customers.^000000";
 			}
-			else if (gettime(3) >= 14 && gettime(3) < 17) {
+			else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 				mes "^3131FFOnly the restaurant";
 				mes "employees are around,";
 				mes "and they busy chatting";
 				mes "amongst each other.^000000";
 			}
-			else if (gettime(3) >= 17 && gettime(3) < 22) {
+			else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 				mes "^3131FFThe restaurant is filled";
 				mes "with customers, and the";
 				mes "hustle and bustle of the";
@@ -844,7 +844,7 @@ lou_in02,49,185,5	script	Pot#2	111,{
 		mes "an empty pot.^000000";
 		close;
 	}
-	if (gettime(3) >= 10 && gettime(3) < 22) {
+	if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 22) {
 		mes "[Chef]";
 		mes "Ah...!";
 		mes "Please, do not";
@@ -896,7 +896,7 @@ lou_in02,58,183,5	script	Chef Assistant#lou1	823,5,5,{
 
 OnTouch_:
 	if (ch_tre == 2 || ch_tre == 3) {
-		if (gettime(3) >= 10 && gettime(3) < 14) {
+		if (gettime(DT_HOUR) >= 10 && gettime(DT_HOUR) < 14) {
 			if (rand(1,10) < 9) {
 				mes "[Jin Wei Ling]";
 				mes "Wait! Who are you!";
@@ -910,7 +910,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 14 && gettime(3) < 17) {
+		else if (gettime(DT_HOUR) >= 14 && gettime(DT_HOUR) < 17) {
 			if (rand(1,10) < 10) {
 				mes "[Jin Wei Ling]";
 				mes "Wait! Who are you!";
@@ -924,7 +924,7 @@ OnTouch_:
 				close;
 			}
 		}
-		else if (gettime(3) >= 17 && gettime(3) < 22) {
+		else if (gettime(DT_HOUR) >= 17 && gettime(DT_HOUR) < 22) {
 			if (rand(1,10) < 6) {
 				mes "[Jin Wei Ling]";
 				mes "Wait! Who are you!";

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -528,7 +528,7 @@ moscovia,135,49,5	script	Mr. Ibanoff#npc	4_M_RUSBALD,{
 		mes "Oh. Are you ready to depart?";
 		mes "Good, let's see...";
 		next;
-		if ((gettime(3) >= 0 && gettime(3) < 3) || (gettime(3) >= 6 && gettime(3) < 9) || (gettime(3) >= 12 && gettime(3) < 15) || (gettime(3) >= 18 && gettime(3) < 21)) {
+		if ((gettime(DT_HOUR) >= 0 && gettime(DT_HOUR) < 3) || (gettime(DT_HOUR) >= 6 && gettime(DT_HOUR) < 9) || (gettime(DT_HOUR) >= 12 && gettime(DT_HOUR) < 15) || (gettime(DT_HOUR) >= 18 && gettime(DT_HOUR) < 21)) {
 			// if (isbegin_quest(18106))
 				// changequest 18106,18107;
 			mes "[Mr. Ibanoff]";
@@ -562,7 +562,7 @@ moscovia,135,49,5	script	Mr. Ibanoff#npc	4_M_RUSBALD,{
 			mes "When you are ready to depart, tell me.";
 			close;
 		}
-		if ((gettime(3) >= 0 && gettime(3) < 3) || (gettime(3) >= 6 && gettime(3) < 9) || (gettime(3) >= 12 && gettime(3) < 15) || (gettime(3) >= 18 && gettime(3) < 21)) {
+		if ((gettime(DT_HOUR) >= 0 && gettime(DT_HOUR) < 3) || (gettime(DT_HOUR) >= 6 && gettime(DT_HOUR) < 9) || (gettime(DT_HOUR) >= 12 && gettime(DT_HOUR) < 15) || (gettime(DT_HOUR) >= 18 && gettime(DT_HOUR) < 21)) {
 			mos_whale_edq = 4;
 			mes "[Mr. Ibanoff]";
 			mes "Hmm. It's not a bad time.";
@@ -699,7 +699,7 @@ moscovia,135,49,5	script	Mr. Ibanoff#npc	4_M_RUSBALD,{
 			mes "When you are ready to depart, tell me.";
 			close;
 		}
-		if ((gettime(3) >= 0 && gettime(3) < 3) || (gettime(3) >= 6 && gettime(3) < 9) || (gettime(3) >= 12 && gettime(3) < 15) || (gettime(3) >= 18 && gettime(3) < 21)) {
+		if ((gettime(DT_HOUR) >= 0 && gettime(DT_HOUR) < 3) || (gettime(DT_HOUR) >= 6 && gettime(DT_HOUR) < 9) || (gettime(DT_HOUR) >= 12 && gettime(DT_HOUR) < 15) || (gettime(DT_HOUR) >= 18 && gettime(DT_HOUR) < 21)) {
 			mes "[Mr. Ibanoff]";
 			mes "Hmm. It's not a bad time.";
 			mes "We should hurry up";
@@ -731,7 +731,7 @@ moscovia,135,49,5	script	Mr. Ibanoff#npc	4_M_RUSBALD,{
 		mes "I can guess you'd like to go to";
 		mes "Whale Island once again...";
 		next;
-		if ((gettime(3) >= 0 && gettime(3) < 3) || (gettime(3) >= 6 && gettime(3) < 9) || (gettime(3) >= 12 && gettime(3) < 15) || (gettime(3) >= 18 && gettime(3) < 21)) {
+		if ((gettime(DT_HOUR) >= 0 && gettime(DT_HOUR) < 3) || (gettime(DT_HOUR) >= 6 && gettime(DT_HOUR) < 9) || (gettime(DT_HOUR) >= 12 && gettime(DT_HOUR) < 15) || (gettime(DT_HOUR) >= 18 && gettime(DT_HOUR) < 21)) {
 			mes "[Mr. Ibanoff]";
 			mes "Hmm. It's not a bad time.";
 			mes "We should hurry up";
@@ -8399,7 +8399,7 @@ OnTouch_:
 		end;
 	}
 	if (rhea_rus_hair == 2) {
-		if (gettime(3) >= 17 || gettime(3) <= 6) {
+		if (gettime(DT_HOUR) >= 17 || gettime(DT_HOUR) <= 6) {
 			mes "- Splash !! -";
 			next;
 			if (countitem(523) > 0) {// Holy_Water
@@ -8424,7 +8424,7 @@ OnTouch_:
 		mes "And please, tell him to stop suffering and to be happy. This is my request.";
 		close;
 	} else if (rhea_rus_hair == 7) {
-		if (gettime(3) >= 17 || gettime(3) <= 6) {
+		if (gettime(DT_HOUR) >= 17 || gettime(DT_HOUR) <= 6) {
 			mes "- Splash !! -";
 			next;
 			if (countitem(523) > 0) {
@@ -9214,12 +9214,12 @@ mosk_fild02,243,270,0	script	Marozka#rus31	4_M_LGTGRAND,{
 			mes "[Marozka]";
 			mes "I will begin making it now... let me see... Could you please come back to me in an hour?";
 			rhea_rus_quiz = 4;
-			rus_time01 = gettime(3);
-			rus_time02 = gettime(4);
+			rus_time01 = gettime(DT_HOUR);
+			rus_time02 = gettime(DT_DAYOFWEEK);
 			// changequest 8155,8156;
 			close;
 		} else if (rhea_rus_quiz == 4) {
-			if (rus_time01 != gettime(3) || rus_time02 != gettime(4)) {
+			if (rus_time01 != gettime(DT_HOUR) || rus_time02 != gettime(DT_DAYOFWEEK)) {
 				mes "[Marozka]";
 				mes "Ah, just in time.";
 				mes "I have finally finished making the 'Golden Thread'. Just wait one more second and it'll be ready.";

--- a/npc/quests/quests_umbala.txt
+++ b/npc/quests/quests_umbala.txt
@@ -1128,7 +1128,7 @@ um_in,101,73,3	script	Wainatan	783,{
 		close;
 	}
 	if (um_wind == 1) {
-		if (gettime(3) > 18) {
+		if (gettime(DT_HOUR) > 18) {
 			set um_wind,2;
 			emotion e_an;
 			mes "[Wainatan]";
@@ -1172,7 +1172,7 @@ um_in,94,123,5	script	Bertztan	783,{
 		close;
 	}
 	if (um_wind == 2) {
-		if (gettime(3) > 18) {
+		if (gettime(DT_HOUR) > 18) {
 			set um_wind,3;
 			emotion e_an;
 			mes "[Bertztan]";
@@ -1224,7 +1224,7 @@ umbala,145,217,3	script	Chabimatan	783,{
 		close;
 	}
 	if (um_wind == 3) {
-		if (gettime(3) > 18) {
+		if (gettime(DT_HOUR) > 18) {
 			set um_wind,4;
 			emotion e_an;
 			mes "[Chabimatan]";

--- a/npc/quests/the_sign_quest.txt
+++ b/npc/quests/the_sign_quest.txt
@@ -554,7 +554,7 @@ prt_in,227,45,0	script	Archeologist#sign	804,{
 		mes "this and come back later~";
 		delitem 7314,1; //The_Sign
 		set sign_q,138;
-		set .@stime_s,gettime(3);
+		set .@stime_s,gettime(DT_HOUR);
 		if (.@stime_s < 1) set sign_sq,1;
 		else if (.@stime_s < 3) set sign_sq,2;
 		else if (.@stime_s < 5) set sign_sq,3;
@@ -569,7 +569,7 @@ prt_in,227,45,0	script	Archeologist#sign	804,{
 		else set sign_sq,12;
 	}
 	else if (sign_q == 138) {
-		set .@stime_s1,gettime(3);
+		set .@stime_s1,gettime(DT_HOUR);
 		if (.@stime_s1 < 1) {
 			if (sign_sq == 11) {
 				set .@pass_s,1;
@@ -2568,7 +2568,7 @@ aldeba_in,139,103,5	script	Monograph#sign	111,{
 
 aldeba_in,155,101,3	script	Sir Jore#sign	805,7,7,{
 	callfunc "F_UpdateSignVars";
-	if ((gettime(3) > 16) && (gettime(3) < 22)) {
+	if ((gettime(DT_HOUR) > 16) && (gettime(DT_HOUR) < 22)) {
 		if (sign_q == 15) {
 			mes "["+ strcharinfo(0) +"]";
 			mes "Excuse me...";
@@ -2859,7 +2859,7 @@ aldeba_in,155,101,3	script	Sir Jore#sign	805,7,7,{
 			close;
 		}
 	}
-	else if ((gettime(3) > 6) && (gettime(3) < 17)) {
+	else if ((gettime(DT_HOUR) > 6) && (gettime(DT_HOUR) < 17)) {
 		mes "^3355FFYou find a tense man";
 		mes "holding test tubes between";
 		mes "his fingers, standing in a pile";
@@ -2939,7 +2939,7 @@ OnTouch_:
 aldeba_in,156,118,4	script	Piru Piru#sign	102,{
 	callfunc "F_UpdateSignVars";
 	mes "[Piru Piru]";
-	if ((gettime(3) >= 12) && (gettime(3) <= 24)) { //235959
+	if ((gettime(DT_HOUR) >= 12) && (gettime(DT_HOUR) <= 24)) { //235959
 		if (sign_q == 17) {
 			emotion e_sob;
 			mes "Oh, I'm sooo tired~";
@@ -3019,7 +3019,7 @@ aldeba_in,156,118,4	script	Piru Piru#sign	102,{
 			close;
 		}
 	}
-	else if ((gettime(3) >= 6) && (gettime(3) < 12)) {
+	else if ((gettime(DT_HOUR) >= 6) && (gettime(DT_HOUR) < 12)) {
 		mes "Everyday we study and";
 		mes "take notes and test and";
 		mes "experiment and record";
@@ -4536,7 +4536,7 @@ cmd_in02,88,51,4	script	Strange Guy#sign	806,{
 		}
 	}
 	else if (sign_q == 27) {
-		if ((gettime(3) > 18) && (gettime(3) < 23)) {
+		if ((gettime(DT_HOUR) > 18) && (gettime(DT_HOUR) < 23)) {
 			mes "Nice, you're here";
 			mes "just in time. Well,";
 			mes "all that matters is that";
@@ -7553,7 +7553,7 @@ mjo_dun02,88,295,4	script	Flaming Spirit Man	85,{
 		mes "But I'll do my best for you.";
 		delitem 7314,1; //The_Sign
 		set sign_q,140;
-		set .@stime_e,gettime(3);
+		set .@stime_e,gettime(DT_HOUR);
 		if (.@stime_e < 2) set sign_sq,1;
 		else if (.@stime_e < 4) set sign_sq,2;
 		else if (.@stime_e < 6) set sign_sq,3;
@@ -7569,7 +7569,7 @@ mjo_dun02,88,295,4	script	Flaming Spirit Man	85,{
 		close;
 	}
 	else if (sign_q == 140) {
-		set .@stime_e1,gettime(3);
+		set .@stime_e1,gettime(DT_HOUR);
 		if (.@stime_e1 < 2) {
 			if (sign_sq == 11) {
 				set .@pass_s1,1;

--- a/npc/re/guild/invest_main.txt
+++ b/npc/re/guild/invest_main.txt
@@ -63,48 +63,48 @@ $@vfund_*_extra
 // Note: The times in this section are almost entirely custom.
 
 -	script	#invest_timer	-1,{
-OnClock0000:	// Open investments on Wed (1 hour after WoE)
-	if (gettime(4) == 3 && !agitcheck()) {
+OnClock0000:	// Open investments on Wednesday (1 hour after WoE)
+	if (gettime(DT_DAYOFWEEK) == WEDNESDAY && !agitcheck()) {
 		set $2011_agit_invest,1;
 		donpcevent "#fund_master::OnInvest_start";
 	}
 	end;
-OnClock1200:	// Close investments on Fri (60 hours after investments open)
-	if (gettime(4) == 5 && !agitcheck()) {
+OnClock1200:	// Close investments on Friday (60 hours after investments open)
+	if (gettime(DT_DAYOFWEEK) == FRIDAY && !agitcheck()) {
 		set $2011_agit_invest,2;
 		donpcevent "#fund_master::OnInvest_stop";
 	}
 	end;
-OnClock1235:	// Open dungeons on Fri (at least 31 minutes after investments close)
-	if (gettime(4) == 5 && !agitcheck())
+OnClock1235:	// Open dungeons on Friday (at least 31 minutes after investments close)
+	if (gettime(DT_DAYOFWEEK) == FRIDAY && !agitcheck())
 		donpcevent "#fund_master::OnResult";
 	end;
-OnClock2000:	// Close dungeons on Tues (1 hour before WoE)
-	if (gettime(4) == 2)
+OnClock2000:	// Close dungeons on Tuesday (1 hour before WoE)
+	if (gettime(DT_DAYOFWEEK) == TUESDAY)
 		donpcevent "#fund_master::OnReset";
 	end;
 }
 
 function	script	F_Invest_Status	{
-	set .@day, gettime(4);
-	set .@hour, gettime(3);
-	set .@minute, gettime(2);
+	set .@day, gettime(DT_DAYOFWEEK);
+	set .@hour, gettime(DT_HOUR);
+	set .@minute, gettime(DT_MINUTE);
 
 	// Inactive.
 	if (agitcheck())
 		return 0;
 
 	// Open for investments.
-	if (.@day >= 3 && (.@day < 5 || (.@day == 5 && .@hour <= 12)))
+	if (.@day >= WEDNESDAY && (.@day < FRIDAY || (.@day == FRIDAY && .@hour <= 12)))
 		return 1;
 
 	// Investments closed, calculating results.
-	if (.@day == 5 && .@hour == 12 && .@minute < 35)
+	if (.@day == FRIDAY && .@hour == 12 && .@minute < 35)
 		return 2;
 
 	// Calculations complete, dungeons open.
-	if ((.@day == 5 && (.@hour > 12 || (.@hour == 12 && .@minute >= 35))) || .@day > 5 ||
-	    .@day < 2 || (.@day == 2 && .@hour < 20))
+	if ((.@day == FRIDAY && (.@hour > 12 || (.@hour == 12 && .@minute >= 35))) || .@day > FRIDAY ||
+	    .@day < TUESDAY || (.@day == TUESDAY && .@hour < 20))
 		return 3;
 
 	// Dungeons closed.

--- a/npc/re/guild3/agit_start_te.txt
+++ b/npc/re/guild3/agit_start_te.txt
@@ -19,24 +19,16 @@ OnSun2100:// date woe end
 	end;
 
 OnAgitInit3:
-	WoeTimer( "Sunday",20,21 );// <day>, <hour start>, <hour end>
+	WoeTimer( SUNDAY,20,21 );// <day>, <hour start>, <hour end>
 	end;
 
 function WoeTimer {
-	.@Sunday    = 0;
-	.@Monday    = 1;
-	.@Tuesday   = 2;
-	.@Wednesday = 3;
-	.@Thursday  = 4;
-	.@Friday    = 5;
-	.@Saturday  = 6;
-
-	.@day = getd( ".@"+ getarg(0) );
+	.@day = getarg(0);
 	.@hour_start = getarg(1);
 	.@hour_end   = getarg(2);
 	.@woe_status = agitcheck3();
-	.@hour_today = gettime(3);
-	.@day_today  = gettime(4);
+	.@hour_today = gettime(DT_HOUR);
+	.@day_today  = gettime(DT_DAYOFWEEK);
 	setd ".day_"+ .@day, 1;
 	setd ".hour_start_"+ .@hour_start, 1;
 

--- a/npc/re/other/Global_Functions.txt
+++ b/npc/re/other/Global_Functions.txt
@@ -11,9 +11,9 @@
 // WoeTETimeStart(<seconds>) : return true if the woe te will start in X seconds or less, false otherwise
 function	script	WoeTETimeStart	{
 	.@woe_status = agitcheck3();
-	.@min_today  = gettime(2);
-	.@hour_today = gettime(3);
-	.@day_today  = gettime(4);
+	.@min_today  = gettime(DT_MINUTE);
+	.@hour_today = gettime(DT_HOUR);
+	.@day_today  = gettime(DT_DAYOFWEEK);
 
 	if (getvariableofnpc( getd( ".day_"+ .@day_today ),"woe_TE_contoller" )) {
 		.@h = getvariableofnpc( getd( ".hour_start_"+ .@hour_today ),"woe_TE_contoller" );

--- a/npc/re/quests/newgears/2010_headgears.txt
+++ b/npc/re/quests/newgears/2010_headgears.txt
@@ -1054,7 +1054,7 @@ alberta,120,206,3	script	Alonie#Solo_Play_Box	787,{
 			mes "My affection-lacked student!";
 			mes "This is the end of your training!";
 			next;
-			if (gettime(3) < 12) {
+			if (gettime(DT_HOUR) < 12) {
 				set .@item,5448; //Solo_Play_Box1
 				set .@time$,"AM";
 			} else {

--- a/npc/re/quests/quests_mora.txt
+++ b/npc/re/quests/quests_mora.txt
@@ -2524,7 +2524,7 @@ mora,31,138,6	script	Raffle Researcher#ep14	522,{
 		close;
 	}
 	// NPC disabled from 12am ~ 5am.
-	if (gettime(3) >= 0 && gettime(3) < 5) {
+	if (gettime(DT_HOUR) >= 0 && gettime(DT_HOUR) < 5) {
 		if (ep14_1_muk > 0) {
 			mes "[Raffle Researcher]";
 			mes "Don't humans sleep?";

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -3487,16 +3487,13 @@ ACMD_FUNC(agitstart)
 {
 	nullpo_retr(-1, sd);
 
-	if (agit_flag) {
+	if( guild_agit_start() ){
+		clif_displaymessage(fd, msg_txt(sd,72)); // War of Emperium has been initiated.
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,73)); // War of Emperium is currently in progress.
 		return -1;
 	}
-
-	agit_flag = true;
-	guild_agit_start();
-	clif_displaymessage(fd, msg_txt(sd,72)); // War of Emperium has been initiated.
-
-	return 0;
 }
 
 /**
@@ -3506,16 +3503,13 @@ ACMD_FUNC(agitstart2)
 {
 	nullpo_retr(-1, sd);
 
-	if (agit2_flag) {
+	if( guild_agit2_start() ){
+		clif_displaymessage(fd, msg_txt(sd,403)); // "War of Emperium SE has been initiated."
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,404)); // "War of Emperium SE is currently in progress."
 		return -1;
 	}
-
-	agit2_flag = true;
-	guild_agit2_start();
-	clif_displaymessage(fd, msg_txt(sd,403)); // "War of Emperium SE has been initiated."
-
-	return 0;
 }
 
 /**
@@ -3525,16 +3519,13 @@ ACMD_FUNC(agitstart3)
 {
 	nullpo_retr(-1, sd);
 
-	if (agit3_flag) {
+	if( guild_agit3_start() ){
+		clif_displaymessage(fd, msg_txt(sd,749)); // "War of Emperium TE has been initiated."
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,750)); // "War of Emperium TE is currently in progress."
 		return -1;
 	}
-
-	agit3_flag = true;
-	guild_agit3_start();
-	clif_displaymessage(fd, msg_txt(sd,749)); // "War of Emperium TE has been initiated."
-
-	return 0;
 }
 
 /**
@@ -3544,16 +3535,13 @@ ACMD_FUNC(agitend)
 {
 	nullpo_retr(-1, sd);
 
-	if (!agit_flag) {
+	if( guild_agit_end() ){
+		clif_displaymessage(fd, msg_txt(sd,74)); // War of Emperium has been ended.
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,75)); // War of Emperium is currently not in progress.
 		return -1;
 	}
-
-	agit_flag = false;
-	guild_agit_end();
-	clif_displaymessage(fd, msg_txt(sd,74)); // War of Emperium has been ended.
-
-	return 0;
 }
 
 /**
@@ -3563,16 +3551,13 @@ ACMD_FUNC(agitend2)
 {
 	nullpo_retr(-1, sd);
 
-	if (!agit2_flag) {
+	if( guild_agit2_end() ){
+		clif_displaymessage(fd, msg_txt(sd,405)); // "War of Emperium SE has been ended."
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,406)); // "War of Emperium SE is currently not in progress."
 		return -1;
 	}
-
-	agit2_flag = false;
-	guild_agit2_end();
-	clif_displaymessage(fd, msg_txt(sd,405)); // "War of Emperium SE has been ended."
-
-	return 0;
 }
 
 /**
@@ -3582,16 +3567,13 @@ ACMD_FUNC(agitend3)
 {
 	nullpo_retr(-1, sd);
 
-	if (!agit3_flag) {
+	if( guild_agit3_end() ){
+		clif_displaymessage(fd, msg_txt(sd,751));// War of Emperium TE has been ended.
+		return 0;
+	}else{
 		clif_displaymessage(fd, msg_txt(sd,752));// War of Emperium TE is currently not in progress.
 		return -1;
 	}
-
-	agit3_flag = false;
-	guild_agit3_end();
-	clif_displaymessage(fd, msg_txt(sd,751));// War of Emperium TE has been ended.
-
-	return 0;
 }
 
 /*==========================================

--- a/src/map/chrif.c
+++ b/src/map/chrif.c
@@ -23,6 +23,7 @@
 #include "mercenary.h"
 #include "elemental.h"
 #include "chrif.h"
+#include "script.h" // script_config
 #include "storage.h"
 
 #include <stdlib.h>
@@ -505,9 +506,9 @@ int chrif_connectack(int fd) {
 
 	chrif_sendmap(fd);
 
-	ShowStatus("Event '"CL_WHITE"OnInterIfInit"CL_RESET"' executed with '"CL_WHITE"%d"CL_RESET"' NPCs.\n", npc_event_doall("OnInterIfInit"));
+	npc_event_runall(script_config.inter_init_event_name);
 	if( !char_init_done ) {
-		ShowStatus("Event '"CL_WHITE"OnInterIfInitOnce"CL_RESET"' executed with '"CL_WHITE"%d"CL_RESET"' NPCs.\n", npc_event_doall("OnInterIfInitOnce"));
+		npc_event_runall(script_config.inter_init_once_event_name);
 		guild_castle_map_init();
 		intif_clan_requestclans();
 	}

--- a/src/map/date.c
+++ b/src/map/date.c
@@ -19,13 +19,37 @@ int date_get_year(void)
 /*
  * Get the current month
  */
-int date_get_month(void)
+enum e_month date_get_month(void)
 {
 	time_t t;
 	struct tm * lt;
 	t = time(NULL);
 	lt = localtime(&t);
-	return lt->tm_mon+1;
+	return (enum e_month)(lt->tm_mon+1);
+}
+
+/*
+ * Get the day of the month
+ */
+int date_get_dayofmonth(void)
+{
+	time_t t;
+	struct tm * lt;
+	t = time(NULL);
+	lt = localtime(&t);
+	return lt->tm_mday;
+}
+
+/*
+ * Get the day of the week
+ */
+enum e_dayofweek date_get_dayofweek(void)
+{
+	time_t t;
+	struct tm * lt;
+	t = time(NULL);
+	lt = localtime(&t);
+	return (enum e_dayofweek)lt->tm_wday;
 }
 
 /*
@@ -77,9 +101,36 @@ int date_get_sec(void)
 }
 
 /*
+ * Get the value for the specific type
+ */
+int date_get( enum e_date_type type )
+{
+	switch( type ){
+		case DT_SECOND:
+			return date_get_sec();
+		case DT_MINUTE:
+			return date_get_min();
+		case DT_HOUR:
+			return date_get_hour();
+		case DT_DAYOFWEEK:
+			return date_get_dayofweek();
+		case DT_DAYOFMONTH:
+			return date_get_dayofmonth();
+		case DT_MONTH:
+			return date_get_month();
+		case DT_YEAR:
+			return date_get_year();
+		case DT_DAYOFYEAR:
+			return date_get_day();
+		default:
+			return -1;
+	}
+}
+
+/*
  * Does this day is a day of the Sun, (for SG)
  */
-int is_day_of_sun(void)
+bool is_day_of_sun(void)
 {
 	return date_get_day()%2 == 0;
 }
@@ -87,7 +138,7 @@ int is_day_of_sun(void)
 /*
  * Does this day is a day of the Moon, (for SG)
  */
-int is_day_of_moon(void)
+bool is_day_of_moon(void)
 {
 	return date_get_day()%2 == 1;
 }
@@ -95,7 +146,7 @@ int is_day_of_moon(void)
 /*
  * Does this day is a day of the Star, (for SG)
  */
-int is_day_of_star(void)
+bool is_day_of_star(void)
 {
 	return date_get_day()%5 == 0;
 }

--- a/src/map/date.h
+++ b/src/map/date.h
@@ -4,19 +4,64 @@
 #ifndef _DATE_H_
 #define _DATE_H_
 
+#include "../common/cbasetypes.h"
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
+
+enum e_month{
+	JANUARY = 1,
+	FEBRUARY,
+	MARCH,
+	APRIL,
+	MAY,
+	JUNE,
+	JULY,
+	AUGUST,
+	SEPTEMBER,
+	OCTOBER,
+	NOVEMBER,
+	DECEMBER
+};
+
+enum e_dayofweek{
+	SUNDAY = 0,
+	MONDAY,
+	TUESDAY,
+	WEDNESDAY,
+	THURSDAY,
+	FRIDAY,
+	SATURDAY
+};
+
+enum e_date_type{
+	DT_MIN = 0,
+	DT_SECOND,
+	DT_MINUTE,
+	DT_HOUR,
+	DT_DAYOFWEEK,
+	DT_DAYOFMONTH,
+	DT_MONTH,
+	DT_YEAR,
+	DT_DAYOFYEAR,
+	DT_MAX
+};
+
 int date_get_year(void);
-int date_get_month(void);
+enum e_month date_get_month(void);
+int date_get_dayofmonth(void);
+enum e_dayofweek date_get_dayofweek(void);
 int date_get_day(void);
 int date_get_hour(void);
 int date_get_min(void);
 int date_get_sec(void);
 
-int is_day_of_sun(void);
-int is_day_of_moon(void);
-int is_day_of_star(void);
+int date_get( enum e_date_type type );
+
+bool is_day_of_sun(void);
+bool is_day_of_moon(void);
+bool is_day_of_star(void);
 
 #ifdef	__cplusplus
 }

--- a/src/map/guild.c
+++ b/src/map/guild.c
@@ -406,7 +406,7 @@ int guild_request_info(int guild_id) {
 int guild_npc_request_info(int guild_id,const char *event) {
 	if( guild_search(guild_id) ) {
 		if( event && *event )
-			npc_event_do(event);
+			npc_event_doall(event);
 
 		return 0;
 	}
@@ -415,7 +415,7 @@ int guild_npc_request_info(int guild_id,const char *event) {
 		struct eventlist *ev;
 		DBData prev;
 		ev=(struct eventlist *)aCalloc(sizeof(struct eventlist),1);
-		memcpy(ev->name,event,strlen(event));
+		safestrncpy(ev->name,event,EVENT_NAME_LENGTH);
 		//The one in the db (if present) becomes the next event from this.
 		if (guild_infoevent_db->put(guild_infoevent_db, db_i2key(guild_id), db_ptr2data(ev), &prev))
 			ev->next = (struct eventlist *)db_data2ptr(&prev);
@@ -1708,8 +1708,8 @@ int castle_guild_broken_sub(DBKey key, DBData *data, va_list ap)
 		char name[EVENT_NAME_LENGTH];
 		// We call castle_event::OnGuildBreak of all castles of the guild
 		// You can set all castle_events in the 'db/castle_db.txt'
-		safestrncpy(name, gc->castle_event, sizeof(name));
-		npc_event_do(strcat(name, "::OnGuildBreak"));
+		safesnprintf(name, EVENT_NAME_LENGTH, "%s::%s", gc->castle_event, script_config.guild_break_event_name);
+		npc_event_do(name);
 
 		//Save the new 'owner', this should invoke guardian clean up and other such things.
 		guild_castledatasave(gc->castle_id, 1, 0);
@@ -2035,9 +2035,9 @@ int guild_castledataloadack(int len, struct guild_castle *gc) {
 	ev = i; // offset of castle or -1
 
 	if( ev < 0 ) { //No castles owned, invoke OnAgitInit as it is.
-		npc_event_doall("OnAgitInit");
-		npc_event_doall("OnAgitInit2");
-		npc_event_doall("OnAgitInit3");
+		npc_event_doall( script_config.agit_init_event_name );
+		npc_event_doall( script_config.agit_init2_event_name );
+		npc_event_doall( script_config.agit_init3_event_name );
 	} else // load received castles into memory, one by one
 	for( i = 0; i < n; i++, gc++ ) {
 		struct guild_castle *c = guild_castle_search(gc->castle_id);
@@ -2053,9 +2053,9 @@ int guild_castledataloadack(int len, struct guild_castle *gc) {
 			if( i != ev )
 				guild_request_info(c->guild_id);
 			else { // last owned one
-				guild_npc_request_info(c->guild_id, "::OnAgitInit");
-				guild_npc_request_info(c->guild_id, "::OnAgitInit2");
-				guild_npc_request_info(c->guild_id, "::OnAgitInit3");
+				guild_npc_request_info(c->guild_id, script_config.agit_init_event_name);
+				guild_npc_request_info(c->guild_id, script_config.agit_init2_event_name);
+				guild_npc_request_info(c->guild_id, script_config.agit_init3_event_name);
 			}
 		}
 	}
@@ -2066,55 +2066,91 @@ int guild_castledataloadack(int len, struct guild_castle *gc) {
 /**
  * Start WoE:FE and triggers all npc OnAgitStart
  */
-void guild_agit_start(void)
-{
-	int c = npc_event_doall("OnAgitStart");
-	ShowStatus("NPC_Event:[OnAgitStart] Run (%d) Events by @AgitStart.\n",c);
+bool guild_agit_start(void){
+	if( agit_flag ){
+		return false;
+	}
+
+	agit_flag = true;
+
+	npc_event_runall( script_config.agit_start_event_name );
+
+	return true;
 }
 
 /**
  * End WoE:FE and triggers all npc OnAgitEnd
  */
-void guild_agit_end(void)
-{
-	int c = npc_event_doall("OnAgitEnd");
-	ShowStatus("NPC_Event:[OnAgitEnd] Run (%d) Events by @AgitEnd.\n",c);
+bool guild_agit_end(void){
+	if( !agit_flag ){
+		return false;
+	}
+
+	agit_flag = false;
+
+	npc_event_runall( script_config.agit_end_event_name );
+
+	return true;
 }
 
 /**
  * Start WoE:SE and triggers all npc OnAgitStart2
  */
-void guild_agit2_start(void)
-{
-	int c = npc_event_doall("OnAgitStart2");
-	ShowStatus("NPC_Event:[OnAgitStart2] Run (%d) Events by @AgitStart2.\n",c);
+bool guild_agit2_start(void){
+	if( agit2_flag ){
+		return false;
+	}
+
+	agit2_flag = true;
+
+	npc_event_runall( script_config.agit_start2_event_name );
+
+	return true;
 }
 
 /**
  * End WoE:SE and triggers all npc OnAgitEnd2
  */
-void guild_agit2_end(void)
-{
-	int c = npc_event_doall("OnAgitEnd2");
-	ShowStatus("NPC_Event:[OnAgitEnd2] Run (%d) Events by @AgitEnd2.\n",c);
+bool guild_agit2_end(void){
+	if( !agit2_flag ){
+		return false;
+	}
+
+	agit2_flag = false;
+
+	npc_event_runall( script_config.agit_end2_event_name );
+
+	return true;
 }
 
 /**
  * Start WoE:TE and triggers all npc OnAgitStart3
  */
-void guild_agit3_start(void)
-{
-	int c = npc_event_doall("OnAgitStart3");
-	ShowStatus("NPC_Event:[OnAgitStart3] Run (%d) Events by @AgitStart3.\n",c);
+bool guild_agit3_start(void){
+	if( agit3_flag ){
+		return false;
+	}
+
+	agit3_flag = true;
+
+	npc_event_runall( script_config.agit_start3_event_name );
+
+	return true;
 }
 
 /**
  * End WoE:TE and triggers all npc OnAgitEnd3
  */
-void guild_agit3_end(void)
-{
-	int c = npc_event_doall("OnAgitEnd3");
-	ShowStatus("NPC_Event:[OnAgitEnd3] Run (%d) Events by @AgitEnd3.\n",c);
+bool guild_agit3_end(void){
+	if( !agit3_flag ){
+		return false;
+	}
+
+	agit3_flag = false;
+
+	npc_event_runall( script_config.agit_end3_event_name );
+
+	return true;
 }
 
 // How many castles does this guild have?

--- a/src/map/guild.h
+++ b/src/map/guild.h
@@ -94,14 +94,14 @@ int guild_castledatasave(int castle_id,int index,int value);
 int guild_castledataloadack(int len, struct guild_castle *gc);
 void guild_castle_reconnect(int castle_id, int index, int value);
 
-void guild_agit_start(void);
-void guild_agit_end(void);
+bool guild_agit_start(void);
+bool guild_agit_end(void);
 
-void guild_agit2_start(void);
-void guild_agit2_end(void);
+bool guild_agit2_start(void);
+bool guild_agit2_end(void);
 
-void guild_agit3_start(void);
-void guild_agit3_end(void);
+bool guild_agit3_start(void);
+bool guild_agit3_end(void);
 
 /* guild flag cachin */
 void guild_flag_add(struct npc_data *nd);

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -291,6 +291,20 @@ static int instance_npcinit(struct block_list *bl, va_list ap)
 }
 
 /*==========================================
+ * Run the OnInstanceDestroy events for duplicated NPCs
+ *------------------------------------------*/
+static int instance_npcdestroy(struct block_list *bl, va_list ap)
+{
+	struct npc_data* nd;
+
+	nullpo_retr(0, bl);
+	nullpo_retr(0, ap);
+	nullpo_retr(0, nd = (struct npc_data *)bl);
+
+	return npc_instancedestroy(nd);
+}
+
+/*==========================================
  * Add an NPC to an instance
  *------------------------------------------*/
 static int instance_addnpc_sub(struct block_list *bl, va_list ap)
@@ -597,6 +611,11 @@ int instance_destroy(unsigned short instance_id)
 			type = 2;
 		else
 			type = 3;
+
+		// Run OnInstanceDestroy on all NPCs in the instance
+		for(i = 0; i < im->cnt_map; i++){
+			map_foreachinarea(instance_npcdestroy, im->map[i]->m, 0, 0, map[im->map[i]->m].xs, map[im->map[i]->m].ys, BL_NPC, im->map[i]->m);
+		}
 
 		for(i = 0; i < im->cnt_map; i++) {
 			map_delinstancemap(im->map[i]->m);

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -163,7 +163,7 @@ int npc_ontouch_event(struct map_session_data *sd, struct npc_data *nd)
 	if( pc_ishiding(sd) )
 		return 1; // Can't trigger 'OnTouch_'. try 'OnTouch' later.
 
-	snprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch_name);
+	safesnprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch_event_name);
 	return npc_event(sd,name,1);
 }
 
@@ -174,7 +174,7 @@ int npc_ontouch2_event(struct map_session_data *sd, struct npc_data *nd)
 	if( sd->areanpc_id == nd->bl.id )
 		return 0;
 
-	snprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch2_name);
+	safesnprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch2_event_name);
 	return npc_event(sd,name,2);
 }
 
@@ -938,7 +938,7 @@ int npc_touchnext_areanpc(struct map_session_data* sd, bool leavemap)
 		char name[EVENT_NAME_LENGTH];
 
 		nd->touching_id = sd->touching_id = 0;
-		snprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch_name);
+		safesnprintf(name, ARRAYLENGTH(name), "%s::%s", nd->exname, script_config.ontouch_event_name);
 		map_forcountinarea(npc_touch_areanpc_sub,nd->bl.m,nd->bl.x - xs,nd->bl.y - ys,nd->bl.x + xs,nd->bl.y + ys,1,BL_PC,sd->bl.id,name);
 	}
 	return 0;
@@ -1082,7 +1082,7 @@ int npc_touch_areanpc2(struct mob_data *md)
 				case NPCTYPE_SCRIPT:
 					if( map[m].npc[i]->bl.id == md->areanpc_id )
 						break; // Already touch this NPC
-					snprintf(eventname, ARRAYLENGTH(eventname), "%s::OnTouchNPC", map[m].npc[i]->exname);
+					safesnprintf(eventname, ARRAYLENGTH(eventname), "%s::%s", map[m].npc[i]->exname, script_config.ontouchnpc_event_name);
 					if( (ev = (struct event_data*)strdb_get(ev_db, eventname)) == NULL || ev->nd == NULL )
 						break; // No OnTouchNPC Event
 					md->areanpc_id = map[m].npc[i]->bl.id;

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -13,6 +13,7 @@
 #include "map.h"
 #include "log.h"
 #include "clif.h"
+#include "date.h" // days of week enum
 #include "intif.h"
 #include "pc.h"
 #include "pet.h"
@@ -475,13 +476,13 @@ int npc_event_do_clock(int tid, unsigned int tick, int id, intptr_t data)
 		c += npc_event_doall(buf);
 
 		switch (t->tm_wday) {
-			case 0: day = script_config.timer_sunday_event_name; break;
-			case 1: day = script_config.timer_monday_event_name; break;
-			case 2: day = script_config.timer_tuesday_event_name; break;
-			case 3: day = script_config.timer_wednesday_event_name; break;
-			case 4: day = script_config.timer_thursday_event_name; break;
-			case 5: day = script_config.timer_friday_event_name; break;
-			case 6: day = script_config.timer_saturday_event_name; break;
+			case SUNDAY:	day = script_config.timer_sunday_event_name; break;
+			case MONDAY:	day = script_config.timer_monday_event_name; break;
+			case TUESDAY:	day = script_config.timer_tuesday_event_name; break;
+			case WEDNESDAY:	day = script_config.timer_wednesday_event_name; break;
+			case THURSDAY:	day = script_config.timer_thursday_event_name; break;
+			case FRIDAY:	day = script_config.timer_friday_event_name; break;
+			case SATURDAY:	day = script_config.timer_saturday_event_name; break;
 		}
 
 		if( day != NULL ){

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -173,6 +173,7 @@ void npc_event_do_oninit(void);
 int npc_event_do(const char* name);
 int npc_event_do_id(const char* name, int rid);
 int npc_event_doall(const char* name);
+void npc_event_runall( const char* eventname );
 int npc_event_doall_id(const char* name, int rid);
 
 int npc_timerevent_start(struct npc_data* nd, int rid);
@@ -189,6 +190,7 @@ int npc_script_event(struct map_session_data* sd, enum npce_event type);
 
 int npc_duplicate4instance(struct npc_data *snd, int16 m);
 int npc_instanceinit(struct npc_data* nd);
+int npc_instancedestroy(struct npc_data* nd);
 int npc_cashshop_buy(struct map_session_data *sd, unsigned short nameid, int amount, int points);
 
 void npc_shop_currency_type(struct map_session_data *sd, struct npc_data *nd, int cost[2], bool display);

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1187,7 +1187,7 @@ struct sg_data {
 	short comfort_id;
 	char feel_var[NAME_LENGTH];
 	char hate_var[NAME_LENGTH];
-	int (*day_func)(void);
+	bool (*day_func)(void);
 };
 extern const struct sg_data sg_info[MAX_PC_FEELHATE];
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -182,7 +182,8 @@ struct Script_Config script_config = {
 	1, // warn_func_mismatch_argtypes
 	1, 65535, 2048, //warn_func_mismatch_paramnum/check_cmdcount/check_gotocount
 	0, INT_MAX, // input_min_value/input_max_value
-	// NOTE: None of these event labels should be longer than <NAME_LENGTH> characters
+	// NOTE: None of these event labels should be longer than <EVENT_NAME_LENGTH> characters
+	// PC related
 	"OnPCDieEvent", //die_event_name
 	"OnPCKillEvent", //kill_pc_event_name
 	"OnNPCKillEvent", //kill_mob_event_name
@@ -192,12 +193,14 @@ struct Script_Config script_config = {
 	"OnPCBaseLvUpEvent", //baselvup_event_name
 	"OnPCJobLvUpEvent", //joblvup_event_name
 	"OnPCStatCalcEvent", //stat_calc_event_name
-	"OnTouch_",	//ontouch_name (runs on first visible char to enter area, picks another char if the first char leaves)
-	"OnTouch",	//ontouch2_name (run whenever a char walks into the OnTouch area)
+	// NPC related
+	"OnTouch_",	//ontouch_event_name (runs on first visible char to enter area, picks another char if the first char leaves)
+	"OnTouch",	//ontouch2_event_name (run whenever a char walks into the OnTouch area)
+	"OnTouchNPC", //ontouchnpc_event_name (run whenever a monster walks into the OnTouch area)
 	"OnWhisperGlobal",	//onwhisper_event_name (is executed when a player sends a whisper message to the NPC)
 	"OnCommand", //oncommand_event_name (is executed by script command cmdothernpc)
 	// Init related
-	"OnInit", //init_event_name (is exuted on all npcs when all npcs were loaded)
+	"OnInit", //init_event_name (is executed on all npcs when all npcs were loaded)
 	"OnInterIfInit", //inter_init_event_name (is executed on inter server connection)
 	"OnInterIfInitOnce", //inter_init_once_event_name (is only executed on the first inter server connection)
 	// Guild related

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -33,6 +33,7 @@
 #include "clan.h"
 #include "clif.h"
 #include "chrif.h"
+#include "date.h" // date type enum, date_get()
 #include "itemdb.h"
 #include "pc.h"
 #include "storage.h"
@@ -9503,7 +9504,7 @@ BUILDIN_FUNC(savepoint)
 }
 
 /*==========================================
- * GetTimeTick(0: System Tick, 1: Time Second Tick)
+ * GetTimeTick(0: System Tick, 1: Time Second Tick, 2: Unix epoch)
  *------------------------------------------*/
 BUILDIN_FUNC(gettimetick)	/* Asgard Version */
 {
@@ -9535,51 +9536,36 @@ BUILDIN_FUNC(gettimetick)	/* Asgard Version */
 }
 
 /*==========================================
- * GetTime(Type);
- * 1: Sec     2: Min     3: Hour
- * 4: WeekDay     5: MonthDay     6: Month
- * 7: Year
+ * GetTime(Type)
+ *
+ * Returns the current value of a certain date type.
+ * Possible types are:
+ * - DT_SECOND Current seconds
+ * - DT_MINUTE Current minute
+ * - DT_HOUR Current hour
+ * - DT_DAYOFWEEK Day of current week
+ * - DT_DAYOFMONTH Day of current month
+ * - DT_MONTH Current month
+ * - DT_YEAR Current year
+ * - DT_DAYOFYEAR Day of current year
+ *
+ * If none of the above types is supplied -1 will be returned to the script
+ * and the script source will be reported into the mapserver console.
  *------------------------------------------*/
-BUILDIN_FUNC(gettime)	/* Asgard Version */
+BUILDIN_FUNC(gettime)
 {
 	int type;
-	time_t timer;
-	struct tm *t;
 
-	type=script_getnum(st,2);
+	type = script_getnum(st,2);
 
-	time(&timer);
-	t=localtime(&timer);
-
-	switch(type){
-	case 1://Sec(0~59)
-		script_pushint(st,t->tm_sec);
-		break;
-	case 2://Min(0~59)
-		script_pushint(st,t->tm_min);
-		break;
-	case 3://Hour(0~23)
-		script_pushint(st,t->tm_hour);
-		break;
-	case 4://WeekDay(0~6)
-		script_pushint(st,t->tm_wday);
-		break;
-	case 5://MonthDay(01~31)
-		script_pushint(st,t->tm_mday);
-		break;
-	case 6://Month(01~12)
-		script_pushint(st,t->tm_mon+1);
-		break;
-	case 7://Year(20xx)
-		script_pushint(st,t->tm_year+1900);
-		break;
-	case 8://Year Day(01~366)
-		script_pushint(st,t->tm_yday+1);
-		break;
-	default://(format error)
+	if( type <= DT_MIN || type >= DT_MAX ){
+		ShowError( "buildin_gettime: Invalid date type %d\n", type );
+		script_reportsrc(st);
 		script_pushint(st,-1);
-		break;
+	}else{
+		script_pushint(st,date_get((enum e_date_type)type));
 	}
+
 	return SCRIPT_CMD_SUCCESS;
 }
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -195,6 +195,38 @@ struct Script_Config script_config = {
 	"OnTouch_",	//ontouch_name (runs on first visible char to enter area, picks another char if the first char leaves)
 	"OnTouch",	//ontouch2_name (run whenever a char walks into the OnTouch area)
 	"OnWhisperGlobal",	//onwhisper_event_name (is executed when a player sends a whisper message to the NPC)
+	"OnCommand", //oncommand_event_name (is executed by script command cmdothernpc)
+	// Init related
+	"OnInit", //init_event_name (is exuted on all npcs when all npcs were loaded)
+	"OnInterIfInit", //inter_init_event_name (is executed on inter server connection)
+	"OnInterIfInitOnce", //inter_init_once_event_name (is only executed on the first inter server connection)
+	// Guild related
+	"OnGuildBreak", //guild_break_event_name (is executed on all castles of the guild that is broken)
+	"OnAgitStart", //agit_start_event_name (is executed when WoE FE is started)
+	"OnAgitInit", //agit_init_event_name (is executed after all castle owning guilds have been loaded)
+	"OnAgitEnd", //agit_end_event_name (is executed when WoE FE has ended)
+	"OnAgitStart2", //agit_start2_event_name (is executed when WoE SE is started)
+	"OnAgitInit2", //agit_init2_event_name (is executed after all castle owning guilds have been loaded)
+	"OnAgitEnd2", //agit_end2_event_name (is executed when WoE SE has ended)
+	"OnAgitStart3", //agit_start3_event_name (is executed when WoE TE is started)
+	"OnAgitInit3", //agit_init3_event_name (is executed after all castle owning guilds have been loaded)
+	"OnAgitEnd3", //agit_end3_event_name (is executed when WoE TE has ended)
+	// Timer related
+	"OnTimer", //timer_event_name (is executed by a timer at the specific second)
+	"OnMinute", //timer_minute_event_name (is executed by a timer at the specific minute)
+	"OnHour", //timer_hour_event_name (is executed by a timer at the specific hour)
+	"OnClock", //timer_clock_event_name (is executed by a timer at the specific hour and minute)
+	"OnDay", //timer_day_event_name (is executed by a timer at the specific month and day)
+	"OnSun", //timer_sunday_event_name (is executed by a timer on sunday at the specific hour and minute)
+	"OnMon", //timer_monday_event_name (is executed by a timer on monday at the specific hour and minute)
+	"OnTue", //timer_tuesday_event_name (is executed by a timer on tuesday at the specific hour and minute)
+	"OnWed", //timer_wednesday_event_name (is executed by a timer on wednesday at the specific hour and minute)
+	"OnThu", //timer_thursday_event_name (is executed by a timer on thursday at the specific hour and minute)
+	"OnFri", //timer_friday_event_name (is executed by a timer on friday at the specific hour and minute)
+	"OnSat", //timer_saturday_event_name (is executed by a timer on saturday at the specific hour and minute)
+	// Instance related
+	"OnInstanceInit", //instance_init_event_name (is executed right after instance creation)
+	"OnInstanceDestroy", //instance_destroy_event_name (is executed right before instance destruction)
 };
 
 static jmp_buf     error_jump;
@@ -10118,9 +10150,18 @@ BUILDIN_FUNC(cmdothernpc)	// Added by RoVeRT
 	const char* npc = script_getstr(st,2);
 	const char* command = script_getstr(st,3);
 	char event[EVENT_NAME_LENGTH];
-	snprintf(event, sizeof(event), "%s::OnCommand%s", npc, command);
+
+	safesnprintf(event,EVENT_NAME_LENGTH, "%s::%s%s",npc,script_config.oncommand_event_name,command);
 	check_event(st, event);
-	npc_event_do(event);
+
+	if( npc_event_do(event) ){
+		script_pushint(st, true);
+	}else{
+		struct npc_data * nd = map_id2nd(st->oid);
+		ShowDebug("NPCEvent '%s' not found! (source: %s)\n", event, nd ? nd->name : "Unknown");
+		script_pushint(st, false);
+	}
+
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -12360,9 +12401,6 @@ BUILDIN_FUNC(maprespawnguildid)
  */
 BUILDIN_FUNC(agitstart)
 {
-	if (agit_flag)
-		return SCRIPT_CMD_SUCCESS;// Agit already Started.
-	agit_flag = true;
 	guild_agit_start();
 
 	return SCRIPT_CMD_SUCCESS;
@@ -12374,9 +12412,6 @@ BUILDIN_FUNC(agitstart)
  */
 BUILDIN_FUNC(agitend)
 {
-	if (!agit_flag)
-		return SCRIPT_CMD_SUCCESS;// Agit already Ended.
-	agit_flag = false;
 	guild_agit_end();
 
 	return SCRIPT_CMD_SUCCESS;
@@ -12388,9 +12423,6 @@ BUILDIN_FUNC(agitend)
  */
 BUILDIN_FUNC(agitstart2)
 {
-	if (agit2_flag)
-		return SCRIPT_CMD_SUCCESS;// Agit2 already Started.
-	agit2_flag = true;
 	guild_agit2_start();
 
 	return SCRIPT_CMD_SUCCESS;
@@ -12416,9 +12448,6 @@ BUILDIN_FUNC(agitend2)
  */
 BUILDIN_FUNC(agitstart3)
 {
-	if (agit3_flag)
-		return SCRIPT_CMD_SUCCESS;// AgitTE already Started.
-	agit3_flag = true;
 	guild_agit3_start();
 
 	return SCRIPT_CMD_SUCCESS;
@@ -12430,9 +12459,6 @@ BUILDIN_FUNC(agitstart3)
  */
 BUILDIN_FUNC(agitend3)
 {
-	if (!agit3_flag)
-		return SCRIPT_CMD_SUCCESS;// AgitTE already Ended.
-	agit3_flag = false;
 	guild_agit3_end();
 
 	return SCRIPT_CMD_SUCCESS;

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -161,6 +161,42 @@ extern struct Script_Config {
 	const char* ontouch_name;
 	const char* ontouch2_name;
 	const char* onwhisper_event_name;
+	const char* oncommand_event_name;
+
+	// Init related
+	const char* init_event_name;
+	const char* inter_init_event_name;
+	const char* inter_init_once_event_name;
+
+	// Guild related
+	const char* guild_break_event_name;
+	const char* agit_start_event_name;
+	const char* agit_init_event_name;
+	const char* agit_end_event_name;
+	const char* agit_start2_event_name;
+	const char* agit_init2_event_name;
+	const char* agit_end2_event_name;
+	const char* agit_start3_event_name;
+	const char* agit_init3_event_name;
+	const char* agit_end3_event_name;
+
+	// Timer related
+	const char* timer_event_name;
+	const char* timer_minute_event_name;
+	const char* timer_hour_event_name;
+	const char* timer_clock_event_name;
+	const char* timer_day_event_name;
+	const char* timer_sunday_event_name;
+	const char* timer_monday_event_name;
+	const char* timer_tuesday_event_name;
+	const char* timer_wednesday_event_name;
+	const char* timer_thursday_event_name;
+	const char* timer_friday_event_name;
+	const char* timer_saturday_event_name;
+
+	// Instance related
+	const char* instance_init_event_name;
+	const char* instance_destroy_event_name;
 } script_config;
 
 typedef enum c_op {

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -148,6 +148,7 @@ extern struct Script_Config {
 	int input_min_value;
 	int input_max_value;
 
+	// PC related
 	const char *die_event_name;
 	const char *kill_pc_event_name;
 	const char *kill_mob_event_name;
@@ -158,8 +159,10 @@ extern struct Script_Config {
 	const char *joblvup_event_name;
 	const char *stat_calc_event_name;
 
-	const char* ontouch_name;
-	const char* ontouch2_name;
+	// NPC related
+	const char* ontouch_event_name;
+	const char* ontouch2_event_name;
+	const char* ontouchnpc_event_name;
 	const char* onwhisper_event_name;
 	const char* oncommand_event_name;
 

--- a/src/map/script_constants.h
+++ b/src/map/script_constants.h
@@ -3185,6 +3185,39 @@
 	export_constant(STOR_MODE_NONE);
 	export_constant(STOR_MODE_GET);
 	export_constant(STOR_MODE_PUT);
+	
+	/* months */
+	export_constant(JANUARY);
+	export_constant(FEBRUARY);
+	export_constant(MARCH);
+	export_constant(APRIL);
+	export_constant(MAY);
+	export_constant(JUNE);
+	export_constant(JULY);
+	export_constant(AUGUST);
+	export_constant(SEPTEMBER);
+	export_constant(OCTOBER);
+	export_constant(NOVEMBER);
+	export_constant(DECEMBER);
+	
+	/* days of the week */
+	export_constant(SUNDAY);
+	export_constant(MONDAY);
+	export_constant(TUESDAY);
+	export_constant(WEDNESDAY);
+	export_constant(THURSDAY);
+	export_constant(FRIDAY);
+	export_constant(SATURDAY);
+	
+	/* date types */
+	export_constant(DT_SECOND);
+	export_constant(DT_MINUTE);
+	export_constant(DT_HOUR);
+	export_constant(DT_DAYOFWEEK);
+	export_constant(DT_DAYOFMONTH);
+	export_constant(DT_MONTH);
+	export_constant(DT_YEAR);
+	export_constant(DT_DAYOFYEAR);
 
 	#undef export_constant
 


### PR DESCRIPTION
While refactoring those events the following other changes were made:

Introducing OnInstanceDestroy event. This event can be used to hook script code right in front of the instance destruction. This can be useful if you have any stored references to an instance id for example.

The script command cmdothernpc will now check if the target event exists and report failures. Therefore it now returns true or false.

All agit(FE,SE,TE) start and end commands from atcommand and script commands have been merged in their respective guild function which now returns a bool value of true for successful actions and false if it did not succeed(if the specific WoE was [not] running).

All global triggered events with mapserver status output now call the same function and therefore have the same mapserver output(including their respective event name of course).