### PR TITLE
Fixed duplicated condition

### DIFF
--- a/src/common/db.c
+++ b/src/common/db.c
@@ -2920,7 +2920,7 @@ void* linkdb_search( struct linkdb_node** head, void *key)
 		if( node->key == key ) {
 			if( node->prev && n > 5 ) {
 				//Moving the head in order to improve processing efficiency
-				if(node->prev) node->prev->next = node->next;
+				node->prev->next = node->next;
 				if(node->next) node->next->prev = node->prev;
 				node->next = *head;
 				node->prev = (*head)->prev;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
rathena/src/common/db.c     2923    warn    V571 Recurring check. The 'node->prev' condition was already verified in line 2921.

The condition `if(node->prev)` was checked in the previous:
`if( node->prev && n > 5 ) {`

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->