### PR TITLE
Fixed compatibility with newer MySQL client library derivatives

### DIFF
--- a/src/common/sql.c
+++ b/src/common/sql.c
@@ -78,7 +78,8 @@ Sql* Sql_Malloc(void)
 	self->lengths = NULL;
 	self->result = NULL;
 	self->keepalive = INVALID_TIMER;
-	self->handle.reconnect = 1;
+	my_bool reconnect = 1;
+	mysql_options(&self->handle, MYSQL_OPT_RECONNECT, &reconnect);
 	return self;
 }
 


### PR DESCRIPTION
* **Addressed Issue(s)**: None
* **Server Mode**: Irrelevant
* **Description of Pull Request**: 
MYSQL.reconnect does not exist in some new versions of MariaDB client library.
This PR fixes the issue by using MYSQL_OPT_RECONNECT instead of setting MYSQL.reconnect variable.