### PR TITLE
Fixed chat color bug in Channel System

### DIFF
--- a/src/map/channel.c
+++ b/src/map/channel.c
@@ -857,7 +857,7 @@ int channel_pccolor(struct map_session_data *sd, char *chname, char *color){
 		clif_displaymessage(sd->fd, output);
 		return -1;
 	}
-	channel->color = k;
+	channel->color = channel_config.colors[k];
 	sprintf(output, msg_txt(sd,1413),chname,channel_config.colors_name[k]);// '%s' channel color updated to '%s'.
 	clif_displaymessage(sd->fd, output);
 	return 0;
@@ -1290,7 +1290,7 @@ unsigned long channel_getColor(const char *color_str) {
 		if (strcmpi(channel_config.colors_name[i], color_str) == 0)
 			return channel_config.colors[i];
 	}
-	return 1;
+	return channel_config.colors[0];
 }
 
 /**


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: `@channel setcolor` command failed to change the font color, resulting in black font color.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
