### PR TITLE
Fixes Tetra Vortex Fire animation

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -3350,6 +3350,9 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 		case WL_CHAINLIGHTNING_ATK:
 			dmg.dmotion = clif_skill_damage(src,bl,tick,dmg.amotion,dmg.dmotion,damage,1,WL_CHAINLIGHTNING_ATK,-2,DMG_SKILL);
 			break;
+		case WL_TETRAVORTEX_FIRE:
+			dmg.dmotion = clif_skill_damage(dsrc, bl, tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, WL_TETRAVORTEX_WIND, -1, DMG_SPLASH);
+			break;
 		case LG_SHIELDPRESS:
 			dmg.dmotion = clif_skill_damage(dsrc, bl, tick, status_get_amotion(src), dmg.dmotion, damage, dmg.div_, skill_id, -1, DMG_SKILL);
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: #1353

* **Server Mode**: Pre-Renewal and Renewal

* **Description of Pull Request**: 
  * Added a damage animation motion for Tetra Vortex Fire.
  * Resolves the black animation being displayed.
Thanks @exneval, @spinzaku, @secretdataz, @reigneil, and @feltenc!