### PR TITLE
Enabled import for translations by default

### DIFF
--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -1668,4 +1668,4 @@
 1504: You've entered a PK Zone (safe until level %d).
 
 //Custom translations
-//import: conf/msg_conf/import/map_msg_eng_conf.txt
+import: conf/msg_conf/import/map_msg_eng_conf.txt

--- a/conf/msg_conf/map_msg_chn.conf
+++ b/conf/msg_conf/map_msg_chn.conf
@@ -1498,4 +1498,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Custom translations
-//import: conf/msg_conf/import/map_msg_chn_conf.txt
+import: conf/msg_conf/import/map_msg_chn_conf.txt

--- a/conf/msg_conf/map_msg_frn.conf
+++ b/conf/msg_conf/map_msg_frn.conf
@@ -1490,4 +1490,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Custom translations
-//import: conf/msg_conf/import/map_msg_frn_conf.txt
+import: conf/msg_conf/import/map_msg_frn_conf.txt

--- a/conf/msg_conf/map_msg_idn.conf
+++ b/conf/msg_conf/map_msg_idn.conf
@@ -1606,4 +1606,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Bila ada terjemahan lain
-//import: conf/msg_conf/import/map_msg_idn_conf.txt
+import: conf/msg_conf/import/map_msg_idn_conf.txt

--- a/conf/msg_conf/map_msg_por.conf
+++ b/conf/msg_conf/map_msg_por.conf
@@ -1467,4 +1467,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Custom translations
-//import: conf/msg_conf/import/map_msg_por_conf.txt
+import: conf/msg_conf/import/map_msg_por_conf.txt

--- a/conf/msg_conf/map_msg_rus.conf
+++ b/conf/msg_conf/map_msg_rus.conf
@@ -1490,4 +1490,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 // Пользовательский перевод
-//import: conf/msg_conf/import/map_msg_rus_conf.txt
+import: conf/msg_conf/import/map_msg_rus_conf.txt

--- a/conf/msg_conf/map_msg_spn.conf
+++ b/conf/msg_conf/map_msg_spn.conf
@@ -1470,4 +1470,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Traducciones personalizadas
-//import: conf/msg_conf/import/map_msg_spn_conf.txt
+import: conf/msg_conf/import/map_msg_spn_conf.txt

--- a/conf/msg_conf/map_msg_tha.conf
+++ b/conf/msg_conf/map_msg_tha.conf
@@ -1509,4 +1509,4 @@
 1498: You cannot create a guild because you are in a clan.
 
 //Custom translations
-//import: conf/msg_conf/import/map_msg_tha_conf.txt
+import: conf/msg_conf/import/map_msg_tha_conf.txt

--- a/src/common/msg_conf.h
+++ b/src/common/msg_conf.h
@@ -4,6 +4,8 @@
 #ifndef MSG_CONF_H
 #define	MSG_CONF_H
 
+#include "../config/core.h"
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -20,10 +22,13 @@ enum lang_types {
 	LANG_THA = 0x100,
 	LANG_MAX
 };
-// Multilanguage System.
-// Define which languages to enable (bitmask).
-// 0xFFF will enable all, while 0x000 will enable English only.
-#define LANG_ENABLE 0x000
+
+#ifndef LANG_ENABLE
+	// Multilanguage System.
+	// Define which languages to enable (bitmask).
+	// 0xFFF will enable all, while 0x000 will enable English only.
+	#define LANG_ENABLE 0x000
+#endif
 
 //read msg in table
 const char* _msg_txt(int msg_number,int size, char ** msg_table);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -115,7 +115,9 @@ static int block_free_count = 0, block_free_lock = 0;
 static struct block_list *bl_list[BL_LIST_MAX];
 static int bl_list_count = 0;
 
-#define MAP_MAX_MSG 1550
+#ifndef MAP_MAX_MSG
+	#define MAP_MAX_MSG 1550
+#endif
 
 struct map_data map[MAX_MAP_PER_SERVER];
 int map_num = 0;


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Right now the translations are the only configurations that are not imported by default.
Added possibility to override MAP_MAX_MSG with defines_pre.h