### PR TITLE
Resolved Guild Storage Expansion not updating

### DIFF
--- a/src/char/int_storage.cpp
+++ b/src/char/int_storage.cpp
@@ -16,6 +16,7 @@
 
 #include "char.hpp"
 #include "inter.hpp"
+#include "int_guild.hpp"
 
 /**
  * Check if storage ID is valid
@@ -135,7 +136,7 @@ bool storage_fromsql(uint32 account_id, struct s_storage* p)
 bool guild_storage_tosql(int guild_id, struct s_storage* p)
 {
 	//ShowInfo("Guild Storage has been saved (GID: %d)\n", guild_id);
-	return char_memitemdata_to_sql(p->u.items_guild, MAX_GUILD_STORAGE, guild_id, TABLE_GUILD_STORAGE, p->stor_id);
+	return char_memitemdata_to_sql(p->u.items_guild, inter_guild_storagemax(guild_id), guild_id, TABLE_GUILD_STORAGE, p->stor_id);
 }
 
 /**
@@ -146,7 +147,7 @@ bool guild_storage_tosql(int guild_id, struct s_storage* p)
  */
 bool guild_storage_fromsql(int guild_id, struct s_storage* p)
 {
-	return char_memitemdata_from_sql( p, MAX_GUILD_STORAGE, guild_id, TABLE_GUILD_STORAGE, p->stor_id );
+	return char_memitemdata_from_sql( p, inter_guild_storagemax(guild_id), guild_id, TABLE_GUILD_STORAGE, p->stor_id );
 }
 
 void inter_storage_checkDB(void) {

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -603,7 +603,12 @@ char storage_guild_storageopen(struct map_session_data* sd)
 		return GSTORAGE_ALREADY_OPEN;
 	}
 
-	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr || (gstor && gstor->max_amount < guild_checkskill(sd->guild, GD_GUILD_STORAGE) * 100)) {
+	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr
+#ifdef OFFICIAL_GUILD_STORAGE
+		|| (gstor && gstor->max_amount < guild_checkskill(sd->guild, GD_GUILD_STORAGE) * 100)
+#endif
+		)
+	{
 		intif_request_guild_storage(sd->status.account_id,sd->status.guild_id);
 		return GSTORAGE_OPEN;
 	}

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -574,7 +574,7 @@ void storage_guild_delete(int guild_id)
  */
 char storage_guild_storageopen(struct map_session_data* sd)
 {
-	struct s_storage *gstor = nullptr;
+	struct s_storage *gstor;
 
 	nullpo_ret(sd);
 
@@ -605,10 +605,9 @@ char storage_guild_storageopen(struct map_session_data* sd)
 
 	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr
 #ifdef OFFICIAL_GUILD_STORAGE
-		|| (gstor && gstor->max_amount < guild_checkskill(sd->guild, GD_GUILD_STORAGE) * 100)
+		|| (gstor->max_amount != guild_checkskill(sd->guild, GD_GUILD_STORAGE) * 100)
 #endif
-		)
-	{
+	) {
 		intif_request_guild_storage(sd->status.account_id,sd->status.guild_id);
 		return GSTORAGE_OPEN;
 	}

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -574,7 +574,7 @@ void storage_guild_delete(int guild_id)
  */
 char storage_guild_storageopen(struct map_session_data* sd)
 {
-	struct s_storage *gstor;
+	struct s_storage *gstor = nullptr;
 
 	nullpo_ret(sd);
 
@@ -603,7 +603,7 @@ char storage_guild_storageopen(struct map_session_data* sd)
 		return GSTORAGE_ALREADY_OPEN;
 	}
 
-	if((gstor = guild2storage2(sd->status.guild_id)) == NULL) {
+	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr || (gstor && gstor->max_amount < guild_checkskill(sd->guild, GD_GUILD_STORAGE) * 100)) {
 		intif_request_guild_storage(sd->status.account_id,sd->status.guild_id);
 		return GSTORAGE_OPEN;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #3317

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Resolves the Guild Storage Expansion skill not refreshing the map server cached data.
  * Updated some inter server checks to grab the proper max size of guild storages.
Thanks to @admkakaroto!