### PR TITLE
Corrected refine bonus when importing

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14355,6 +14355,12 @@ static bool status_yaml_readdb_refine_sub(const YAML::Node &node, int refine_inf
 	int bonus_per_level = node["StatsPerLevel"].as<int>();
 	int random_bonus_start_level = node["RandomBonusStartLevel"].as<int>();
 	int random_bonus = node["RandomBonusValue"].as<int>();
+
+	if (file_name.find("import") != std::string::npos) { // Import file, reset refine bonus before calculation
+		for (int refine_level = 0; refine_level < MAX_REFINE; ++refine_level)
+			refine_info[refine_info_index].bonus[refine_level] = 0;
+	}
+
 	const YAML::Node &costs = node["Costs"];
 
 	for (const auto costit : costs) {
@@ -14431,7 +14437,7 @@ static void status_yaml_readdb_refine(const std::string &directory, const std::s
 	for (int i = 0; i < ARRAYLENGTH(labels); i++) {
 		const YAML::Node &node = config[labels[i]];
 
-		if (node.IsDefined() && status_yaml_readdb_refine_sub(node, i, file))
+		if (node.IsDefined() && status_yaml_readdb_refine_sub(node, i, current_file))
 			count++;
 	}
 	ShowStatus("Done reading '" CL_WHITE "%d" CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'.\n", count, current_file.c_str());


### PR DESCRIPTION
* **Addressed Issue(s)**: #2722

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Properly reset refine bonuses before parsing the import file.
Thanks to @sader1992!