### PR TITLE
Removed reset of monster drops on mobdb reload.

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4407,7 +4407,7 @@ void do_final(void)
 	do_final_pet();
 	do_final_homunculus();
 	do_final_mercenary();
-	do_final_mob();
+	do_final_mob(false);
 	do_final_msg();
 	do_final_skill();
 	do_final_status();

--- a/src/map/mob.h
+++ b/src/map/mob.h
@@ -337,7 +337,7 @@ void mob_heal(struct mob_data *md,unsigned int heal);
 
 void mob_clear_spawninfo();
 void do_init_mob(void);
-void do_final_mob(void);
+void do_final_mob(bool is_reload);
 
 int mob_timer_delete(int tid, unsigned int tick, int id, intptr_t data);
 int mob_deleteslave(struct mob_data *md);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2355

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Does not clear item_drop_ers on mobdbreload anymore.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->

I already tested this pr ingame. Seems to work fine. I'd just like to have input of another dev, if there are any concerns left.