### PR TITLE
Fixed athena-start newlines not set to unix type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.vcxproj merge=union
 *.sln text eol=crlf
 *.bat text eol=crlf
+athena-start text eol=lf
 configure text eol=lf
 configure.in text eol=lf
 Makefile text eol=lf


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Set athena-start newlines to unix type (LF) as it should.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
