### PR TITLE
Corrected some item bonuses not triggering

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -608,7 +608,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 	struct map_session_data *sd, ///< Attacker session data if BL_PC
 		*tsd; ///< Target session data if BL_PC
 	short cardfix = 1000;
-	enum e_classAE s_class, ///< Attacker class
+	int s_class, ///< Attacker class
 		t_class; ///< Target class
 	enum e_race2 s_race2, /// Attacker Race2
 		t_race2; ///< Target Race2
@@ -625,8 +625,8 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 
 	sd = BL_CAST(BL_PC, src);
 	tsd = BL_CAST(BL_PC, target);
-	t_class = (enum e_classAE)status_get_class(target);
-	s_class = (enum e_classAE)status_get_class(src);
+	t_class = status_get_class(target);
+	s_class = status_get_class(src);
 	sstatus = status_get_status_data(src);
 	tstatus = status_get_status_data(target);
 	s_race2 = status_get_race2(src);


### PR DESCRIPTION
* **Addressed Issue(s)**: #3265

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes bAddDamageClass, bAddMagicDamageClass, bAddDefMonster, and bAddMDefMonster not checking for the correct source/target class.
Thanks to @uddevil!