### PR TITLE
Corrected guild storage saving

### DIFF
--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -908,7 +908,7 @@ bool storage_guild_storagesave(uint32 account_id, int guild_id, int flag)
 	struct s_storage *stor = guild2storage2(guild_id);
 
 	if (stor) {
-		if (flag) //Char quitting, close it.
+		if (flag&CSAVE_QUIT) //Char quitting, close it.
 			stor->status = false;
 
 		if (stor->dirty)


### PR DESCRIPTION
* **Addressed Issue(s)**: #2946

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves players being unable to transfer items when the character data is saved while a guild storage is open.
Thanks to @CodexRegius!