### PR TITLE
Adjusting Vending tax to match official

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -20,8 +20,8 @@ vending_over_max: yes
 // When a tax is applied, the item's full price is charged to the buyer, but
 // the vender will not get the whole price paid (they get 100% - this tax).
 // Officially there is no tax for anything less than 100 million zeny, but anything greater incurs a 5% tax.
-// Value of 0 will follow official behavior, anything else will apply a global tax.
-vending_tax: 0
+// -1 will follow official behavior, 0 will disable taxes while anything else will apply a global tax.
+vending_tax: -1
 
 // Show the buyer's name when successfully vended an item
 buyer_name: yes

--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -19,7 +19,9 @@ vending_over_max: yes
 // Tax to apply to all vending transactions (eg: 10000 = 100%, 50 = 0.50%)
 // When a tax is applied, the item's full price is charged to the buyer, but
 // the vender will not get the whole price paid (they get 100% - this tax).
-vending_tax: 200
+// Officially there is no tax for anything less than 100 million zeny, but anything greater incurs a 5% tax.
+// Value of 0 will follow official behavior, anything else will apply a global tax.
+vending_tax: 0
 
 // Show the buyer's name when successfully vended an item
 buyer_name: yes

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8276,7 +8276,7 @@ static const struct _battle_data {
 	{ "hom_rename",                         &battle_config.hom_rename,                      0,      0,      1,              },
 	{ "homunculus_show_growth",             &battle_config.homunculus_show_growth,          0,      0,      1,              },
 	{ "homunculus_friendly_rate",           &battle_config.homunculus_friendly_rate,        100,    0,      INT_MAX,        },
-	{ "vending_tax",                        &battle_config.vending_tax,                     0,      0,      10000,          },
+	{ "vending_tax",                        &battle_config.vending_tax,                     -1,    -1,      10000,          },
 	{ "day_duration",                       &battle_config.day_duration,                    0,      0,      INT_MAX,        },
 	{ "night_duration",                     &battle_config.night_duration,                  0,      0,      INT_MAX,        },
 	{ "mob_remove_delay",                   &battle_config.mob_remove_delay,                60000,  1000,   INT_MAX,        },

--- a/src/map/vending.cpp
+++ b/src/map/vending.cpp
@@ -97,6 +97,22 @@ void vending_vendinglistreq(struct map_session_data* sd, int id)
 }
 
 /**
+ * Calculates taxes for vending
+ * @param sd: Vender
+ * @param zeny: Amount of zeny to tax
+ * @return Taxed total amount
+ */
+static void vending_calc_tax(struct map_session_data *sd, double &zeny)
+{
+	if (battle_config.vending_tax) // Use custom value
+		zeny -= zeny * (battle_config.vending_tax / 10000.);
+	else { // Official servers incur a 5% tax on 100+ million
+		if (zeny >= 100000000)
+			zeny -= zeny * (5 / 100.);
+	}
+}
+
+/**
  * Purchase item(s) from a shop
  * @param sd : buyer player session
  * @param aid : account id of vender
@@ -200,8 +216,7 @@ void vending_purchasereq(struct map_session_data* sd, int aid, int uid, const ui
 
 	pc_payzeny(sd, (int)z, LOG_TYPE_VENDING, vsd);
 	achievement_update_objective(sd, AG_SPEND_ZENY, 1, (int)z);
-	if( battle_config.vending_tax )
-		z -= z * (battle_config.vending_tax/10000.);
+	vending_calc_tax(sd, z);
 	pc_getzeny(vsd, (int)z, LOG_TYPE_VENDING, sd);
 
 	for( i = 0; i < count; i++ ) {
@@ -226,8 +241,7 @@ void vending_purchasereq(struct map_session_data* sd, int aid, int uid, const ui
 		}
 
 		pc_cart_delitem(vsd, idx, amount, 0, LOG_TYPE_VENDING);
-		if( battle_config.vending_tax )
-			z -= z * (battle_config.vending_tax/10000.);
+		vending_calc_tax(sd, z);
 		clif_vendingreport(vsd, idx, amount, sd->status.char_id, (int)z);
 
 		//print buyer's name


### PR DESCRIPTION
* **Addressed Issue(s)**: #2528

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * There are no taxes on items being sold for less than 100 million. Anything above incurs a 5% tax.
  * Refactored the tax code to use a single function.
Thanks to @mazvi!