### PR TITLE
Fixes #2022

### DIFF
--- a/src/map/storage.c
+++ b/src/map/storage.c
@@ -204,9 +204,6 @@ int compare_item(struct item *a, struct item *b)
  * @return @see enum e_storage_add
  **/
 static enum e_storage_add storage_canAddItem(struct s_storage *stor, int idx, struct item items[], int amount, int max_num) {
-	if (stor->amount >= stor->max_amount)
-		return STORAGE_ADD_NOROOM; // storage full
-
 	if (idx < 0 || idx >= max_num)
 		return STORAGE_ADD_INVALID;
 
@@ -253,7 +250,7 @@ static enum e_storage_add storage_canGetItem(struct s_storage *stor, int idx, in
  * @param stor : Storage data
  * @param item_data : item to add
  * @param amount : quantity of items
- * @return 0:success, 1:failed
+ * @return 0:success, 1:failed, 2:failed because of room or stack checks
  */
 static int storage_additem(struct map_session_data* sd, struct s_storage *stor, struct item *it, int amount)
 {
@@ -266,7 +263,7 @@ static int storage_additem(struct map_session_data* sd, struct s_storage *stor, 
 	data = itemdb_search(it->nameid);
 
 	if( data->stack.storage && amount > data->stack.amount ) // item stack limitation
-		return 1;
+		return 2;
 
 	if( !itemdb_canstore(it, pc_get_group_level(sd)) ) { // Check if item is storable. [Skotlex]
 		clif_displaymessage (sd->fd, msg_txt(sd,264));
@@ -282,7 +279,7 @@ static int storage_additem(struct map_session_data* sd, struct s_storage *stor, 
 		for( i = 0; i < stor->max_amount; i++ ) {
 			if( compare_item(&stor->u.items_storage[i], it) ) { // existing items found, stack them
 				if( amount > MAX_AMOUNT - stor->u.items_storage[i].amount || ( data->stack.storage && amount > data->stack.amount - stor->u.items_storage[i].amount ) )
-					return 1;
+					return 2;
 
 				stor->u.items_storage[i].amount += amount;
 				stor->dirty = true;
@@ -296,7 +293,7 @@ static int storage_additem(struct map_session_data* sd, struct s_storage *stor, 
 	// find free slot
 	ARR_FIND( 0, stor->max_amount, i, stor->u.items_storage[i].nameid == 0 );
 	if( i >= stor->max_amount )
-		return 1;
+		return 2;
 
 	// add item to slot
 	memcpy(&stor->u.items_storage[i],it,sizeof(stor->u.items_storage[0]));
@@ -354,9 +351,17 @@ void storage_storageadd(struct map_session_data* sd, struct s_storage *stor, int
 	result = storage_canAddItem(stor, index, sd->inventory.u.items_inventory, amount, MAX_INVENTORY);
 	if (result == STORAGE_ADD_INVALID)
 		return;
-	else if (result == STORAGE_ADD_OK && storage_additem(sd,stor,&sd->inventory.u.items_inventory[index],amount) == 0) {
-		pc_delitem(sd,index,amount,0,4,LOG_TYPE_STORAGE);
-		return;
+	else if (result == STORAGE_ADD_OK) {
+		switch( storage_additem(sd, stor, &sd->inventory.u.items_inventory[index], amount) ){
+			case 0:
+				pc_delitem(sd,index,amount,0,4,LOG_TYPE_STORAGE);
+				return;
+			case 1:
+				break;
+			case 2:
+				result = STORAGE_ADD_NOROOM;
+				break;
+		}
 	}
 
 	clif_storageitemremoved(sd,index,0);
@@ -402,12 +407,20 @@ void storage_storageaddfromcart(struct map_session_data *sd, struct s_storage *s
 	enum e_storage_add result;
 	nullpo_retv(sd);
 
-	result = storage_canAddItem(stor, index, sd->cart.u.items_inventory, amount, MAX_INVENTORY);
+	result = storage_canAddItem(stor, index, sd->cart.u.items_inventory, amount, MAX_CART);
 	if (result == STORAGE_ADD_INVALID)
 		return;
-	else if (result == STORAGE_ADD_OK && storage_additem(sd,stor,&sd->cart.u.items_cart[index],amount) == 0) {
-		pc_cart_delitem(sd,index,amount,0,LOG_TYPE_STORAGE);
-		return;
+	else if (result == STORAGE_ADD_OK) {
+		switch( storage_additem(sd, stor, &sd->cart.u.items_cart[index], amount) ){
+			case 0:
+				pc_cart_delitem(sd,index,amount,0,LOG_TYPE_STORAGE);
+				return;
+			case 1:
+				break;
+			case 2:
+				result = STORAGE_ADD_NOROOM;
+				break;
+		}
 	}
 
 	clif_storageitemremoved(sd,index,0);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->
#2022 

* **Server Mode**:

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Both

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
The check I removed is actually done correctly in storage_additem.

I removed the duplicate check and introduced another return value to know when the storage add operation failed because of these kind of checks. If it fails because of them I also set the result value to the no room enumeration value.

While I was at it I found another wrong constant usage. The from cart version used MAX_INVENTORY instead of MAX_CART to check the validity of the index sent by the client. This would cause problems if these two sizes are not defined with the same value.
