### PR TITLE
Fix duplicate NPC location

### DIFF
--- a/npc/re/merchants/shadow_refiner.txt
+++ b/npc/re/merchants/shadow_refiner.txt
@@ -140,4 +140,4 @@
 }
 
 //moc_paraup,45,185,5	duplicate(ShadowBlacksmith)	Shadow Blacksmith#eden1	4_F_JOB_BLACKSMITH // Commented out until it's added to the map index
-prt_in,59,54,3	duplicate(ShadowBlacksmith)	Shadow Blacksmith#itemmall	4_F_JOB_BLACKSMITH
+prt_in,61,54,3	duplicate(ShadowBlacksmith)	Shadow Blacksmith#itemmall	4_F_JOB_BLACKSMITH


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
The location of Shadow Blacksmith is same as Mighty Hammer (prt_in,59,54)
