### PR TITLE
When we try to run the application we got the signal Abort trap 6 and…

### DIFF
--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3989,7 +3989,7 @@ int inter_config_read(char *cfgName)
 #ifdef RENEWAL
 			// Copy the original name
 			// Do not use safestrncpy here - enforces zero termination before copying and will break it [Lemongrass]
-			strncpy(w1, w1 + strlen(RENEWALPREFIX), strlen(w1) - strlen(RENEWALPREFIX) + 1);
+			memmove(w1, w1 + strlen(RENEWALPREFIX), strlen(w1 + strlen(RENEWALPREFIX)) + 1);
 #else
 			// In Pre-Renewal the Renewal specific configurations can safely be ignored
 			continue;

--- a/src/map/map.c
+++ b/src/map/map.c
@@ -3987,9 +3987,8 @@ int inter_config_read(char *cfgName)
 #define RENEWALPREFIX "renewal-"
 		if (!strncmpi(w1, RENEWALPREFIX, strlen(RENEWALPREFIX))) {
 #ifdef RENEWAL
-			// Copy the original name
-			// Do not use safestrncpy here - enforces zero termination before copying and will break it [Lemongrass]
-			memmove(w1, w1 + strlen(RENEWALPREFIX), strlen(w1 + strlen(RENEWALPREFIX)) + 1);
+			// Move the original name to the beginning of the string
+			memmove(w1, w1 + strlen(RENEWALPREFIX), strlen(w1) - strlen(RENEWALPREFIX) + 1);
 #else
 			// In Pre-Renewal the Renewal specific configurations can safely be ignored
 			continue;


### PR DESCRIPTION
… the application is interrupted by the OS.

This issue is related with the fact that when using strncpy the source and destination string should not overlap, as we can see in the man page:

man strncpy()
...
The source and destination strings should not overlap, as the behavior is undefined.

We've replaced it by the function memmove:

man memmove()
...
The two strings may overlap; the copy is always done in a non-destructive manner.

Follow ec1fe15d7d480e4fa6ff3f56986bbfd49a4cde2a

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
