### PR TITLE
fix negative on timer in sc_start

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11222,7 +11222,7 @@ BUILDIN_FUNC(sc_start)
 	else
 		bl = map_id2bl(st->rid);
 
-	if(tick == 0 && val1 > 0 && type > SC_NONE && type < SC_MAX && status_sc2skill(type) != 0)
+	if(tick <= 0 && val1 > 0 && type > SC_NONE && type < SC_MAX && status_sc2skill(type) != 0)
 	{// When there isn't a duration specified, try to get it from the skill_db
 		tick = skill_get_time(status_sc2skill(type), val1);
 	}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11221,8 +11221,11 @@ BUILDIN_FUNC(sc_start)
 		bl = map_id2bl(script_getnum(st,(6+start_type)));
 	else
 		bl = map_id2bl(st->rid);
+	
+	if(tick < 0)//it the timer is negative number it will fail
+		return SCRIPT_CMD_FAILURE;
 
-	if(tick <= 0 && val1 > 0 && type > SC_NONE && type < SC_MAX && status_sc2skill(type) != 0)
+	if(tick == 0 && val1 > 0 && type > SC_NONE && type < SC_MAX && status_sc2skill(type) != 0)
 	{// When there isn't a duration specified, try to get it from the skill_db
 		tick = skill_get_time(status_sc2skill(type), val1);
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/2716

* **Server Mode**: both

* **Description of Pull Request**: 
when using negative value for the timer the buff stuck with no time
~the PR is for if the timer value is less or equal 0 it will return the time from the skill_db~

after thinking about it there is effects dose not have timer in the skill db (like foods effect) so i am making it return script fail