### PR TITLE
Negative MDEF should not increase damage taken from magic

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6286,8 +6286,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 			 * RE MDEF Reduction
 			 * Damage = Magic Attack * (1000+eMDEF)/(1000+eMDEF) - sMDEF
 			 */
-			if (mdef < -99)
-				mdef = -99; // Avoid divide by 0
+			if (mdef < 0)
+				mdef = 0; // Negative eMDEF is treated as 0 on official
 
 			ad.damage = ad.damage * (1000 + mdef) / (1000 + mdef * 10) - mdef2;
 #else


### PR DESCRIPTION
* **Addressed Issue(s)**: #3189 
* **Server Mode**: Renewal
* **Description of Pull Request**: Set negative MDEF to 0 before damage reduction calculation.