### PR TITLE
Added new mapflag: MF_INSTAKILL

### DIFF
--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -323,6 +323,13 @@ Notes:
 
 ---------------------------------------
 
+*instakill
+
+Applies maximum damage on every hit or skill from players or monsters.
+Ignores damage reduction.
+
+---------------------------------------
+
 ==================
 | 3. Map Effects |
 ==================
@@ -423,12 +430,5 @@ character server.
 
 Hides monster's HP bar on a map.
 Ignores config value of 'monster_hp_bars_info'.
-
----------------------------------------
-
-*instakill
-
-Applies maximum damage on every hit or skill from players or monsters.
-Ignores damage reduction.
 
 ---------------------------------------

--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -428,8 +428,7 @@ Ignores config value of 'monster_hp_bars_info'.
 
 *instakill
 
-Outputs maximum damage when attacking/receiving a/from players or monsters.
-Ignores any damage reduction.
-Attacks may either be a skill or a normal attack.
+Applies maximum damage on every hit or skill from players or monsters.
+Ignores damage reduction.
 
 ---------------------------------------

--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -425,3 +425,11 @@ Hides monster's HP bar on a map.
 Ignores config value of 'monster_hp_bars_info'.
 
 ---------------------------------------
+
+*instakill
+
+Outputs maximum damage when attacking/receiving a/from players or monsters.
+Ignores any damage reduction.
+Attacks may either be a skill or a normal attack.
+
+---------------------------------------

--- a/src/map/atcommand.c
+++ b/src/map/atcommand.c
@@ -8138,7 +8138,7 @@ ACMD_FUNC(mapflag) {
 		checkflag(partylock);			checkflag(guildlock);			checkflag(reset);				checkflag(chmautojoin);
 		checkflag(nousecart);			checkflag(noitemconsumption);	checkflag(nosumstarmiracle);	checkflag(nomineeffect);
 		checkflag(nolockon);			checkflag(notomb);				checkflag(nocostume);			checkflag(gvg_te);
-		checkflag(gvg_te_castle);		checkflag(hidemobhpbar);
+		checkflag(gvg_te_castle);		checkflag(hidemobhpbar);		checkflag(instakill);
 #ifdef ADJUST_SKILL_DAMAGE
 		checkflag(skill_damage);
 #endif
@@ -8163,7 +8163,7 @@ ACMD_FUNC(mapflag) {
 	setflag(partylock);			setflag(guildlock);			setflag(reset);					setflag(chmautojoin);
 	setflag(nousecart);			setflag(noitemconsumption);	setflag(nosumstarmiracle);		setflag(nomineeffect);
 	setflag(nolockon);			setflag(notomb);			setflag(nocostume);				setflag(gvg_te);
-	setflag(gvg_te_castle);		setflag(hidemobhpbar);
+	setflag(gvg_te_castle);		setflag(hidemobhpbar);		setflag(instakill);
 #ifdef ADJUST_SKILL_DAMAGE
 	setflag(skill_damage);
 #endif
@@ -8179,7 +8179,7 @@ ACMD_FUNC(mapflag) {
 	clif_displaymessage(sd->fd,"fog, fireworks, sakura, leaves, nogo, nobaseexp, nojobexp, nomobloot, nomvploot,");
 	clif_displaymessage(sd->fd,"nightenabled, restricted, nodrop, novending, loadevent, nochat, partylock, guildlock,");
 	clif_displaymessage(sd->fd,"reset, chmautojoin, nousecart, noitemconsumption, nosumstarmiracle, nolockon, notomb,");
-	clif_displaymessage(sd->fd,"nocostume, gvg_te, gvg_te_castle, hidemobhpbar");
+	clif_displaymessage(sd->fd,"nocostume, gvg_te, gvg_te_castle, hidemobhpbar, instakill");
 #ifdef ADJUST_SKILL_DAMAGE
 	clif_displaymessage(sd->fd,"skill_damage");
 #endif

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -1044,6 +1044,9 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 	if (sc && sc->data[SC_MAXPAIN])
 		return 0;
 
+	if (map[bl->m].flag.instakill)
+		return INT64_MAX;
+
 	if (skill_id == PA_PRESSURE || skill_id == HW_GRAVITATION)
 		return damage; //These skills bypass everything else.
 

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -680,6 +680,7 @@ struct map_data {
 		unsigned gvg_te : 1; // GVG WOE:TE. This was added as purpose to change 'gvg' for GVG TE, so item_noequp, skill_nocast exlude GVG TE maps from 'gvg' (flag &4)
 		unsigned gvg_te_castle : 1; // GVG WOE:TE Castle
 		unsigned hidemobhpbar : 1;
+		unsigned instakill : 1;
 #ifdef ADJUST_SKILL_DAMAGE
 		unsigned skill_damage : 1;
 #endif

--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -4190,6 +4190,8 @@ static const char* npc_parse_mapflag(char* w1, char* w2, char* w3, char* w4, con
 		map[m].flag.nocostume = state;
 	else if (!strcmpi(w3,"hidemobhpbar"))
 		map[m].flag.hidemobhpbar = state;
+	else if (!strcmpi(w3, "instakill"))
+		map[m].flag.instakill = state;
 	else if (!strcmpi(w3,"skill_damage")) {
 #ifdef ADJUST_SKILL_DAMAGE
 		char skill[SKILL_NAME_LENGTH];

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -460,6 +460,7 @@ enum {
 	MF_GVG_TE_CASTLE,
 	MF_GVG_TE,
 	MF_HIDEMOBHPBAR,
+	MF_INSTAKILL,
 };
 
 const char* script_op2name(int op)
@@ -12379,6 +12380,7 @@ BUILDIN_FUNC(setmapflag)
 				clif_map_property_mapall(m, MAPPROPERTY_AGITZONE);
 				break;
 			case MF_HIDEMOBHPBAR:		map[m].flag.hidemobhpbar = 1; break;
+			case MF_INSTAKILL:		map[m].flag.instakill = 1; break;
 #ifdef ADJUST_SKILL_DAMAGE
 			case MF_SKILL_DAMAGE:
 				{
@@ -12487,6 +12489,7 @@ BUILDIN_FUNC(removemapflag)
 				clif_map_property_mapall(m, MAPPROPERTY_NOTHING);
 				break;
 			case MF_HIDEMOBHPBAR:		map[m].flag.hidemobhpbar = 0; break;
+			case MF_INSTAKILL:			map[m].flag.instakill = 0; break;
 #ifdef ADJUST_SKILL_DAMAGE
 			case MF_SKILL_DAMAGE:
 				{

--- a/src/map/script_constants.h
+++ b/src/map/script_constants.h
@@ -436,6 +436,7 @@
 	export_constant(MF_GVG_TE_CASTLE);
 	export_constant(MF_GVG_TE);
 	export_constant(MF_HIDEMOBHPBAR);
+	export_constant(MF_INSTAKILL);
 
 	/* setcell types */
 	export_constant(CELL_WALKABLE);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-re/Re

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Had problems with tons of conflicts that broke the previous PR for MF_INSTAKILL.
Fixed.

* **Description of Pull Request**: 
Please check: https://rathena.org/board/topic/111199-release-instakill-mapflag/

**Purpose**
Create a mapflag for instakill. As it would suggest, all damages done within the map will be amplified to max damage, thus instakilling the target.
It works for the following use cases:
1. Player attacking a Monster
2. Player attacking another Player
3. Monster attacking a Player
4. Monster attacking another monster
Where "Monster" can be a normal mob or a Homunculus

**Usage**
In-game: @mapflag instakill [0|1]
Script as mapflag: prontera"tab"mapflag"tab"instakill
Script as used in setmapflag: setmapflag .EventMap$, mf_instakill;

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
