### PR TITLE
Corrected Elemental Cure healing behavior

### DIFF
--- a/src/map/skill.c
+++ b/src/map/skill.c
@@ -10319,17 +10319,20 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case SO_EL_CURE:
 		if( sd ) {
 			struct elemental_data *ed = sd->ed;
-			int s_hp = sd->battle_status.hp * 10 / 100, s_sp = sd->battle_status.sp * 10 / 100;
-			int e_hp, e_sp;
+			int s_hp, s_sp;
 
-			if( !ed )	break;
+			if( !ed )
+				break;
+
+			s_hp = sd->battle_status.hp * 10 / 100;
+			s_sp = sd->battle_status.sp * 10 / 100;
+
 			if( !status_charge(&sd->bl,s_hp,s_sp) ) {
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				break;
 			}
-			e_hp = ed->battle_status.max_hp * 10 / 100;
-			e_sp = ed->battle_status.max_sp * 10 / 100;
-			status_heal(&ed->bl,e_hp,e_sp,3);
+
+			status_heal(&ed->bl,s_hp,s_sp,3);
 			clif_skill_nodamage(src,&ed->bl,skill_id,skill_lv,1);
 		}
 		break;


### PR DESCRIPTION
* **Addressed Issue(s)**: #2440

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * The HP/SP heal should be based on the caster's current HP/SP, not the Elemental's max HP/SP.
Thanks to @Barigas!