### PR TITLE
Fixed twice assigned values

### DIFF
--- a/src/common/db.c
+++ b/src/common/db.c
@@ -2920,7 +2920,7 @@ void* linkdb_search( struct linkdb_node** head, void *key)
 		if( node->key == key ) {
 			if( node->prev && n > 5 ) {
 				//Moving the head in order to improve processing efficiency
-				if(node->prev) node->prev->next = node->next;
+				node->prev->next = node->next;
 				if(node->next) node->next->prev = node->prev;
 				node->next = *head;
 				node->prev = (*head)->prev;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11130,7 +11130,6 @@ int skill_castend_id(int tid, unsigned int tick, int id, intptr_t data)
 
 		if( sd && ud->skilltimer != INVALID_TIMER && (pc_checkskill(sd,SA_FREECAST) > 0 || ud->skill_id == LG_EXEEDBREAK) )
 		{// restore original walk speed
-			ud->skilltimer = INVALID_TIMER;
 			status_calc_bl(&sd->bl, SCB_SPEED);
 		}
 
@@ -11411,7 +11410,6 @@ int skill_castend_pos(int tid, unsigned int tick, int id, intptr_t data)
 
 	if( sd && ud->skilltimer != INVALID_TIMER && ( pc_checkskill(sd,SA_FREECAST) > 0 || ud->skill_id == LG_EXEEDBREAK ) )
 	{// restore original walk speed
-		ud->skilltimer = INVALID_TIMER;
 		status_calc_bl(&sd->bl, SCB_SPEED);
 	}
 	ud->skilltimer = INVALID_TIMER;


### PR DESCRIPTION
I like your project and I'm exploring it as part of the competition the Pinguem.ru competition on finding errors in open source projects. New warnings, found using PVS-Studio:
rathena/src/map/skill.cpp	11137	warn	V519 The 'ud->skilltimer' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 11133, 11137.
rathena/src/map/skill.cpp	11417	warn	V519 The 'ud->skilltimer' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 11414, 11417.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->