### PR TITLE
Refine UI Updates

### DIFF
--- a/db/re/refine_db.yml
+++ b/db/re/refine_db.yml
@@ -73,30 +73,45 @@ Armor:
       EventNormalChance: 20
       EventEnrichedChance: 50
       Bonus: 200
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 1
     - Level: 9
       NormalChance: 20
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 50
       Bonus: 300
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 2
     - Level: 10
       NormalChance: 9
       EnrichedChance: 20
       EventNormalChance: 9
       EventEnrichedChance: 35
       Bonus: 300
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 4
     - Level: 11
       NormalChance: 8
       EnrichedChance: 8
       EventNormalChance: 20
       EventEnrichedChance: 20
       Bonus: 300
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 7
     - Level: 12
       NormalChance: 8
       EnrichedChance: 8
       EventNormalChance: 20
       EventEnrichedChance: 20
       Bonus: 300
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 11
     - Level: 13
       NormalChance: 8
       EnrichedChance: 8
@@ -173,26 +188,41 @@ WeaponLv1:
       EnrichedChance: 90
       EventNormalChance: 60
       EventEnrichedChance: 95
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 1
     - Level: 9
       NormalChance: 40
       EnrichedChance: 70
       EventNormalChance: 40
       EventEnrichedChance: 85
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 2
     - Level: 10
       NormalChance: 19
       EnrichedChance: 30
       EventNormalChance: 19
       EventEnrichedChance: 55
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 4
     - Level: 11
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 7
     - Level: 12
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 11
     - Level: 13
       NormalChance: 18
       EnrichedChance: 18
@@ -271,26 +301,41 @@ WeaponLv2:
       EnrichedChance: 70
       EventNormalChance: 40
       EventEnrichedChance: 85
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 1
     - Level: 9
       NormalChance: 20
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 60
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 2
     - Level: 10
       NormalChance: 19
       EnrichedChance: 30
       EventNormalChance: 19
       EventEnrichedChance: 45
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 4
     - Level: 11
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 7
     - Level: 12
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 11
     - Level: 13
       NormalChance: 18
       EnrichedChance: 18
@@ -374,26 +419,41 @@ WeaponLv3:
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 70
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 1
     - Level: 9
       NormalChance: 20
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 60
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 2
     - Level: 10
       NormalChance: 19
       EnrichedChance: 30
       EventNormalChance: 19
       EventEnrichedChance: 45
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 4
     - Level: 11
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 7
     - Level: 12
       NormalChance: 18
       EnrichedChance: 18
       EventNormalChance: 40
       EventEnrichedChance: 40
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 11
     - Level: 13
       NormalChance: 18
       EnrichedChance: 18
@@ -482,26 +542,41 @@ WeaponLv4:
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 60
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 1
     - Level: 9
       NormalChance: 20
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 50
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 2
     - Level: 10
       NormalChance: 9
       EnrichedChance: 20
       EventNormalChance: 9
       EventEnrichedChance: 35
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 4
     - Level: 11
       NormalChance: 8
       EnrichedChance: 8
       EventNormalChance: 20
       EventEnrichedChance: 20
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 7
     - Level: 12
       NormalChance: 8
       EnrichedChance: 8
       EventNormalChance: 20
       EventEnrichedChance: 20
+      BlacksmithBlessing:
+        ItemID: 6635
+        Count: 11
     - Level: 13
       NormalChance: 8
       EnrichedChance: 8
@@ -583,13 +658,26 @@ Shadow:
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 50
+    #  BlacksmithBlessing:
+    #    ItemID: 6635
+    #    Count: 1
     - Level: 9
       NormalChance: 20
       EnrichedChance: 40
       EventNormalChance: 20
       EventEnrichedChance: 50
+    #  BlacksmithBlessing:
+    #    ItemID: 6635
+    #    Count: 2
     - Level: 10
       NormalChance: 9
       EnrichedChance: 20
       EventNormalChance: 9
       EventEnrichedChance: 35
+    #  BlacksmithBlessing:
+    #    ItemID: 6635
+    #    Count: 4
+    #- Level: 11
+    #  BlacksmithBlessing:
+    #     ItemID: 6635
+    #     Count: 7

--- a/db/re/refine_db.yml
+++ b/db/re/refine_db.yml
@@ -96,69 +96,69 @@ Armor:
         Count: 4
     - Level: 11
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 300
       BlacksmithBlessing:
         ItemID: 6635
         Count: 7
     - Level: 12
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 300
       BlacksmithBlessing:
         ItemID: 6635
         Count: 11
     - Level: 13
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 16
-      EventEnrichedChance: 16
+      EventEnrichedChance: 0
       Bonus: 400
     - Level: 14
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 16
-      EventEnrichedChance: 16
+      EventEnrichedChance: 0
       Bonus: 400
     - Level: 15
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 400
     - Level: 16
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 400
     - Level: 17
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 14
-      EventEnrichedChance: 14
+      EventEnrichedChance: 0
       Bonus: 500
     - Level: 18
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 14
-      EventEnrichedChance: 14
+      EventEnrichedChance: 0
       Bonus: 500
     - Level: 19
       NormalChance: 5
-      EnrichedChance: 5
+      EnrichedChance: 0
       EventNormalChance: 10
-      EventEnrichedChance: 10
+      EventEnrichedChance: 0
       Bonus: 500
     - Level: 20
       NormalChance: 5
-      EnrichedChance: 5
+      EnrichedChance: 0
       EventNormalChance: 10
-      EventEnrichedChance: 10
+      EventEnrichedChance: 0
       Bonus: 500
 WeaponLv1:
   StatsPerLevel: 200
@@ -209,64 +209,64 @@ WeaponLv1:
         Count: 4
     - Level: 11
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 7
     - Level: 12
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 11
     - Level: 13
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 14
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 15
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
     - Level: 16
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
       Bonus: 300
     - Level: 17
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 300
     - Level: 18
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 300
     - Level: 19
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 300
     - Level: 20
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 300
 WeaponLv2:
   StatsPerLevel: 300
@@ -322,64 +322,64 @@ WeaponLv2:
         Count: 4
     - Level: 11
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 7
     - Level: 12
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 11
     - Level: 13
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 14
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 15
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
     - Level: 16
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
       Bonus: 600
     - Level: 17
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 600
     - Level: 18
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 600
     - Level: 19
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 600
     - Level: 20
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 600
 WeaponLv3:
   StatsPerLevel: 500
@@ -440,64 +440,64 @@ WeaponLv3:
         Count: 4
     - Level: 11
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 7
     - Level: 12
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 40
-      EventEnrichedChance: 40
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 11
     - Level: 13
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 14
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 35
-      EventEnrichedChance: 35
+      EventEnrichedChance: 0
     - Level: 15
       NormalChance: 18
-      EnrichedChance: 18
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
     - Level: 16
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 30
-      EventEnrichedChance: 30
+      EventEnrichedChance: 0
       Bonus: 900
     - Level: 17
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 900
     - Level: 18
       NormalChance: 17
-      EnrichedChance: 17
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       Bonus: 900
     - Level: 19
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 900
     - Level: 20
       NormalChance: 15
-      EnrichedChance: 15
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 900
 WeaponLv4:
   StatsPerLevel: 700
@@ -563,64 +563,64 @@ WeaponLv4:
         Count: 4
     - Level: 11
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 7
     - Level: 12
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 20
-      EventEnrichedChance: 20
+      EventEnrichedChance: 0
       BlacksmithBlessing:
         ItemID: 6635
         Count: 11
     - Level: 13
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 16
-      EventEnrichedChance: 16
+      EventEnrichedChance: 0
     - Level: 14
       NormalChance: 8
-      EnrichedChance: 8
+      EnrichedChance: 0
       EventNormalChance: 16
-      EventEnrichedChance: 16
+      EventEnrichedChance: 0
     - Level: 15
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
     - Level: 16
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 15
-      EventEnrichedChance: 15
+      EventEnrichedChance: 0
       Bonus: 1200
     - Level: 17
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 14
-      EventEnrichedChance: 14
+      EventEnrichedChance: 0
       Bonus: 1200
     - Level: 18
       NormalChance: 7
-      EnrichedChance: 7
+      EnrichedChance: 0
       EventNormalChance: 14
-      EventEnrichedChance: 14
+      EventEnrichedChance: 0
       Bonus: 1200
     - Level: 19
       NormalChance: 5
-      EnrichedChance: 5
+      EnrichedChance: 0
       EventNormalChance: 10
-      EventEnrichedChance: 10
+      EventEnrichedChance: 0
       Bonus: 1200
     - Level: 20
       NormalChance: 5
-      EnrichedChance: 5
+      EnrichedChance: 0
       EventNormalChance: 10
-      EventEnrichedChance: 10
+      EventEnrichedChance: 0
       Bonus: 1200
 Shadow:
   StatsPerLevel: 0

--- a/npc/re/merchants/blessed_refiner.txt
+++ b/npc/re/merchants/blessed_refiner.txt
@@ -136,7 +136,7 @@
 	set Zeny, Zeny-.@price;
 	mes "[Blacksmith Dister]";
 	mes "Tac! Tac! Tac!";
-	if (getequippercentrefinery(.@part, true) > rand(100)) {
+	if (getequippercentrefinery(.@part) > rand(100)) {
 		specialeffect EF_BLESSING;
 		successrefitem .@part;
 		next;

--- a/npc/re/merchants/hd_refiner.txt
+++ b/npc/re/merchants/hd_refiner.txt
@@ -140,7 +140,7 @@
 	Zeny = Zeny - .@price;
 	mes "[Blacksmith Mighty Hammer]";
 	mes "Tac! Tac! Tac!";
-	if (getequippercentrefinery(.@part, true) > rand(100)) {
+	if (getequippercentrefinery(.@part) > rand(100)) {
 		successrefitem .@part;
 		next;
 		emotion e_no1;
@@ -277,7 +277,7 @@ OnInit:
 		mes "Okay. If that's what you want...";
 		close;
 	}
-	if (getequippercentrefinery(.@part, true) < 100) {
+	if (getequippercentrefinery(.@part) < 100) {
 		mes "[Basta]";
 		mes "This " + .@type$ + " has already been refined pretty high.";
 		mes "If you try to refine it more, the refine level could decrease.";
@@ -327,7 +327,7 @@ OnInit:
 	delitem .@material,1;
 	Zeny = Zeny - .@price;
 	mes "Pow! Pow! Pow! Pow!";
-	if (getequippercentrefinery(.@part, true) > rand(100)) {
+	if (getequippercentrefinery(.@part) > rand(100)) {
 		successrefitem .@part;
 		next;
 		emotion e_no1;

--- a/npc/re/merchants/shadow_refiner.txt
+++ b/npc/re/merchants/shadow_refiner.txt
@@ -131,7 +131,7 @@
 		next;
 		delitem .@choose,1;
 		Zeny -= .@zeny_cost;
-		if (getequippercentrefinery(.@part, .@option > 1) > rand(100)) {
+		if (getequippercentrefinery(.@part, .@option == 2) > rand(100)) {
 			successrefitem .@part;
 			mes "[Shadow Blacksmith]";
 			mes "It worked! It worked!";

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -20087,7 +20087,8 @@ void clif_parse_refineui_close( int fd, struct map_session_data* sd ){
 #endif
 }
 
-#define REFINEUI_MAT_CNT 4
+#define REFINEUI_MAT_BS_BLESS 4
+#define REFINEUI_MAT_CNT (REFINEUI_MAT_BS_BLESS+1)
 
 /**
  * Structure to store all required data about refine requirements
@@ -20095,6 +20096,7 @@ void clif_parse_refineui_close( int fd, struct map_session_data* sd ){
 struct refine_materials {
 	struct refine_cost cost;
 	uint8 chance;
+	struct refine_bs_blessing bs_bless;
 };
 
 /**
@@ -20102,7 +20104,7 @@ struct refine_materials {
  * returns true on success or false on failure.
  */
 static inline bool clif_refineui_materials_sub( struct item *item, struct item_data *id, struct refine_materials materials[REFINEUI_MAT_CNT], int index, enum refine_cost_type type ){
-	if( index < 0 || index > REFINEUI_MAT_CNT ){
+	if( index < 0 || index >= REFINEUI_MAT_CNT ){
 		return false;
 	}
 
@@ -20165,6 +20167,9 @@ static inline uint8 clif_refineui_materials( struct item *item, struct item_data
 	if( clif_refineui_materials_sub( item, id, materials, count, REFINE_COST_ENRICHED ) ){
 		count++;
 	}
+
+	// Blacksmith Blessing requirements if any
+	status_get_refine_blacksmithBlessing(&materials[REFINEUI_MAT_BS_BLESS].bs_bless, (enum refine_type)id->wlv, item->refine);
 
 	// Return the amount of found materials
 	return count;
@@ -20238,7 +20243,7 @@ void clif_refineui_info( struct map_session_data* sd, uint16 index ){
 	WFIFOW(fd,0) = 0x0AA2;
 	WFIFOW(fd,2) = length;
 	WFIFOW(fd,4) = index + 2;
-	WFIFOB(fd,6) = 0; //TODO: required amount of "Blacksmith Blessing"(id: 6635)
+	WFIFOB(fd,6) = (uint8)materials[REFINEUI_MAT_BS_BLESS].bs_bless.count;
 
 	for( i = 0; i < material_count; i++ ){
 		WFIFOW(fd,7 + i * 7) = materials[i].cost.nameid;
@@ -20370,6 +20375,16 @@ void clif_parse_refineui_refine( int fd, struct map_session_data* sd ){
 		return;
 	}
 
+	if (use_blacksmith_blessing && materials[REFINEUI_MAT_BS_BLESS].bs_bless.count) {
+		if ((j = pc_search_inventory(sd, materials[REFINEUI_MAT_BS_BLESS].bs_bless.nameid)) < 0) {
+			return;
+		}
+
+		if (pc_delitem(sd, j, materials[REFINEUI_MAT_BS_BLESS].bs_bless.count, 0, 0, LOG_TYPE_CONSUME)) {
+			return;
+		}
+	}
+
 	// Try to refine the item
 	if( materials[i].chance >= rnd() % 100 ){
 		// Success
@@ -20381,8 +20396,10 @@ void clif_parse_refineui_refine( int fd, struct map_session_data* sd ){
 	}else{
 		// Failure
 
-		// Delete the item if it is breakable
-		if( materials[i].cost.breakable ){
+		if (use_blacksmith_blessing) { // Blacksmith Blessing were used, no break & no down refine
+			clif_refine(fd, 1, index, item->refine);
+			clif_refineui_info(sd, index);
+		} else if (materials[i].cost.breakable) { // Delete the item if it is breakable
 			clif_refine( fd, 1, index, item->refine );
 			pc_delitem( sd, index, 1, 0, 0, LOG_TYPE_CONSUME );
 		}else{

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -20157,8 +20157,9 @@ static inline uint8 clif_refineui_materials( struct item *item, struct item_data
 			count++;
 		}
 		
-		// HD refine requirements
-		if( clif_refineui_materials_sub( item, id, materials, count, REFINE_COST_HD ) ){
+		// HD refine requirements only if the refine is +7 ~ +9
+		// TODO: Remove this hardcoded check, add HD values separetd from 'normal' rates
+		if( item->refine >= 7 && item->refine <= 9 && clif_refineui_materials_sub( item, id, materials, count, REFINE_COST_HD ) ){
 			count++;
 		}
 	}

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6418,6 +6418,7 @@ void clif_map_property_mapall(int map_idx, enum map_property property)
 ///     0 = success
 ///     1 = failure
 ///     2 = downgrade
+///     3 = failure without breaking nor downgrade
 void clif_refine(int fd, int fail, int index, int val)
 {
 	WFIFOHEAD(fd,packet_len(0x188));
@@ -20385,6 +20386,9 @@ void clif_parse_refineui_refine( int fd, struct map_session_data* sd ){
 			return;
 		}
 	}
+	else {
+		use_blacksmith_blessing = false;
+	}
 
 	// Try to refine the item
 	if( materials[i].chance >= rnd() % 100 ){
@@ -20398,7 +20402,7 @@ void clif_parse_refineui_refine( int fd, struct map_session_data* sd ){
 		// Failure
 
 		if (use_blacksmith_blessing) { // Blacksmith Blessing were used, no break & no down refine
-			clif_refine(fd, 1, index, item->refine);
+			clif_refine(fd, 3, index, item->refine);
 			clif_refineui_info(sd, index);
 		} else if (materials[i].cost.breakable) { // Delete the item if it is breakable
 			clif_refine( fd, 1, index, item->refine );

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -42,6 +42,7 @@ static struct {
 	int bonus[MAX_REFINE]; /// Cumulative fixed bonus damage
 	int randombonus_max[MAX_REFINE]; /// Cumulative maximum random bonus damage
 	struct refine_cost cost[REFINE_COST_MAX];
+	struct refine_bs_blessing bs_blessing[MAX_REFINE];
 } refine_info[REFINE_TYPE_MAX];
 
 static int atkmods[3][MAX_WEAPON_TYPE];	/// ATK weapon modification for size (size_fix.txt)
@@ -14132,6 +14133,25 @@ int status_get_refine_chance(enum refine_type wlv, int refine, bool enriched)
 }
 
 /**
+ * Get Blacksmith Blessing requirement for refining
+ * @param bs Pointer to store the value
+ * @param type Armor or weapon level (see enum refine_type)
+ * @param refine Current refine level
+ * @return True if has valid value, false otherwise.
+ **/
+bool status_get_refine_blacksmithBlessing(struct refine_bs_blessing* bs, enum refine_type type, int refine)
+{
+	if (refine < 0 || refine >= MAX_REFINE)
+		return false;
+
+	if (type < REFINE_TYPE_ARMOR || type > REFINE_TYPE_SHADOW)
+		return false;
+
+	memcpy(bs, &refine_info[type].bs_blessing[refine], sizeof(struct refine_bs_blessing));
+	return true;
+}
+
+/**
  * Check if status is disabled on a map
  * @param type: Status Change data
  * @param mapIsVS: If the map is a map_flag_vs type
@@ -14310,6 +14330,24 @@ static bool status_yaml_readdb_refine_sub(yamlwrapper* wrapper, int refine_info_
 
 			if (refine_level >= random_bonus_start_level - 1)
 				refine_info[refine_info_index].randombonus_max[refine_level] = random_bonus * (refine_level - random_bonus_start_level + 2);
+
+			// Blacksmith Blessing
+			if (yaml_node_is_defined(level, "BlacksmithBlessing")) {
+				yamlwrapper* bswrap = yaml_get_subnode(level, "BlacksmithBlessing");
+				static char* keys[] = { "ItemID", "Count" };
+				char* result;
+
+				if ((result = yaml_verify_nodes(bswrap, ARRAYLENGTH(keys), keys)) != NULL) {
+					ShowWarning("status_yaml_readdb_refine_sub: Invalid refine cost with undefined " CL_WHITE "%s" CL_RESET "in file" CL_WHITE "%s" CL_RESET ".\n", result, file_name);
+					yaml_destroy_wrapper(bswrap);
+				}
+				else {
+					refine_info[refine_info_index].bs_blessing[refine_level].nameid = yaml_get_int(bswrap, "ItemID");
+					refine_info[refine_info_index].bs_blessing[refine_level].count = yaml_get_uint16(bswrap, "Count");
+					yaml_destroy_wrapper(bswrap);
+				}
+			}
+
 			yaml_destroy_wrapper(level);
 		}
 		for (int refine_level = 0; refine_level < MAX_REFINE; ++refine_level) {
@@ -14457,7 +14495,8 @@ int status_readdb(void)
 	// refine_db.yml
 	for(i=0;i<ARRAYLENGTH(refine_info);i++)
 	{
-		memset(refine_info[i].cost, 0, sizeof(struct refine_cost));
+		memset(&refine_info[i].cost, 0, sizeof(struct refine_cost)*REFINE_COST_MAX);
+		memset(&refine_info[i].bs_blessing, 0, sizeof(struct refine_bs_blessing)*MAX_REFINE);
 		for(j = 0; j < REFINE_CHANCE_TYPE_MAX; j++)
 			for(k=0;k<MAX_REFINE; k++)
 			{

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -61,9 +61,14 @@ struct refine_cost {
 	bool breakable;
 };
 
+struct refine_bs_blessing {
+	unsigned short nameid, count;
+};
+
 /// Get refine chance
 int status_get_refine_chance(enum refine_type wlv, int refine, bool enriched);
 int status_get_refine_cost(int weapon_lv, int type, enum refine_info_type what);
+bool status_get_refine_blacksmithBlessing(struct refine_bs_blessing* bs, enum refine_type type, int refine);
 
 /// Status changes listing. These code are for use by the server.
 typedef enum sc_type {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

### **Addressed Issue(s)**:
Related to #2494 (Initial release of the refine UI) by @Lemongrass3110 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

### **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

### **Description of Pull Request**: 
* Enabled Blacksmith Blessing check for refining to disable downrefine on fail! (of course without breaking the refined item)
  * +7 to +8 needs 1 ea
  * +8 to +9 needs 2 ea
  * +9 to +10 needs 4 ea
  * +10 to +11 needs 7 ea
  * +11 to +12 needs 11 ea
* Added Blacksmith Blessing entries to refine_db.yml follow the values above.
* Fixed refine_info clearances on loading files.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

**IMPORTANT**
* I make this as a new branch and as PR because, the structure itself wasn't discussed and just curious 'how if I add the Blacksmith Blessing'.
* If you want to try the changes, checkout/merge the branch from #2494 then merge this branch/apply the diff to your test server.