### PR TITLE
Added automatic clan member removal

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -255,4 +255,10 @@ default_map: prontera
 default_map_x: 156
 default_map_y: 191
 
+// After how many days should inactive clan members be removed from their clan?
+// 0: never remove them
+// X: remove clan members if they did not log in for X days
+// Default: 14
+clan_remove_inactive_days: 14
+
 import: conf/import/char_conf.txt

--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -230,6 +230,7 @@ CREATE TABLE IF NOT EXISTS `char` (
   `sex` ENUM('M','F','U') NOT NULL default 'U',
   `hotkey_rowshift` tinyint(3) unsigned NOT NULL default '0',
   `clan_id` int(11) unsigned NOT NULL default '0',
+  `last_login` datetime DEFAULT NULL,
   PRIMARY KEY  (`char_id`),
   UNIQUE KEY `name_key` (`name`),
   KEY `account_id` (`account_id`),

--- a/sql-files/upgrades/upgrade_20170509.sql
+++ b/sql-files/upgrades/upgrade_20170509.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `char`
+	ADD COLUMN `last_login` datetime DEFAULT NULL AFTER `clan_id`;

--- a/src/char/char.h
+++ b/src/char/char.h
@@ -165,6 +165,8 @@ struct CharServ_Config {
 	char default_map[MAP_NAME_LENGTH];
 	unsigned short default_map_x;
 	unsigned short default_map_y;
+
+	int clan_remove_inactive_days;
 };
 extern struct CharServ_Config charserv_config;
 

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -10841,6 +10841,17 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				tick_time = tick;
 				tick = tick_time + max(val4,0);
 				break;
+			case SC_SWORDCLAN:
+			case SC_ARCWANDCLAN:
+			case SC_GOLDENMACECLAN:
+			case SC_CROSSBOWCLAN:
+			case SC_JUMPINGCLAN:
+			case SC_CLAN_INFO:
+				// If the player still has a clan status, but was removed from his clan
+				if( sd && sd->status.clan_id == 0 ){
+					return 0;
+				}
+				break;
 		}
 
 	// Values that must be set regardless of flag&4 e.g. val_flag [Ind]


### PR DESCRIPTION
* **Addressed Issue(s)**: #2134 

* **Server Mode**: Renewal

* **Description of Pull Request**: 
This pull requests adds a interval timer(60 minutes) into the character server that removes all characters from the clans they joined if they have not logged in for 14 days or whatever value the new configuration is set to.
As mentioned above a configuration is given how long characters can stay in a clan when they do not log in.
It also adds a column to the character table to store the last login of each character.
Because of this it was necessary to check if a player is still in a clan, when a player logs in with a clan status change without actually being in a clan. If this happens the status changes will not be started anymore.
