### PR TITLE
Sword Mastery affects 1H-Sword damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1772,6 +1772,8 @@ int64 battle_addmastery(struct map_session_data *sd,struct block_list *target,in
 			if((skill = pc_checkskill(sd,AM_AXEMASTERY)) > 0)
 				damage += (skill * 3);
 #endif
+			if((skill = pc_checkskill(sd,SM_SWORD)) > 0)
+				damage += (skill * 4);
 		case W_DAGGER:
 			if((skill = pc_checkskill(sd,SM_SWORD)) > 0)
 				damage += (skill * 4);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2885
* **Server Mode**: Classic, Renewal
* **Description of Pull Request**: Add Sword Mastery bonus to sword damage
