### PR TITLE
Updated Shadow Chaser skills

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7450,7 +7450,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 	}
 	if (sd) {
 		uint16 r_skill = 0, sk_idx = 0;
-		if( wd.flag&BF_SHORT && sc && sc->data[SC__AUTOSHADOWSPELL] && rnd()%100 < sc->data[SC__AUTOSHADOWSPELL]->val3 &&
+		if( wd.flag&BF_WEAPON && sc && sc->data[SC__AUTOSHADOWSPELL] && rnd()%100 < sc->data[SC__AUTOSHADOWSPELL]->val3 &&
 			(r_skill = (uint16)sc->data[SC__AUTOSHADOWSPELL]->val1) && (sk_idx = skill_get_index(r_skill)) &&
 			sd->status.skill[sk_idx].id != 0 && sd->status.skill[sk_idx].flag == SKILL_FLAG_PLAGIARIZED )
 		{

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16121,6 +16121,9 @@ struct skill_condition skill_get_requirement(struct map_session_data* sd, uint16
 	if( i < ARRAYLENGTH(sd->skillusesp) )
 		req.sp -= sd->skillusesp[i].val;
 
+	if (skill_id == sd->status.skill[sd->reproduceskill_idx].id)
+		require.sp += require.sp * 30 / 100;
+
 	req.sp = cap_value(req.sp * sp_skill_rate_bonus / 100, 0, SHRT_MAX);
 
 	if( sc ) {
@@ -19800,7 +19803,7 @@ int skill_select_menu(struct map_session_data *sd,uint16 skill_id) {
 		return 0;
 	}
 
-	lv = (aslvl + 1) / 2; // The level the skill will be autocasted
+	lv = (aslvl + 5) / 2; // The level the skill will be autocasted
 	lv = min(lv,sd->status.skill[sk_idx].lv);
 	prob = (aslvl >= 10) ? 15 : (30 - 2 * aslvl); // Probability at level 10 was increased to 15.
 	sc_start4(&sd->bl,&sd->bl,SC__AUTOSHADOWSPELL,100,id,lv,prob,0,skill_get_time(SC_AUTOSHADOWSPELL,aslvl));

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16122,7 +16122,7 @@ struct skill_condition skill_get_requirement(struct map_session_data* sd, uint16
 		req.sp -= sd->skillusesp[i].val;
 
 	if (skill_id == sd->status.skill[sd->reproduceskill_idx].id)
-		require.sp += require.sp * 30 / 100;
+		req.sp += req.sp * 30 / 100;
 
 	req.sp = cap_value(req.sp * sp_skill_rate_bonus / 100, 0, SHRT_MAX);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #2972

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Updated Auto Shadow Spell:
    * Will now trigger even on ranged physical attacks.
    * Increased spell cast level to 3/3/4/4/5/5/6/6/7/7.
  * Updated Reproduce:
    * SP penalty for casting spells is now 30% extra.
Thanks to @zackdreaver!