### PR TITLE
Fixed character rename feature

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -238,6 +238,15 @@ char_movetoused: yes
 // Allow users to move characters as often as they like?
 char_moves_unlimited: no
 
+// Character renaming
+// Allow users to rename a character while being in a party?
+// Default: no
+char_rename_party: no
+
+// Allow users to rename a character while being in a guild?
+// Default: no
+char_rename_guild: no
+
 // Should we check if sql-tables are correct on server startup ?
 char_checkdb: yes
 

--- a/src/char/char.c
+++ b/src/char/char.c
@@ -1247,16 +1247,31 @@ int char_rename_char_sql(struct char_session_data *sd, uint32 char_id)
 	if( !char_mmo_char_fromsql(char_id, &char_dat, false) ) // Only the short data is needed.
 		return 2;
 
+	// If the new name is exactly the same as the old one
+	if( !strcmp( sd->new_name, char_dat.name ) )
+		return 0;
+
 	if( char_dat.rename == 0 )
 		return 1;
 
+	if( !charserv_config.char_config.char_rename_party && char_dat.party_id ){
+		return 6;
+	}
+
+	if( !charserv_config.char_config.char_rename_guild && char_dat.guild_id ){
+		return 5;
+	}
+
 	Sql_EscapeStringLen(sql_handle, esc_name, sd->new_name, strnlen(sd->new_name, NAME_LENGTH));
 
-	// check if the char exist
-	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT 1 FROM `%s` WHERE `name` LIKE '%s' LIMIT 1", schema_config.char_db, esc_name) )
-	{
-		Sql_ShowDebug(sql_handle);
-		return 4;
+	switch( char_check_char_name( sd->new_name, esc_name ) ){
+		case 0:
+			break;
+		case -1:
+			// character already exists
+			return 4;
+		default:
+			return 8;
 	}
 
 	if( SQL_ERROR == Sql_Query(sql_handle, "UPDATE `%s` SET `name` = '%s', `rename` = '%d' WHERE `char_id` = '%d'", schema_config.char_db, esc_name, --char_dat.rename, char_id) )
@@ -2879,6 +2894,10 @@ bool char_config_read(const char* cfgName, bool normal){
 			charserv_config.char_config.char_del_option = atoi(w2);
 		} else if (strcmpi(w1, "char_del_restriction") == 0) {
 			charserv_config.char_config.char_del_restriction = atoi(w2);
+		} else if (strcmpi(w1, "char_rename_party") == 0) {
+			charserv_config.char_config.char_rename_party = (bool)config_switch(w2);
+		} else if (strcmpi(w1, "char_rename_guild") == 0) {
+			charserv_config.char_config.char_rename_guild = (bool)config_switch(w2);
 		} else if(strcmpi(w1,"db_path")==0) {
 			safestrncpy(schema_config.db_path, w2, sizeof(schema_config.db_path));
 		} else if (strcmpi(w1, "fame_list_alchemist") == 0) {

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -119,6 +119,8 @@ struct Char_Config {
 	int char_name_option; // Option to know which letters/symbols are authorised in the name of a character (0: all, 1: only those in char_name_letters, 2: all EXCEPT those in char_name_letters) by [Yor]
 	int char_del_option;	// Character deletion type, email = 1, birthdate = 2 (default)
 	int char_del_restriction;	// Character deletion restriction (0: none, 1: if the character is in a party, 2: if the character is in a guild, 3: if the character is in a party or a guild)
+	bool char_rename_party;	// Character renaming in a party
+	bool char_rename_guild;	// Character renaming in a guild
 };
 
 #define TRIM_CHARS "\255\xA0\032\t\x0A\x0D " //The following characters are trimmed regardless because they cause confusion and problems on the servers. [Skotlex]

--- a/src/char/char_clif.c
+++ b/src/char/char_clif.c
@@ -1176,7 +1176,7 @@ void chclif_block_character( int fd, struct char_session_data* sd){
 //		9: The name change is prohibited. Character name change failed.
 //		10: Character name change failed, due an unknown error.
 void chclif_rename_response(int fd, struct char_session_data* sd, int16 response) {
-#if PACKETVER > 20130000
+#if PACKETVER >= 20111101
 	WFIFOHEAD(fd, 6);
 	WFIFOW(fd, 0) = 0x8fd;
 	WFIFOL(fd, 2) = response;

--- a/src/char/char_clif.h
+++ b/src/char/char_clif.h
@@ -48,7 +48,7 @@ int chclif_parse_charselect(int fd, struct char_session_data* sd,uint32 ipl);
 int chclif_parse_createnewchar(int fd, struct char_session_data* sd,int cmd);
 int chclif_parse_delchar(int fd,struct char_session_data* sd, int cmd);
 int chclif_parse_keepalive(int fd);
-int chclif_parse_reqrename(int fd, struct char_session_data* sd, int cmd);
+int chclif_parse_reqrename(int fd, struct char_session_data* sd);
 int chclif_parse_ackrename(int fd, struct char_session_data* sd);
 int chclif_ack_captcha(int fd);
 int chclif_parse_reqcaptcha(int fd);


### PR DESCRIPTION
* **Addressed Issue(s)**: 
#1942

* **Server Mode**: 
Both.

* **Description of Pull Request**: 
This feature was broken for clients after 2011-11-01.
Added 2 new options for allowing it when the character is inside a party or guild.
The server now delivers the corresponding error messages if the player is inside a party or guild.
