### PR TITLE
reloadmobdb clears db/mob_drop.txt

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5199,6 +5199,7 @@ void mob_reload(void) {
 			memset(&mob_db_data[i]->skill,0,sizeof(mob_db_data[i]->skill));
 			mob_db_data[i]->maxskill = 0;
 			memset(&mob_db_data[i]->dropitem, 0, sizeof(mob_db_data[i]->dropitem));
+			memset(&mob_db_data[i]->mvpitem, 0, sizeof(mob_db_data[i]->mvpitem));
 		}
 	}
 

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5193,10 +5193,12 @@ void mob_reload(void) {
 	int i;
 
 	//Mob skills need to be cleared before re-reading them. [Skotlex]
+	//Also clear mob drops to reload db/../mob_drop.txt
 	for (i = 0; i < MAX_MOB_DB; i++) {
 		if (mob_db_data[i]) {
 			memset(&mob_db_data[i]->skill,0,sizeof(mob_db_data[i]->skill));
 			mob_db_data[i]->maxskill = 0;
+			memset(&mob_db_data[i]->dropitem, 0, sizeof(mob_db_data[i]->dropitem));
 		}
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #2304 

* **Server Mode**: Both

* **Description of Pull Request**: 
When using `@reloadmobdb`, the mob drop lists need to be cleared on reload since it can't be handled in `mob_readdb_drop`.