### PR TITLE
Expanded bg_get_data script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8863,7 +8863,7 @@ Example:
 Retrieves data related to given Battle Group. Type can be one of the following:
 
     0 - Amount of players currently belonging to the group.
-	1 - Store GID of players in <Battle Group> in a temporary global array $@arenamembers
+    1 - Store GID of players in <Battle Group> in a temporary global array $@arenamembers
 		and returns amount of players currently belonging to the group.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8863,6 +8863,8 @@ Example:
 Retrieves data related to given Battle Group. Type can be one of the following:
 
     0 - Amount of players currently belonging to the group.
+	1 - Store GID of players in <Battle Group> in a temporary global array $@arenamembers
+		and returns amount of players currently belonging to the group.
 
 ---------------------------------------
 

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19504,7 +19504,7 @@ BUILDIN_FUNC(bg_get_data)
 		case 1:
 			for (i = 0; bg->members[i].sd != NULL; i++)
 				mapreg_setreg(reference_uid(add_str("$@arenamembers"), i), bg->members[i].sd->bl.id);
-			mapreg_setreg(reference_uid(add_str("$@arenamemberscount"), i), i);
+			mapreg_setreg(add_str("$@arenamemberscount"), i);
 			script_pushint(st, i);
 			break;
 		default:

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -19490,7 +19490,7 @@ BUILDIN_FUNC(bg_get_data)
 {
 	struct battleground_data *bg;
 	int bg_id = script_getnum(st,2),
-		type = script_getnum(st,3);
+		type = script_getnum(st,3), i;
 
 	if( (bg = bg_team_search(bg_id)) == NULL )
 	{
@@ -19501,6 +19501,12 @@ BUILDIN_FUNC(bg_get_data)
 	switch( type )
 	{
 		case 0: script_pushint(st, bg->count); break;
+		case 1:
+			for (i = 0; bg->members[i].sd != NULL; i++)
+				mapreg_setreg(reference_uid(add_str("$@arenamembers"), i), bg->members[i].sd->bl.id);
+			mapreg_setreg(reference_uid(add_str("$@arenamemberscount"), i), i);
+			script_pushint(st, i);
+			break;
 		default:
 			ShowError("script:bg_get_data: unknown data identifier %d\n", type);
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
  Allows GID of players in certain battleground to be retrieved via the script engine by expanding `bg_get_data` script command.
