### PR TITLE
Updated sleep2:

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6383,7 +6383,7 @@ sleep and sleep2 will pause the script for the given amount of milliseconds.
 Awake is used to cancel a sleep. When awake is called on a NPC it will run as
 if the sleep timer ran out, and thus making the script continue. Sleep and sleep2
 basically do the same, but the main difference is that sleep will not keep the rid,
-while sleep2 does. Also sleep2 will stop the script if there is none unit attached.
+while sleep2 does. Also sleep2 will stop the script if there is no unit attached.
 
 Examples:
 	sleep 10000; //pause the script for 10 seconds and ditch the RID (so no player is attached anymore)

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6383,7 +6383,7 @@ sleep and sleep2 will pause the script for the given amount of milliseconds.
 Awake is used to cancel a sleep. When awake is called on a NPC it will run as
 if the sleep timer ran out, and thus making the script continue. Sleep and sleep2
 basically do the same, but the main difference is that sleep will not keep the rid,
-while sleep2 does.
+while sleep2 does. Also sleep2 will stop the script if there is none unit attached.
 
 Examples:
 	sleep 10000; //pause the script for 10 seconds and ditch the RID (so no player is attached anymore)

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -4089,8 +4089,8 @@ int run_script_timer(int tid, unsigned int tick, int id, intptr_t data)
 
 		// Attached player is offline or another unit type - should not happen
 		if( !sd ){
-			ShowWarning( "Script sleep timer called by an offline character or non player unit.\n" );
-			script_reportsrc(st);
+			// ShowWarning( "Script sleep timer called by an offline character or non player unit.\n" );
+			// script_reportsrc(st);
 			st->rid = 0;
 			st->state = END;
 		// Character mismatch. Cancel execution.
@@ -18410,7 +18410,7 @@ BUILDIN_FUNC(sleep)
 }
 
 /// Pauses the execution of the script, keeping the unit attached
-/// Returns if the unit is still attached
+/// Stop the script if none unit attached
 ///
 /// sleep2(<mili secconds>) -> <bool>
 BUILDIN_FUNC(sleep2)
@@ -18419,20 +18419,17 @@ BUILDIN_FUNC(sleep2)
 
 	ticks = script_getnum(st,2);
 
-	if( ticks <= 0 )
-	{// do nothing
-		script_pushint(st, (map_id2bl(st->rid)!=NULL));
-	}
-	else if( !st->sleep.tick )
-	{// sleep for the target amount of time
+	if (ticks <= 0) {
+		return SCRIPT_CMD_SUCCESS;
+	} else if (map_id2bl(st->rid) == NULL) {
+		st->rid = 0;
+		st->state = END;
+	} else if (!st->sleep.tick) {// sleep for the target amount of time
 		st->state = RERUNLINE;
 		st->sleep.tick = ticks;
-	}
-	else
-	{// sleep time is over
+	} else {// sleep time is over
 		st->state = RUN;
 		st->sleep.tick = 0;
-		script_pushint(st, (map_id2bl(st->rid)!=NULL));
 	}
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18410,9 +18410,9 @@ BUILDIN_FUNC(sleep)
 }
 
 /// Pauses the execution of the script, keeping the unit attached
-/// Stop the script if none unit attached
+/// Stop the script if no unit attached
 ///
-/// sleep2(<mili secconds>) -> <bool>
+/// sleep2(<milli seconds>)
 BUILDIN_FUNC(sleep2)
 {
 	int ticks;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18384,26 +18384,30 @@ BUILDIN_FUNC(unitskillusepos)
 /// sleep <mili seconds>;
 BUILDIN_FUNC(sleep)
 {
-	int ticks;
+	// First call(by function call)
+	if (st->sleep.tick == 0) {
+		int ticks;
 
-	ticks = script_getnum(st,2);
+		ticks = script_getnum(st, 2);
 
-	// detach the player
-	script_detach_rid(st);
+		if (ticks <= 0) {
+			ShowError("buildin_sleep2: negative amount('%d') of milli seconds is not supported\n", ticks);
+			return SCRIPT_CMD_FAILURE;
+		}
 
-	if( ticks <= 0 )
-	{// do nothing
-	}
-	else if( st->sleep.tick == 0 )
-	{// sleep for the target amount of time
+		// detach the player
+		script_detach_rid(st);
+
+		// sleep for the target amount of time
 		st->state = RERUNLINE;
 		st->sleep.tick = ticks;
-	}
-	else
-	{// sleep time is over
+	// Second call(by timer after sleeping time is over)
+	} else {		
+		// Continue the script
 		st->state = RUN;
 		st->sleep.tick = 0;
 	}
+
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -18414,7 +18418,7 @@ BUILDIN_FUNC(sleep)
 BUILDIN_FUNC(sleep2)
 {
 	// First call(by function call)
-	if (!st->sleep.tick) {
+	if (st->sleep.tick == 0) {
 		int ticks;
 
 		ticks = script_getnum(st, 2);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -18412,7 +18412,7 @@ BUILDIN_FUNC(sleep)
 }
 
 /// Pauses the execution of the script, keeping the unit attached
-/// Stop the script if no unit attached
+/// Stops the script if no unit is attached
 ///
 /// sleep2(<milli seconds>)
 BUILDIN_FUNC(sleep2)


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Currently sleep2 is supposed to return 0 or 1 if the unit is still attached. Actually mapserv throws a warning and the script end if the timer is still running and unit offline. With this update the script end if there is no unit attached for sleep2.