### PR TITLE
Skip MapN parsing if it is equal to EnterMap for instances

### DIFF
--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -911,6 +911,10 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 				ShowWarning("instance_readdb_sub: Invalid map '%s' in maplist, skipping...\n", str[i]);
 				continue;
 			}
+			if (strcmpi(str[4], str[i])) {
+				ShowWarning("instance_readdb_sub: Map%d must not be equal to EnterMap for instance id '%d', skipping...\n", i-5, id);
+				continue;
+			}
 			RECREATE(db->maplist, StringBuf *, db->maplist_count+1);
 			db->maplist[db->maplist_count] = StringBuf_Malloc();
 			StringBuf_AppendStr(db->maplist[db->maplist_count], str[i]);

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -911,7 +911,7 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 				ShowWarning("instance_readdb_sub: Invalid map '%s' in maplist, skipping...\n", str[i]);
 				continue;
 			}
-			if (strcmpi(str[4], str[i])) {
+			if (strcmpi(str[4], str[i]) == 0) {
 				ShowWarning("instance_readdb_sub: Map%d must not be equal to EnterMap for instance id '%d', skipping...\n", i-5, id);
 				continue;
 			}

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -839,7 +839,7 @@ static bool instance_db_free_sub(struct instance_db *db);
  *------------------------------------------*/
 static bool instance_readdb_sub(char* str[], int columns, int current)
 {
-	uint8 i;
+	uint8 i,j;
 	char *ptr;
 	int id = strtol(str[0], &ptr, 10);
 	struct instance_db *db;
@@ -854,6 +854,7 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 		ShowError("instance_readdb_sub: Invalid map '%s' as entrance map, skipping...\n", str[4]);
 		return false;
 	}
+
 
 	if (!(db = (struct instance_db *)uidb_get(InstanceDB, id))) {
 		CREATE(db, struct instance_db, 1);
@@ -915,6 +916,28 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 				ShowWarning("instance_readdb_sub: Map%d must not be equal to EnterMap for instance id '%d', skipping...\n", i-5, id);
 				continue;
 			}
+
+			if (strcmpi(str[4], str[i]) == 0) {
+				ShowWarning("instance_readdb_sub: '%s'(Map%d) must not be equal to EnterMap for instance id '%d', skipping...\n", str[i], i - 5, id);
+				continue;
+			}
+			// Check if the map is in the list already
+			for (j = 7; j < i; j++) {
+				// Skip empty columns
+				if (!strlen(str[j])) {
+					continue;
+				}
+
+				if (strcmpi(str[j], str[i]) == 0) {
+					break;
+				}
+			}
+			// If it was already in the list
+			if (j < i) {
+				ShowWarning("instance_readdb_sub: '%s'(Map%d) was already added for instance id '%d', skipping...\n", str[i], i - 5, id);
+				continue; // Skip it
+			}
+
 			RECREATE(db->maplist, StringBuf *, db->maplist_count+1);
 			db->maplist[db->maplist_count] = StringBuf_Malloc();
 			StringBuf_AppendStr(db->maplist[db->maplist_count], str[i]);

--- a/src/map/instance.c
+++ b/src/map/instance.c
@@ -855,7 +855,6 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 		return false;
 	}
 
-
 	if (!(db = (struct instance_db *)uidb_get(InstanceDB, id))) {
 		CREATE(db, struct instance_db, 1);
 		db->id = id;
@@ -912,15 +911,12 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 				ShowWarning("instance_readdb_sub: Invalid map '%s' in maplist, skipping...\n", str[i]);
 				continue;
 			}
-			if (strcmpi(str[4], str[i]) == 0) {
-				ShowWarning("instance_readdb_sub: Map%d must not be equal to EnterMap for instance id '%d', skipping...\n", i-5, id);
-				continue;
-			}
 
 			if (strcmpi(str[4], str[i]) == 0) {
 				ShowWarning("instance_readdb_sub: '%s'(Map%d) must not be equal to EnterMap for instance id '%d', skipping...\n", str[i], i - 5, id);
 				continue;
 			}
+
 			// Check if the map is in the list already
 			for (j = 7; j < i; j++) {
 				// Skip empty columns
@@ -932,6 +928,7 @@ static bool instance_readdb_sub(char* str[], int columns, int current)
 					break;
 				}
 			}
+
 			// If it was already in the list
 			if (j < i) {
 				ShowWarning("instance_readdb_sub: '%s'(Map%d) was already added for instance id '%d', skipping...\n", str[i], i - 5, id);


### PR DESCRIPTION
* **Addressed Issue(s)**:  None

* **Server Mode**: Both

* **Description of Pull Request**: 

This pull request makes the map server skip Map2-Map255 when it is reading instance_db.txt and warn the user if said map is equal to the EnterMap entry of that line.
