### PR TITLE
Adjusted skill_nocast_db settings.

### DIFF
--- a/db/re/skill_nocast_db.txt
+++ b/db/re/skill_nocast_db.txt
@@ -30,11 +30,12 @@
 2423,1	//WM_SIRCLEOFNATURE
 2430,1	//WM_SATURDAY_NIGHT_FEVER
 2455,1	//SO_ARRULLO
+2299,1	//SC_MANHOLE
 
 //----------------------------------------------------------------------------
 // PVP
 //----------------------------------------------------------------------------
-
+2300,2	//SC_DIMENSIONDOOR
 
 //----------------------------------------------------------------------------
 // GVG
@@ -126,9 +127,9 @@
 529,16	// NJ_SHADOWJUMP
 // 530,16	// NJ_KIRIKAGE
 691,16	// CASH_ASSUMPTIO
+2300,16	// SC_DIMENSIONDOOR
 //!TODO: More 3rd Class skills
 // 2284,16	// SC_FATALMENACE
-// 2300,16	// SC_DIMENSIONDOOR
 // 2293,16	// SC_GROOMY
 // 2296,16	// SC_UNLUCKY
 // 2494,16	// GN_CHANGEMATERIAL
@@ -209,10 +210,6 @@
 233,2048	//AM_SPHEREMINE
 491,2048	//CR_CULTIVATION
 1013,2048	//BS_GREED
-2299,2048	//SC_MANHOLE
-2300,2048	//SC_DIMENSIONDOOR
-2301,2048	//SC_CHAOSPANIC
-2303,2048	//SC_BLOODYLUST
 2419,2048	//WM_POEMOFNETHERWORLD
 2482,2048	//GN_WALLOFTHORN
 2493,2048	//GN_SLINGITEM


### PR DESCRIPTION
For the following skills:
* SC_MANHOLE - PvP only
* SC_DIMENSIONDOOR - town and field, doesn't work in PvP
* SC_CHAOSPANIC - No restriction
* SC_BLOODYLUST - Enabled in town

Fixes #1496.

Thanks to @Everade and @aleos89.