### PR TITLE
Made prevent_logout effect on log-in optional

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -120,9 +120,14 @@ max_cart_weight: 8000
 // Prevent logout of players after being hit for how long (in ms, 0 disables)?
 prevent_logout: 10000
 
-// Prevent logout of players after connecting to map server? Have no effect if prevent_logout is disabled.
-// Official servers does not prevent players from logging out after connecting to zone server.
-prevent_logout_on_login: no
+// When should the server prevent a player from logging out? Have no effect if prevent_logout is disabled. (Note 3)
+// Official servers prevent players from logging out after attacking, casting skills, and taking damage.
+// 0 = Players can always logout
+// 1 = Prevent logout on login
+// 2 = Prevent logout after attacking
+// 4 = Prevent logout after casting skill
+// 8 = Prevent logout after being hit
+prevent_logout_trigger: 14
 
 // Display the drained hp/sp values from normal attacks? (Ie: Hunter Fly card)
 show_hp_sp_drain: no

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -120,6 +120,10 @@ max_cart_weight: 8000
 // Prevent logout of players after being hit for how long (in ms, 0 disables)?
 prevent_logout: 10000
 
+// Prevent logout of players after connecting to map server? Have no effect if prevent_logout is disabled.
+// Official servers does not prevent players from logging out after connecting to zone server.
+prevent_logout_on_login: no
+
 // Display the drained hp/sp values from normal attacks? (Ie: Hunter Fly card)
 show_hp_sp_drain: no
 

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8141,7 +8141,7 @@ static const struct _battle_data {
 	{ "item_rate_adddrop",                  &battle_config.item_rate_adddrop,               100,    0,      1000000,        },
 	{ "item_rate_treasure",                 &battle_config.item_rate_treasure,              100,    0,      1000000,        },
 	{ "prevent_logout",                     &battle_config.prevent_logout,                  10000,  0,      60000,          },
-	{ "prevent_logout_on_login",			&battle_config.prevent_logout_on_login,			0,		0,		1,				},
+	{ "prevent_logout_on_login",            &battle_config.prevent_logout_on_login,         0,      0,      1,              },
 	{ "alchemist_summon_reward",            &battle_config.alchemist_summon_reward,         1,      0,      2,              },
 	{ "drops_by_luk",                       &battle_config.drops_by_luk,                    0,      0,      INT_MAX,        },
 	{ "drops_by_luk2",                      &battle_config.drops_by_luk2,                   0,      0,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8141,6 +8141,7 @@ static const struct _battle_data {
 	{ "item_rate_adddrop",                  &battle_config.item_rate_adddrop,               100,    0,      1000000,        },
 	{ "item_rate_treasure",                 &battle_config.item_rate_treasure,              100,    0,      1000000,        },
 	{ "prevent_logout",                     &battle_config.prevent_logout,                  10000,  0,      60000,          },
+	{ "prevent_logout_on_login",			&battle_config.prevent_logout_on_login,			0,		0,		1,				},
 	{ "alchemist_summon_reward",            &battle_config.alchemist_summon_reward,         1,      0,      2,              },
 	{ "drops_by_luk",                       &battle_config.drops_by_luk,                    0,      0,      INT_MAX,        },
 	{ "drops_by_luk2",                      &battle_config.drops_by_luk2,                   0,      0,      INT_MAX,        },

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8141,7 +8141,7 @@ static const struct _battle_data {
 	{ "item_rate_adddrop",                  &battle_config.item_rate_adddrop,               100,    0,      1000000,        },
 	{ "item_rate_treasure",                 &battle_config.item_rate_treasure,              100,    0,      1000000,        },
 	{ "prevent_logout",                     &battle_config.prevent_logout,                  10000,  0,      60000,          },
-	{ "prevent_logout_on_login",            &battle_config.prevent_logout_on_login,         0,      0,      1,              },
+	{ "prevent_logout_trigger",             &battle_config.prevent_logout_trigger,          0xE,    0,      0xF,            },
 	{ "alchemist_summon_reward",            &battle_config.alchemist_summon_reward,         1,      0,      2,              },
 	{ "drops_by_luk",                       &battle_config.drops_by_luk,                    0,      0,      INT_MAX,        },
 	{ "drops_by_luk2",                      &battle_config.drops_by_luk2,                   0,      0,      INT_MAX,        },

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -331,6 +331,7 @@ extern struct Battle_Config
 	int item_drop_adddrop_min,item_drop_adddrop_max; //[Skotlex]
 
 	int prevent_logout;	// Added by RoVeRT
+	int prevent_logout_on_login;
 
 	int alchemist_summon_reward;	// [Valaris]
 	int drops_by_luk;

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -331,7 +331,7 @@ extern struct Battle_Config
 	int item_drop_adddrop_min,item_drop_adddrop_max; //[Skotlex]
 
 	int prevent_logout;	// Added by RoVeRT
-	int prevent_logout_on_login;
+	int prevent_logout_trigger;
 
 	int alchemist_summon_reward;	// [Valaris]
 	int drops_by_luk;

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -653,7 +653,8 @@ void pc_setnewpc(struct map_session_data *sd, uint32 account_id, uint32 char_id,
 	sd->client_tick = client_tick;
 	sd->state.active = 0; //to be set to 1 after player is fully authed and loaded.
 	sd->bl.type = BL_PC;
-	sd->canlog_tick = gettick();
+	if(battle_config.prevent_logout_on_login)
+		sd->canlog_tick = gettick();
 	//Required to prevent homunculus copuing a base speed of 0.
 	sd->battle_status.speed = sd->base_status.speed = DEFAULT_WALK_SPEED;
 }

--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -653,7 +653,7 @@ void pc_setnewpc(struct map_session_data *sd, uint32 account_id, uint32 char_id,
 	sd->client_tick = client_tick;
 	sd->state.active = 0; //to be set to 1 after player is fully authed and loaded.
 	sd->bl.type = BL_PC;
-	if(battle_config.prevent_logout_on_login)
+	if(battle_config.prevent_logout_trigger&PLT_LOGIN)
 		sd->canlog_tick = gettick();
 	//Required to prevent homunculus copuing a base speed of 0.
 	sd->battle_status.speed = sd->base_status.speed = DEFAULT_WALK_SPEED;
@@ -7465,7 +7465,8 @@ void pc_damage(struct map_session_data *sd,struct block_list *src,unsigned int h
 	if( sd->status.ele_id > 0 )
 		elemental_set_target(sd,src);
 
-	sd->canlog_tick = gettick();
+	if(battle_config.prevent_logout_trigger&PLT_DAMAGE)
+		sd->canlog_tick = gettick();
 }
 
 int pc_close_npc_timer(int tid, unsigned int tick, int id, intptr_t data)

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -69,6 +69,14 @@ enum equip_index {
 	EQI_MAX
 };
 
+enum prevent_logout_trigger {
+	PLT_NONE = 0,
+	PLT_LOGIN = 1,
+	PLT_ATTACK = 2,
+	PLT_SKILL = 4,
+	PLT_DAMAGE = 8
+};
+
 extern unsigned int equip_bitmask[EQI_MAX];
 
 #define equip_index_check(i) ( (i) >= EQI_ACC_L && (i) < EQI_MAX )

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1899,7 +1899,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 	} else
 		skill_castend_id(ud->skilltimer,tick,src->id,0);
 
-	if( sd )
+	if( sd && battle_config.prevent_logout_trigger&PLT_SKILL )
 		sd->canlog_tick = gettick();
 
 	return 1;
@@ -2081,7 +2081,7 @@ int unit_skilluse_pos2( struct block_list *src, short skill_x, short skill_y, ui
 		skill_castend_pos(ud->skilltimer,tick,src->id,0);
 	}
 
-	if( sd )
+	if( sd && battle_config.prevent_logout_trigger&PLT_SKILL )
 		sd->canlog_tick = gettick();
 
 	return 1;
@@ -2618,7 +2618,7 @@ static int unit_attack_timer_sub(struct block_list* src, int tid, unsigned int t
 		ud->attacktimer = add_timer(ud->attackabletime,unit_attack_timer,src->id,0);
 	}
 
-	if( sd )
+	if( sd && battle_config.prevent_logout_trigger&PLT_ATTACK )
 		sd->canlog_tick = gettick();
 
 	return 1;


### PR DESCRIPTION
kRO does not prevent players from logging out after connecting to its zone servers, so I adjusted this behavior on rAthena to follow kRO.

There is a new battle config called `prevent_logout_on_login` to opt-in this behavior again.