### PR TITLE
Resolved function timers not being freed properly

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -3689,6 +3689,7 @@ static const char* npc_parse_function(char* w1, char* w2, char* w3, char* w4, co
 		struct script_code *oldscript = (struct script_code*)db_data2ptr(&old_data);
 
 		ShowInfo("npc_parse_function: Overwriting user function [%s] (%s:%d)\n", w3, filepath, strline(buffer,start-buffer));
+		script_stop_scriptinstances(oldscript);
 		script_free_vars(oldscript->local.vars);
 		aFree(oldscript->script_buf);
 		aFree(oldscript);

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -3483,7 +3483,7 @@ void script_free_code(struct script_code* code)
 	nullpo_retv(code);
 
 	if (code->instances)
-		script_stop_instances(code);
+		script_stop_scriptinstances(code);
 	script_free_vars(code->local.vars);
 	if (code->local.arrays)
 		code->local.arrays->destroy(code->local.arrays, script_free_array_db);
@@ -4058,7 +4058,11 @@ void run_script(struct script_code *rootscript, int pos, int rid, int oid)
 	run_script_main(st);
 }
 
-void script_stop_instances(struct script_code *code) {
+/**
+ * Free all related script code
+ * @param code: Script code to free
+ */
+void script_stop_scriptinstances(struct script_code *code) {
 	DBIterator *iter;
 	struct script_state* st;
 

--- a/src/map/script.h
+++ b/src/map/script.h
@@ -730,7 +730,7 @@ void script_stop_sleeptimers(int id);
 struct linkdb_node *script_erase_sleepdb(struct linkdb_node *n);
 void run_script_main(struct script_state *st);
 
-void script_stop_instances(struct script_code *code);
+void script_stop_scriptinstances(struct script_code *code);
 void script_free_code(struct script_code* code);
 void script_free_vars(struct DBMap *storage);
 struct script_state* script_alloc_state(struct script_code* rootscript, int pos, int rid, int oid);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2216

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Properly free a function's timer when reloading scripts.
  * Renamed script_stop_instances to not confuse it with the Instance System.
Thanks to @Tokeiburu!