### PR TITLE
No matter what MAX_ITEM_RDM_OPT is, send 5 random options

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -15393,7 +15393,7 @@ void clif_Mail_read(struct map_session_data *sd, int mail_id)
 
 		msg_len += 1; // Zero Termination
 
-		itemsize = 24 + 5 * MAX_ITEM_RDM_OPT;
+		itemsize = 24 + 5 * 5;
 		len = 24 + msg_len+1 + itemsize * count;
 
 		WFIFOHEAD(fd, len);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -17992,7 +17992,7 @@ static void clif_parse_SearchStoreInfo(int fd, struct map_session_data* sd)
 void clif_search_store_info_ack(struct map_session_data* sd)
 {
 #if PACKETVER >= 20150225
-	const unsigned int blocksize = MESSAGE_SIZE+26+5*MAX_ITEM_RDM_OPT;
+	const unsigned int blocksize = MESSAGE_SIZE+26+5*5;
 #else
 	const unsigned int blocksize = MESSAGE_SIZE+26;
 #endif


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
`clif_search_store_info_ack` uses `MAX_ITEM_RDM_OPT` to determine how big the size is of the items sent to the client. When someone changes that define, it breaks the expected format, as seen here: https://cdn.discordapp.com/attachments/352836475982839808/431831626956275732/30221803_10157335496584867_3015278105872227643_n_1.jpg