### PR TITLE
Fixed broken guild notices

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10475,8 +10475,10 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 		}
 #endif
 
-		if (sd->guild && battle_config.guild_notice_changemap == 1)
+		if (sd->guild && battle_config.guild_notice_changemap == 1){
 			clif_guild_notice(sd); // Displays after VIP
+			guild_notice = false; // Do not display it twice
+		}
 
 		if( (battle_config.bg_flee_penalty != 100 || battle_config.gvg_flee_penalty != 100) &&
 			(map_flag_gvg(sd->state.pmap) || map_flag_gvg(sd->bl.m) || map[sd->state.pmap].flag.battleground || map[sd->bl.m].flag.battleground) )
@@ -10536,9 +10538,11 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 			channel_mjoin(sd); //join new map
 
 		clif_pk_mode_message(sd);
-	} else if (sd->guild && (battle_config.guild_notice_changemap == 2 || guild_notice))
+	}
+	
+	if( sd->guild && ( battle_config.guild_notice_changemap == 2 || guild_notice ) ){
 		clif_guild_notice(sd); // Displays at end
-
+	}
 
 	mail_clear(sd);
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #641

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Guild messages were broken in general. Probably by some move around for VIP system. Who cares.
This fixes the issue now and you will all be able to have guild notices again.
Sorry for taking so long!

Thanks to @tmav94, @RadianFord, @Akkarinage and @vykimo

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
