### PR TITLE
Mob MATK Update

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2581,16 +2581,14 @@ void status_calc_misc(struct block_list *bl, struct status_data *status, int lev
 	status->matk_min = status->matk_max = status_base_matk(bl, status, level);
 
 	///! TODO: Confirm these RENEWAL calculations. Currently is using previous calculation before 083cf5d9 (issue: #321) and until re/mob_db.txt is updated.
-	//switch (bl->type) {
-	//	case BL_MOB:
-	//		status->matk_min += 70 * ((TBL_MOB*)bl)->status.rhw.atk2 / 100;
-	//		status->matk_max += 130 * ((TBL_MOB*)bl)->status.rhw.atk2 / 100;
-	//		break;
+	switch (bl->type) {
+			status->matk_min += 70 * (((TBL_MOB*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
+			status->matk_max += 130 * (((TBL_MOB*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
 	//	case BL_MER:
 	//		status->matk_min += 70 * ((TBL_MER*)bl)->battle_status.rhw.atk2 / 100;
 	//		status->matk_max += 130 * ((TBL_MER*)bl)->battle_status.rhw.atk2 / 100;
 	//		break;
-	//}
+	}
 #else
 	// Matk
 	status->matk_min = status_base_matk_min(status);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2582,12 +2582,14 @@ void status_calc_misc(struct block_list *bl, struct status_data *status, int lev
 
 	///! TODO: Confirm these RENEWAL calculations. Currently is using previous calculation before 083cf5d9 (issue: #321) and until re/mob_db.txt is updated.
 	switch (bl->type) {
+		case BL_MOB:
 			status->matk_min += 70 * (((TBL_MOB*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
 			status->matk_max += 130 * (((TBL_MOB*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
-	//	case BL_MER:
-	//		status->matk_min += 70 * ((TBL_MER*)bl)->battle_status.rhw.atk2 / 100;
-	//		status->matk_max += 130 * ((TBL_MER*)bl)->battle_status.rhw.atk2 / 100;
-	//		break;
+			break;
+		case BL_MER:
+			status->matk_min += 70 * (((TBL_MER*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
+			status->matk_max += 130 * (((TBL_MER*)bl)->status.rhw.atk2 - ((TBL_MOB*)bl)->status.rhw.atk) / 100;
+			break;
 	}
 #else
 	// Matk


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: [https://github.com/rathena/rathena/issues/2866](url)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: In AEGIS atk2 is the variance. To get variance, i just minus atk2-atk1. For MATK values it is just 70-130% of atk2[variance]. Therefore in rathena it is 70-30%[atk2-atk1]. No need to revamp the whole mob_db as in my opinion, rAthena have a better atk1/atk2 system..

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
