### PR TITLE
Fixed std::string reference being an incomplete type in inter.h

### DIFF
--- a/src/char/inter.h
+++ b/src/char/inter.h
@@ -11,6 +11,7 @@
 
 #ifdef __cplusplus // C codes can't see this
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 extern "C" {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2339

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixed std::string reference being an incomplete type in inter.h

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
