### PR TITLE
neutral barrier fix

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2471,7 +2471,7 @@ static bool is_attack_hitting(struct Damage wd, struct block_list *src, struct b
 	else if (nk&NK_IGNORE_FLEE)
 		return true;
 
-	if( sc && sc->data[SC_NEUTRALBARRIER] && (wd.flag&(BF_LONG|BF_MAGIC)) == BF_LONG )
+	if( tsc && tsc->data[SC_NEUTRALBARRIER] && (wd.flag&(BF_LONG|BF_MAGIC)) == BF_LONG )
 		return false;
 
 	flee = tstatus->flee;


### PR DESCRIPTION
This function should check target is in neutralbarrier instead of source. (Every ranged attacks are missing from neutralbarrier, regardless of the target's position)