### PR TITLE
Fixed titles only being added on relog

### DIFF
--- a/src/map/achievement.cpp
+++ b/src/map/achievement.cpp
@@ -292,11 +292,6 @@ bool achievement_update_achievement(struct map_session_data *sd, int achievement
 	clif_achievement_update(sd, &sd->achievement_data.achievements[i], sd->achievement_data.count - sd->achievement_data.incompleteCount);
 	sd->achievement_data.save = true; // Flag to save with the autosave interval
 
-	if (sd->achievement_data.sendlist) {
-		clif_achievement_list_all(sd);
-		sd->achievement_data.sendlist = false;
-	}
-
 	return true;
 }
 
@@ -329,15 +324,16 @@ void achievement_get_reward(struct map_session_data *sd, int achievement_id, tim
 
 	// Only update in the cache, db was updated already
 	sd->achievement_data.achievements[i].rewarded = rewarded;
+	sd->achievement_data.save = true;
 
 	run_script(adb->rewards.script, 0, sd->bl.id, fake_nd->bl.id);
 	if (adb->rewards.title_id) {
 		sd->titles.push_back(adb->rewards.title_id);
-		sd->achievement_data.sendlist = true;
+		clif_achievement_list_all(sd);
+	}else{
+		clif_achievement_reward_ack(sd->fd, 1, achievement_id);
+		clif_achievement_update(sd, &sd->achievement_data.achievements[i], sd->achievement_data.count - sd->achievement_data.incompleteCount);
 	}
-
-	clif_achievement_reward_ack(sd->fd, 1, achievement_id);
-	clif_achievement_update(sd, &sd->achievement_data.achievements[i], sd->achievement_data.count - sd->achievement_data.incompleteCount);
 }
 
 /**

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1534,7 +1534,6 @@ void pc_reg_received(struct map_session_data *sd)
 		sd->achievement_data.total_score = 0;
 		sd->achievement_data.level = 0;
 		sd->achievement_data.save = false;
-		sd->achievement_data.sendlist = false;
 		sd->achievement_data.count = 0;
 		sd->achievement_data.incompleteCount = 0;
 		sd->achievement_data.achievements = NULL;

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -607,7 +607,6 @@ struct map_session_data {
 		int total_score;                  ///< Total achievement points
 		int level;                        ///< Achievement level
 		bool save;                        ///< Flag to know if achievements need to be saved
-		bool sendlist;                    ///< Flag to know if all achievements should be sent to the player (refresh list if an achievement has a title)
 		uint16 count;                     ///< Total achievements in log
 		uint16 incompleteCount;           ///< Total incomplete achievements in log
 		struct achievement *achievements; ///< Achievement log entries


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #2944

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Removed leftover sendlist variable and always send the full list as soon as title is added.
Also set the auto save flag on reward retrieval

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
