### PR TITLE
Fixed a few problems with homunculus autofeed

### DIFF
--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -71,7 +71,3 @@ feature.achievement: on
 // Homunculues Autofeeding (Note 1)
 // Requires: 2017-09-20bRagexeRE or later
 feature.homunculus_autofeed: off
-
-// At which rate should homunculus autofeeding trigger?
-// Default: 30
-feature.homunculus_autofeed_rate: 30

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8513,8 +8513,7 @@ static const struct _battle_data {
 	{ "broadcast_hide_name",                &battle_config.broadcast_hide_name,             2,      0,      NAME_LENGTH,    },
 	{ "skill_drop_items_full",              &battle_config.skill_drop_items_full,           0,      0,      1,              },
 	{ "feature.homunculus_autofeed",        &battle_config.feature_homunculus_autofeed,     1,      0,      1,              },
-	{ "feature.homunculus_autofeed_rate",   &battle_config.feature_homunculus_autofeed_rate,30,     0,    100,              },
-    { "summoner_trait",                     &battle_config.summoner_trait,                  3,      0,      3,              },
+	{ "summoner_trait",                     &battle_config.summoner_trait,                  3,      0,      3,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -641,8 +641,7 @@ struct Battle_Config
 	int autoloot_adjust;
 	int broadcast_hide_name;
 	int skill_drop_items_full;
-    int feature_homunculus_autofeed;
-	int feature_homunculus_autofeed_rate;
+	int feature_homunculus_autofeed;
 	int summoner_trait;
 
 #include "../custom/battle_config_struct.inc"

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10448,7 +10448,7 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 		clif_equipcheckbox(sd);
 #endif
 #if PACKETVER >= 20170920
-		if( sd->hd ){
+		if( sd->hd && battle_config.feature_homunculus_autofeed ){
 			clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, sd->hd->homunculus.autofeed );
 		}else{
 			clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, false );
@@ -16568,7 +16568,7 @@ void clif_parse_configuration( int fd, struct map_session_data* sd ){
 			break;
 		case CONFIG_HOMUNCULUS_AUTOFEED:
 			// Player can not click this if he does not have a homunculus or it is vaporized
-			if( sd->hd == nullptr || sd->hd->homunculus.vaporize ){
+			if( sd->hd == nullptr || sd->hd->homunculus.vaporize || !battle_config.feature_homunculus_autofeed ){
 				return;
 			}
 

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -892,10 +892,6 @@ static int hom_hungry(int tid, unsigned int tick, int id, intptr_t data)
 		clif_emotion(&hd->bl, ET_OK);
 	}
 
-	if( battle_config.feature_homunculus_autofeed && hd->homunculus.autofeed && hd->homunculus.hunger <= battle_config.feature_homunculus_autofeed_rate ){
-		hom_food( sd, hd );
-	}
-
 	if (hd->homunculus.hunger < 0) {
 		hd->homunculus.hunger = 0;
 		// Delete the homunculus if intimacy <= 100


### PR DESCRIPTION
* **Addressed Issue(s)**: #3060 

* **Server Mode**: Both

* **Description of Pull Request**: 
Removed server side logic, since the client will automatically send a feed request.
Removed the rate configuration that is related to this.
Ignore requests when the feature is disabled.
Do not activate the client side triggering if the feature is disabled.
