### PR TITLE
Re-gain Bioethics on Skill Reset

### DIFF
--- a/npc/quests/skills/alchemist_skills.txt
+++ b/npc/quests/skills/alchemist_skills.txt
@@ -1150,7 +1150,7 @@ yuno_in04,33,106,4	script	Pile of Books#qsk_al	111,{
 
 // Start Bioethics quest
 lhz_in01,224,140,3	script	Kellasus#qsk_al	57,{
-	if (BaseJob == Job_Alchemist && bioeth == 13) {
+	if (getskilllv("AM_BIOETHICS") != 0 && BaseJob == Job_Alchemist && bioeth == 13) {
 		mes "[Kellasus]";
 		mes "Keep up the";
 		mes "good work. I get";
@@ -1159,7 +1159,7 @@ lhz_in01,224,140,3	script	Kellasus#qsk_al	57,{
 		mes "be depending on you...";
 		close;
 	}
-	if (BaseJob == Job_Alchemist && bioeth == 12) {
+	if (BaseJob == Job_Alchemist && bioeth >= 12) {
 		mes "[Kellasus]";
 		mes "Alright then, I'll begin";
 		mes "by teaching you ^FF0000Bioethics^000000,";


### PR DESCRIPTION
If a PC reset using neuralizer, there is currently no way that they can regain the bioethics skill. Modified first and second check to fallback to teaching the skill if AM_BIOETHICS is not available. 