### PR TITLE
Added an option to disable homun autofeed notify

### DIFF
--- a/conf/battle/homunc.conf
+++ b/conf/battle/homunc.conf
@@ -57,3 +57,7 @@ homunculus_S_max_level: 150
 // Without this, a shuffle causes all levels of a Homunculus S to use their
 // growth tables, causing imbalanced stats
 homunculus_S_growth_level: 99
+
+// Send auto-feed notice even if OFF (Note 1) 
+// Official: yes
+homunculus_autofeed_always: yes

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8499,6 +8499,7 @@ static const struct _battle_data {
 	{ "skill_drop_items_full",              &battle_config.skill_drop_items_full,           0,      0,      1,              },
 	{ "feature.homunculus_autofeed",        &battle_config.feature_homunculus_autofeed,     1,      0,      1,              },
 	{ "summoner_trait",                     &battle_config.summoner_trait,                  3,      0,      3,              },
+	{ "homunculus_autofeed_always",         &battle_config.homunculus_autofeed_always,      1,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -643,6 +643,7 @@ struct Battle_Config
 	int skill_drop_items_full;
 	int feature_homunculus_autofeed;
 	int summoner_trait;
+	int homunculus_autofeed_always;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10457,10 +10457,18 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 		clif_equipcheckbox(sd);
 #endif
 #if PACKETVER >= 20170920
-		if( sd->hd && battle_config.feature_homunculus_autofeed ){
-			clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, sd->hd->homunculus.autofeed );
+		if( battle_config.homunculus_autofeed_always ){
+			// Always send ON or OFF
+			if( sd->hd && battle_config.feature_homunculus_autofeed ){
+				clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, sd->hd->homunculus.autofeed );
+			}else{
+				clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, false );
+			}
 		}else{
-			clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, false );
+			// Only send when enabled
+			if( sd->hd && battle_config.feature_homunculus_autofeed && sd->hd->homunculus.autofeed ){
+				clif_configuration( sd, CONFIG_HOMUNCULUS_AUTOFEED, true );
+			}
 		}
 #endif
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Adds an option so that the ON/OFF notification is only sent when the player has a homunculus and has the option set to ON.

Thanks to @haikenz for the suggestion.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
