### PR TITLE
Added a config for maprespawnguildid's behaviour

### DIFF
--- a/conf/battle/guild.conf
+++ b/conf/battle/guild.conf
@@ -57,3 +57,7 @@ max_guild_alliance: 3
 // Upon changing maps: 1
 // Do not re-display: 0 (disabled)
 guild_notice_changemap: 2
+
+// Should maprespawnguildid kill clones too?
+// Default: no
+guild_maprespawn_clones: no

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -8384,6 +8384,7 @@ static const struct _battle_data {
 	{ "tarotcard_equal_chance",             &battle_config.tarotcard_equal_chance,          0,      0,      1,              },
 	{ "change_party_leader_samemap",        &battle_config.change_party_leader_samemap,     1,      0,      1,              },
 	{ "dispel_song",                        &battle_config.dispel_song,                     0,      0,      1,              },
+	{ "guild_maprespawn_clones",			&battle_config.guild_maprespawn_clones,			0,		0,		1,				},
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -615,6 +615,7 @@ extern struct Battle_Config
 	int tarotcard_equal_chance; //Official or equal chance for each card
 	int change_party_leader_samemap;
 	int dispel_song; //Can songs be dispelled?
+	int guild_maprespawn_clones; // Should clones be killed by maprespawnguildid?
 
 #include "../custom/battle_config_struct.inc"
 } battle_config;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -12389,10 +12389,10 @@ static int buildin_maprespawnguildid_sub_mob(struct block_list *bl,va_list ap)
 {
 	struct mob_data *md=(struct mob_data *)bl;
 
-	if(!md->guardian_data && md->mob_id != MOBID_EMPERIUM)
+	if(!md->guardian_data && md->mob_id != MOBID_EMPERIUM && ( !mob_is_clone(md->mob_id) || battle_config.guild_maprespawn_clones ))
 		status_kill(bl);
 
-	return 0;
+	return 1;
 }
 
 /*


### PR DESCRIPTION
This will allow you to configure if clones should be killed by the script command maprespawnguildid called with flag & 4(kill mobs).

Fixes #1835.