### PR TITLE
Fix Mob AI initialization

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3770,7 +3770,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	short m,x,y,xs = -1, ys = -1;
 	char mapname[MAP_NAME_LENGTH_EXT], mobname[NAME_LENGTH];
 	struct spawn_data mob, *data;
-	int ai; // mob_ai
+	int ai = AI_NONE; // mob_ai
 
 	memset(&mob, 0, sizeof(struct spawn_data));
 


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: Depending on the optimization level, variables might not be initialized to 0 if there's no explicit initialization.  In `npc_parse_mob`, `ai` should default to AI_NONE (0), but sometimes it might be another value (in my case, AI_ATTACK (1)). This PR will ensure the AI be defaulted to AI_NONE.