### PR TITLE
Added missing getpartymember calls in MVP ladder script

### DIFF
--- a/npc/custom/events/mvp_ladder.txt
+++ b/npc/custom/events/mvp_ladder.txt
@@ -160,6 +160,8 @@ prontera,164,171,3	script	MvP Ladder Warper	56,{
 	end;
 
 OnMvpDead:
+	getpartymember .party_id, 1;
+	getpartymember .party_id, 2;
 	.round++;
 	if ( .round >= 2 && .round != .totalround +1 && .round_item_amount ) {
 		for ( .@i = 0; .@i < $@partymembercount; .@i++ ) {


### PR DESCRIPTION
* **Addressed Issue(s)**: None
* **Server Mode**: Both
* **Description of Pull Request**: 
The script accesses $@partymemberaid, $@partymembercid, $@partymembercount in the OnMvpDead label without calling getpartymember first.
Thanks to @AnnieRuru for the heads up