### PR TITLE
Missing returns for inarray and countinarray

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -6415,7 +6415,8 @@ BUILDIN_FUNC(inarray)
 
 	array_size = script_array_highest_key(st, sd, name, ref) - 1;
 
-	if (array_size < 0) {
+	if (array_size < 0)
+	{
 		script_pushint(st, -1);
 		return SCRIPT_CMD_SUCCESS;
 	}
@@ -6502,7 +6503,8 @@ BUILDIN_FUNC(countinarray)
 	array_size1 = script_array_highest_key(st, sd, name1, ref1) - 1;
 	array_size2 = script_array_highest_key(st, sd, name2, ref2) - 1;
 
-	if (array_size1 < 0 || array_size2 < 0) {
+	if (array_size1 < 0 || array_size2 < 0)
+	{
 		script_pushint(st, 0);
 		return SCRIPT_CMD_SUCCESS;
 	}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -6415,6 +6415,11 @@ BUILDIN_FUNC(inarray)
 
 	array_size = script_array_highest_key(st, sd, name, ref) - 1;
 
+	if (array_size < 0) {
+		script_pushint(st, -1);
+		return SCRIPT_CMD_SUCCESS;
+	}
+
 	if (array_size > SCRIPT_MAX_ARRAYSIZE)
 	{
 		ShowError("buildin_inarray: The array is too large.\n");
@@ -6496,6 +6501,11 @@ BUILDIN_FUNC(countinarray)
 
 	array_size1 = script_array_highest_key(st, sd, name1, ref1) - 1;
 	array_size2 = script_array_highest_key(st, sd, name2, ref2) - 1;
+
+	if (array_size1 < 0 || array_size2 < 0) {
+		script_pushint(st, 0);
+		return SCRIPT_CMD_SUCCESS;
+	}
 
 	if (array_size1 > SCRIPT_MAX_ARRAYSIZE || array_size2 > SCRIPT_MAX_ARRAYSIZE)
 	{


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: Both

* **Description of Pull Request**: 
`inarray` return -1 if the array not assigned yet ,as this mean the value not found
`countinarray` would return 0 if one of the arrays is not assigned yet ,as 0 mean no matches found

Example:
```cs
prontera,147,172,0	script	ERROR_TEST	100,{
	//.@complete is an array will be assigned inside the for loop as a way to add in the char ids that completed the code
	setarray .@charID,1,2,3,4,5,6,7,1,2,3,1,5,6,8,2;
	for(.@i=0;.@i<getarraysize(.@charID);.@i++){
		//Here is the error it should return -1 at the first time as the array not assigned yet
		if(inarray(.@complete,.@charID[.@i]) == -1){//if the char id not in the array .@complete
			//do this
			.@complete[getarraysize(.@complete)] = .@charID[.@i];//the next time the inarray see this value it would pass the if statment
		}
	}
}
```