### PR TITLE
Corrected the Chorus skills damage bonus

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -2185,16 +2185,16 @@ static int battle_skill_damage(struct block_list *src, struct block_list *target
 
 /**
  * Calculates Minstrel/Wanderer bonus for Chorus skills.
- * @param sd Player who has Chorus skill active
+ * @param sd: Player who has Chorus skill active
  * @return Bonus value based on party count
  */
-static int battle_calc_chorusbonus(struct map_session_data *sd) {
+int battle_calc_chorusbonus(struct map_session_data *sd) {
 	int members = 0;
 
 	if (!sd || !sd->status.party_id)
 		return 0;
 
-	members = party_foreachsamemap(party_sub_count_class, sd, MAPID_THIRDMASK, MAPID_MINSTRELWANDERER);
+	members = party_foreachsamemap(party_sub_count_class, sd, 0, MAPID_THIRDMASK, MAPID_MINSTRELWANDERER);
 
 	if (members < 3)
 		return 0; // Bonus remains 0 unless 3 or more Minstrels/Wanderers are in the party.

--- a/src/map/battle.h
+++ b/src/map/battle.h
@@ -106,6 +106,8 @@ int64 battle_calc_bg_damage(struct block_list *src,struct block_list *bl,int64 d
 void battle_damage(struct block_list *src, struct block_list *target, int64 damage, int delay, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, unsigned short attack_type, bool additional_effects, unsigned int tick, bool spdamage);
 int battle_delay_damage (unsigned int tick, int amotion, struct block_list *src, struct block_list *target, int attack_type, uint16 skill_id, uint16 skill_lv, int64 damage, enum damage_lv dmg_lv, int ddelay, bool additional_effects, bool spdamage);
 
+int battle_calc_chorusbonus(struct map_session_data *sd);
+
 // Summary normal attack treatment (basic attack)
 enum damage_lv battle_weapon_attack( struct block_list *bl,struct block_list *target,unsigned int tick,int flag);
 

--- a/src/map/party.c
+++ b/src/map/party.c
@@ -1202,9 +1202,12 @@ int party_send_dot_remove(struct map_session_data *sd)
 	return 0;
 }
 
-// To use for Taekwon's "Fighting Chant"
-// int c = 0;
-// party_foreachsamemap(party_sub_count, sd, 0, &c);
+/**
+ * Check whether a party member is in autotrade or idle for count functions
+ * @param bl: Object invoking the counter
+ * @param ap: List of parameters
+ * @return 1 when neither autotrading and not idle or 0 otherwise
+ */
 int party_sub_count(struct block_list *bl, va_list ap)
 {
 	struct map_session_data *sd = (TBL_PC *)bl;
@@ -1218,7 +1221,12 @@ int party_sub_count(struct block_list *bl, va_list ap)
 	return 1;
 }
 
-// To use for counting classes in a party.
+/**
+ * To use for counting classes in a party.
+ * @param bl: Object invoking the counter
+ * @param ap: List of parameters: Class_Mask, Class_ID
+ * @return 1 when class exists in party or 0 otherwise
+ */
 int party_sub_count_class(struct block_list *bl, va_list ap)
 {
 	struct map_session_data *sd = (TBL_PC *)bl;

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1007,7 +1007,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 	enum sc_type status;
 	int skill;
 	int rate;
-	int chorusbonus = 0;
+	int chorusbonus;
 
 	nullpo_ret(src);
 	nullpo_ret(bl);
@@ -1064,13 +1064,8 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 
 	// Minstrel/Wanderer number check for chorus skills.
 	// Bonus remains 0 unless 3 or more Minstrels/Wanderers are in the party.
-	if( sd && sd->status.party_id ) {
-		chorusbonus = party_foreachsamemap(party_sub_count_class, sd, AREA_SIZE, MAPID_THIRDMASK, MAPID_MINSTRELWANDERER);
-		if( chorusbonus > 7 )
-			chorusbonus = 5; // Maximum effect possible from 7 or more Minstrels/Wanderers
-		else if( chorusbonus > 2 )
-			chorusbonus = chorusbonus - 2; // Effect bonus from additional Minstrels/Wanderers if not above the max possible.
-	}
+	if (sd && sd->status.party_id)
+		chorusbonus = battle_calc_chorusbonus(sd);
 
 	if( sd )
 	{ // These statuses would be applied anyway even if the damage was blocked by some skills. [Inkfish]
@@ -6078,7 +6073,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	struct status_data *sstatus, *tstatus;
 	struct status_change *tsc;
 	struct status_change_entry *tsce;
-	int chorusbonus = 0;
+	int chorusbonus;
 
 	int i = 0;
 	enum sc_type type;
@@ -6121,13 +6116,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	// Minstrel/Wanderer number check for chorus skills.
 	// Bonus remains 0 unless 3 or more Minstrels/Wanderers are in the party.
-	if( sd && sd->status.party_id ) {
-		chorusbonus = party_foreachsamemap(party_sub_count_class, sd, AREA_SIZE, MAPID_THIRDMASK, MAPID_MINSTRELWANDERER);
-		if( chorusbonus > 7 )
-			chorusbonus = 5; // Maximum effect possible from 7 or more Minstrels/Wanderers
-		else if( chorusbonus > 2 )
-			chorusbonus = chorusbonus - 2; // Effect bonus from additional Minstrels/Wanderers if not above the max possible.
-	}
+	if (sd && sd->status.party_id)
+		chorusbonus = battle_calc_chorusbonus(sd);
 
 	//Check for undead skills that convert a no-damage skill into a damage one. [Skotlex]
 	switch (skill_id) {

--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -1644,7 +1644,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 	case SR_HOWLINGOFLION:
 		sc_start(src,bl, SC_FEAR, 5 + 5 * skill_lv, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
-	case WM_SOUND_OF_DESTRUCTION: {
+	case WM_SOUND_OF_DESTRUCTION:
 		if( tsc && ( tsc->data[SC_SWINGDANCE] || tsc->data[SC_SYMPHONYOFLOVER] || tsc->data[SC_MOONLITSERENADE] || 
 		tsc->data[SC_RUSHWINDMILL] || tsc->data[SC_ECHOSONG] || tsc->data[SC_HARMONIZE] || 
 		tsc->data[SC_VOICEOFSIREN] || tsc->data[SC_DEEPSLEEP] || tsc->data[SC_SIRCLEOFNATURE] || 
@@ -1682,7 +1682,6 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 			status_change_end(bl, SC_BEYONDOFWARCRY, INVALID_TIMER);
 			status_change_end(bl, SC_UNLIMITEDHUMMINGVOICE, INVALID_TIMER);
 		}
-		
 		break;
 	case SO_EARTHGRAVE:
 		sc_start2(src,bl, SC_BLEEDING, 5 * skill_lv, skill_lv, src->id, skill_get_time2(skill_id, skill_lv));	// Need official rate. [LimitLine]


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Added the missing range value when searching the map.
  * Resolves an incorrect calculation in the bonus when less than 8 of the members are a Minstrel or Wanderer.
  * Added documentation.
  * Removed redundancy.
Thanks to @Tokeiburu!