### PR TITLE
Fix Bloody_Roar and Bloody_Roar_C item scripts

### DIFF
--- a/db/pre-re/item_db.txt
+++ b/db/pre-re/item_db.txt
@@ -607,7 +607,7 @@
 1262,Nail_Of_Loki,Loki's Nail,5,20,,1200,115,,1,0,0x00001000,7,2,34,3,55,1,16,{ bonus2 bAddEff,Eff_Bleeding,300; },{},{}
 1263,Unholy_Touch,Unholy Touch,5,20,,1250,151,,1,0,0x00001000,7,2,34,4,70,1,16,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Curse,200; bonus bCritical,-1; bonus bUnbreakableWeapon; },{},{}
 1264,Various_Jur,Specialty Jur,5,20,,800,90,,1,4,0x00001000,7,2,34,1,1,1,16,{ bonus2 bAddEff2,Eff_Bleeding,10; },{},{}
-1265,Bloody_Roar,Bloody Roar,5,20,,1000,120,,1,0,0x00001000,7,2,34,4,75,1,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-160; bonus bFlee2,-160; bonus bHPrecovRate,-100; bonus bSPrecovRate,-100; },{},{}
+1265,Bloody_Roar,Bloody Roar,5,20,,1000,120,,1,0,0x00001000,7,2,34,4,75,1,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-(readparam(bAgi)+BaseLevel); bonus bHPrecovRate,-100; bonus bSPrecovRate,-100; },{},{}
 1266,Infiltrator_,Infiltrator,5,57000,,1500,140,,1,1,0x00001000,7,2,34,4,75,1,16,{ bonus2 bAddRace,RC_DemiHuman,50; bonus2 bAddRace,RC_Player,50; bonus bDef,3; bonus bFlee,5; bonus bFlee2,2; },{},{}
 1267,Infiltrator_C,Infiltrator,5,1,,0,189,,1,0,0x00001000,7,2,34,4,1,0,16,{ bonus2 bAddRace,RC_DemiHuman,70; bonus2 bAddRace,RC_Player,70; bonus bDef,3; bonus bFlee,5; bonus bFlee2,2; bonus bAspdRate,5; },{},{}
 1268,Wild_Beast_Claw,Wild Beast Claw,5,20,,1450,160,,1,1,0x00001000,2,2,34,4,55,1,16,{ if(getrefine()>=9){ bonus3 bAutoSpell,"NPC_CRITICALWOUND",2,100; } else bonus3 bAutoSpell,"NPC_CRITICALWOUND",1,100; },{},{}
@@ -615,7 +615,7 @@
 1270,Drill_Katar,Drill Katar,5,20,,1400,110,,1,1,0x00001000,2,2,34,4,55,1,16,{ bonus bHit,30; bonus3 bAutoSpell,"ST_FULLSTRIP",1,150; },{},{}
 1271,Blood_Tears,Blood Tears,5,20,,1700,120,,1,2,0x00001000,2,2,34,4,55,1,16,{ if(getrefine()>=9){ bonus3 bAutoSpell,"NPC_WIDEBLEEDING",2,30; } else bonus3 bAutoSpell,"NPC_WIDEBLEEDING",1,30; },{},{}
 1272,Scratcher,Scratcher,5,20,,0,120,,1,0,0x00001000,7,2,34,1,0,0,16,{ bonus2 bAddClass,Class_All,50; },{},{}
-1273,Bloody_Roar_C,Refined Bloody Roar,5,1,,0,148,,1,0,0x00001000,7,2,34,4,0,0,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-160; bonus bFlee2,-160; },{},{}
+1273,Bloody_Roar_C,Refined Bloody Roar,5,1,,0,148,,1,0,0x00001000,7,2,34,4,0,0,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus2 bHPRegenRate,3,5000; },{},{}
 1274,Unholy_Touch_C,Refined Unholy Touch,5,1,,0,179,,1,0,0x00001000,7,2,34,4,0,0,16,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Curse,5000; bonus bCritical,-1; bonus bUnbreakableWeapon; },{},{}
 1275,Katar_Of_Cold_Icicle_,Katar of Frozen Icicle,5,45000,,1200,105,,1,3,0x00001000,7,2,34,3,55,1,16,{ bonus bAtkEle,Ele_Water; bonus2 bAddEff,Eff_Freeze,500; },{},{}
 1276,Katar_Of_Thornbush_,Katar of Quaking,5,45000,,1200,105,,1,3,0x00001000,7,2,34,3,55,1,16,{ bonus bAtkEle,Ele_Earth; bonus2 bAddEff,Eff_Blind,500; },{},{}

--- a/db/re/item_db.txt
+++ b/db/re/item_db.txt
@@ -625,7 +625,7 @@
 1262,Nail_Of_Loki,Loki's Nail,5,20,,1200,115,,1,0,0x00001000,63,2,34,3,55,1,16,{ bonus2 bAddEff,Eff_Bleeding,300; },{},{}
 1263,Unholy_Touch,Unholy Touch,5,20,,1250,151,,1,0,0x00001000,63,2,34,4,70,1,16,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Curse,200; bonus bCritical,-1; bonus bUnbreakableWeapon; },{},{}
 1264,Various_Jur,Specialty Jur,5,20,,800,90,,1,4,0x00001000,63,2,34,1,1,1,16,{ bonus2 bAddEff2,Eff_Bleeding,10; },{},{}
-1265,Bloody_Roar,Bloody Roar,5,20,,1000,120,,1,0,0x00001000,63,2,34,4,75,1,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-160; bonus bFlee2,-160; bonus bHPrecovRate,-100; bonus bSPrecovRate,-100; },{},{}
+1265,Bloody_Roar,Bloody Roar,5,20,,1000,120,,1,0,0x00001000,63,2,34,4,75,1,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-(readparam(bAgi)+BaseLevel); bonus bHPrecovRate,-100; bonus bSPrecovRate,-100; },{},{}
 1266,Infiltrator_,Infiltrator,5,57000,,1500,140,,1,1,0x00001000,63,2,34,4,75,1,16,{ bonus2 bAddRace,RC_DemiHuman,50; bonus2 bAddRace,RC_Player,50; bonus bDef,3; bonus bFlee,5; bonus bFlee2,2; },{},{}
 1267,Infiltrator_C,Infiltrator,5,1,,0,189,,1,0,0x00001000,63,2,34,4,1,0,16,{ bonus2 bAddRace,RC_DemiHuman,70; bonus2 bAddRace,RC_Player,70; bonus bDef,3; bonus bFlee,5; bonus bFlee2,2; bonus bAspdRate,5; },{},{}
 1268,Wild_Beast_Claw,Wild Beast Claw,5,20,,1450,160,,1,1,0x00001000,18,2,34,4,55,1,16,{ bonus3 bAutoSpell,"NPC_CRITICALWOUND",(getrefine()>=9?2:1),100; },{},{}
@@ -633,7 +633,7 @@
 1270,Drill_Katar,Drill Katar,5,20,,1400,110,,1,1,0x00001000,18,2,34,4,55,1,16,{ bonus bHit,30; bonus3 bAutoSpell,"ST_FULLSTRIP",1,150; },{},{}
 1271,Blood_Tears,Blood Tears,5,20,,1700,120,,1,2,0x00001000,18,2,34,4,55,1,16,{ bonus3 bAutoSpell,"NPC_WIDEBLEEDING",(getrefine()>=9?2:1),30; },{},{}
 1272,Scratcher,Scratcher,5,20,,0,120,,1,0,0x00001000,63,2,34,1,0,0,16,{ bonus2 bAddClass,Class_All,50; },{},{}
-1273,Bloody_Roar_C,Refined Bloody Roar,5,1,,0,148,,1,0,0x00001000,63,2,34,4,0,0,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus bFlee,-160; bonus bFlee2,-160; },{},{}
+1273,Bloody_Roar_C,Refined Bloody Roar,5,1,,0,148,,1,0,0x00001000,63,2,34,4,0,0,16,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus2 bHPRegenRate,3,5000; },{},{}
 1274,Unholy_Touch_C,Refined Unholy Touch,5,1,,0,179,,1,0,0x00001000,63,2,34,4,0,0,16,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Curse,5000; bonus bCritical,-1; bonus bUnbreakableWeapon; },{},{}
 1275,Katar_Of_Cold_Icicle_,Katar of Frozen Icicle,5,45000,,1200,105,,1,3,0x00001000,63,2,34,3,55,1,16,{ bonus bAtkEle,Ele_Water; bonus2 bAddEff,Eff_Freeze,500; },{},{}
 1276,Katar_Of_Thornbush_,Katar of Quaking,5,45000,,1200,105,,1,3,0x00001000,63,2,34,3,55,1,16,{ bonus bAtkEle,Ele_Earth; bonus2 bAddEff,Eff_Blind,500; },{},{}


### PR DESCRIPTION
* **Addressed Issue(s)**: #3197 

* **Server Mode**: Both

* **Description of Pull Request**: 
   * Bloody_Roar: Perfect dodge should not be affected, Flee should be reduced by Agi + BLvl instead of flat -160
   * Bloody_Roar_C: Flee/Perfect dodge should not be affected, should restore 3 HP every 5 seconds