### PR TITLE
Fixed Mystical Amplification and Chain Lightning

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4101,8 +4101,8 @@ static int skill_timerskill(int tid, unsigned int tick, int id, intptr_t data)
 					}
 					break;
 				case WL_CHAINLIGHTNING_ATK: {
-						skill_attack(BF_MAGIC,src,src,target,skl->skill_id,skl->skill_lv,tick,9 - skl->type); // Hit a Lightning on the current Target
 						skill_toggle_magicpower(src, skl->skill_id); // Only the first hit will be amplified
+						skill_attack(BF_MAGIC,src,src,target,skl->skill_id,skl->skill_lv,tick,9 - skl->type); // Hit a Lightning on the current Target
 						if( skl->type < (4 + skl->skill_lv - 1) && skl->x < 3  )
 						{ // Remaining Chains Hit
 							struct block_list *nbl = NULL; // Next Target of Chain


### PR DESCRIPTION
* **Addressed Issue(s)**: #2897

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Mystical Amplification should only boost the damage for the first Chain Lightning attack.
Thanks to @admkakaroto!