### PR TITLE
Made view_data for mob unit changes persistent

### DIFF
--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -336,7 +336,7 @@ int mobdb_checkid(const int id)
 struct view_data * mob_get_viewdata(int mob_id)
 {
 	if (mob_db(mob_id) == mob_dummy)
-		return 0;
+		return NULL;
 	return &mob_db(mob_id)->vd;
 }
 /*==========================================

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5201,9 +5201,26 @@ void mob_db_load(void){
 	mob_load();
 }
 
+static int mob_reload_sub( struct mob_data *md, va_list args ){
+	if( md->bl.prev == NULL ){
+		return 0;
+	}
+
+	if( !md->vd_changed ){
+		md->vd = mob_get_viewdata(md->mob_id);
+
+		// Respawn all mobs on client side so that they are displayed correctly(if their view id changed)
+		clif_clearunit_area(&md->bl, CLR_OUTSIGHT);
+		clif_spawn(&md->bl);
+	}
+
+	return 0;
+}
+
 void mob_reload(void) {
 	do_final_mob();
 	mob_db_load();
+	map_foreachmob(mob_reload_sub);
 }
 
 void mob_clear_spawninfo()

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -340,6 +340,10 @@ struct view_data * mob_get_viewdata(int mob_id)
 	return &mob_db(mob_id)->vd;
 }
 
+/**
+ * Create unique view data associated to a spawned monster.
+ * @param md: Mob to adjust
+ */
 void mob_set_dynamic_viewdata( struct mob_data* md ){
 	// If it is a valid monster and it has not already been created
 	if( md && !md->vd_changed ){
@@ -357,6 +361,10 @@ void mob_set_dynamic_viewdata( struct mob_data* md ){
 	}
 }
 
+/**
+ * Free any view data associated to a spawned monster.
+ * @param md: Mob to free
+ */
 void mob_free_dynamic_viewdata( struct mob_data* md ){
 	// If it is a valid monster and it has already been allocated
 	if( md && md->vd_changed ){
@@ -5221,6 +5229,9 @@ static void mob_load(void)
 	mob_skill_db_set();
 }
 
+/**
+ * Initialize monster data
+ */
 void mob_db_load(void){
 	memset(mob_db_data,0,sizeof(mob_db_data)); //Clear the array
 	mob_db_data[0] = (struct mob_db*)aCalloc(1, sizeof (struct mob_db));	//This mob is used for random spawns
@@ -5233,6 +5244,12 @@ void mob_db_load(void){
 	mob_load();
 }
 
+/**
+ * Apply the proper view data on monsters during mob_db reload.
+ * @param md: Mob to adjust
+ * @param args: va_list of arguments
+ * @return 0
+ */
 static int mob_reload_sub( struct mob_data *md, va_list args ){
 	if( md->bl.prev == NULL ){
 		return 0;
@@ -5251,12 +5268,18 @@ static int mob_reload_sub( struct mob_data *md, va_list args ){
 	return 0;
 }
 
+/**
+ * Reload monster data
+ */
 void mob_reload(void) {
 	do_final_mob();
 	mob_db_load();
 	map_foreachmob(mob_reload_sub);
 }
 
+/**
+ * Clear spawn data for all monsters
+ */
 void mob_clear_spawninfo()
 {	//Clears spawn related information for a script reload.
 	int i;

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -299,6 +299,8 @@ int mobdb_searchname(const char *str);
 int mobdb_searchname_array(struct mob_db** data, int size, const char *str);
 int mobdb_checkid(const int id);
 struct view_data* mob_get_viewdata(int mob_id);
+void mob_set_dynamic_viewdata( struct mob_data* md );
+void mob_free_dynamic_viewdata( struct mob_data* md );
 
 struct mob_data *mob_once_spawn_sub(struct block_list *bl, int16 m, int16 x, int16 y, const char *mobname, int mob_id, const char *event, unsigned int size, unsigned int ai);
 

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -173,6 +173,7 @@ struct mob_data {
 	struct block_list bl;
 	struct unit_data  ud;
 	struct view_data *vd;
+	bool vd_changed;
 	struct status_data status, *base_status; //Second one is in case of leveling up mobs, or tiny/large mobs.
 	struct status_change sc;
 	struct mob_db *db;	//For quick data access (saves doing mob_db(md->mob_id) all the time) [Skotlex]

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17763,6 +17763,21 @@ BUILDIN_FUNC(setunitdata)
 			md->base_status = (struct status_data*)aCalloc(1, sizeof(struct status_data));
 			memcpy(md->base_status, &md->db->status, sizeof(struct status_data));
 		}
+
+#define MOB_VD_CHANGE(vd_field,clif_look) { \
+			struct view_data* mobdb_vd = mob_get_viewdata(md->mob_id); \
+			\
+			if( !md->vd_changed ){ \
+				md->vd = (struct view_data*)aMalloc( sizeof( struct view_data ) ); \
+				memcpy( md->vd, mobdb_vd, sizeof( struct view_data ) ); \
+				md->vd_changed = true; \
+			} \
+			\
+			md->vd->vd_field = value; \
+			\
+			clif_changelook(bl, clif_look, (unsigned short)value); \
+		}
+
 		switch (type) {
 			case UMOB_SIZE: md->base_status->size = (unsigned char)value; calc_status = true; break;
 			case UMOB_LEVEL: md->level = (unsigned short)value; break;
@@ -17778,14 +17793,14 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_SCOPTION: md->sc.option = (unsigned short)value; break;
 			case UMOB_SEX: md->vd->sex = (char)value; break;
 			case UMOB_CLASS: status_set_viewdata(bl, (unsigned short)value); break;
-			case UMOB_HAIRSTYLE: clif_changelook(bl, LOOK_HAIR, (unsigned short)value); break;
-			case UMOB_HAIRCOLOR: clif_changelook(bl, LOOK_HAIR_COLOR, (unsigned short)value); break;
-			case UMOB_HEADBOTTOM: clif_changelook(bl, LOOK_HEAD_BOTTOM, (unsigned short)value); break;
-			case UMOB_HEADMIDDLE: clif_changelook(bl, LOOK_HEAD_MID, (unsigned short)value); break;
-			case UMOB_HEADTOP: clif_changelook(bl, LOOK_HEAD_TOP, (unsigned short)value); break;
-			case UMOB_CLOTHCOLOR: clif_changelook(bl, LOOK_CLOTHES_COLOR, (unsigned short)value); break;
-			case UMOB_SHIELD: clif_changelook(bl, LOOK_SHIELD, (unsigned short)value); break;
-			case UMOB_WEAPON: clif_changelook(bl, LOOK_WEAPON, (unsigned short)value); break;
+			case UMOB_HAIRSTYLE: MOB_VD_CHANGE(hair_style, LOOK_HAIR); break;
+			case UMOB_HAIRCOLOR: MOB_VD_CHANGE(hair_color, LOOK_HAIR_COLOR); break;
+			case UMOB_HEADBOTTOM: MOB_VD_CHANGE(head_bottom, LOOK_HEAD_BOTTOM); break;
+			case UMOB_HEADMIDDLE: MOB_VD_CHANGE(head_mid, LOOK_HEAD_MID); break;
+			case UMOB_HEADTOP: MOB_VD_CHANGE(head_top, LOOK_HEAD_TOP); break;
+			case UMOB_CLOTHCOLOR: MOB_VD_CHANGE(cloth_color, LOOK_CLOTHES_COLOR); break;
+			case UMOB_SHIELD: MOB_VD_CHANGE(shield, LOOK_SHIELD); break;
+			case UMOB_WEAPON: MOB_VD_CHANGE(weapon, LOOK_WEAPON); break;
 			case UMOB_LOOKDIR: unit_setdir(bl, (uint8)value); break;
 			case UMOB_CANMOVETICK: md->ud.canmove_tick = value > 0 ? (unsigned int)value : 0; break;
 			case UMOB_STR: md->base_status->str = (unsigned short)value; status_calc_misc(bl, &md->status, md->level); calc_status = true; break;
@@ -17831,6 +17846,7 @@ BUILDIN_FUNC(setunitdata)
 			}
 			if (calc_status)
 				status_calc_bl(&md->bl, SCB_BATTLE);
+#undef MOB_VD_CHANGE
 		break;
 
 	case BL_HOM:

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17764,14 +17764,20 @@ BUILDIN_FUNC(setunitdata)
 			memcpy(md->base_status, &md->db->status, sizeof(struct status_data));
 		}
 
-#define MOB_VD_CHANGE() { \
-			struct view_data* mobdb_vd = mob_get_viewdata(md->mob_id); \
-			\
-			if( !md->vd_changed ){ \
-				md->vd = (struct view_data*)aMalloc( sizeof( struct view_data ) ); \
-				memcpy( md->vd, mobdb_vd, sizeof( struct view_data ) ); \
-				md->vd_changed = true; \
-			} \
+		// Check if the view data will be modified
+		switch( type ){
+			case UMOB_SEX:
+			//case UMOB_CLASS: // Called by status_set_viewdata
+			case UMOB_HAIRSTYLE:
+			case UMOB_HAIRCOLOR:
+			case UMOB_HEADBOTTOM:
+			case UMOB_HEADMIDDLE:
+			case UMOB_HEADTOP:
+			case UMOB_CLOTHCOLOR:
+			case UMOB_SHIELD:
+			case UMOB_WEAPON:
+				mob_set_dynamic_viewdata( md );
+				break;
 		}
 
 		switch (type) {
@@ -17787,16 +17793,16 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_MODE: md->base_status->mode = (enum e_mode)value; calc_status = true; break;
 			case UMOB_AI: md->special_state.ai = (enum mob_ai)value; break;
 			case UMOB_SCOPTION: md->sc.option = (unsigned short)value; break;
-			case UMOB_SEX: MOB_VD_CHANGE(); md->vd->sex = (char)value; clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
+			case UMOB_SEX: md->vd->sex = (char)value; clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
 			case UMOB_CLASS: status_set_viewdata(bl, (unsigned short)value); clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
-			case UMOB_HAIRSTYLE: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR, (unsigned short)value); break;
-			case UMOB_HAIRCOLOR: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR_COLOR, (unsigned short)value); break;
-			case UMOB_HEADBOTTOM: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_BOTTOM, (unsigned short)value); break;
-			case UMOB_HEADMIDDLE: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_MID, (unsigned short)value); break;
-			case UMOB_HEADTOP: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_TOP, (unsigned short)value); break;
-			case UMOB_CLOTHCOLOR: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_CLOTHES_COLOR, (unsigned short)value); break;
-			case UMOB_SHIELD: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_SHIELD, (unsigned short)value); break;
-			case UMOB_WEAPON: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_WEAPON, (unsigned short)value); break;
+			case UMOB_HAIRSTYLE: clif_changelook(bl, LOOK_HAIR, (unsigned short)value); break;
+			case UMOB_HAIRCOLOR: clif_changelook(bl, LOOK_HAIR_COLOR, (unsigned short)value); break;
+			case UMOB_HEADBOTTOM: clif_changelook(bl, LOOK_HEAD_BOTTOM, (unsigned short)value); break;
+			case UMOB_HEADMIDDLE: clif_changelook(bl, LOOK_HEAD_MID, (unsigned short)value); break;
+			case UMOB_HEADTOP: clif_changelook(bl, LOOK_HEAD_TOP, (unsigned short)value); break;
+			case UMOB_CLOTHCOLOR: clif_changelook(bl, LOOK_CLOTHES_COLOR, (unsigned short)value); break;
+			case UMOB_SHIELD: clif_changelook(bl, LOOK_SHIELD, (unsigned short)value); break;
+			case UMOB_WEAPON: clif_changelook(bl, LOOK_WEAPON, (unsigned short)value); break;
 			case UMOB_LOOKDIR: unit_setdir(bl, (uint8)value); break;
 			case UMOB_CANMOVETICK: md->ud.canmove_tick = value > 0 ? (unsigned int)value : 0; break;
 			case UMOB_STR: md->base_status->str = (unsigned short)value; status_calc_misc(bl, &md->status, md->level); calc_status = true; break;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17764,7 +17764,7 @@ BUILDIN_FUNC(setunitdata)
 			memcpy(md->base_status, &md->db->status, sizeof(struct status_data));
 		}
 
-#define MOB_VD_CHANGE(vd_field,clif_look) { \
+#define MOB_VD_CHANGE() { \
 			struct view_data* mobdb_vd = mob_get_viewdata(md->mob_id); \
 			\
 			if( !md->vd_changed ){ \
@@ -17772,10 +17772,6 @@ BUILDIN_FUNC(setunitdata)
 				memcpy( md->vd, mobdb_vd, sizeof( struct view_data ) ); \
 				md->vd_changed = true; \
 			} \
-			\
-			md->vd->vd_field = value; \
-			\
-			clif_changelook(bl, clif_look, (unsigned short)value); \
 		}
 
 		switch (type) {
@@ -17791,16 +17787,16 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_MODE: md->base_status->mode = (enum e_mode)value; calc_status = true; break;
 			case UMOB_AI: md->special_state.ai = (enum mob_ai)value; break;
 			case UMOB_SCOPTION: md->sc.option = (unsigned short)value; break;
-			case UMOB_SEX: md->vd->sex = (char)value; break;
+			case UMOB_SEX: MOB_VD_CHANGE(); md->vd->sex = (char)value; clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
 			case UMOB_CLASS: status_set_viewdata(bl, (unsigned short)value); break;
-			case UMOB_HAIRSTYLE: MOB_VD_CHANGE(hair_style, LOOK_HAIR); break;
-			case UMOB_HAIRCOLOR: MOB_VD_CHANGE(hair_color, LOOK_HAIR_COLOR); break;
-			case UMOB_HEADBOTTOM: MOB_VD_CHANGE(head_bottom, LOOK_HEAD_BOTTOM); break;
-			case UMOB_HEADMIDDLE: MOB_VD_CHANGE(head_mid, LOOK_HEAD_MID); break;
-			case UMOB_HEADTOP: MOB_VD_CHANGE(head_top, LOOK_HEAD_TOP); break;
-			case UMOB_CLOTHCOLOR: MOB_VD_CHANGE(cloth_color, LOOK_CLOTHES_COLOR); break;
-			case UMOB_SHIELD: MOB_VD_CHANGE(shield, LOOK_SHIELD); break;
-			case UMOB_WEAPON: MOB_VD_CHANGE(weapon, LOOK_WEAPON); break;
+			case UMOB_HAIRSTYLE: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR, (unsigned short)value); break;
+			case UMOB_HAIRCOLOR: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR_COLOR, (unsigned short)value); break;
+			case UMOB_HEADBOTTOM: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_BOTTOM, (unsigned short)value); break;
+			case UMOB_HEADMIDDLE: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_MID, (unsigned short)value); break;
+			case UMOB_HEADTOP: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_TOP, (unsigned short)value); break;
+			case UMOB_CLOTHCOLOR: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_CLOTHES_COLOR, (unsigned short)value); break;
+			case UMOB_SHIELD: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_SHIELD, (unsigned short)value); break;
+			case UMOB_WEAPON: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_WEAPON, (unsigned short)value); break;
 			case UMOB_LOOKDIR: unit_setdir(bl, (uint8)value); break;
 			case UMOB_CANMOVETICK: md->ud.canmove_tick = value > 0 ? (unsigned int)value : 0; break;
 			case UMOB_STR: md->base_status->str = (unsigned short)value; status_calc_misc(bl, &md->status, md->level); calc_status = true; break;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17788,7 +17788,7 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_AI: md->special_state.ai = (enum mob_ai)value; break;
 			case UMOB_SCOPTION: md->sc.option = (unsigned short)value; break;
 			case UMOB_SEX: MOB_VD_CHANGE(); md->vd->sex = (char)value; clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
-			case UMOB_CLASS: status_set_viewdata(bl, (unsigned short)value); break;
+			case UMOB_CLASS: status_set_viewdata(bl, (unsigned short)value); clif_clearunit_area(bl, CLR_OUTSIGHT); clif_spawn(bl); break;
 			case UMOB_HAIRSTYLE: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR, (unsigned short)value); break;
 			case UMOB_HAIRCOLOR: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HAIR_COLOR, (unsigned short)value); break;
 			case UMOB_HEADBOTTOM: MOB_VD_CHANGE(); clif_changelook(bl, LOOK_HEAD_BOTTOM, (unsigned short)value); break;

--- a/src/map/script.c
+++ b/src/map/script.c
@@ -17848,7 +17848,6 @@ BUILDIN_FUNC(setunitdata)
 			}
 			if (calc_status)
 				status_calc_bl(&md->bl, SCB_BATTLE);
-#undef MOB_VD_CHANGE
 		break;
 
 	case BL_HOM:

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7672,9 +7672,15 @@ void status_set_viewdata(struct block_list *bl, int class_)
 	case BL_MOB:
 		{
 			TBL_MOB* md = (TBL_MOB*)bl;
-			if (vd)
+			if (vd){
+				if( md->vd_changed ){
+					aFree(md->vd);
+					md->vd = NULL;
+					md->vd_changed = false;
+				}
+
 				md->vd = vd;
-			else
+			}else
 				ShowError("status_set_viewdata (MOB): No view data for class %d\n", class_);
 		}
 	break;

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7673,20 +7673,11 @@ void status_set_viewdata(struct block_list *bl, int class_)
 		{
 			TBL_MOB* md = (TBL_MOB*)bl;
 			if (vd){
-				if( md->vd_changed ){
-					aFree(md->vd);
-					md->vd = NULL;
-					md->vd_changed = false;
-				}
+				mob_free_dynamic_viewdata( md );
 
 				md->vd = vd;
 			}else if( pcdb_checkid( class_ ) ){
-				if( !md->vd_changed ){
-					vd = (struct view_data*)aMalloc( sizeof( struct view_data ) );
-					memcpy( vd, md->vd, sizeof( struct view_data ) );
-					md->vd = vd;
-					md->vd_changed = true;
-				}
+				mob_set_dynamic_viewdata( md );
 
 				md->vd->class_ = class_;
 			}else

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -7680,6 +7680,15 @@ void status_set_viewdata(struct block_list *bl, int class_)
 				}
 
 				md->vd = vd;
+			}else if( pcdb_checkid( class_ ) ){
+				if( !md->vd_changed ){
+					vd = (struct view_data*)aMalloc( sizeof( struct view_data ) );
+					memcpy( vd, md->vd, sizeof( struct view_data ) );
+					md->vd = vd;
+					md->vd_changed = true;
+				}
+
+				md->vd->class_ = class_;
 			}else
 				ShowError("status_set_viewdata (MOB): No view data for class %d\n", class_);
 		}

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -3305,11 +3305,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 		case BL_MOB: {
 			struct mob_data *md = (struct mob_data*)bl;
 
-			if( md->vd_changed ){
-				aFree(md->vd);
-				md->vd = NULL;
-				md->vd_changed = false;
-			}
+			mob_free_dynamic_viewdata( md );
 
 			if( md->spawn_timer != INVALID_TIMER ) {
 				delete_timer(md->spawn_timer,mob_delayspawn);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -3305,6 +3305,12 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 		case BL_MOB: {
 			struct mob_data *md = (struct mob_data*)bl;
 
+			if( md->vd_changed ){
+				aFree(md->vd);
+				md->vd = NULL;
+				md->vd_changed = false;
+			}
+
 			if( md->spawn_timer != INVALID_TIMER ) {
 				delete_timer(md->spawn_timer,mob_delayspawn);
 				md->spawn_timer = INVALID_TIMER;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2269, #2326 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Introduced a new variable to flag a view_data pointer as changed so that we are able to differentiate between original mob_db entries and customized ones. Additionally changes to these unit data types are persisted now as well. Before they were only sent to all inside the area when the command was executed.

Thanks to @Yuchinin for reporting this issue.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
