### PR TITLE
Fixed typos in Phantasmagorika quests

### DIFF
--- a/npc/re/quests/quests_15_1.txt
+++ b/npc/re/quests/quests_15_1.txt
@@ -1496,6 +1496,7 @@ verus04,172,149,3	script	Commander Arquien#e152v0	4_F_EDEN_MASTER,{
 			close3;
 		}
 	}
+	close3;
 }
 
 // Note : 2 players can use the npc at the same time
@@ -3343,7 +3344,7 @@ verus02,60,30,1	script	Strewn paper#e152a01	4_ENERGY_BLUE,{
 		close;
 	}
 	progressbar "00ff00",3;
-	hideonnpc strnpcinfo(0);
+	disablenpc strnpcinfo(0);
 	getitem 6757,1;// The_Memory_Recorder
 	if (VER_MAIN == 19) {
 		mes "You find a object never seen before as you go through the clutter of documents and office supplies.";
@@ -3360,7 +3361,8 @@ verus02,60,30,1	script	Strewn paper#e152a01	4_ENERGY_BLUE,{
 	close;
 
 OnTimer60000:
-	hideoffnpc strnpcinfo(0);
+	stopnpctimer;
+	enablenpc strnpcinfo(0);
 	end;
 }
 verus02,178,32,3	duplicate(Strewn paper#e152a01)	Strewn paper#e152a02	4_ENERGY_BLUE
@@ -3427,7 +3429,7 @@ un_bunker,382,335,3	script	Box#e152p00	4_ENERGY_BLUE,{
 		close;
 	}
 	if (VER_MAIN == 27 || isbegin_quest(7652) > 0) {// Collect Memory Records of Laboratories
-		if (countitem(6824) < 5) {
+		if (countitem(6824) > 4) {
 			mes "Enough Memory Records are collected.";
 			mes "No need to keep on crawling and searching.";
 			close;
@@ -3440,13 +3442,18 @@ un_bunker,382,335,3	script	Box#e152p00	4_ENERGY_BLUE,{
 		if (select( "Check below.", "Quit." ) == 1) {
 			progressbar "00ff00",3;
 			mes "Found a Memory Record under the desk.";
-			hideonnpc strnpcinfo(0);
 			getitem 6824,1;// Experimental_Dong_Memory_Record
+			initnpctimer;
+			disablenpc strnpcinfo(0);
 		}
 		close;
 	}
 	mes "Nothing special is found.";
 	close;
+OnTimer60000:
+	stopnpctimer;
+	enablenpc strnpcinfo(0);
+	end;
 }
 un_bunker,87,167,3	duplicate(Box#e152p00)	Under desk#e152p01	4_ENERGY_BLUE
 un_bunker,316,243,3	duplicate(Box#e152p00)	Under desk#e152p02	4_ENERGY_BLUE
@@ -3852,10 +3859,12 @@ verus04,133,212,4	script	Police Chief Kesler#EP15_1	2_M_SWORDMASTER,{
 		mes "- You are carrying too many items to continue. -";
 		close;
 	}
-	.@playtime_5318 = checkquest(5318,PLAYTIME);
-	.@quest_5309 = isbegin_quest(5309);
+	.@playtime_5318 = checkquest(5318,PLAYTIME);	// Come Back Tomorrow
+	.@quest_5309 = isbegin_quest(5309);				// Police Chief's Request
 	mes "[Police Chief Kesler]";
 	if (VER_MAIN < 5 || .@playtime_5318 == 2) {
+		if (.@playtime_5318 == 2)
+			erasequest 5318;
 		emotion ET_DELIGHT;
 		mes "Nice to meet you. I'm Kesler, chief of the Phantasmagorika Police.";
 	}
@@ -3863,8 +3872,6 @@ verus04,133,212,4	script	Police Chief Kesler#EP15_1	2_M_SWORDMASTER,{
 		emotion ET_PROFUSELY_SWEAT;
 		mes "Welcome to the Phantasmagorika Police.";
 	}
-	if (.@playtime_5318 == 2)
-		erasequest 5318;
 	next;
 	if (countitem(6753) > 0)// Token_Of_Destruction
 		.@string$ = "I brought Doom Tokens.";
@@ -3935,7 +3942,7 @@ verus04,133,212,4	script	Police Chief Kesler#EP15_1	2_M_SWORDMASTER,{
 			}
 			if (.@quest_5309 == 2)
 				erasequest 5309;
-			setquest 5309;
+			setquest 5309;// Police Chief's Request
 			mes "[Police Chief Kesler]";
 			mes "Thank you.";
 			close;
@@ -4161,10 +4168,8 @@ verus03,36,113,4	script	Police Officer Salgran#EP15	2_M_THIEFMASTER,{
 				next;
 				if (select( "Help.", "Maybe next time." ) == 2) {
 					emotion ET_OHNO;
-					if (isbegin_quest(5305) == 0) {
-						setquest 5305;// Police Officer Salgran
-						completequest 5305;// Police Officer Salgran
-					}
+					setquest 5305;// Police Officer Salgran
+					completequest 5305;// Police Officer Salgran
 					setquest 5310;// Salgran's Problem
 					mes "[Police Officer Salgran]";
 					mes "You must be busy. All right, then tell the Chief that everything's good in my sector.";
@@ -4188,10 +4193,8 @@ verus03,36,113,4	script	Police Officer Salgran#EP15	2_M_THIEFMASTER,{
 				if (select( "OK", "Maybe next time." ) == 2) {
 					// inaccurate
 					emotion ET_OHNO;
-					if (isbegin_quest(5305) == 0) {
-						setquest 5305;// Police Officer Salgran
-						completequest 5305;// Police Officer Salgran
-					}
+					setquest 5305;// Police Officer Salgran
+					completequest 5305;// Police Officer Salgran
 					setquest 5310;// Salgran's Problem
 					mes "[Police Officer Salgran]";
 					mes "You must be busy. All right, then tell the Chief that everything's good in my sector.";
@@ -4270,7 +4273,6 @@ verus03,36,113,4	script	Police Officer Salgran#EP15	2_M_THIEFMASTER,{
 	close;
 }
 
-
 verus03,116,36,6	script	Police Officer Gerev#EP15_1D	4_M_ALCHE_A,{
 	if (checkweight(1301,1) == 0) {
 		mes "- You are carrying too many items to continue. -";
@@ -4324,10 +4326,8 @@ verus03,116,36,6	script	Police Officer Gerev#EP15_1D	4_M_ALCHE_A,{
 				mes "Ah, Chief Kesler sent you. If I didn't know him, I'd have thought he was too busy to come see me. I bet I'm busier than him, though.";
 				next;
 				if (select( "I can help.", "Sorry I can't be of help." ) == 2) {
-					if (isbegin_quest(5306) == 0) {
-						setquest 5306;
-						completequest 5306;
-					}
+					setquest 5306;
+					completequest 5306;
 					setquest 5311;// Gerev's Problem
 					mes "[Police Officer Gerev]";
 					mes "You're willing to help the Chief, but not me. Why not because I'm not a chief?";
@@ -4355,10 +4355,8 @@ verus03,116,36,6	script	Police Officer Gerev#EP15_1D	4_M_ALCHE_A,{
 				next;
 				if (select( "Sure thing.", "Maybe next time." ) == 2) {
 					emotion ET_FRET;
-					if (isbegin_quest(5306) == 0) {
-						setquest 5306;
-						completequest 5306;
-					}
+					setquest 5306;
+					completequest 5306;
 					setquest 5311;
 					mes "[Police Officer Gerev]";
 					mes "*Snort* I knew it. Just go tell Chief Kesler everything's quiet in my sector.";
@@ -4424,8 +4422,9 @@ verus03,116,36,6	script	Police Officer Gerev#EP15_1D	4_M_ALCHE_A,{
 				mes "[Police Officer Gerev]";
 				mes "I must be stressed out again. I feel my stomach tightening...";
 				close;
-			case 3:// can redo
+			case 3:
 				erasequest 5315;// Gerev's Request
+				// setquest 5311;	// note: official can redo
 				trap_doom_prayers = 0;
 				if (isbegin_quest(5306) == 0) {
 					setquest 5306;
@@ -4491,10 +4490,8 @@ verus03,81,241,6	script	Police Officer Seiden#EP15_1	4_M_ORIENT02,{
 				next;
 				if (select( "Sure.", "Not now." ) == 2) {
 					emotion ET_SCRATCH;
-					if (isbegin_quest(5307) == 0) {
-						setquest 5307;
-						completequest 5307;
-					}
+					setquest 5307;
+					completequest 5307;
 					setquest 5312;// Seiden's Problem
 					mes "[Police Officer Seiden]";
 					mes "I don't understand. My friend swore this never failed on people, hm... Oh well, tell Chief Kesler everything's good on my end.";
@@ -4515,10 +4512,8 @@ verus03,81,241,6	script	Police Officer Seiden#EP15_1	4_M_ORIENT02,{
 				next;
 				if (select( "I'll be back.", "Maybe next time." ) == 2) {
 					emotion ET_SCRATCH;
-					if (isbegin_quest(5307) == 0) {
-						setquest 5307;
-						completequest 5307;
-					}
+					setquest 5307;
+					completequest 5307;
 					setquest 5312;// Seiden's Problem
 					mes "[Police Officer Seiden]";
 					mes "I don't understand. My friend swore this never failed on people, hm... Oh well, tell Chief Kesler everything's good on my end.";
@@ -4747,10 +4742,8 @@ verus04,202,258,4	script	Police Officer Piffs#EP15_1	4_M_SAGE_C,{
 				mes "I'm running short on some supplies, but I can't leave my post unattended. Can you help me?";
 				next;
 				if (select("Sure thing.", "Not now.") == 2) {
-					if (isbegin_quest(5308) == 0) {
-						setquest 5308;// Police Officer Piffs
-						completequest 5308;
-					}
+					setquest 5308;// Police Officer Piffs
+					completequest 5308;
 					setquest 5313;// Piffs's Problem
 					mes "[Police Officer Piffs]";
 					mes "I understand. If you change your mind, though, come back to me.";
@@ -4864,10 +4857,9 @@ verus04,187,219,4	script	Thicket#EP15_1D_01	4_CREEPER,{
 			mes "You've decided to forget about it.";
 			close;
 		}
-		if (rand(2)) {
-			progressbar "00ff00",2;
+		progressbar "00ff00",2;
+		if (rand(2))
 			mes "No herbs were found in the thicket.";
-		}
 		else {
 			getitem 6754,1;// Collected_Medicinal_Herbs
 			mes "Gathered the herb.";

--- a/npc/re/quests/quests_15_1.txt
+++ b/npc/re/quests/quests_15_1.txt
@@ -3450,7 +3450,7 @@ un_bunker,382,335,3	script	Box#e152p00	4_ENERGY_BLUE,{
 	}
 	mes "Nothing special is found.";
 	close;
-OnTimer60000:
+OnTimer30000:
 	stopnpctimer;
 	enablenpc strnpcinfo(0);
 	end;
@@ -4424,12 +4424,13 @@ verus03,116,36,6	script	Police Officer Gerev#EP15_1D	4_M_ALCHE_A,{
 				close;
 			case 3:
 				erasequest 5315;// Gerev's Request
-				// setquest 5311;	// note: official can redo
 				trap_doom_prayers = 0;
 				if (isbegin_quest(5306) == 0) {
 					setquest 5306;
 					completequest 5306;
 				}
+				// note: officially 'setquest 5311;' is commented
+				setquest 5311;
 				close;
 			case 4:
 				emotion ET_OTL;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #3018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: From issue tracker :

- npc Commander Arquien#e152v0 dialogs line 1185, 1200, 1207, 1237, 1249, 1263, 1276, 1282, 1325 are not closing the cutin
- npc Box#e152p00 is not counting memory records as proper line 3430
- npc from police quest Thicket#EP15_1D_01 has incorrect behaviour with progressbar when looking for herbs, line 4868

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
