### PR TITLE
Hotfix Geffen Magic Tournament

### DIFF
--- a/npc/custom/official/GeffenMagicTournament.txt
+++ b/npc/custom/official/GeffenMagicTournament.txt
@@ -148,9 +148,9 @@ OnTimer1000:
 		case 106:
 			npctalk "Our friendship is forever~!!!", instance_npcname("Young Lady#gef3");
 			emotion ET_THROB, getnpcid(0, instance_npcname("Handsome Adventurer#gef"));
-			sleep2 500;
+			sleep 500;
 			npctalk "Our friendship is forever~!!!", instance_npcname("Young Lady#gef1");
-			sleep2 500;
+			sleep 500;
 			npctalk "Our friendship is forever~!!!", instance_npcname("Young Lady#gef2");
 			'm1_timer++;
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 
fix sleep in the script after killing the first monster getting the following
```
[Info]: Saved char 150000 - sader: status.
[Error]: buildin_sleep2: no unit is attached
[Debug]: Source (NPC): MOVIECONTROL#gef at 0011@gef (73,84)
[Error]: buildin_sleep2: no unit is attached
[Debug]: Source (NPC): MOVIECONTROL#gef at 0011@gef (73,84)
[Info]: Saved Inventory (0) data to table inventory for char_id: 150000
```
How to Reproduce: 
enter Geffen Magic Tournament Instance and fight the error would be in the terminal after you defite the first monster inside the Tournament (not the wolf)
