### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,9 @@ relevant to your Operation System, please refer to the Wiki (links at the end of
 	* Configure and compile:
 
 				./configure && make clean && make server
-				
 	* Configure and compile (for Centos 64 bit with Maria DB):
 
 				./configure --enable-64bit --with-MYSQL_LIBS=/usr/lib64/libmysqlclient.so && make clean && make server
-				
 	* When you're ready, start the servers:
 
 				./athena-start start

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ relevant to your Operation System, please refer to the Wiki (links at the end of
 	* Configure and compile:
 
 				./configure && make clean && make server
+				
+	* Configure and compile (for Centos 64 bit with Maria DB):
+
+				./configure --enable-64bit --with-MYSQL_LIBS=/usr/lib64/libmysqlclient.so && make clean && make server
+				
 	* When you're ready, start the servers:
 
 				./athena-start start


### PR DESCRIPTION
Centos 64bit not work with only ./configure

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Cannot ./configure if youre using centos 64 bit with Maria DB, this function can help you to ./configure without any issue

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
