### PR TITLE
Converted pet_data::petDB into a getter function

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -7902,20 +7902,23 @@ void clif_send_petstatus(struct map_session_data *sd)
 void clif_pet_emotion(struct pet_data *pd,int param)
 {
 	unsigned char buf[16];
+	s_pet_db *pet_db_ptr;
 
 	nullpo_retv(pd);
+
+	pet_db_ptr = pd->get_pet_db();
 
 	memset(buf,0,packet_len(0x1aa));
 
 	WBUFW(buf,0)=0x1aa;
 	WBUFL(buf,2)=pd->bl.id;
-	if(param >= 100 && pd->petDB->talk_convert_class) {
-		if(pd->petDB->talk_convert_class < 0)
+	if(param >= 100 && pet_db_ptr->talk_convert_class) {
+		if(pet_db_ptr->talk_convert_class < 0)
 			return;
-		else if(pd->petDB->talk_convert_class > 0) {
+		else if(pet_db_ptr->talk_convert_class > 0) {
 			// replace mob_id component of talk/act data
 			param -= (pd->pet.class_ - 100)*100;
-			param += (pd->petDB->talk_convert_class - 100)*100;
+			param += (pet_db_ptr->talk_convert_class - 100)*100;
 		}
 	}
 	WBUFL(buf,6)=param;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7714,7 +7714,7 @@ int pc_dead(struct map_session_data *sd,struct block_list *src)
 	if(sd->status.pet_id > 0 && sd->pd) {
 		struct pet_data *pd = sd->pd;
 		if( !map[sd->bl.m].flag.noexppenalty ) {
-			pet_set_intimate(pd, pd->pet.intimate - pd->petDB->die);
+			pet_set_intimate(pd, pd->pet.intimate - pd->get_pet_db()->die);
 			if( pd->pet.intimate < 0 )
 				pd->pet.intimate = 0;
 			clif_send_petdata(sd,sd->pd,1,pd->pet.intimate);

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -884,9 +884,11 @@ int pet_equipitem(struct map_session_data *sd,int index)
 	nullpo_retr(1, sd);
 
 	pd = sd->pd;
-	pet_db_ptr = pd->get_pet_db();
 
 	if (!pd)
+		return 1;
+	
+	if((pet_db_ptr = pd->get_pet_db()) == nullptr)
 		return 1;
 
 	nameid = sd->inventory.u.items_inventory[index].nameid;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -167,10 +167,13 @@ int pet_attackskill(struct pet_data *pd, int target_id)
 int pet_target_check(struct pet_data *pd,struct block_list *bl,int type)
 {
 	int rate;
+	s_pet_db* pet_db_ptr;
 
 	nullpo_ret(pd);
 
 	Assert((pd->master == 0) || (pd->master->pd == pd));
+
+	pet_db_ptr = pd->get_pet_db();
 
 	if(bl == NULL || bl->type != BL_MOB || bl->prev == NULL ||
 		pd->pet.intimate < battle_config.pet_support_min_friendly ||
@@ -191,21 +194,21 @@ int pet_target_check(struct pet_data *pd,struct block_list *bl,int type)
 		return 0;
 
 	if(!type) {
-		rate = pd->petDB->attack_rate;
+		rate = pet_db_ptr->attack_rate;
 		rate = rate * pd->rate_fix / 1000;
 
-		if(pd->petDB->attack_rate > 0 && rate <= 0)
+		if(pet_db_ptr->attack_rate > 0 && rate <= 0)
 			rate = 1;
 	} else {
-		rate = pd->petDB->defence_attack_rate;
+		rate = pet_db_ptr->defence_attack_rate;
 		rate = rate * pd->rate_fix / 1000;
 
-		if(pd->petDB->defence_attack_rate > 0 && rate <= 0)
+		if(pet_db_ptr->defence_attack_rate > 0 && rate <= 0)
 			rate = 1;
 	}
 
 	if(rnd()%10000 < rate) {
-		if(pd->target_id == 0 || rnd()%10000 < pd->petDB->change_target_rate)
+		if(pd->target_id == 0 || rnd()%10000 < pet_db_ptr->change_target_rate)
 			pd->target_id = bl->id;
 	}
 
@@ -249,6 +252,7 @@ static int pet_hungry(int tid, unsigned int tick, int id, intptr_t data)
 {
 	struct map_session_data *sd;
 	struct pet_data *pd;
+	s_pet_db *pet_db_ptr;
 	int interval;
 
 	sd = map_id2sd(id);
@@ -260,6 +264,7 @@ static int pet_hungry(int tid, unsigned int tick, int id, intptr_t data)
 		return 1;
 
 	pd = sd->pd;
+	pet_db_ptr = pd->get_pet_db();
 
 	if(pd->pet_hungry_timer != tid) {
 		ShowError("pet_hungry_timer %d != %d\n",pd->pet_hungry_timer,tid);
@@ -290,9 +295,9 @@ static int pet_hungry(int tid, unsigned int tick, int id, intptr_t data)
 	clif_send_petdata(sd,pd,2,pd->pet.hungry);
 
 	if(battle_config.pet_hungry_delay_rate != 100)
-		interval = (pd->petDB->hungry_delay*battle_config.pet_hungry_delay_rate)/100;
+		interval = (pet_db_ptr->hungry_delay*battle_config.pet_hungry_delay_rate)/100;
 	else
-		interval = pd->petDB->hungry_delay;
+		interval = pet_db_ptr->hungry_delay;
 
 	if(interval <= 0)
 		interval = 1;
@@ -354,7 +359,7 @@ static int pet_performance(struct map_session_data *sd, struct pet_data *pd)
 	int val;
 
 	if (pd->pet.intimate > 900)
-		val = (pd->petDB->s_perfor > 0) ? 4 : 3;
+		val = (pd->get_pet_db()->s_perfor > 0) ? 4 : 3;
 	else if(pd->pet.intimate > 750) //TODO: this is way too high
 		val = 2;
 	else
@@ -380,7 +385,7 @@ static int pet_return_egg(struct map_session_data *sd, struct pet_data *pd)
 
 	pet_lootitem_drop(pd,sd);
 	memset(&tmp_item,0,sizeof(tmp_item));
-	tmp_item.nameid = pd->petDB->EggID;
+	tmp_item.nameid = pd->get_pet_db()->EggID;
 	tmp_item.identify = 1;
 	tmp_item.card[0] = CARD0_PET;
 	tmp_item.card[1] = GetWord(pd->pet.pet_id,0);
@@ -450,7 +455,6 @@ bool pet_data_init(struct map_session_data *sd, struct s_pet *pet)
 	pd->bl.id = npc_get_new_npc_id();
 
 	pd->master = sd;
-	pd->petDB = pet_db_ptr;
 	pd->db = mob_db(pet->class_);
 	memcpy(&pd->pet, pet, sizeof(struct s_pet));
 	status_set_viewdata(&pd->bl, pet->class_);
@@ -473,7 +477,7 @@ bool pet_data_init(struct map_session_data *sd, struct s_pet *pet)
 	if( battle_config.pet_status_support )
 		run_script(pet_db_ptr->pet_script,0,sd->bl.id,0);
 
-	if( pd->petDB ) {
+	if( pd->get_pet_db() ) {
 		if( pet_db_ptr->pet_loyal_script )
 			status_calc_pc(sd,SCO_NONE);
 
@@ -778,7 +782,7 @@ int pet_menu(struct map_session_data *sd,int menunum)
 	if(!sd->status.pet_id || sd->pd->pet.intimate <= 0 || sd->pd->pet.incubate)
 		return 1;
 
-	egg_id = itemdb_exists(sd->pd->petDB->EggID);
+	egg_id = itemdb_exists(sd->pd->get_pet_db()->EggID);
 
 	if (egg_id) {
 		if ((egg_id->flag.trade_restriction&0x01) && !pc_inventoryblank(sd)) {
@@ -874,18 +878,20 @@ int pet_change_name_ack(struct map_session_data *sd, char* name, int flag)
 int pet_equipitem(struct map_session_data *sd,int index)
 {
 	struct pet_data *pd;
+	s_pet_db *pet_db_ptr;
 	unsigned short nameid;
 
 	nullpo_retr(1, sd);
 
 	pd = sd->pd;
+	pet_db_ptr = pd->get_pet_db();
 
 	if (!pd)
 		return 1;
 
 	nameid = sd->inventory.u.items_inventory[index].nameid;
 
-	if(pd->petDB->AcceID == 0 || nameid != pd->petDB->AcceID || pd->pet.equip != 0) {
+	if(pet_db_ptr->AcceID == 0 || nameid != pet_db_ptr->AcceID || pd->pet.equip != 0) {
 		clif_equipitemack(sd,0,0,ITEM_EQUIP_ACK_FAIL);
 		return 1;
 	}
@@ -971,9 +977,13 @@ static int pet_unequipitem(struct map_session_data *sd, struct pet_data *pd)
  */
 static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 {
+	nullpo_retr(1, sd);
+	nullpo_retr(1, pd);
+
+	s_pet_db *pet_db_ptr = pd->get_pet_db();
 	int i,k;
 
-	k = pd->petDB->FoodID;
+	k = pet_db_ptr->FoodID;
 	i = pc_search_inventory(sd,k);
 
 	if( i < 0 ) {
@@ -985,12 +995,12 @@ static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 	pc_delitem(sd,i,1,0,0,LOG_TYPE_CONSUME);
 
 	if( pd->pet.hungry > 90 )
-		pet_set_intimate(pd, pd->pet.intimate - pd->petDB->r_full);
+		pet_set_intimate(pd, pd->pet.intimate - pet_db_ptr->r_full);
 	else {
 		if( battle_config.pet_friendly_rate != 100 )
-			k = (pd->petDB->r_hungry * battle_config.pet_friendly_rate) / 100;
+			k = (pet_db_ptr->r_hungry * battle_config.pet_friendly_rate) / 100;
 		else
-			k = pd->petDB->r_hungry;
+			k = pet_db_ptr->r_hungry;
 
 		if( pd->pet.hungry > 75 ) {
 			k = k >> 1;
@@ -1009,16 +1019,16 @@ static int pet_food(struct map_session_data *sd, struct pet_data *pd)
 		pd->pet.intimate = 1000;
 
 	status_calc_pet(pd,SCO_NONE);
-	pd->pet.hungry += pd->petDB->fullness;
+	pd->pet.hungry += pet_db_ptr->fullness;
 
 	if( pd->pet.hungry > 100 )
 		pd->pet.hungry = 100;
 
-	log_feeding(sd, LOG_FEED_PET, pd->petDB->FoodID);
+	log_feeding(sd, LOG_FEED_PET, pet_db_ptr->FoodID);
 
 	clif_send_petdata(sd,pd,2,pd->pet.hungry);
 	clif_send_petdata(sd,pd,1,pd->pet.intimate);
-	clif_pet_food(sd,pd->petDB->FoodID,1);
+	clif_pet_food(sd, pet_db_ptr->FoodID,1);
 
 	return 0;
 }
@@ -1136,11 +1146,11 @@ static int pet_ai_sub_hard(struct pet_data *pd, struct map_session_data *sd, uns
 	}
 
 	// Return speed to normal.
-	if (pd->status.speed != pd->petDB->speed) {
+	if (pd->status.speed != pd->get_pet_db()->speed) {
 		if (pd->ud.walktimer != INVALID_TIMER)
 			return 0; // Wait until the pet finishes walking back to master.
 
-		pd->status.speed = pd->petDB->speed;
+		pd->status.speed = pd->get_pet_db()->speed;
 		pd->ud.state.change_walk_target = pd->ud.state.speed_changed = 1;
 	}
 

--- a/src/map/pet.hpp
+++ b/src/map/pet.hpp
@@ -98,6 +98,8 @@ struct pet_loot {
 	unsigned short max;
 };
 
+struct s_pet_db *pet_db(uint16 pet_id);
+
 struct pet_data {
 	struct block_list bl;
 	struct unit_data ud;
@@ -105,7 +107,6 @@ struct pet_data {
 	struct s_pet pet;
 	struct status_data status;
 	struct mob_db *db;
-	struct s_pet_db *petDB;
 	int pet_hungry_timer;
 	int target_id;
 	struct {
@@ -123,9 +124,11 @@ struct pet_data {
 
 	int masterteleport_timer;
 	struct map_session_data *master;
-};
 
-struct s_pet_db *pet_db(uint16 pet_id);
+	s_pet_db* get_pet_db() {
+		return pet_db(this->pet.class_);
+	}
+};
 
 bool pet_create_egg(struct map_session_data *sd, unsigned short item_id);
 int pet_hungry_val(struct pet_data *pd);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2882,7 +2882,7 @@ void status_calc_pet_(struct pet_data *pd, enum e_status_calc_opt opt)
 		memcpy(&pd->status, &pd->db->status, sizeof(struct status_data));
 		pd->status.mode = MD_CANMOVE; // Pets discard all modes, except walking
 		pd->status.class_ = CLASS_NORMAL;
-		pd->status.speed = pd->petDB->speed;
+		pd->status.speed = pd->get_pet_db()->speed;
 
 		if(battle_config.pet_attack_support || battle_config.pet_damage_support) {
 			// Attack support requires the pet to be able to attack
@@ -3724,9 +3724,11 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 
 	if( sd->pd ) { // Pet Bonus
 		struct pet_data *pd = sd->pd;
-		if( pd && pd->petDB && pd->petDB->pet_loyal_script && pd->pet.intimate >= battle_config.pet_equip_min_friendly )
-			run_script(pd->petDB->pet_loyal_script,0,sd->bl.id,0);
-		if( pd && pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus )
+		s_pet_db *pet_db_ptr = pd->get_pet_db();
+
+		if( pet_db_ptr != nullptr && pd->get_pet_db() && pd->get_pet_db()->pet_loyal_script && pd->pet.intimate >= battle_config.pet_equip_min_friendly )
+			run_script(pd->get_pet_db()->pet_loyal_script,0,sd->bl.id,0);
+		if( pet_db_ptr != nullptr && pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus )
 			pc_bonus(sd,pd->bonus->type, pd->bonus->val);
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3726,9 +3726,9 @@ int status_calc_pc_(struct map_session_data* sd, enum e_status_calc_opt opt)
 		struct pet_data *pd = sd->pd;
 		s_pet_db *pet_db_ptr = pd->get_pet_db();
 
-		if( pet_db_ptr != nullptr && pd->get_pet_db() && pd->get_pet_db()->pet_loyal_script && pd->pet.intimate >= battle_config.pet_equip_min_friendly )
+		if( pet_db_ptr != nullptr && pet_db_ptr->pet_loyal_script && pd->pet.intimate >= battle_config.pet_equip_min_friendly )
 			run_script(pd->get_pet_db()->pet_loyal_script,0,sd->bl.id,0);
-		if( pet_db_ptr != nullptr && pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus )
+		if( pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus )
 			pc_bonus(sd,pd->bonus->type, pd->bonus->val);
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #2900 
* **Server Mode**: Both
* **Description of Pull Request**: 
pd->petDB pointer is not updated upon monster database reloading. This PR fixes the issue by removing the pointer storing behavior and put a getter function to retrieve the pointer instead.