### PR TITLE
Fixed a crash caused by setquest in login events

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -12256,6 +12256,8 @@ void pc_show_questinfo(struct map_session_data *sd) {
 		return;
 	if (!map[sd->bl.m].qi_count || !map[sd->bl.m].qi_data)
 		return;
+	if (map[sd->bl.m].qi_count != sd->qi_count)
+		return; // init was not called yet
 
 	for(i = 0; i < map[sd->bl.m].qi_count; i++) {
 		qi = &map[sd->bl.m].qi_data[i];


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2700 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Fixed a bug where using setquest in a login event and a player spawning next to a NPC with setquestinfo causing a crash, because the players quest display data was not initialized yet.

Thanks to @ignizh

Reproducible through the following script and logging in at lasagna,173,157 for example.

```
-	script	Issue2700	-1,{
OnPCLoginEvent:
	setquest 1000;
	end;
}
``` 
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
