### PR TITLE
Removes SCRIPT_CALLFUNC_CHECK ifdef-directives.

### DIFF
--- a/src/config/core.h
+++ b/src/config/core.h
@@ -22,13 +22,6 @@
 /// while with OFFICIAL_WALKPATH disabled if they click to walk around a obstacle the server will do it automatically
 #define OFFICIAL_WALKPATH
 
-/// leave this line uncommented to enable callfunc checks when processing scripts.
-/// while allowed, the script engine will attempt to match user-defined functions
-/// in scripts allowing direct function callback (without the use of callfunc.)
-/// this CAN affect performance, so if you find scripts running slower or find
-/// your map-server using more resources while this is active, comment the line
-#define SCRIPT_CALLFUNC_CHECK
-
 /// uncomment to enable query_sql script command and mysql logs to function on it's own thread
 /// be aware this feature is under tests and you should use at your own risk, we however
 /// welcome any feedback you may have regarding this feature, please send us all bug reports.

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -1052,12 +1052,9 @@ const char* parse_callfunc(const char* p, int require_paren, int is_custom)
 		if( *arg != '*' )
 			++arg; // count func as argument
 	} else {
-#ifdef SCRIPT_CALLFUNC_CHECK
 		const char* name = get_str(func);
 		if( !is_custom && strdb_get(userfunc_db, name) == NULL ) {
-#endif
 			disp_error_message("parse_line: expect command, missing function name or calling undeclared function",p);
-#ifdef SCRIPT_CALLFUNC_CHECK
 		} else {;
 			add_scriptl(buildin_callfunc_ref);
 			add_scriptc(C_ARG);
@@ -1067,7 +1064,6 @@ const char* parse_callfunc(const char* p, int require_paren, int is_custom)
 			arg = buildin_func[str_data[buildin_callfunc_ref].val].arg;
 			if( *arg != '*' ) ++ arg;
 		}
-#endif
 	}
 
 	p = skip_word(p);
@@ -1410,14 +1406,12 @@ const char* parse_simpleexpr(const char *p)
 		l=add_word(p);
 		if( str_data[l].type == C_FUNC || str_data[l].type == C_USERFUNC || str_data[l].type == C_USERFUNC_POS)
 			return parse_callfunc(p,1,0);
-#ifdef SCRIPT_CALLFUNC_CHECK
 		else {
 			const char* name = get_str(l);
 			if( strdb_get(userfunc_db,name) != NULL ) {
 				return parse_callfunc(p,1,1);
 			}
 		}
-#endif
 
 		if( (pv = parse_variable(p)) )
 		{// successfully processed a variable assignment


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2205

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
* The SCRIPT_CALLFUNC_CHECK define was to enforce function
  calling with callfunc in scripts. Because I don't think calling
  functions without callfunc will give us performancy issues,
  this check is simply removed by this commit.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
