### PR TITLE
fix typo in pc.c

### DIFF
--- a/src/char/inter.c
+++ b/src/char/inter.c
@@ -278,9 +278,13 @@ const char* job_name(int class_) {
 
 		case JOB_KAGEROU:
 		case JOB_OBORO:
-		case JOB_REBELLION:
-		case JOB_SUMMONER:
 			return msg_txt(103 - JOB_KAGEROU+class_);
+
+		case JOB_REBELLION:
+			return msg_txt(106);
+
+		case JOB_SUMMONER:
+			return msg_txt(108);
 
 		default:
 			return msg_txt(109);


### PR DESCRIPTION
as accoding to char_msg.conf

103: Kagerou
104: Oboro
105: Hanbok
106: Rebellion
107: Oktoberfest
108: Summoner

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
