### PR TITLE
Added a 'force' option to attachrid

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3904,7 +3904,7 @@ not.
 ==============================
 -------------------------
 
-*attachrid(<account ID>)
+*attachrid(<account ID>{,force})
 *detachrid;
 
 These commands allow the manipulation of the script's currently attached player.
@@ -3912,8 +3912,13 @@ While 'attachrid' allows attaching of a different player by using its account id
 for the parameter RID, 'detachrid' makes the following commands run as if the
 script was never invoked by a player.
 
-The command returns 0 if the player cannot be attached (if the account is offline
-or does not exist), and 1 upon success.
+The command returns false if the player cannot be attached (if the account is offline
+or does not exist), and true upon success.
+
+By default the command is executed with force, which causes to attach the player
+even if he is currently attached to another script. Since this is not always the
+desired behavior you can also specify false to the command and it will only return 
+true if the player is online and was not attached to another script.
 
 -------------------------
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12198,15 +12198,26 @@ BUILDIN_FUNC(addrid)
 BUILDIN_FUNC(attachrid)
 {
 	int rid = script_getnum(st,2);
+	bool force;
 
-	if (map_id2sd(rid) != NULL) {
+	if( script_hasdata(st,3) ){
+		force = script_getnum(st,3) != 0;
+	}else{
+		force = true;
+	}
+
+	struct map_session_data* sd = map_id2sd(rid);
+
+	if( sd != NULL && ( !sd->npc_id || force ) ){
 		script_detach_rid(st);
 
 		st->rid = rid;
 		script_attach_state(st);
-		script_pushint(st,1);
-	} else
-		script_pushint(st,0);
+		script_pushint(st,true);
+	}else{
+		script_pushint(st,false);
+	}
+
 	return SCRIPT_CMD_SUCCESS;
 }
 /*==========================================
@@ -24237,7 +24248,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(disablewaitingroomevent,"disablearena",""),	// Added by RoVeRT
 	BUILDIN_DEF(getwaitingroomstate,"i?"),
 	BUILDIN_DEF(warpwaitingpc,"sii?"),
-	BUILDIN_DEF(attachrid,"i"),
+	BUILDIN_DEF(attachrid,"i?"),
 	BUILDIN_DEF(addrid,"i?????"),
 	BUILDIN_DEF(detachrid,""),
 	BUILDIN_DEF(isloggedin,"i?"),


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #1763

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Added a field that allows users to specify whether they want to force attaching a player or not. By default it is the current behavior(force=true) and if false is specified the player will only get attached if he is not currently running any script while you try to attach him.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
