### PR TITLE
Fixed memory leak when import/castle_db overwrites existing castles.

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -165,12 +165,16 @@ int guild_check_skill_require(struct guild *g,int id) {
 static bool guild_read_castledb(char* str[], int columns, int current) {// <castle id>,<map name>,<castle name>,<castle event>[,<reserved/unused switch flag>]
 	struct guild_castle *gc;
 	int mapindex = mapindex_name2id(str[1]);
-
+	const int castle_id = atoi(str[0]);
+	
 	if (map_mapindex2mapid(mapindex) < 0) // Map not found or on another map-server
 		return false;
 
-	CREATE(gc, struct guild_castle, 1);
-	gc->castle_id = atoi(str[0]);
+	if ((gc = static_cast<guild_castle*>(idb_get(castle_db, castle_id))) == nullptr) {
+		CREATE(gc, struct guild_castle, 1);
+	}
+	
+	gc->castle_id = castle_id;
 	gc->mapindex = mapindex;
 	safestrncpy(gc->castle_name, trim(str[2]), sizeof(gc->castle_name));
 	safestrncpy(gc->castle_event, trim(str[3]), sizeof(gc->castle_event));


### PR DESCRIPTION
* **Addressed Issue(s)**: #2793 
* **Server Mode**: Both
* **Description of Pull Request**: Made `guild_read_castledb` function re-use already allocated memory for the old data