### PR TITLE
Fixed MySQL 5.7 compatibility

### DIFF
--- a/sql-files/logs.sql
+++ b/sql-files/logs.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE IF NOT EXISTS `atcommandlog` (
   `atcommand_id` mediumint(9) unsigned NOT NULL auto_increment,
-  `atcommand_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `atcommand_date` datetime NOT NULL,
   `account_id` int(11) unsigned NOT NULL default '0',
   `char_id` int(11) unsigned NOT NULL default '0',
   `char_name` varchar(25) NOT NULL default '',
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS `atcommandlog` (
 
 CREATE TABLE IF NOT EXISTS `branchlog` (
   `branch_id` mediumint(9) unsigned NOT NULL auto_increment,
-  `branch_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `branch_date` datetime NOT NULL,
   `account_id` int(11) NOT NULL default '0',
   `char_id` int(11) NOT NULL default '0',
   `char_name` varchar(25) NOT NULL default '',
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS `branchlog` (
 
 CREATE TABLE IF NOT EXISTS `cashlog` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `char_id` int(11) NOT NULL DEFAULT '0',
   `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','$') NOT NULL DEFAULT 'S',
   `cash_type` enum('O','K','C') NOT NULL DEFAULT 'O',
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `cashlog` (
 
 CREATE TABLE IF NOT EXISTS `chatlog` (
   `id` bigint(20) NOT NULL auto_increment,
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `type` enum('O','W','P','G','M','C') NOT NULL default 'O',
   `type_id` int(11) NOT NULL default '0',
   `src_charid` int(11) NOT NULL default '0',
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS `chatlog` (
 
 CREATE TABLE IF NOT EXISTS `feedinglog` (
   `id` INT(11) NOT NULL AUTO_INCREMENT,
-  `time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `time` DATETIME NOT NULL,
   `char_id` INT(11) NOT NULL,
   `target_id` INT(11) NOT NULL,
   `target_class` SMALLINT(11) NOT NULL,
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS `feedinglog` (
 --
 
 CREATE TABLE IF NOT EXISTS `loginlog` (
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `ip` varchar(15) NOT NULL default '',
   `user` varchar(23) NOT NULL default '',
   `rcode` tinyint(4) NOT NULL default '0',
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS `loginlog` (
 
 CREATE TABLE IF NOT EXISTS `mvplog` (
   `mvp_id` mediumint(9) unsigned NOT NULL auto_increment,
-  `mvp_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `mvp_date` datetime NOT NULL,
   `kill_char_id` int(11) NOT NULL default '0',
   `monster_id` smallint(6) NOT NULL default '0',
   `prize` smallint(5) unsigned NOT NULL default '0',
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS `mvplog` (
 
 CREATE TABLE IF NOT EXISTS `npclog` (
   `npc_id` mediumint(9) unsigned NOT NULL auto_increment,
-  `npc_date` datetime NOT NULL default '0000-00-00 00:00:00',
+  `npc_date` datetime NOT NULL,
   `account_id` int(11) unsigned NOT NULL default '0',
   `char_id` int(11) unsigned NOT NULL default '0',
   `char_name` varchar(25) NOT NULL default '',
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS `npclog` (
 
 CREATE TABLE IF NOT EXISTS `picklog` (
   `id` int(11) NOT NULL auto_increment,
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `char_id` int(11) NOT NULL default '0',
   `type` enum('M','P','L','T','V','S','N','C','A','R','G','E','B','O','I','X','D','U','$','F','Z','Q') NOT NULL default 'P',
   `nameid` smallint(5) unsigned NOT NULL default '0',
@@ -216,7 +216,7 @@ CREATE TABLE IF NOT EXISTS `picklog` (
 
 CREATE TABLE IF NOT EXISTS `zenylog` (
   `id` int(11) NOT NULL auto_increment,
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `char_id` int(11) NOT NULL default '0',
   `src_id` int(11) NOT NULL default '0',
   `type` enum('T','V','P','M','S','N','D','C','A','E','I','B','K') NOT NULL default 'S',

--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -269,7 +269,7 @@ CREATE TABLE IF NOT EXISTS `char_reg_str` (
 --
 
 CREATE TABLE IF NOT EXISTS `charlog` (
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `char_msg` varchar(255) NOT NULL default 'char select',
   `account_id` int(11) NOT NULL default '0',
   `char_num` tinyint(4) NOT NULL default '0',
@@ -602,7 +602,7 @@ CREATE TABLE IF NOT EXISTS `hotkey` (
 --
 
 CREATE TABLE IF NOT EXISTS `interlog` (
-  `time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `time` datetime NOT NULL,
   `log` varchar(255) NOT NULL default ''
 ) ENGINE=MyISAM; 
 
@@ -662,8 +662,8 @@ CREATE TABLE IF NOT EXISTS `inventory` (
 
 CREATE TABLE IF NOT EXISTS `ipbanlist` (
   `list` varchar(255) NOT NULL default '',
-  `btime` datetime NOT NULL default '0000-00-00 00:00:00',
-  `rtime` datetime NOT NULL default '0000-00-00 00:00:00',
+  `btime` datetime NOT NULL,
+  `rtime` datetime NOT NULL,
   `reason` varchar(255) NOT NULL default '',
   KEY (`list`)
 ) ENGINE=MyISAM;
@@ -683,9 +683,9 @@ CREATE TABLE IF NOT EXISTS `login` (
   `unban_time` int(11) unsigned NOT NULL default '0',
   `expiration_time` int(11) unsigned NOT NULL default '0',
   `logincount` mediumint(9) unsigned NOT NULL default '0',
-  `lastlogin` datetime NOT NULL default '0000-00-00 00:00:00',
+  `lastlogin` datetime,
   `last_ip` varchar(100) NOT NULL default '',
-  `birthdate` DATE NOT NULL DEFAULT '0000-00-00',
+  `birthdate` DATE,
   `character_slots` tinyint(3) unsigned NOT NULL default '0',
   `pincode` varchar(4) NOT NULL DEFAULT '',
   `pincode_change` int(11) unsigned NOT NULL DEFAULT '0',

--- a/sql-files/upgrades/upgrade_20170417.sql
+++ b/sql-files/upgrades/upgrade_20170417.sql
@@ -1,0 +1,18 @@
+ALTER TABLE `charlog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `interlog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `ipbanlist` ALTER `btime` DROP DEFAULT;
+ALTER TABLE `ipbanlist` ALTER `rtime` DROP DEFAULT;
+ALTER TABLE `login` ALTER `lastlogin` DROP DEFAULT;
+ALTER TABLE `login` ALTER `birthdate` DROP DEFAULT;
+
+ALTER TABLE `login` MODIFY `lastlogin` datetime;
+ALTER TABLE `login` MODIFY `birthdate` date;
+
+UPDATE `login` SET `lastlogin` = NULL WHERE `lastlogin` = '0000-00-00 00:00:00';
+UPDATE `login` SET `birthdate` = NULL WHERE `birthdate` = '0000-00-00';
+
+-- Optional: delete useless entries
+-- DELETE FROM `charlog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `interlog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `ipbanlist` WHERE `btime` = '0000-00-00 00:00:00';
+-- DELETE FROM `ipbanlist` WHERE `rtime` = '0000-00-00 00:00:00';

--- a/sql-files/upgrades/upgrade_20170417_logs.sql
+++ b/sql-files/upgrades/upgrade_20170417_logs.sql
@@ -1,0 +1,22 @@
+ALTER TABLE `atcommandlog` ALTER `atcommand_date` DROP DEFAULT;
+ALTER TABLE `branchlog` ALTER `branch_date` DROP DEFAULT;
+ALTER TABLE `cashlog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `chatlog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `feedinglog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `loginlog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `mvplog` ALTER `mvp_date` DROP DEFAULT;
+ALTER TABLE `npclog` ALTER `npc_date` DROP DEFAULT;
+ALTER TABLE `picklog` ALTER `time` DROP DEFAULT;
+ALTER TABLE `zenylog` ALTER `time` DROP DEFAULT;
+
+-- Optional: delete useless entries
+-- DELETE FROM `atcommandlog` WHERE `atcommand_date` = '0000-00-00 00:00:00';
+-- DELETE FROM `branchlog` WHERE `branch_date` = '0000-00-00 00:00:00';
+-- DELETE FROM `cashlog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `chatlog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `feedinglog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `loginlog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `mvplog` WHERE `mvp_date` = '0000-00-00 00:00:00';
+-- DELETE FROM `npclog` WHERE `npc_date` = '0000-00-00 00:00:00';
+-- DELETE FROM `picklog` WHERE `time` = '0000-00-00 00:00:00';
+-- DELETE FROM `zenylog` WHERE `time` = '0000-00-00 00:00:00';

--- a/src/char/char_clif.c
+++ b/src/char/char_clif.c
@@ -547,7 +547,7 @@ static bool chclif_delchar_check(struct char_session_data *sd, char *delcode, ui
 	if (flag&CHAR_DEL_BIRTHDATE && (
 		!strcmp(sd->birthdate+2, delcode) || // +2 to cut off the century
 		(
-			!strcmp("0000-00-00", sd->birthdate) && // it is default birthdate and
+			!strcmp("",sd->birthdate) && // it is default birthdate and
 			!strcmp("",delcode) // user sent an empty birthdate
 		))) {
 		ShowInfo(""CL_RED"Char Deleted"CL_RESET" "CL_GREEN"(Birthdate)"CL_RESET".\n");

--- a/src/login/account.c
+++ b/src/login/account.c
@@ -527,9 +527,9 @@ static bool mmo_auth_fromsql(AccountDB_SQL* db, struct mmo_account* acc, uint32 
 	Sql_GetData(sql_handle,  7, &data, NULL); acc->unban_time = atol(data);
 	Sql_GetData(sql_handle,  8, &data, NULL); acc->expiration_time = atol(data);
 	Sql_GetData(sql_handle,  9, &data, NULL); acc->logincount = (unsigned int) strtoul(data, NULL, 10);
-	Sql_GetData(sql_handle, 10, &data, NULL); safestrncpy(acc->lastlogin, data, sizeof(acc->lastlogin));
+	Sql_GetData(sql_handle, 10, &data, NULL); safestrncpy(acc->lastlogin, data==NULL?"":data, sizeof(acc->lastlogin));
 	Sql_GetData(sql_handle, 11, &data, NULL); safestrncpy(acc->last_ip, data, sizeof(acc->last_ip));
-	Sql_GetData(sql_handle, 12, &data, NULL); safestrncpy(acc->birthdate, data, sizeof(acc->birthdate));
+	Sql_GetData(sql_handle, 12, &data, NULL); safestrncpy(acc->birthdate, data==NULL?"":data, sizeof(acc->birthdate));
 	Sql_GetData(sql_handle, 13, &data, NULL); acc->char_slots = (uint8) atoi(data);
 	Sql_GetData(sql_handle, 14, &data, NULL); safestrncpy(acc->pincode, data, sizeof(acc->pincode));
 	Sql_GetData(sql_handle, 15, &data, NULL); acc->pincode_change = atol(data);
@@ -583,9 +583,9 @@ static bool mmo_auth_tosql(AccountDB_SQL* db, const struct mmo_account* acc, boo
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  7, SQLDT_LONG,      (void*)&acc->unban_time,      sizeof(acc->unban_time))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  8, SQLDT_INT,       (void*)&acc->expiration_time, sizeof(acc->expiration_time))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  9, SQLDT_UINT,      (void*)&acc->logincount,      sizeof(acc->logincount))
-		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 10, SQLDT_STRING,    (void*)&acc->lastlogin,       strlen(acc->lastlogin))
+		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 10, acc->lastlogin[0]?SQLDT_STRING:SQLDT_NULL,    (void*)&acc->lastlogin,       strlen(acc->lastlogin))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 11, SQLDT_STRING,    (void*)&acc->last_ip,         strlen(acc->last_ip))
-		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 12, SQLDT_STRING,    (void*)&acc->birthdate,       strlen(acc->birthdate))
+		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 12, acc->birthdate[0]?SQLDT_STRING:SQLDT_NULL,    (void*)&acc->birthdate,       strlen(acc->birthdate))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 13, SQLDT_UCHAR,     (void*)&acc->char_slots,      sizeof(acc->char_slots))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 14, SQLDT_STRING,    (void*)&acc->pincode,         strlen(acc->pincode))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 15, SQLDT_LONG,      (void*)&acc->pincode_change,  sizeof(acc->pincode_change))
@@ -617,9 +617,9 @@ static bool mmo_auth_tosql(AccountDB_SQL* db, const struct mmo_account* acc, boo
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  6, SQLDT_LONG,      (void*)&acc->unban_time,      sizeof(acc->unban_time))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  7, SQLDT_LONG,      (void*)&acc->expiration_time, sizeof(acc->expiration_time))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  8, SQLDT_UINT,      (void*)&acc->logincount,      sizeof(acc->logincount))
-		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  9, SQLDT_STRING,    (void*)&acc->lastlogin,       strlen(acc->lastlogin))
+		||  SQL_SUCCESS != SqlStmt_BindParam(stmt,  9, acc->lastlogin[0]?SQLDT_STRING:SQLDT_NULL,    (void*)&acc->lastlogin,       strlen(acc->lastlogin))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 10, SQLDT_STRING,    (void*)&acc->last_ip,         strlen(acc->last_ip))
-		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 11, SQLDT_STRING,    (void*)&acc->birthdate,       strlen(acc->birthdate))
+		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 11, acc->birthdate[0]?SQLDT_STRING:SQLDT_NULL,    (void*)&acc->birthdate,       strlen(acc->birthdate))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 12, SQLDT_UCHAR,     (void*)&acc->char_slots,      sizeof(acc->char_slots))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 13, SQLDT_STRING,    (void*)&acc->pincode,         strlen(acc->pincode))
 		||  SQL_SUCCESS != SqlStmt_BindParam(stmt, 14, SQLDT_LONG,      (void*)&acc->pincode_change,  sizeof(acc->pincode_change))

--- a/src/login/account.h
+++ b/src/login/account.h
@@ -35,7 +35,7 @@ struct mmo_account {
 	unsigned int logincount;// number of successful auth attempts
 	char lastlogin[24];     // date+time of last successful login
 	char last_ip[16];       // save of last IP of connection
-	char birthdate[10+1];   // assigned birth date (format: YYYY-MM-DD, default: 0000-00-00)
+	char birthdate[10+1];   // assigned birth date (format: YYYY-MM-DD)
 	char pincode[PINCODE_LENGTH+1];		// pincode system
 	time_t pincode_change;	// (timestamp): last time of pincode change
 #ifdef VIP_ENABLE

--- a/src/login/login.c
+++ b/src/login/login.c
@@ -237,9 +237,9 @@ int login_mmo_auth_new(const char* userid, const char* pass, const char sex, con
 	acc.sex = sex;
 	safestrncpy(acc.email, "a@a.com", sizeof(acc.email));
 	acc.expiration_time = ( login_config.start_limited_time != -1 ) ? time(NULL) + login_config.start_limited_time : 0;
-	safestrncpy(acc.lastlogin, "0000-00-00 00:00:00", sizeof(acc.lastlogin));
+	safestrncpy(acc.lastlogin, "", sizeof(acc.lastlogin));
 	safestrncpy(acc.last_ip, last_ip, sizeof(acc.last_ip));
-	safestrncpy(acc.birthdate, "0000-00-00", sizeof(acc.birthdate));
+	safestrncpy(acc.birthdate, "", sizeof(acc.birthdate));
 	safestrncpy(acc.pincode, "", sizeof(acc.pincode));
 	acc.pincode_change = 0;
 	acc.char_slots = MIN_CHARS;


### PR DESCRIPTION
* **Addressed Issue(s)**: 
#1210

* **Server Mode**: 
Both

* **Description of Pull Request**: 
Instead of using another default value I decided to just drop the default value, since we always provide values where they are required and we can leave the columns empty where no value is required by default.
Added the source side requirements to prevent crashes caused by these changes.

Fixes #1210 - thanks to @majimboo, @Jeybla, @Daegaladh and @anacondaqq!
Based on #2026 from @Daegaladh - thank you again!
