### PR TITLE
GTB should not block Masquerade status changes

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7752,12 +7752,6 @@ int status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_typ
 			case SC_QUAGMIRE:
 			case SC_SUITON:
 			case SC_SWINGDANCE:
-			case SC__ENERVATION:
-			case SC__GROOMY:
-			case SC__IGNORANCE:
-			case SC__LAZINESS:
-			case SC__UNLUCKY:
-			case SC__WEAKNESS:
 				return 0;
 		}
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: 
#1901 

* **Server Mode**: 
Renewal

* **Description of Pull Request**: 
The status changes triggered by the different Masquerade skills of the Shadow Chaser job class were removed from the Golden Thief Bug immunity list in status_get_sc_def.
