### PR TITLE
Updated Rune Knight Runestone effects

### DIFF
--- a/db/pre-re/item_stack.txt
+++ b/db/pre-re/item_stack.txt
@@ -18,15 +18,12 @@
 // 512,4,12  // Will not allow more than 4 Apples in storages.
 
 // Rune Knight
-12725,20,1  // Nauthiz Rune
-12726,20,1  // Raido Rune
-12727,20,1  // Berkana Rune
-12728,20,1  // Isa Rune
-12729,20,1  // Othila Rune
-12730,20,1  // Uruz Rune
-12731,20,1  // Thurisaz Rune
-12732,20,1  // Wyrd Rune
-12733,20,1  // Hagalaz Rune
+12725,60,1  // Nauthiz Rune
+12726,60,1  // Raido Rune
+12727,60,1  // Berkana Rune
+12728,60,1  // Isa Rune
+12730,60,1  // Uruz Rune
+12733,60,1  // Hagalaz Rune
 
 // Arch Bishop
 12333,3,1  // Ancilla

--- a/db/re/item_stack.txt
+++ b/db/re/item_stack.txt
@@ -18,16 +18,13 @@
 // 512,4,12  // Will not allow more than 4 Apples in storages.
 
 // Rune Knight
-12725,20,1  // Nauthiz Rune
-12726,20,1  // Raido Rune
-12727,20,1  // Berkana Rune
-12728,20,1  // Isa Rune
-12729,20,1  // Othila Rune
-12730,20,1  // Uruz Rune
-12731,20,1  // Thurisaz Rune
-12732,20,1  // Wyrd Rune
-12733,20,1  // Hagalaz Rune
-22540,20,1  // Lux Anima Rune
+12725,60,1  // Nauthiz Rune
+12726,60,1  // Raido Rune
+12727,60,1  // Berkana Rune
+12728,60,1  // Isa Rune
+12730,60,1  // Uruz Rune
+12733,60,1  // Hagalaz Rune
+22540,60,1  // Lux Anima Rune
 
 // Arch Bishop
 12333,3,1  // Ancilla

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -3768,7 +3768,7 @@ static int battle_calc_attack_skill_ratio(struct Damage wd, struct block_list *s
 				skillratio += 100 * skill_lv;
 			break;
 		case RK_STORMBLAST:
-			skillratio += -100 + (((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : 0) + (status_get_int(src) / 8)) * 100; // ATK = [{Rune Mastery Skill Level + (Caster's INT / 8)} x 100] %
+			skillratio += -100 + (((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : 0) + (status_get_str(src) / 8)) * 100; // ATK = [{Rune Mastery Skill Level + (Caster's STR / 8)} x 100] %
 			break;
 		case RK_PHANTOMTHRUST: // ATK = [{(Skill Level x 50) + (Spear Master Level x 10)} x Caster's Base Level / 150] %
 			skillratio += -100 + 50 * skill_lv + 10 * (sd ? pc_checkskill(sd,KN_SPEARMASTERY) : 5);
@@ -7237,8 +7237,15 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 			} else
 				status_change_end(src,SC_SPELLFIST,INVALID_TIMER);
 		}
-		if( sc->data[SC_GIANTGROWTH] && (wd.flag&BF_SHORT) && rnd()%100 < sc->data[SC_GIANTGROWTH]->val2 && !is_infinite_defense(target, wd.flag) && !vanish_damage )
-			wd.damage *= 3; // Triple Damage
+		if (sc->data[SC_GIANTGROWTH] && (wd.flag&BF_SHORT) && rnd()%100 < sc->data[SC_GIANTGROWTH]->val2 && !is_infinite_defense(target, wd.flag) && !vanish_damage) {
+			wd.damage << 1; // Double Damage
+			if (!sc->data[SC_CRUSHSTRIKE]) { // Increase damage again if Crush Strike is not active
+				if (map_flag_vs(src->m)) // Only half of the 2.5x increase on versus-type maps
+					wd.damage += wd.damage * 125 / 100;
+				else
+					wd.damage += wd.damage * 250 / 100;
+			}
+		}
 
 		if( sd && battle_config.arrow_decrement && sc->data[SC_FEARBREEZE] && sc->data[SC_FEARBREEZE]->val4 > 0) {
 			short idx = sd->equip_index[EQI_AMMO];

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -9024,23 +9024,23 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
  		break;
 
 	case RK_FIGHTINGSPIRIT: {
-			// val1: ATKBonus: Caster: 7*PartyMember. Member: 7*PartyMember/4
+			// val1: ATKBonus: Caster: 70 + 7 * PartyMember. Member: 70 + 7 * PartyMember / 2
 			// val2: ASPD boost: [RK_RUNEMASTERYlevel * 4 / 10] * 10 ==> RK_RUNEMASTERYlevel * 4
 			if( flag&1 ) {
 				if( skill_area_temp[1] == bl->id )
-					sc_start2(src,bl,type,100,7 * skill_area_temp[0],4 * ((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : skill_get_max(RK_RUNEMASTERY)),skill_area_temp[4]);
+					sc_start2(src,bl,type,100,70 + 7 * skill_area_temp[0],4 * ((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : skill_get_max(RK_RUNEMASTERY)),skill_area_temp[4]);
 				else
 					sc_start(src,bl,type,100,skill_area_temp[3],skill_area_temp[4]);
 			} else {
 				if( sd && sd->status.party_id ) {
 					skill_area_temp[0] = party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,BCT_PARTY,skill_area_sub_count);
 					skill_area_temp[1] = src->id;
-					skill_area_temp[3] = 7 * skill_area_temp[0] / 4;
+					skill_area_temp[3] = 70 + 7 * skill_area_temp[0] / 2;
 					skill_area_temp[4] = skill_get_time(skill_id,skill_lv);
 					party_foreachsamemap(skill_area_sub,sd,skill_get_splash(skill_id,skill_lv),src,skill_id,skill_lv,tick,flag|BCT_PARTY|1,skill_castend_nodamage_id);
 				}
 				else
-					sc_start2(src,bl,type,100,7,4 * ((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : skill_get_max(RK_RUNEMASTERY)),skill_get_time(skill_id,skill_lv));
+					sc_start2(src,bl,type,100,77,4 * ((sd) ? pc_checkskill(sd,RK_RUNEMASTERY) : skill_get_max(RK_RUNEMASTERY)),skill_get_time(skill_id,skill_lv));
 				clif_skill_nodamage(src,bl,skill_id,1,1);
 			}
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: #2144

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Based on kRO update: http://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=3708477&curpage=1
  * Turisus Runestone - Reduce amplified bonus damage when dealing normal attacks from 300% to 200%. Add an additional increase ATK-based physical damage by 250% instead on normal maps and 125% on VS maps. Rhydo Runestone won't benefit from this bonus.
  * Asir Runestone - Adds a static +70 ATK. Party members now receive 1/2 of the bonus instead of 1/4.
  * Pertz Runestone - Changed factor in formula from INT to STR.
  * Removed the limit of Turisus Runestone, Asir Runestone and Pertz Runestone that can be held while increasing the limit of the other runestones from 20 to 60.
Thanks to @Felleonel!