### PR TITLE
Update sc_end_class

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5389,7 +5389,7 @@ and theirs val1, val2, val3, and val4 usage in source.
 perform a complete removal of all statuses (although permanent ones will re-apply).
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
-skill on the invoking character. If <job_id> is provided it will end the effect for the that job.
+skill on the invoking character. If <job_id> is provided it will end the effect for that job.
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5409,17 +5409,17 @@ Examples:
 	// This will end the Freezing status for the invoking character.
 	sc_end SC_FREEZE;
 	
-	//will end the effect of any learned skill for the invoking character.
+	// This will end the effect of any learned skill for the invoking character.
 	sc_end_class;
 	
-	//will end the effect of any learned skill for the invoking character.
+	// This will end the effect of any learned skill for the character with the <char_id> 150000.
 	// val1: <char_id>
 	sc_end_class(150000);
 	
-	//will end the effect of any Arch Bishop skill for the invoking character.
+	// This will end the effect of any Arch Bishop skill for the invoking character.
 	// val1: <char_id> (-1 return the <char_id> of the invoking character.)
 	// val2: <job_id> of Arch Bishop
-	sc_end_class(-1,4057);
+	sc_end_class(-1,Job_Arch_Bishop);
 
 Note: to use SC_NOCHAT you should alter Manner
 	set Manner, -5;	// Will mute a user for 5 minutes

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5389,7 +5389,7 @@ and theirs val1, val2, val3, and val4 usage in source.
 perform a complete removal of all statuses (although permanent ones will re-apply).
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
-skill on the invoking character. if <job_id> was given it will end the effect for that job.
+skill on the invoking character. If <job_id> is provided it will end the effect for the that job.
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5390,7 +5390,6 @@ perform a complete removal of all statuses (although permanent ones will re-appl
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
 skill on the invoking character. if <job_id> was given it will end the effect for that job.
-if the <char_id> was -1 it will return the <char_id> for the invoking character
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.
@@ -5417,9 +5416,9 @@ Examples:
 	sc_end_class(150000);
 	
 	// This will end the effect of any Arch Bishop skill for the invoking character.
-	// val1: <char_id> (-1 return the <char_id> of the invoking character.)
+	// val1: <char_id>
 	// val2: <job_id> of Arch Bishop
-	sc_end_class(-1,Job_Arch_Bishop);
+	sc_end_class(getcharid(0),Job_Arch_Bishop);
 
 Note: to use SC_NOCHAT you should alter Manner
 	set Manner, -5;	// Will mute a user for 5 minutes

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5350,7 +5350,7 @@ Used in reset NPC's (duh!)
 *sc_start2 <effect type>,<ticks>,<value 1>,<value 2>{,<rate>,<flag>{,<GID>}};
 *sc_start4 <effect type>,<ticks>,<value 1>,<value 2>,<value 3>,<value 4>{,<rate>,<flag>{,<GID>}};
 *sc_end <effect type>{,<GID>};
-*sc_end_class {<char_id>};
+*sc_end_class {<job_id>{,<char_id>}};
 
 These commands will bestow a status effect on a character.
 
@@ -5389,7 +5389,7 @@ and theirs val1, val2, val3, and val4 usage in source.
 perform a complete removal of all statuses (although permanent ones will re-apply).
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
-skill on the invoking character.
+skill on the invoking character. if job_id was given it will end the effect for that job.
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.
@@ -5407,6 +5407,13 @@ Examples:
 
 	// This will end the Freezing status for the invoking character.
 	sc_end SC_FREEZE;
+	
+	//will end the effect of any learned skill for the invoking character.
+	sc_end_class;
+	
+	//will end the effect of any Arch Bishop skill for the invoking character.
+	// val1: job_id of Arch Bishop
+	sc_end_class(4057);
 
 Note: to use SC_NOCHAT you should alter Manner
 	set Manner, -5;	// Will mute a user for 5 minutes

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5390,6 +5390,7 @@ perform a complete removal of all statuses (although permanent ones will re-appl
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
 skill on the invoking character. if job_id was given it will end the effect for that job.
+if the job was 0 it will return the <job_id> for the invoking character
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.
@@ -5410,6 +5411,11 @@ Examples:
 	
 	//will end the effect of any learned skill for the invoking character.
 	sc_end_class;
+	
+	//will end the effect of any learned skill for the invoking character.
+	// val1: <job_id> (0 return the character <job_id>)
+	// val2: <char_id>
+	sc_end_class(0,150000);
 	
 	//will end the effect of any Arch Bishop skill for the invoking character.
 	// val1: job_id of Arch Bishop

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5350,7 +5350,7 @@ Used in reset NPC's (duh!)
 *sc_start2 <effect type>,<ticks>,<value 1>,<value 2>{,<rate>,<flag>{,<GID>}};
 *sc_start4 <effect type>,<ticks>,<value 1>,<value 2>,<value 3>,<value 4>{,<rate>,<flag>{,<GID>}};
 *sc_end <effect type>{,<GID>};
-*sc_end_class {<job_id>{,<char_id>}};
+*sc_end_class {<char_id>{,<job_id>}};
 
 These commands will bestow a status effect on a character.
 
@@ -5389,8 +5389,8 @@ and theirs val1, val2, val3, and val4 usage in source.
 perform a complete removal of all statuses (although permanent ones will re-apply).
 
 'sc_end_class' works like 'sc_end' but will remove all status effects from any learned
-skill on the invoking character. if job_id was given it will end the effect for that job.
-if the job was 0 it will return the <job_id> for the invoking character
+skill on the invoking character. if <job_id> was given it will end the effect for that job.
+if the <char_id> was -1 it will return the <char_id> for the invoking character
 
 Examples:
 	// This will poison the invoking character for 10 minutes at 50% chance.
@@ -5413,13 +5413,13 @@ Examples:
 	sc_end_class;
 	
 	//will end the effect of any learned skill for the invoking character.
-	// val1: <job_id> (0 return the character <job_id>)
-	// val2: <char_id>
-	sc_end_class(0,150000);
+	// val1: <char_id>
+	sc_end_class(150000);
 	
 	//will end the effect of any Arch Bishop skill for the invoking character.
-	// val1: job_id of Arch Bishop
-	sc_end_class(4057);
+	// val1: <char_id> (-1 return the <char_id> of the invoking character.)
+	// val2: <job_id> of Arch Bishop
+	sc_end_class(-1,4057);
 
 Note: to use SC_NOCHAT you should alter Manner
 	set Manner, -5;	// Will mute a user for 5 minutes

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11337,18 +11337,25 @@ BUILDIN_FUNC(sc_end)
 
 /**
  * Ends all status effects from any learned skill on the attached player.
- * sc_end_class {<char_id>};
+ * if job id was given it will end all the effect for that job
+ * sc_end_class {<job_id>{,<char_id>}};
  */
 BUILDIN_FUNC(sc_end_class)
 {
 	struct map_session_data *sd;
 	uint16 skill_id;
-	int i;
+	int class_;
+	struct block_list *bl = map_id2bl(st->rid);
 
-	if (!script_charid2sd(2, sd))
-		return SCRIPT_CMD_FAILURE;
+	if (!script_charid2sd(3, sd)) {
+		script_pushint(st, -1);
+		return SCRIPT_CMD_SUCCESS;
+	}
+	class_ = sd->status.class_;
+	if (script_hasdata(st, 2))
+		class_ = script_getnum(st, 2);
 
-	for (i = 0; i < MAX_SKILL_TREE && (skill_id = skill_tree[pc_class2idx(sd->status.class_)][i].skill_id) > 0; i++) { // Remove status specific to your current tree skills.
+	for (int i = 0; i < MAX_SKILL_TREE && (skill_id = skill_tree[pc_class2idx(class_)][i].skill_id) > 0; i++) {
 		enum sc_type sc = status_skill2sc(skill_id);
 
 		if (sc > SC_COMMON_MAX && sd->sc.data[sc])
@@ -23894,7 +23901,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(sc_start,"sc_start2","iiii???"),
 	BUILDIN_DEF2(sc_start,"sc_start4","iiiiii???"),
 	BUILDIN_DEF(sc_end,"i?"),
-	BUILDIN_DEF(sc_end_class,"?"),
+	BUILDIN_DEF(sc_end_class,"??"),
 	BUILDIN_DEF(getstatus, "i??"),
 	BUILDIN_DEF(getscrate,"ii?"),
 	BUILDIN_DEF(debugmes,"s"),

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11338,7 +11338,7 @@ BUILDIN_FUNC(sc_end)
 /**
  * Ends all status effects from any learned skill on the attached player.
  * if <char_id> = -1 it will return the attached player
- * if <class_id> was givin it will end the effect of that class for the attached player
+ * if <job_id> was givin it will end the effect of that class for the attached player
  * sc_end_class {<char_id>{,<job_id>}};
  */
 BUILDIN_FUNC(sc_end_class)

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11355,7 +11355,7 @@ BUILDIN_FUNC(sc_end_class)
 		class_ = sd->status.class_;
 
 	if (!pcdb_checkid(class_)) {
-		ShowError("sc_end_class: bad job id given ,[%s] is not a job id.\n", script_getstr(st, 3));
+		ShowError("buildin_sc_end_class: Invalid job ID '%d' given.\n", script_getnum(st, 3));
 		return SCRIPT_CMD_FAILURE;
 	}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11338,7 +11338,7 @@ BUILDIN_FUNC(sc_end)
 /**
  * Ends all status effects from any learned skill on the attached player.
  * if <char_id> = -1 it will return the attached player
- * if <job_id> was givin it will end the effect of that class for the attached player
+ * if <job_id> was given it will end the effect of that class for the attached player
  * sc_end_class {<char_id>{,<job_id>}};
  */
 BUILDIN_FUNC(sc_end_class)
@@ -11346,12 +11346,12 @@ BUILDIN_FUNC(sc_end_class)
 	struct map_session_data *sd;
 	uint16 skill_id;
 	int class_;
-	struct block_list *bl = map_id2bl(st->rid);
 
-	if (script_getnum(st, 2) == -1)
-		script_rid2sd(sd);
-	else
-		if (!script_charid2sd(2, sd))
+	if (script_getnum(st, 2) == -1) {
+		if (!script_rid2sd(sd))
+			return SCRIPT_CMD_FAILURE;
+	}
+	else if (!script_charid2sd(2, sd))
 			return SCRIPT_CMD_FAILURE;
 
 	if (script_hasdata(st, 3))

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11337,23 +11337,26 @@ BUILDIN_FUNC(sc_end)
 
 /**
  * Ends all status effects from any learned skill on the attached player.
- * if job id was given it will end all the effect for that job
+ * if <job_id> was given it will end all the effect for that job
+ * if <job_id> is 0 it will return the job of the invoking character
  * sc_end_class {<job_id>{,<char_id>}};
  */
 BUILDIN_FUNC(sc_end_class)
 {
 	struct map_session_data *sd;
 	uint16 skill_id;
-	int class_;
+	int class_ = 0;
 	struct block_list *bl = map_id2bl(st->rid);
 
 	if (!script_charid2sd(3, sd)) {
 		script_pushint(st, -1);
 		return SCRIPT_CMD_SUCCESS;
 	}
-	class_ = sd->status.class_;
+
 	if (script_hasdata(st, 2))
 		class_ = script_getnum(st, 2);
+	if (class_ == 0)
+		class_ = sd->status.class_;
 
 	for (int i = 0; i < MAX_SKILL_TREE && (skill_id = skill_tree[pc_class2idx(class_)][i].skill_id) > 0; i++) {
 		enum sc_type sc = status_skill2sc(skill_id);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11337,25 +11337,26 @@ BUILDIN_FUNC(sc_end)
 
 /**
  * Ends all status effects from any learned skill on the attached player.
- * if <job_id> was given it will end all the effect for that job
- * if <job_id> is 0 it will return the job of the invoking character
- * sc_end_class {<job_id>{,<char_id>}};
+ * if <char_id> = -1 it will return the attached player
+ * if <class_id> was givin it will end the effect of that class for the attached player
+ * sc_end_class {<char_id>{,<job_id>}};
  */
 BUILDIN_FUNC(sc_end_class)
 {
 	struct map_session_data *sd;
 	uint16 skill_id;
-	int class_ = 0;
+	int class_;
 	struct block_list *bl = map_id2bl(st->rid);
 
-	if (!script_charid2sd(3, sd)) {
-		script_pushint(st, -1);
-		return SCRIPT_CMD_SUCCESS;
-	}
+	if (script_getnum(st, 2) == -1)
+		script_rid2sd(sd);
+	else
+		if (!script_charid2sd(2, sd))
+			return SCRIPT_CMD_FAILURE;
 
-	if (script_hasdata(st, 2))
-		class_ = script_getnum(st, 2);
-	if (class_ == 0)
+	if (script_hasdata(st, 3))
+		class_ = script_getnum(st, 3);
+	else
 		class_ = sd->status.class_;
 
 	for (int i = 0; i < MAX_SKILL_TREE && (skill_id = skill_tree[pc_class2idx(class_)][i].skill_id) > 0; i++) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11337,7 +11337,6 @@ BUILDIN_FUNC(sc_end)
 
 /**
  * Ends all status effects from any learned skill on the attached player.
- * if <char_id> = -1 it will return the attached player
  * if <job_id> was given it will end the effect of that class for the attached player
  * sc_end_class {<char_id>{,<job_id>}};
  */
@@ -11347,12 +11346,8 @@ BUILDIN_FUNC(sc_end_class)
 	uint16 skill_id;
 	int class_;
 
-	if (script_getnum(st, 2) == -1) {
-		if (!script_rid2sd(sd))
-			return SCRIPT_CMD_FAILURE;
-	}
-	else if (!script_charid2sd(2, sd))
-			return SCRIPT_CMD_FAILURE;
+	if (!script_charid2sd(2, sd))
+		return SCRIPT_CMD_FAILURE;
 
 	if (script_hasdata(st, 3))
 		class_ = script_getnum(st, 3);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11359,6 +11359,11 @@ BUILDIN_FUNC(sc_end_class)
 	else
 		class_ = sd->status.class_;
 
+	if (!pcdb_checkid(class_)) {
+		ShowError("sc_end_class: bad job id given ,[%s] is not a job id.\n", script_getstr(st, 3));
+		return SCRIPT_CMD_FAILURE;
+	}
+
 	for (int i = 0; i < MAX_SKILL_TREE && (skill_id = skill_tree[pc_class2idx(class_)][i].skill_id) > 0; i++) {
 		enum sc_type sc = status_skill2sc(skill_id);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 

sc_end_class now can be end the effect of specific job 
if no job id was given it will end the skill effect for the job of the invoking character
sc_end_class {<char_id>{,<job_id>}};

Example:
the test npc
[sc_end_class.txt](https://github.com/rathena/rathena/files/1532031/sc_end_class.txt)

