### PR TITLE
Fixed an invalid declaration of cached events

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4460,9 +4460,9 @@ int npc_script_event(struct map_session_data* sd, enum npce_event type){
 		return 0;
 	}
 
-	std::vector<struct script_event_s> vector = script_event[type];
+	std::vector<struct script_event_s>& vector = script_event[type];
 
-	for( struct script_event_s evt : vector ){
+	for( struct script_event_s& evt : vector ){
 		npc_event_sub( sd, evt.event, evt.event_name );
 	}
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3,6 +3,9 @@
 
 #include "npc.hpp"
 
+#include <map>
+#include <vector>
+
 #include <stdlib.h>
 #include <errno.h>
 
@@ -108,12 +111,13 @@ static DBMap *npc_path_db;
 static struct view_data npc_viewdb[MAX_NPC_CLASS];
 static struct view_data npc_viewdb2[MAX_NPC_CLASS2_END-MAX_NPC_CLASS2_START];
 
-static struct script_event_s
-{	//Holds pointers to the commonly executed scripts for speedup. [Skotlex]
-	struct event_data *event[UCHAR_MAX];
-	const char *event_name[EVENT_NAME_LENGTH];
-	uint8 event_count;
-} script_event[NPCE_MAX];
+struct script_event_s{
+	struct event_data *event;
+	const char *event_name;
+};
+
+// Holds pointers to the commonly executed scripts for speedup. [Skotlex]
+std::map<enum npce_event, std::vector<struct script_event_s>> script_event;
 
 struct view_data* npc_get_viewdata(int class_)
 {	//Returns the viewdata for normal npc classes.
@@ -4448,18 +4452,21 @@ int npc_parsesrcfile(const char* filepath, bool runOnInit)
 	return 1;
 }
 
-int npc_script_event(struct map_session_data* sd, enum npce_event type)
-{
-	int i;
+int npc_script_event(struct map_session_data* sd, enum npce_event type){
 	if (type == NPCE_MAX)
 		return 0;
 	if (!sd) {
 		ShowError("npc_script_event: NULL sd. Event Type %d\n", type);
 		return 0;
 	}
-	for (i = 0; i<script_event[type].event_count; i++)
-		npc_event_sub(sd,script_event[type].event[i],script_event[type].event_name[i]);
-	return i;
+
+	std::vector<struct script_event_s> vector = script_event[type];
+
+	for( struct script_event_s evt : vector ){
+		npc_event_sub( sd, evt.event, evt.event_name );
+	}
+
+	return vector.size();
 }
 
 const char *npc_get_script_event_name(int npce_index)
@@ -4493,6 +4500,8 @@ void npc_read_event_script(void)
 {
 	int i;
 
+	script_event.clear();
+
 	for (i = 0; i < NPCE_MAX; i++)
 	{
 		DBIterator* iter;
@@ -4502,25 +4511,19 @@ void npc_read_event_script(void)
 
 		safesnprintf(name,EVENT_NAME_LENGTH,"::%s", npc_get_script_event_name(i));
 
-		script_event[i].event_count = 0;
 		iter = db_iterator(ev_db);
 		for( data = iter->first(iter,&key); iter->exists(iter); data = iter->next(iter,&key) )
 		{
 			const char* p = key.str;
 			struct event_data* ed = (struct event_data*)db_data2ptr(data);
-			unsigned char count = script_event[i].event_count;
 
-			if( count >= ARRAYLENGTH(script_event[i].event) )
-			{
-				ShowWarning("npc_read_event_script: too many occurences of event '%s'!\n", npc_get_script_event_name(i));
-				break;
-			}
+			if( (p=strchr(p,':')) && strcmpi(name,p)==0 ){
+				struct script_event_s evt;
 
-			if( (p=strchr(p,':')) && p && strcmpi(name,p)==0 )
-			{
-				script_event[i].event[count] = ed;
-				script_event[i].event_name[count] = key.str;
-				script_event[i].event_count++;
+				evt.event = ed;
+				evt.event_name = key.str;
+
+				script_event[static_cast<enum npce_event>(i)].push_back(evt);
 			}
 		}
 		dbi_destroy(iter);
@@ -4529,7 +4532,7 @@ void npc_read_event_script(void)
 	if (battle_config.etc_log) {
 		//Print summary.
 		for (i = 0; i < NPCE_MAX; i++)
-			ShowInfo("%d '%s' events.\n", script_event[i].event_count, npc_get_script_event_name(i));
+			ShowInfo("%d '%s' events.\n", script_event[static_cast<enum npce_event>(i)].size(), npc_get_script_event_name(i));
 	}
 }
 
@@ -4686,6 +4689,7 @@ void do_clear_npc(void) {
  *------------------------------------------*/
 void do_final_npc(void) {
 	npc_clear_pathlist();
+	script_event.clear();
 	ev_db->destroy(ev_db, NULL);
 	npcname_db->destroy(npcname_db, NULL);
 	npc_path_db->destroy(npc_path_db, NULL);
@@ -4773,7 +4777,6 @@ void do_init_npc(void){
 		npc_id - START_NPC_NUM, npc_warp, npc_shop, npc_script, npc_mob, npc_cache_mob, npc_delay_mob);
 
 	// set up the events cache
-	memset(script_event, 0, sizeof(script_event));
 	npc_read_event_script();
 
 #if PACKETVER >= 20131223


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  #3108

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Fixed wrong usage of EVENT_NAME_LENGTH, since this should have been UCHAR_MAX as well.
Converted C struct to C++ map/vector.
Removed limit of 255 events of a cached type.

Thanks to @ignizh
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
