### PR TITLE
Fix #2425 Character variable lengths and char-server

### DIFF
--- a/doc/sample/npc_test_longvar.txt
+++ b/doc/sample/npc_test_longvar.txt
@@ -1,0 +1,17 @@
+//===== rAthena Script =======================================
+//= Sample: Character variable lengths Test
+//===== By: ==================================================
+//= rAthena Dev Team
+//===== Last Updated: ========================================
+//= 20171125
+//===== Description: ========================================= 
+//= An validation test about long character variable stored on char-serv
+//= from https://github.com/rathena/rathena/issues/2425
+//============================================================
+
+prontera,155,176,3	script	Pront Test	77,{
+	mes "Testing to store long variable on char-serv";
+	test$ = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+	test2$ = "anything really, doesn't matter at this point";
+	end;
+}

--- a/npc/test/npc_test_longvar.txt
+++ b/npc/test/npc_test_longvar.txt
@@ -13,11 +13,11 @@ prontera,155,176,3	script	Pront Test	77,{
 	mes "Testing to store long variable on char-serv";
 //test1 long value
 	test$ = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
-//test2 normal lenght
+//test2 normal length
 	test2$ = "anything really, doesn't matter at this point";
-//test3 longkey (41)
+//test3 long key (41)
         thisisareallylongkeyImeanReallyReallyLong$ = "gotcha";
-//test4 longkey 2 (with int)
+//test4 long key 2 (with int)
 	ReallyReallyReallyReallyReallyReallyLong = 42;
 	end;
 }

--- a/npc/test/npc_test_longvar.txt
+++ b/npc/test/npc_test_longvar.txt
@@ -11,7 +11,13 @@
 
 prontera,155,176,3	script	Pront Test	77,{
 	mes "Testing to store long variable on char-serv";
+//test1 long value
 	test$ = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+//test2 normal lenght
 	test2$ = "anything really, doesn't matter at this point";
+//test3 longkey (41)
+        thisisareallylongkeyImeanReallyReallyLong$ = "gotcha";
+//test4 longkey 2 (with int)
+	ReallyReallyReallyReallyReallyReallyLong = 42;
 	end;
 }

--- a/src/char/inter.cpp
+++ b/src/char/inter.cpp
@@ -1278,9 +1278,9 @@ int mapif_parse_Registry(int fd)
 			chlogif_upd_global_accreg(account_id,char_id);
 
 		for(i = 0; i < count; i++) {
-      size_t lenkey = RFIFOB( fd, cursor );
-      const char* src_key= RFIFOCP(fd, cursor + 1);
-      std::string key( src_key, lenkey );
+			size_t lenkey = RFIFOB( fd, cursor );
+			const char* src_key= RFIFOCP(fd, cursor + 1);
+			std::string key( src_key, lenkey );
 			cursor += lenkey + 1;
 
 			unsigned int  index = RFIFOL(fd, cursor);
@@ -1289,25 +1289,25 @@ int mapif_parse_Registry(int fd)
 			switch (RFIFOB(fd, cursor++)) {
 				// int
 				case 0:
-        {
-          intptr_t lVal = RFIFOL( fd, cursor );
-          inter_savereg( account_id, char_id, key.c_str(), index, lVal, false );
-          cursor += 4;
-          break;
-        }
+				{
+					intptr_t lVal = RFIFOL( fd, cursor );
+					inter_savereg( account_id, char_id, key.c_str(), index, lVal, false );
+					cursor += 4;
+					break;
+				}
 				case 1:
 					inter_savereg(account_id,char_id,key.c_str(),index,0,false);
 					break;
 				// str
 				case 2:
-        {
-          size_t len_val = RFIFOB( fd, cursor );
-          const char* src_val= RFIFOCP(fd, cursor + 1);
-          std::string sval( src_val, len_val );
-          cursor += len_val + 1;
-          inter_savereg( account_id, char_id, key.c_str(), index, (intptr_t)sval.c_str(), true );
-          break;
-        }
+				{
+					size_t len_val = RFIFOB( fd, cursor );
+					const char* src_val= RFIFOCP(fd, cursor + 1);
+					std::string sval( src_val, len_val );
+					cursor += len_val + 1;
+					inter_savereg( account_id, char_id, key.c_str(), index, (intptr_t)sval.c_str(), true );
+					break;
+				}
 				case 3:
 					inter_savereg(account_id,char_id,key.c_str(),index,0,true);
 					break;

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -422,11 +422,14 @@ int intif_saveregistry(struct map_session_data *sd)
 		src->update = false;
 
 		len = strlen(varname)+1;
-
+    if (len > 32) { //this is sql colum size, must be retrive from config
+			ShowError("intif_saveregistry: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, varname, len);
+			continue;
+		}
 		WFIFOB(inter_fd, plen) = (unsigned char)len; // won't be higher; the column size is 32
 		plen += 1;
 
-		safestrncpy(WFIFOCP(inter_fd,plen), varname, len);
+		safestrncpy(WFIFOCP(inter_fd,plen), varname, len); //the key
 		plen += len;
 
 		WFIFOL(inter_fd, plen) = script_getvaridx(key.i64);
@@ -435,13 +438,18 @@ int intif_saveregistry(struct map_session_data *sd)
 		if( src->type ) {
 			struct script_reg_str *p = (struct script_reg_str *)src;
 
-			WFIFOB(inter_fd, plen) = p->value ? 2 : 3;
+			WFIFOB(inter_fd, plen) = p->value ? 2 : 3; //var type
 			plen += 1;
 
 			if( p->value ) {
 				len = strlen(p->value)+1;
+        if ( len > 254 ) { // error can't be higher; the column size is 254. (nb the transmission limit with be fixed with protobuf revamp)
+          ShowDebug( "intif_saveregistry: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%d to be saved with current system and will be truncated\n",sd->status.account_id, sd->status.char_id,p->value,len);
+          len = 254;
+          p->value[len - 1] = '\0'; //this is backward for old char-serv but new one doesn't need this
+        }
 
-				WFIFOB(inter_fd, plen) = (unsigned char)len; // won't be higher; the column size is 254
+				WFIFOB(inter_fd, plen) = len; 
 				plen += 1;
 
 				safestrncpy(WFIFOCP(inter_fd,plen), p->value, len);

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -405,6 +405,7 @@ int intif_saveregistry(struct map_session_data *sd)
 	for( data = iter->first(iter,&key); iter->exists(iter); data = iter->next(iter,&key) ) {
 		const char *varname = NULL;
 		struct script_reg_state *src = NULL;
+		bool lValid = false;
 
 		if( data->type != DB_DATA_PTR ) // it's a @number
 			continue;
@@ -420,8 +421,9 @@ int intif_saveregistry(struct map_session_data *sd)
 			continue;
 
 		src->update = false;
-		bool lValid = script_check_RegistryVariableLenght(0,varname,&len);
+		script_check_RegistryVariableLength(0,varname,&len);
 		++len;
+
 		if (!lValid) { //this is sql colum size, must be retrive from config
 			ShowError("intif_saveregistry: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, varname, len);
 			continue;
@@ -442,7 +444,7 @@ int intif_saveregistry(struct map_session_data *sd)
 			plen += 1;
 
 			if( p->value ) {
-				lValid = script_check_RegistryVariableLenght(1,p->value,&len);
+				lValid = script_check_RegistryVariableLength(1,p->value,&len);
 				++len;
 				if ( !lValid ) { // error can't be higher; the column size is 254. (nb the transmission limit with be fixed with protobuf revamp)
 					ShowDebug( "intif_saveregistry: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%d to be saved with current system and will be truncated\n",sd->status.account_id, sd->status.char_id,p->value,len);
@@ -3675,7 +3677,7 @@ int intif_parse_clan_onlinecount( int fd ){
  * @return
  *  0 (unknow packet).
  *  1 sucess (no error)
- *  2 invalid lenght of packet (not enough data yet)
+ *  2 invalid length of packet (not enough data yet)
  */
 int intif_parse(int fd)
 {

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -421,7 +421,7 @@ int intif_saveregistry(struct map_session_data *sd)
 			continue;
 
 		src->update = false;
-		script_check_RegistryVariableLength(0,varname,&len);
+		lValid = script_check_RegistryVariableLength(0,varname,&len);
 		++len;
 
 		if (!lValid) { //this is sql colum size, must be retrive from config

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9235,6 +9235,18 @@ int pc_setregistry(struct map_session_data *sd, int64 reg, int val)
 	return 1;
 }
 
+//maybe move this as intif or script ?
+bool pc_check_RegistryVariableLenght(struct map_session_data *sd, int pType, const char *val, size_t* vlen) 
+{
+  size_t len = strlen( val );
+  if ( vlen ) *vlen = len;
+  switch ( pType )
+  {
+    case 0: return (len < 33);//checking key
+    case 1: return (len < 255); //checking value
+    default: return false;
+  }
+}
 /**
  * Serves the following variable types:
  * - 'type$' (permanent str char reg)
@@ -9251,6 +9263,12 @@ int pc_setregistry_str(struct map_session_data *sd, int64 reg, const char *val)
 		ShowError("pc_setregistry_str : refusing to set %s until vars are received.\n", regname);
 		return 0;
 	}
+  size_t vlen=0;
+  if ( !pc_check_RegistryVariableLenght( sd, 1, val, &vlen ) )
+  {
+    ShowError("pc_check_RegistryVariableLenght: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%zu\n", sd->status.account_id, sd->status.char_id, val, vlen);
+    return 0;
+  }
 
 	if( (p = (struct script_reg_str *)i64db_get(sd->regs.vars, reg) ) ) {
 		if( val[0] ) {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9235,18 +9235,7 @@ int pc_setregistry(struct map_session_data *sd, int64 reg, int val)
 	return 1;
 }
 
-//maybe move this as intif or script ?
-bool pc_check_RegistryVariableLenght(struct map_session_data *sd, int pType, const char *val, size_t* vlen) 
-{
-  size_t len = strlen( val );
-  if ( vlen ) *vlen = len;
-  switch ( pType )
-  {
-    case 0: return (len < 33);//checking key
-    case 1: return (len < 255); //checking value
-    default: return false;
-  }
-}
+
 /**
  * Serves the following variable types:
  * - 'type$' (permanent str char reg)
@@ -9263,12 +9252,12 @@ int pc_setregistry_str(struct map_session_data *sd, int64 reg, const char *val)
 		ShowError("pc_setregistry_str : refusing to set %s until vars are received.\n", regname);
 		return 0;
 	}
-  size_t vlen=0;
-  if ( !pc_check_RegistryVariableLenght( sd, 1, val, &vlen ) )
-  {
-    ShowError("pc_check_RegistryVariableLenght: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%zu\n", sd->status.account_id, sd->status.char_id, val, vlen);
-    return 0;
-  }
+	size_t vlen=0;
+	if ( !script_check_RegistryVariableLenght(1, val, &vlen ) )
+	{
+		ShowError("pc_check_RegistryVariableLenght: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%zu\n", sd->status.account_id, sd->status.char_id, val, vlen);
+		return 0;
+	}
 
 	if( (p = (struct script_reg_str *)i64db_get(sd->regs.vars, reg) ) ) {
 		if( val[0] ) {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9235,7 +9235,6 @@ int pc_setregistry(struct map_session_data *sd, int64 reg, int val)
 	return 1;
 }
 
-
 /**
  * Serves the following variable types:
  * - 'type$' (permanent str char reg)
@@ -9247,15 +9246,16 @@ int pc_setregistry_str(struct map_session_data *sd, int64 reg, const char *val)
 	struct script_reg_str *p = NULL;
 	const char *regname = get_str(script_getvarid(reg));
 	unsigned int index = script_getvaridx(reg);
+	size_t vlen = 0;
 
 	if (!reg_load && !sd->vars_ok) {
 		ShowError("pc_setregistry_str : refusing to set %s until vars are received.\n", regname);
 		return 0;
 	}
-	size_t vlen=0;
-	if ( !script_check_RegistryVariableLenght(1, val, &vlen ) )
+
+	if ( !script_check_RegistryVariableLength(1, val, &vlen ) )
 	{
-		ShowError("pc_check_RegistryVariableLenght: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%zu\n", sd->status.account_id, sd->status.char_id, val, vlen);
+		ShowError("pc_check_RegistryVariableLength: Variable value length is too long (aid: %d, cid: %d): '%s' sz=%zu\n", sd->status.account_id, sd->status.char_id, val, vlen);
 		return 0;
 	}
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1,6 +1,6 @@
 // Copyright (c) Athena Dev Teams - Licensed under GNU GPL
 // For more information, see LICENCE in the main folder
-
+#pragma once
 #ifndef _PC_HPP_
 #define _PC_HPP_
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -748,15 +748,19 @@ static unsigned int calc_hash(const char* p)
 	return h % SCRIPT_HASH_SIZE;
 }
 
-bool script_check_RegistryVariableLenght(int pType, const char *val, size_t* vlen) 
+bool script_check_RegistryVariableLength(int pType, const char *val, size_t* vlen) 
 {
-	size_t len = strlen( val );
-	if ( vlen ) *vlen = len;
-	switch ( pType )
-	 {
-		case 0: return (len < 33);//checking key
-		case 1: return (len < 255); //checking value
-		default: return false;
+	size_t len = strlen(val);
+
+	if (vlen)
+		*vlen = len;
+	switch (pType) {
+		case 0:
+			return (len < 33); // key check
+		case 1:
+			return (len < 255); // value check
+		default:
+			return false;
 	}
 }
 
@@ -3133,13 +3137,13 @@ int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, con
 {
 	char prefix = name[0];
 	size_t vlen = 0;
-	if ( !script_check_RegistryVariableLenght(0,name,&vlen) )
+	if ( !script_check_RegistryVariableLength(0,name,&vlen) )
 	{
 		ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, name, vlen);
 		return 0;
 	}
 
-	if( is_string_variable(name) ) {// string variable    
+	if( is_string_variable(name) ) {// string variable
 		const char *str = (const char*)value;
 
 		switch (prefix) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -3139,7 +3139,7 @@ int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, con
 	size_t vlen = 0;
 	if ( !script_check_RegistryVariableLength(0,name,&vlen) )
 	{
-		ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, name, vlen);
+		ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd?sd->status.account_id:-1, sd?sd->status.char_id:-1, name, vlen);
 		return 0;
 	}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -3121,8 +3121,14 @@ void script_array_update(struct reg_db *src, int64 num, bool empty)
 int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, const char* name, const void* value, struct reg_db *ref)
 {
 	char prefix = name[0];
+  size_t vlen = strlen( name );
+  if ( vlen > 32 )
+  {
+    ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, name, vlen);
+    return 0;
+  }
 
-	if( is_string_variable(name) ) {// string variable
+	if( is_string_variable(name) ) {// string variable    
 		const char *str = (const char*)value;
 
 		switch (prefix) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -748,6 +748,17 @@ static unsigned int calc_hash(const char* p)
 	return h % SCRIPT_HASH_SIZE;
 }
 
+bool script_check_RegistryVariableLenght(int pType, const char *val, size_t* vlen) 
+{
+	size_t len = strlen( val );
+	if ( vlen ) *vlen = len;
+	switch ( pType )
+	 {
+		case 0: return (len < 33);//checking key
+		case 1: return (len < 255); //checking value
+		default: return false;
+	}
+}
 
 /*==========================================
  * str_data manipulation functions
@@ -3121,12 +3132,12 @@ void script_array_update(struct reg_db *src, int64 num, bool empty)
 int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, const char* name, const void* value, struct reg_db *ref)
 {
 	char prefix = name[0];
-  size_t vlen = strlen( name );
-  if ( vlen > 32 )
-  {
-    ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, name, vlen);
-    return 0;
-  }
+	size_t vlen = 0;
+	if ( !script_check_RegistryVariableLenght(0,name,&vlen) )
+	{
+		ShowError("set_reg: Variable name length is too long (aid: %d, cid: %d): '%s' sz=%d\n", sd->status.account_id, sd->status.char_id, name, vlen);
+		return 0;
+	}
 
 	if( is_string_variable(name) ) {// string variable    
 		const char *str = (const char*)value;

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -1945,4 +1945,6 @@ unsigned int *script_array_cpy_list(struct script_array *sa);
 void queryThread_log(char * entry, int length);
 #endif
 
+bool script_check_RegistryVariableLenght( int pType, const char *val, size_t* vlen );
+
 #endif /* _SCRIPT_HPP_ */

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -1945,6 +1945,6 @@ unsigned int *script_array_cpy_list(struct script_array *sa);
 void queryThread_log(char * entry, int length);
 #endif
 
-bool script_check_RegistryVariableLenght( int pType, const char *val, size_t* vlen );
+bool script_check_RegistryVariableLength(int pType, const char *val, size_t* vlen);
 
 #endif /* _SCRIPT_HPP_ */


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2425 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Medium term fox for crash on char-serv caused by too long character variable.
Add few error msg and safety.
Add doc/sample/npc_test_longvar.txt as a basic test.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
