### PR TITLE
Fixed SC_ESCAPE animation

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -4108,6 +4108,13 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 						skill_attack(skl->type,src,src,target,skl->skill_id,skl->skill_lv,tick,skl->flag);
 						break;
 					}
+				case SC_ESCAPE:
+					if (skl->type < skill_get_blewcount(skl->skill_id, skl->skill_lv)) {
+						clif_skill_damage(src, src, tick, 0, 0, -30000, 1, skl->skill_id, skl->skill_lv, 0);
+						skill_blown(src, src, 1, unit_getdir(src), 0);
+						skill_addtimerskill(src, tick + 100, src->id, 0, 0, skl->skill_id, skl->skill_lv, skl->type + 1, 0);
+					}
+					break;
 				// For SR_FLASHCOMBO
 				case SR_DRAGONCOMBO:
 				case SR_FALLENEMPIRE:
@@ -11914,9 +11921,9 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 		break;
 
 	case SC_ESCAPE:
-		skill_unitsetting(src, skill_id, skill_lv, x, y, 0);
-		skill_blown(src, src, skill_get_blewcount(skill_id, skill_lv), unit_getdir(src), 0);
-		clif_skill_nodamage(src,src,skill_id,skill_lv,1);
+		skill_unitsetting(src, skill_id, skill_lv, x, y, 2);
+		skill_addtimerskill(src, tick, src->id, 0, 0, skill_id, skill_lv, 0, 0);
+		clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
 		flag |= 1;
 		break;
 


### PR DESCRIPTION
This PR fixes issue #1073.

> Staggers the movement correctly but animation of "shadows" left over by the character aren't evenly spread across the 10 cells during movement when they should be. Tested using 20151104 client.