### PR TITLE
Fixed Guild Storage Expansion skill saving

### DIFF
--- a/src/char/int_guild.cpp
+++ b/src/char/int_guild.cpp
@@ -1673,6 +1673,8 @@ int mapif_parse_GuildSkillUp(int fd,int guild_id,uint16 skill_id,uint32 account_
 			mapif_guild_info(-1,g);
 		mapif_guild_skillupack(guild_id,skill_id,account_id);
 		g->save_flag |= (GS_LEVEL|GS_SKILL); // Change guild & guild_skill
+		if (skill_id == GD_GUILD_STORAGE)
+			inter_guild_tosql(g, g->save_flag); // Force save for GD_GUILD_STORAGE
 	}
 	return 0;
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: #3301

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Force the Guild Storage Expansion skill to save on level up so the next time the guild storage is opened the proper increase is shown.
Thanks to @spinzaku!