### PR TITLE
Adjusted Feint Bomb behavior near a Maelstrom Cell.

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -12032,10 +12032,12 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 	case SC_FEINTBOMB: {
 			struct skill_unit_group *group = skill_unitsetting(src,skill_id,skill_lv,x,y,0); // Set bomb on current Position
 
-			if( group != NULL && group->unit != NULL ) {
-				// Release all targets against the caster.
-				map_foreachinrange(skill_mob_releasetarget, src, AREA_SIZE, BL_MOB, src, &group->unit->bl);
+			if( group == NULL || group->unit == NULL ) {
+				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+				return 1;
 			}
+			// Release all targets against the caster.
+			map_foreachinrange(skill_mob_releasetarget, src, AREA_SIZE, BL_MOB, src, &group->unit->bl);
 			skill_blown(src, src, skill_get_blewcount(skill_id, skill_lv), unit_getdir(src), BLOWN_IGNORE_NO_KNOCKBACK); // Don't stop the caster from backsliding if special_state.no_knockback is active
 			clif_skill_nodamage(src,src,skill_id,skill_lv,sc_start(src,src,type,100,skill_lv,skill_get_time2(skill_id,skill_lv)));
 		}
@@ -15388,7 +15390,7 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 			}
 			break;
 		case SC_FEINTBOMB:
-			if( map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKLANDPROTECTOR) ) {
+			if( map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKLANDPROTECTOR) || map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKMAELSTROM) ) {
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				return false;
 			}


### PR DESCRIPTION
* Feint Bomb near a Maelstrom Cell now matches the official behavior.

Rathena before:
* FB was possible to use near Maelstrom, but didn't trigger an explosion

Now:
* FB fails near Maelstrom, displaying a "skill failed" message.
* It's possible to cast FB right after it failed.

(More or less a follow up to cbc3b260c849d3101ee5cda72206a803d8cdb470 )