### PR TITLE
Updates Rolling Cutter counter behavior

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10750,6 +10750,7 @@ void clif_parse_WalkToXY(int fd, struct map_session_data *sd)
 	// not when you move each cell.  This is official behaviour.
 	if (sd->sc.data[SC_CLOAKING])
 		skill_check_cloaking(&sd->bl, sd->sc.data[SC_CLOAKING]);
+	status_change_end(&sd->bl, SC_ROLLINGCUTTER, INVALID_TIMER); // If you move, you lose your counters. [malufett]
 
 	pc_delinvincibletimer(sd);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -415,7 +415,6 @@ int map_moveblock(struct block_list *bl, int x1, int y1, unsigned int tick)
 		skill_unit_move(bl,tick,2);
 		if ( sc && sc->count ) //at least one to cancel
 		{
-			status_change_end(bl, SC_ROLLINGCUTTER, INVALID_TIMER); // If you move, you lose your counters. [malufett]
 			status_change_end(bl, SC_CLOSECONFINE, INVALID_TIMER);
 			status_change_end(bl, SC_CLOSECONFINE2, INVALID_TIMER);
 			status_change_end(bl, SC_TINDER_BREAKER, INVALID_TIMER);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2835

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Rolling Cutter counter should only be reset on physical click-walks, not by any other movement.
Thanks to @ecdarreola and @secretdataz!