### PR TITLE
Added party config `change_party_leader_samemap`

### DIFF
--- a/conf/battle/party.conf
+++ b/conf/battle/party.conf
@@ -59,3 +59,6 @@ display_party_name: no
 
 // Prevent multiple characters of the same account to join the same party. (Note 1)
 block_account_in_same_party: yes
+
+// Prevent to change party leader if not in same map with the specified player (Note 1)
+change_party_leader_samemap: yes

--- a/conf/battle/party.conf
+++ b/conf/battle/party.conf
@@ -60,5 +60,5 @@ display_party_name: no
 // Prevent multiple characters of the same account to join the same party. (Note 1)
 block_account_in_same_party: yes
 
-// Prevent to change party leader if not in same map with the specified player (Note 1)
+// Prevent changing the party leader if the specified player is not on the same map (Note 1)
 change_party_leader_samemap: yes

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8369,6 +8369,7 @@ static const struct _battle_data {
 	{ "atcommand_levelup_events",			&battle_config.atcommand_levelup_events,		0,		0,		1,				},
 	{ "block_account_in_same_party",		&battle_config.block_account_in_same_party,		1,		0,		1,				},
 	{ "tarotcard_equal_chance",             &battle_config.tarotcard_equal_chance,          0,      0,      1,              },
+	{ "change_party_leader_samemap",        &battle_config.change_party_leader_samemap,     1,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -612,6 +612,7 @@ extern struct Battle_Config
 	int atcommand_levelup_events;
 	int block_account_in_same_party;
 	int tarotcard_equal_chance; //Official or equal chance for each card
+	int change_party_leader_samemap;
 
 #include "../custom/battle_config_struct.inc"
 } battle_config;

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -487,7 +487,7 @@ enum clif_messages {
 	ITEM_REUSE_LIMIT = 0x746,
 	WORK_IN_PROGRESS = 0x783,
 	NEED_REINS_OF_MOUNT = 0x78c,
-	PARTY_MASTER_CHANGE_SAME_MAP = 0x82e, ///< "It is possible to change the same map only within the party."
+	PARTY_MASTER_CHANGE_SAME_MAP = 0x82e, ///< "It is only possible to change the party leader while on the same map."
 	MERGE_ITEM_NOT_AVAILABLE = 0x887,
 };
 

--- a/src/map/clif.h
+++ b/src/map/clif.h
@@ -487,6 +487,7 @@ enum clif_messages {
 	ITEM_REUSE_LIMIT = 0x746,
 	WORK_IN_PROGRESS = 0x783,
 	NEED_REINS_OF_MOUNT = 0x78c,
+	PARTY_MASTER_CHANGE_SAME_MAP = 0x82e, ///< "It is possible to change the same map only within the party."
 	MERGE_ITEM_NOT_AVAILABLE = 0x887,
 };
 

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -760,7 +760,6 @@ int party_optionchanged(int party_id,uint32 account_id,int exp,int item,int flag
 int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd, struct party_data *p)
 {
 	int mi, tmi;
-	bool must_samemap = false;
 
 	if ( !p ) {
 		if (!sd || !sd->status.party_id)
@@ -792,7 +791,10 @@ int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd
 		if (tmi == MAX_PARTY)
 			return 0; // Shouldn't happen
 
-		must_samemap = battle_config.change_party_leader_samemap;
+		if (battle_config.change_party_leader_samemap && p->party.member[mi].map != p->party.member[tmi].map) {
+			clif_msg(sd, PARTY_MASTER_CHANGE_SAME_MAP);
+			return 0;
+		}
 	} else {
 		ARR_FIND(0,MAX_PARTY,mi,p->party.member[mi].leader);
 
@@ -803,12 +805,6 @@ int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd
 
 		if (tmi == MAX_PARTY)
 			return 0; // Shouldn't happen
-	}
-
-	if (must_samemap && p->party.member[mi].map != p->party.member[tmi].map) {
-		if (sd)
-			clif_msg(sd, PARTY_MASTER_CHANGE_SAME_MAP);
-		return 0;
 	}
 
 	// Change leadership.

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -760,6 +760,7 @@ int party_optionchanged(int party_id,uint32 account_id,int exp,int item,int flag
 int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd, struct party_data *p)
 {
 	int mi, tmi;
+	bool must_samemap = false;
 
 	if ( !p ) {
 		if (!sd || !sd->status.party_id)
@@ -790,6 +791,8 @@ int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd
 		ARR_FIND( 0, MAX_PARTY, tmi, p->data[tmi].sd == tsd);
 		if (tmi == MAX_PARTY)
 			return 0; // Shouldn't happen
+
+		must_samemap = battle_config.change_party_leader_samemap;
 	} else {
 		ARR_FIND(0,MAX_PARTY,mi,p->party.member[mi].leader);
 
@@ -800,6 +803,12 @@ int party_changeleader(struct map_session_data *sd, struct map_session_data *tsd
 
 		if (tmi == MAX_PARTY)
 			return 0; // Shouldn't happen
+	}
+
+	if (must_samemap && p->party.member[mi].map != p->party.member[tmi].map) {
+		if (sd)
+			clif_msg(sd, PARTY_MASTER_CHANGE_SAME_MAP);
+		return 0;
 	}
 
 	// Change leadership.


### PR DESCRIPTION
* Prevent to change party leader if not in same map with the specified player (Note 1)
* Default is `yes` as official does
* This config will be ignored by `party_changeleader` script command

Signed-off-by: Cydh Ramdh <cydh@pservero.com>