### PR TITLE
Adjusted Madogear interaction with skills

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8888,6 +8888,9 @@ void pc_setoption(struct map_session_data *sd,int type)
 			status_change_end(&sd->bl,SC_ACCELERATION,INVALID_TIMER);
 			status_change_end(&sd->bl,SC_OVERHEAT_LIMITPOINT,INVALID_TIMER);
 			status_change_end(&sd->bl,SC_OVERHEAT,INVALID_TIMER);
+			status_change_end(&sd->bl,SC_MAGNETICFIELD,INVALID_TIMER);
+			status_change_end(&sd->bl,SC_NEUTRALBARRIER_MASTER,INVALID_TIMER);
+			status_change_end(&sd->bl,SC_STEALTHFIELD_MASTER,INVALID_TIMER);
 			pc_bonus_script_clear(sd,BSF_REM_ON_MADOGEAR);
 		}
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #3022

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Magnetic Field, Neutral Barrier, and Stealth Field will now end when a player dismounts from a Madogear.
Thanks to @admkakaroto!