### PR TITLE
Follow up to 716f6c0

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6210,7 +6210,7 @@ void clif_GlobalMessage(struct block_list* bl, const char* message, enum send_ta
 	std::unique_ptr<char> buf(new char[8+len]);
 
 	WBUFW(buf.get(),0)=0x8d;
-	WBUFW(buf.get(),2)=static_cast<int>(len+8);
+	WBUFW(buf.get(),2)=static_cast<int>((uint16)len+8);
 	WBUFL(buf.get(),4)=bl->id;
 	safestrncpy(WBUFCP(buf.get(),8),message,len);
 


### PR DESCRIPTION
fix compile warning `repos\rathena\src\map\clif.cpp(6213): warning C4267: '=': conversion from 'size_t' to 'uint16', possible loss of data`
