### PR TITLE
Fix/#412. Allow negative bBaseAtk scripts

### DIFF
--- a/src/map/pc.c
+++ b/src/map/pc.c
@@ -2485,7 +2485,7 @@ void pc_bonus(struct map_session_data *sd,int type,int val)
 				sd->bonus.eatk += val;
 #else
 				bonus = status->batk + val;
-				status->batk = cap_value(bonus, 0, USHRT_MAX);
+				status->batk = cap_value(bonus, SHRT_MIN, SHRT_MAX);
 #endif
 			}
 			break;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2074,8 +2074,7 @@ struct status_data {
 		hp, sp,  // see status_cpy before adding members before hp and sp
 		max_hp, max_sp;
 	short
-		str, agi, vit, int_, dex, luk;
-	unsigned short
+		str, agi, vit, int_, dex, luk,
 		batk,
 #ifdef RENEWAL
 		watk,

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2075,12 +2075,14 @@ struct status_data {
 		max_hp, max_sp;
 	short
 		str, agi, vit, int_, dex, luk,
-		batk,
+		batk
 #ifdef RENEWAL
 		watk,
 		watk2,
-		eatk,
+		eatk
 #endif
+		;
+	unsigned short
 		matk_min, matk_max,
 		speed,
 		amotion, adelay, dmotion;

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -2075,13 +2075,13 @@ struct status_data {
 		max_hp, max_sp;
 	short
 		str, agi, vit, int_, dex, luk,
-		batk
+		batk;
 #ifdef RENEWAL
+	short
 		watk,
 		watk2,
-		eatk
+		eatk;
 #endif
-		;
 	unsigned short
 		matk_min, matk_max,
 		speed,


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #412 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre and Re

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixed problem about map-server not being able to parse negative bBaseAtk values. Changed variable types of bAtk, watk, watk2 and eatk to SHORT instead of USHORT. Changed cap value of status->bAtk to SHRT_MIN to SHRT_MAX instead of 0 to USHRT_MAX.

Test Cases:
1. Status window update Base attack
* Pre: Adjustment should only affect Base attack
    - [x] 64bit
    - [x] 32bit
* Pre: Adjustment should only affect Bonus
    - [x] 64bit
    - [x] 32bit

2. Atk damage adjustment is evident when attacking monsters
    - [x] 64bit: Pre and Re
    - [x] 32bit: Pre and Re
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
