### PR TITLE
Job Level check for Blacksmith and Alchemist

### DIFF
--- a/npc/quests/skills/merchant_skills.txt
+++ b/npc/quests/skills/merchant_skills.txt
@@ -41,7 +41,7 @@ alberta,83,96,5	script	Necko	98,7,7,{
 			mes "Ppyakikakikakakakakakakaka!!";
 			close;
 		}
-		else if (JobLevel < 15 && (BaseJob != Job_Blacksmith || BaseJob != Job_Alchemist ) {
+		else if (JobLevel < 15 && BaseClass = Job_Merchant ) {
 			mes "[Necko]";
 			mes "Oh, did you come because";
 			mes "you are infatuated with my voice?";

--- a/npc/quests/skills/merchant_skills.txt
+++ b/npc/quests/skills/merchant_skills.txt
@@ -41,7 +41,7 @@ alberta,83,96,5	script	Necko	98,7,7,{
 			mes "Ppyakikakikakakakakakakaka!!";
 			close;
 		}
-		else if (JobLevel < 15) {
+		else if (JobLevel < 15 && (BaseJob != Job_Blacksmith || BaseJob != Job_Alchemist ) {
 			mes "[Necko]";
 			mes "Oh, did you come because";
 			mes "you are infatuated with my voice?";

--- a/npc/quests/skills/merchant_skills.txt
+++ b/npc/quests/skills/merchant_skills.txt
@@ -41,7 +41,7 @@ alberta,83,96,5	script	Necko	98,7,7,{
 			mes "Ppyakikakikakakakakakakaka!!";
 			close;
 		}
-		else if (JobLevel < 15 && BaseClass = Job_Merchant ) {
+		else if (JobLevel < 15 && BaseClass == Job_Merchant ) {
 			mes "[Necko]";
 			mes "Oh, did you come because";
 			mes "you are infatuated with my voice?";

--- a/npc/quests/skills/merchant_skills.txt
+++ b/npc/quests/skills/merchant_skills.txt
@@ -41,7 +41,7 @@ alberta,83,96,5	script	Necko	98,7,7,{
 			mes "Ppyakikakikakakakakakakaka!!";
 			close;
 		}
-		else if (JobLevel < 15 && BaseClass == Job_Merchant ) {
+		else if (JobLevel < 15 && Class == Job_Merchant ) {
 			mes "[Necko]";
 			mes "Oh, did you come because";
 			mes "you are infatuated with my voice?";


### PR DESCRIPTION
Blacksmith and Alchemist should be exempted from reaching LV 15 before being able to learn crazy uproar.
If only job lvl is use, it will not fall through to the code that checks wether the PC is a blacksmith or alchemist.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
