### PR TITLE
Fix to issue #2579: No error when setting MAX_MOB_DB too high

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -64,7 +64,7 @@
 struct mob_db *mob_db_data[MAX_MOB_DB+1];
 struct mob_db *mob_dummy = NULL;	//Dummy mob to be returned when a non-existant one is requested.
 
-struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || MAX_MOB_DB > 51000 || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
+struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
 
 //Dynamic mob chat database
 struct mob_chat *mob_chat_db[MAX_MOB_CHAT+1];

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -64,7 +64,7 @@
 struct mob_db *mob_db_data[MAX_MOB_DB+1];
 struct mob_db *mob_dummy = NULL;	//Dummy mob to be returned when a non-existant one is requested.
 
-struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
+struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || 51000 <= MAX_MOB_DB || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
 
 //Dynamic mob chat database
 struct mob_chat *mob_chat_db[MAX_MOB_CHAT+1];

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -64,7 +64,7 @@
 struct mob_db *mob_db_data[MAX_MOB_DB+1];
 struct mob_db *mob_dummy = NULL;	//Dummy mob to be returned when a non-existant one is requested.
 
-struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || 51000 <= MAX_MOB_DB || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
+struct mob_db *mob_db(int mob_id) { if (mob_id < 0 || MAX_MOB_DB > 51000 || mob_id > MAX_MOB_DB || mob_db_data[mob_id] == NULL) return mob_dummy; return mob_db_data[mob_id]; }
 
 //Dynamic mob chat database
 struct mob_chat *mob_chat_db[MAX_MOB_CHAT+1];

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -367,4 +367,8 @@ void mob_setdropitem_option(struct item *itm, struct s_mob_drop *mobdrop);
 
 #define CHK_MOBSIZE(size) ((size) >= SZ_SMALL && (size) < SZ_MAX) /// Check valid Monster Size
 
+#if MAX_MOB_DB > 51000
+	#error MAX_MOB_DB cannot be that high! Please adjust MAX_MOB_DB to a lower value.
+#endif
+
 #endif /* _MOB_HPP_ */


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

#2579

* **Server Mode**: 

Renewal(from issue), please check if it can apply to both.

* **Description of Pull Request**: 

struct mob_db *mob_db will return mob_dummy if **MAX_MOB_DB** is **51000** or more, plus compile will return error.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
