### PR TITLE
Fixes typo in atcommand.cpp

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8419,7 +8419,7 @@ ACMD_FUNC(accept)
 		return 0;
 	}
 
-	if( duel_check_player_limit( duel_get_duelid( sd->duel_invite ) ) )
+	if( !duel_check_player_limit( duel_get_duelid( sd->duel_invite ) ) )
 	{
 		clif_displaymessage(fd, msg_txt(sd,351)); // "Duel: Limit of players is reached."
 		return 0;


### PR DESCRIPTION
* **Addressed Issue(s)**: #2777 
* **Server Mode**: Tested on Renewal
* **Description of Pull Request**: 
  * Fixes #2777 
  * Fixes typo in `atcommand.cpp` that makes atcommand `@accept` after `@duel` cannot be used because of limit player reached.
  