### PR TITLE
Disable instances from using OnPC Events

### DIFF
--- a/src/map/npc.c
+++ b/src/map/npc.c
@@ -340,10 +340,10 @@ static int npc_event_export(struct npc_data *nd, int i)
 		char buf[EVENT_NAME_LENGTH];
 
 		if (nd->bl.m > -1 && map[nd->bl.m].instance_id > 0) { // Block script events in instances
-			int i;
+			int j;
 
-			for (i = 0; i < NPCE_MAX; i++) {
-				if (strcmpi(npc_get_script_event_name(i), lname) == 0) {
+			for (j = 0; j < NPCE_MAX; j++) {
+				if (strcmpi(npc_get_script_event_name(j), lname) == 0) {
 					ShowWarning("npc_event_export: attempting to duplicate a script event in an instance (%s::%s), ignoring\n", nd->name, lname);
 					return 0;
 				}

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -41,12 +41,6 @@ struct s_npc_buy_list {
 	unsigned short nameid;	///< ID of item will be bought
 };
 
-// Event script list
-struct npc_event_script {
-	char *name;
-	const char *event_name;
-};
-
 struct npc_data {
 	struct block_list bl;
 	struct unit_data  ud; //Because they need to be able to move....

--- a/src/map/npc.h
+++ b/src/map/npc.h
@@ -41,6 +41,12 @@ struct s_npc_buy_list {
 	unsigned short nameid;	///< ID of item will be bought
 };
 
+// Event script list
+struct npc_event_script {
+	char *name;
+	const char *event_name;
+};
+
 struct npc_data {
 	struct block_list bl;
 	struct unit_data  ud; //Because they need to be able to move....
@@ -159,6 +165,7 @@ void npc_parse_mob2(struct spawn_data* mob);
 bool npc_viewisid(const char * viewid);
 struct npc_data* npc_add_warp(char* name, short from_mapid, short from_x, short from_y, short xs, short ys, unsigned short to_mapindex, short to_x, short to_y);
 int npc_globalmessage(const char* name,const char* mes);
+const char *npc_get_script_event_name(int npce_index);
 
 void npc_setcells(struct npc_data* nd);
 void npc_unsetcells(struct npc_data* nd);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2273

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Disable the use of OnPC Events in instance scripts since player's aren't actually attached to the event thus causing a crash.
Thanks to @Tokeiburu!