### PR TITLE
Shadow Refiner and getequiprefinecost 

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2760,6 +2760,9 @@ Valid information types are:
 REFINE_ZENY_COST       - Zeny
 REFINE_MATERIAL_ID     - Material Item ID
 
+This function will return -1 on failure. The function fails if the cost type
+is invalid or if there is no item in the equipment slot. 
+
 ---------------------------------------
 
 *getareadropitem("<map name>",<x1>,<y1>,<x2>,<y2>,<item>)

--- a/npc/re/merchants/shadow_refiner.txt
+++ b/npc/re/merchants/shadow_refiner.txt
@@ -19,9 +19,8 @@
 	for(.@i = 1; .@i <= .@indlen; .@i++)
 		.@menu$ = .@menu$ + (getequipisequiped(.@indices[.@i]) ? getequipname(.@indices[.@i]) : F_getpositionname(.@indices[.@i]) +"-[Not equipped]") +":";
 	.@menu$ = .@menu$ + "Refine info";
-	.@part = .@indices[select(.@menu$)];
-
-	if (.@part == .@indlen + 1) { // Refine info
+	.@choice = select(.@menu$);
+	if (.@choice == .@indlen + 1) { // Refine info
 		mes "[Shadow Blacksmith]";
 		mes "When a shadow item is refined, it gains extra bonuses very much like normal items.";
 		next;
@@ -36,6 +35,15 @@
 		mes "HD ores can be used for gear that is at least refine level +7 and will prevent breaking as long as you stay talking to me.";
 		close;
 	}
+	
+	.@part = .@indices[.@choice];
+	
+	if (!getequipisequiped(.@part)) {
+		mes "[Shadow Blacksmith]";
+		mes "There's nothing here!";
+		close;
+	}
+	
 	while(1) {
 		mes "[Shadow Blacksmith]";
 		mes "I require " + callfunc("F_InsertComma", .@zeny_cost) + " zeny as a fee for EACH refine attempt.";
@@ -85,7 +93,7 @@
 		.@choose = .@material[.@option-1];
 		if (!countitem(.@choose)) {
 			mes "[Shadow Blacksmith]";
-			mes "You do not have enough "+ getitemname(.@choose) +" / "+ getitemname(.@choose) +".";
+			mes "You do not have enough "+ getitemname(.@choose) +".";
 			close;
 		}
 		if (Zeny < .@zeny_cost) {

--- a/npc/re/merchants/shadow_refiner.txt
+++ b/npc/re/merchants/shadow_refiner.txt
@@ -15,12 +15,13 @@
 	mes "Do you want to refine a shadow item? Pick yer poison!";
 	next;
 	setarray .@indices[1], EQI_SHADOW_ARMOR, EQI_SHADOW_WEAPON, EQI_SHADOW_SHIELD, EQI_SHADOW_SHOES, EQI_SHADOW_ACC_R, EQI_SHADOW_ACC_L;
-	for(.@i = 1; .@i <= EQI_SHADOW_ACC_L; .@i++)
+	.@indlen = getarraysize(.@indices) - 1;
+	for(.@i = 1; .@i <= .@indlen; .@i++)
 		.@menu$ = .@menu$ + (getequipisequiped(.@indices[.@i]) ? getequipname(.@indices[.@i]) : F_getpositionname(.@indices[.@i]) +"-[Not equipped]") +":";
 	.@menu$ = .@menu$ + "Refine info";
 	.@part = .@indices[select(.@menu$)];
 
-	if (.@part == EQI_SHADOW_ACC_L + 1) { // Refine info
+	if (.@part == .@indlen + 1) { // Refine info
 		mes "[Shadow Blacksmith]";
 		mes "When a shadow item is refined, it gains extra bonuses very much like normal items.";
 		next;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -23565,6 +23565,7 @@ BUILDIN_FUNC(achievementupdate) {
 /**
  * Get an equipment's refine cost
  * getequiprefinecost(<equipment slot>,<type>,<information>{,<char id>})
+ * returns -1 on fail
  */
 BUILDIN_FUNC(getequiprefinecost) {
 	int i = -1, slot, type, info;
@@ -23579,8 +23580,18 @@ BUILDIN_FUNC(getequiprefinecost) {
 		return SCRIPT_CMD_FAILURE;
 	}
 
+	if (type < 0 || type >= REFINE_COST_MAX) {
+		script_pushint(st, -1);
+		return SCRIPT_CMD_SUCCESS;
+	}
+
 	if (equip_index_check(slot))
 		i = pc_checkequip(sd, equip_bitmask[slot]);
+
+	if (i < 0) {
+		script_pushint(st, -1);
+		return SCRIPT_CMD_SUCCESS;
+	}
 
 	int weapon_lv = sd->inventory_data[i]->wlv;
 	if (sd->inventory_data[i]->type == IT_SHADOWGEAR) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #2445 #2446 

* **Server Mode**: Renewal

* **Description of Pull Request**: 
The Shadow Refiner used the values of the equip indexes instead of the indices of their array. This caused for huge lists of items being shown in the menu.

Also, if you selected an equip slot that had nothing in it, the script would try to use the item id of the item in that slot (which is -1) and use it to index an array, causing a segmentation fault and therefore a server crash.

In calling the `getequiprefinecost` function, if the type is out of bounds of the refine_cost_type enum, it will be out of bounds. 