### PR TITLE
Corrected character slot movement

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1725,10 +1725,7 @@ enum e_char_del_response char_delete(struct char_session_data* sd, uint32 char_i
 		inter_guild_leave(guild_id, account_id, char_id);// Leave your guild.
 
 	// refresh character list cache
-	for(k = i; k < MAX_CHARS-1; k++){
-		sd->found_char[k] = sd->found_char[k+1];
-	}
-	sd->found_char[MAX_CHARS-1] = -1;
+	sd->found_char[i] = -1;
 
 	return CHAR_DELETE_OK;
 }

--- a/src/char/char_clif.c
+++ b/src/char/char_clif.c
@@ -950,7 +950,7 @@ int chclif_parse_createnewchar(int fd, struct char_session_data* sd,int cmd){
 		}
 		WFIFOSET(fd,3);
 	} else {
-		int len, ch;
+		int len;
 		// retrieve data
 		struct mmo_charstatus char_dat;
 		char_mmo_char_fromsql(i, &char_dat, false); //Only the short data is needed.
@@ -962,9 +962,7 @@ int chclif_parse_createnewchar(int fd, struct char_session_data* sd,int cmd){
 		WFIFOSET(fd,len);
 
 		// add new entry to the chars list
-		ARR_FIND( 0, MAX_CHARS, ch, sd->found_char[ch] == -1 );
-		if( ch < MAX_CHARS )
-			sd->found_char[ch] = i; // the char_id of the new char
+		sd->found_char[char_dat.slot] = i; // the char_id of the new char
 	}
 	return 1;
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves characters changing slots (on the char-selection screen) to the first empty slot rather than to the actual slot index.
Thanks to @Tokeiburu!