### PR TITLE
Fixed msvc warning casting int to bool in getequiprefinecost

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -23590,7 +23590,7 @@ BUILDIN_FUNC(getequiprefinecost) {
 			weapon_lv = REFINE_TYPE_SHADOW;
 	}
 
-	script_pushint(st, status_get_refine_cost(weapon_lv, type, info));
+	script_pushint(st, status_get_refine_cost(weapon_lv, type, info != 0));
 
 	return SCRIPT_CMD_SUCCESS;
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2428 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Either

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Force int to bool in function call.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
