### PR TITLE
Fixed mapserver crash on script command warp

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -304,7 +304,7 @@ int npc_rr_secure_timeout_timer(int tid, unsigned int tick, int id, intptr_t dat
 /*==========================================
  * Dequeue event and add timer for execution (100ms)
  *------------------------------------------*/
-int npc_event_dequeue(struct map_session_data* sd)
+int npc_event_dequeue(struct map_session_data* sd,bool free_script_stack)
 {
 	nullpo_ret(sd);
 
@@ -314,7 +314,7 @@ int npc_event_dequeue(struct map_session_data* sd)
 			clif_clearunit_single(sd->npc_id, CLR_OUTSIGHT, sd->fd);
 			sd->state.using_fake_npc = 0;
 		}
-		if (sd->st) {
+		if (free_script_stack&&sd->st) {
 			script_free_state(sd->st);
 			sd->st = NULL;
 		}

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -1123,7 +1123,7 @@ enum npce_event : uint8 {
 };
 struct view_data* npc_get_viewdata(int class_);
 int npc_chat_sub(struct block_list* bl, va_list ap);
-int npc_event_dequeue(struct map_session_data* sd);
+int npc_event_dequeue(struct map_session_data* sd,bool free_script_stack=true);
 int npc_event(struct map_session_data* sd, const char* eventname, int ontouch);
 int npc_touch_areanpc(struct map_session_data* sd, int16 m, int16 x, int16 y);
 int npc_touch_areanpc2(struct mob_data *md); // [Skotlex]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  #2765

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
The mapserver was freeing the script stack to early and the current iteration was not able to notice that the data behind it's pointer had already been freed. Because of that it would try to continue the script execution after the warp command, which will lead in a crash, because the script stack was freed already.
By adding an optional argument to prevent freeing the current script stack of a player while dequeueing npc events the script can continue as intended. But since we do not want the script to continue we manually stop it by setting the state to END so the current execution will halt after the warp command and the calling function can do a cleanup by itself - as intended.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
