### PR TITLE
Further cleanup to mapflags

### DIFF
--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -319,9 +319,6 @@ This mapflag can also be used to adjust the damage of one skill by a percentage:
 	SKILLDMG_BOSS = against boss monster
 	SKILLDMG_OTHER = against other (homunculus, mercenary, pet, elemental)
 
-Note:
- - Each map can contain up to UINT16_MAX adjustments.
-
 ---------------------------------------
 
 ==================

--- a/doc/mapflags.txt
+++ b/doc/mapflags.txt
@@ -319,8 +319,7 @@ This mapflag can also be used to adjust the damage of one skill by a percentage:
 	SKILLDMG_BOSS = against boss monster
 	SKILLDMG_OTHER = against other (homunculus, mercenary, pet, elemental)
 
-Notes:
- - You MUST enable ADJUST_SKILL_DAMAGE in 'src/config/core.hpp' for this mapflag to take effect.
+Note:
  - Each map can contain up to UINT16_MAX adjustments.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7001,7 +7001,7 @@ specified.
 *setmapflag "<map name>",<flag>{,<zone>{,<type>}};
 
 This command marks a specified map with the given map flag, which will alter the
-behavior of the map. A full list of mapflags is located in 'src/map/script_constants.h' with
+behavior of the map. A full list of mapflags is located in 'src/map/script_constants.hpp' with
 the 'mf_' prefix, and documentation can be found in 'doc/mapflags.txt'.
 
 The map flags alter the behavior of the map regarding teleporting (mf_nomemo,
@@ -7014,7 +7014,7 @@ current weather effects (mf_snow, mf_fog, mf_sakura, mf_leaves, mf_rain, mf_clou
 mf_fireworks) and whether night will be in effect on this map (mf_nightenabled).
 
 The optional parameter <zone> is used to set the zone for 'restricted' mapflags,
-GM level bypass from 'nocommand', base/job experience for 'bexp'/'jexp', and
+GM level bypass for 'nocommand', base/job experience for 'bexp'/'jexp', and
 flag for 'battleground'.
 
 For 'skill_damage' mapflag:

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7013,7 +7013,14 @@ skills or open up trade deals (mf_notrade, mf_novending, mf_noskill, mf_noicewal
 current weather effects (mf_snow, mf_fog, mf_sakura, mf_leaves, mf_rain, mf_clouds,
 mf_fireworks) and whether night will be in effect on this map (mf_nightenabled).
 
-The optional parameter 'zone' is used to set the zone for restricted mapflags.
+The optional parameter <zone> is used to set the zone for 'restricted' mapflags,
+GM level bypass from 'nocommand', base/job experience for 'bexp'/'jexp', and
+flag for 'battleground'.
+
+For 'skill_damage' mapflag:
+	- Setting the flag here will adjust the global (all skills) damage on the map.
+	- <zone> is the -100 to 100000 damage adjustment value of the skills.
+	- See 'getmapflag' for the different <type> values.
 
 ---------------------------------------
 
@@ -7032,12 +7039,12 @@ This command checks the status of a given mapflag and returns the mapflag's stat
 0 means OFF, and 1 means ON. See 'setmapflag' for a list of mapflags.
 
 The optional parameter 'type' is used in the 'skill_damage' mapflag:
- 0: if mapflag is set (default)
- 1: damage against players
- 2: damage against mobs
- 3: damage against bosses
- 4: damage against other
- 5: caster type
+ SKILLDMG_MAX: if mapflag is set (default)
+ SKILLDMG_PC: damage against players
+ SKILLDMG_MOB: damage against mobs
+ SKILLDMG_BOSS: damage against bosses
+ SKILLDMG_OTHER: damage against other
+ SKILLDMG_CASTER: caster type
 
 ---------------------------------------
 

--- a/npc/mapflag/skill_damage.txt
+++ b/npc/mapflag/skill_damage.txt
@@ -11,9 +11,6 @@
 //= skill_damage_db.txt for 'Map' type 16 will be applied.
 //= See the mapflag documentation for details about extra
 //= parameters.
-//=
-//= You MUST enable ADJUST_SKILL_DAMAGE in 'src/config/core.hpp'
-//= for this mapflag to take effect.
 //===== Additional Comments: ================================= 
 //= 1.0 Initial script. [Cydh]
 //============================================================

--- a/src/config/core.hpp
+++ b/src/config/core.hpp
@@ -43,11 +43,6 @@
 /// Uncomment to enable real-time server stats (in and out data and ram usage).
 //#define SHOW_SERVER_STATS
 
-/// Uncomment to enable skills damage adjustments
-/// By enabling this, db/skill_damage_db.txt and the skill_damage mapflag will adjust the
-/// damage rate of specified skills.
-//#define ADJUST_SKILL_DAMAGE
-
 /// Uncomment to enable the job base HP/SP table (job_basehpsp_db.txt)
 #define HP_SP_TABLES
 

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8158,7 +8158,9 @@ ACMD_FUNC(mapflag) {
 		clif_displaymessage(sd->fd,msg_txt(sd,1311)); // Enabled Mapflags in this map:
 		clif_displaymessage(sd->fd,"----------------------------------");
 		for( i = MF_MIN; i < MF_MAX; i++ ){
-			if( map_getmapflag_name(static_cast<e_mapflag>(i), flag_name) && map_getmapflag( sd->bl.m, static_cast<e_mapflag>(i) ) ){
+			union u_mapflag_args args = {};
+
+			if( map_getmapflag_name(static_cast<e_mapflag>(i), flag_name) && map_getmapflag_sub( sd->bl.m, static_cast<e_mapflag>(i), &args ) ){
 				clif_displaymessage(sd->fd, flag_name);
 			}
 		}
@@ -8182,7 +8184,7 @@ ACMD_FUNC(mapflag) {
 				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be enabled as it requires unique values.", flag_name);
 				clif_displaymessage(sd->fd,atcmd_output);
 			} else {
-				map_setmapflag(sd->bl.m, static_cast<e_mapflag>(mapflag), flag != 0);
+				map_setmapflag(sd->bl.m, mapflag, flag != 0);
 				sprintf(atcmd_output,"[ @mapflag ] %s flag has been set to %s value = %hd",flag_name,flag?"On":"Off",flag);
 				clif_displaymessage(sd->fd,atcmd_output);
 			}

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8178,7 +8178,14 @@ ACMD_FUNC(mapflag) {
 		enum e_mapflag mapflag = map_getmapflag_by_name(flag_name);
 
 		if( mapflag != MF_INVALID ){
-			std::vector<e_mapflag> disabled_mf = { MF_NOSAVE, MF_PVP_NIGHTMAREDROP, MF_RESTRICTED, MF_NOCOMMAND, MF_BEXP, MF_JEXP, MF_BATTLEGROUND, MF_SKILL_DAMAGE };
+			std::vector<e_mapflag> disabled_mf = { MF_NOSAVE,
+												MF_PVP_NIGHTMAREDROP,
+												MF_RESTRICTED,
+												MF_NOCOMMAND,
+												MF_BEXP,
+												MF_JEXP,
+												MF_BATTLEGROUND,
+												MF_SKILL_DAMAGE };
 
 			if (flag && std::find(disabled_mf.begin(), disabled_mf.end(), mapflag) != disabled_mf.end()) {
 				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be enabled as it requires unique values.", flag_name);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2156,7 +2156,6 @@ static int battle_blewcount_bonus(struct map_session_data *sd, uint16 skill_id)
 	return 0;
 }
 
-#ifdef ADJUST_SKILL_DAMAGE
 static enum e_skill_damage_type battle_skill_damage_type( struct block_list* bl ){
 	switch( bl->type ){
 		case BL_PC:
@@ -2248,7 +2247,6 @@ static int battle_skill_damage(struct block_list *src, struct block_list *target
 	skill_id = skill_dummy2skill_id(skill_id);
 	return battle_skill_damage_skill(src, target, skill_id) + battle_skill_damage_map(src, target, skill_id);
 }
-#endif
 
 /**
  * Calculates Minstrel/Wanderer bonus for Chorus skills.
@@ -5103,9 +5101,7 @@ struct Damage battle_calc_weapon_final_atk_modifiers(struct Damage wd, struct bl
 	struct status_change *tsc = status_get_sc(target);
 	struct status_data *sstatus = status_get_status_data(src);
 	struct status_data *tstatus = status_get_status_data(target);
-#ifdef ADJUST_SKILL_DAMAGE
 	int skill_damage = 0;
-#endif
 
 	//Reject Sword bugreport:4493 by Daegaladh
 	if(wd.damage && tsc && tsc->data[SC_REJECTSWORD] &&
@@ -5187,10 +5183,8 @@ struct Damage battle_calc_weapon_final_atk_modifiers(struct Damage wd, struct bl
 	}
 
 	// Skill damage adjustment
-#ifdef ADJUST_SKILL_DAMAGE
 	if ((skill_damage = battle_skill_damage(src, target, skill_id)) != 0)
 		ATK_ADDRATE(wd.damage, wd.damage2, skill_damage);
-#endif
 	return wd;
 }
 
@@ -5679,10 +5673,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
  */
 struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list *target,uint16 skill_id,uint16 skill_lv,int mflag)
 {
-	int i, nk;
-#ifdef ADJUST_SKILL_DAMAGE
-	int skill_damage = 0;
-#endif
+	int i, nk, skill_damage = 0;
 	short s_ele = 0;
 
 	TBL_PC *sd;
@@ -6396,10 +6387,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 		ad.damage = battle_calc_bg_damage(src,target,ad.damage,skill_id,ad.flag);
 
 	// Skill damage adjustment
-#ifdef ADJUST_SKILL_DAMAGE
 	if ((skill_damage = battle_skill_damage(src,target,skill_id)) != 0)
 		MATK_ADDRATE(skill_damage);
-#endif
 
 	battle_absorb_damage(target, &ad);
 
@@ -6416,9 +6405,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
  */
 struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *target,uint16 skill_id,uint16 skill_lv,int mflag)
 {
-#ifdef ADJUST_SKILL_DAMAGE
 	int skill_damage = 0;
-#endif
 	short i, nk;
 	short s_ele;
 
@@ -6792,10 +6779,8 @@ struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *
 		md.damage = battle_calc_bg_damage(src,target,md.damage,skill_id,md.flag);
 
 	// Skill damage adjustment
-#ifdef ADJUST_SKILL_DAMAGE
 	if ((skill_damage = battle_skill_damage(src,target,skill_id)) != 0)
 		md.damage += (int64)md.damage * skill_damage / 100;
-#endif
 
 	battle_absorb_damage(target, &md);
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2191,11 +2191,13 @@ static int battle_skill_damage_skill(struct block_list *src, struct block_list *
 	if (!(damage->caster&src->type))
 		return 0;
 
-	if ((damage->map&1 && (!map_getmapflag(m, MF_PVP) && !map_flag_gvg2(m) && !map_getmapflag(m, MF_BATTLEGROUND) && !map_getmapflag(m, MF_SKILL_DAMAGE) && !map_getmapflag(m, MF_RESTRICTED))) ||
+	union u_mapflag_args args = {};
+
+	if ((damage->map&1 && (!map_getmapflag(m, MF_PVP) && !map_flag_gvg2(m) && !map_getmapflag(m, MF_BATTLEGROUND) && !map_getmapflag_sub(m, MF_SKILL_DAMAGE, &args) && !map_getmapflag(m, MF_RESTRICTED))) ||
 		(damage->map&2 && map_getmapflag(m, MF_PVP)) ||
 		(damage->map&4 && map_flag_gvg2(m)) ||
 		(damage->map&8 && map_getmapflag(m, MF_BATTLEGROUND)) ||
-		(damage->map&16 && map_getmapflag(m, MF_SKILL_DAMAGE)) ||
+		(damage->map&16 && map_getmapflag_sub(m, MF_SKILL_DAMAGE, &args)) ||
 		(map_getmapflag(m, MF_RESTRICTED) && damage->map&(8*map[m].zone)))
 	{
 		return damage->rate[battle_skill_damage_type(target)];
@@ -2214,8 +2216,9 @@ static int battle_skill_damage_skill(struct block_list *src, struct block_list *
 static int battle_skill_damage_map(struct block_list *src, struct block_list *target, uint16 skill_id) {
 	int rate = 0;
 	struct map_data *mapd = &map[src->m];
+	union u_mapflag_args args = {};
 
-	if (!mapd || !map_getmapflag(src->m, MF_SKILL_DAMAGE))
+	if (!mapd || !map_getmapflag_sub(src->m, MF_SKILL_DAMAGE, &args))
 		return 0;
 
 	// Damage rate for all skills at this map

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2193,6 +2193,7 @@ static int battle_skill_damage_skill(struct block_list *src, struct block_list *
 
 	union u_mapflag_args args = {};
 
+	args.flag_val = SKILLDMG_MAX; // Check if it's enabled first
 	if ((damage->map&1 && (!map_getmapflag(m, MF_PVP) && !map_flag_gvg2(m) && !map_getmapflag(m, MF_BATTLEGROUND) && !map_getmapflag_sub(m, MF_SKILL_DAMAGE, &args) && !map_getmapflag(m, MF_RESTRICTED))) ||
 		(damage->map&2 && map_getmapflag(m, MF_PVP)) ||
 		(damage->map&4 && map_flag_gvg2(m)) ||
@@ -2218,6 +2219,7 @@ static int battle_skill_damage_map(struct block_list *src, struct block_list *ta
 	struct map_data *mapd = &map[src->m];
 	union u_mapflag_args args = {};
 
+	args.flag_val = SKILLDMG_MAX; // Check if it's enabled first
 	if (!mapd || !map_getmapflag_sub(src->m, MF_SKILL_DAMAGE, &args))
 		return 0;
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -595,8 +595,8 @@ enum e_skill_damage_type : uint8 {
 	SKILLDMG_MOB,
 	SKILLDMG_BOSS,
 	SKILLDMG_OTHER,
+	SKILLDMG_MAX,
 	SKILLDMG_CASTER, ///< Only used on getter for caster value
-	SKILLDMG_MAX
 };
 
 /// Struct for MF_SKILL_DAMAGE

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -595,18 +595,17 @@ enum e_skill_damage_type : uint8 {
 	SKILLDMG_MOB,
 	SKILLDMG_BOSS,
 	SKILLDMG_OTHER,
+	SKILLDMG_CASTER, ///< Only used on getter for caster value
 	SKILLDMG_MAX
 };
 
-#ifdef ADJUST_SKILL_DAMAGE
-/// Struct for MF_SKILLDAMAGE
+/// Struct for MF_SKILL_DAMAGE
 struct s_skill_damage {
 	unsigned int map; ///< Maps (used for skill_damage_db.txt)
 	uint16 skill_id; ///< Skill ID (used for mapflag)
 	uint16 caster; ///< Caster type
 	int rate[SKILLDMG_MAX]; ///< Used for when all skills are adjusted
 };
-#endif
 
 /// Enum for item drop type for MF_PVP_NIGHTMAREDROP
 enum e_nightmare_drop_type : uint8 {
@@ -626,9 +625,7 @@ struct s_drop_list {
 union u_mapflag_args {
 	struct point nosave;
 	struct s_drop_list nightmaredrop;
-#ifdef ADJUST_SKILL_DAMAGE
 	struct s_skill_damage skill_damage;
-#endif
 	int flag_val;
 };
 
@@ -739,10 +736,8 @@ struct map_data {
 	struct point save;
 	std::vector<s_drop_list> drop_list;
 	uint32 zone; // zone number (for item/skill restrictions)
-#ifdef ADJUST_SKILL_DAMAGE
 	struct s_skill_damage damage_adjust; // Used for overall skill damage adjustment
 	std::vector<s_skill_damage> skill_damage; // Used for single skill damage adjustment
-#endif
 
 	struct npc_data *npc[MAX_NPC_PER_MAP];
 	struct spawn_data *moblist[MAX_MOB_LIST_PER_MAP]; // [Wizputer]
@@ -954,9 +949,7 @@ void map_removemobs(int16 m); // [Wizputer]
 void map_addmap2db(struct map_data *m);
 void map_removemapdb(struct map_data *m);
 
-#ifdef ADJUST_SKILL_DAMAGE
 void map_skill_damage_add(struct map_data *m, uint16 skill_id, int rate[SKILLDMG_MAX], uint16 caster);
-#endif
 
 enum e_mapflag map_getmapflag_by_name(char* name);
 bool map_getmapflag_name(enum e_mapflag mapflag, char* output);

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4052,17 +4052,15 @@ static const char* npc_parse_mapflag(char* w1, char* w2, char* w3, char* w4, con
 			break;
 
 		case MF_SKILL_DAMAGE: {
-#ifdef ADJUST_SKILL_DAMAGE
 			char skill_name[SKILL_NAME_LENGTH];
 			char caster_constant[NAME_LENGTH];
+			union u_mapflag_args args = {};
 
 			memset(skill_name, 0, sizeof(skill_name));
 
 			if (!state)
-				map_setmapflag(m, MF_SKILL_DAMAGE, false);
+				map_setmapflag_sub(m, MF_SKILL_DAMAGE, false, &args);
 			else {
-				union u_mapflag_args args = {};
-
 				if (sscanf(w4, "%30[^,],%23[^,],%11d,%11d,%11d,%11d[^\n]", skill_name, caster_constant, &args.skill_damage.rate[SKILLDMG_PC], &args.skill_damage.rate[SKILLDMG_MOB], &args.skill_damage.rate[SKILLDMG_BOSS], &args.skill_damage.rate[SKILLDMG_OTHER]) >= 3) {
 					if (ISDIGIT(caster_constant[0]))
 						args.skill_damage.caster = atoi(caster_constant);
@@ -4088,14 +4086,12 @@ static const char* npc_parse_mapflag(char* w1, char* w2, char* w3, char* w4, con
 					else if (skill_name2id(skill_name) <= 0)
 						ShowWarning("npc_parse_mapflag: Invalid skill name '%s' for Skill Damage mapflag. Skipping (file '%s', line '%d').\n", skill_name, filepath, strline(buffer, start - buffer));
 					else { // Adjusted damage for specified skill
-						map_setmapflag(m, MF_SKILL_DAMAGE, true);
+						args.flag_val = 1;
+						map_setmapflag_sub(m, MF_SKILL_DAMAGE, true, &args);
 						map_skill_damage_add(&map[m], skill_name2id(skill_name), args.skill_damage.rate, args.skill_damage.caster);
 					}
 				}
 			}
-#else
-			ShowWarning("npc_parse_mapflag: skill_damage: ADJUST_SKILL_DAMAGE is inactive (src/config/core.hpp). Skipping this mapflag..\n");
-#endif
 			break;
 		}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12310,12 +12310,16 @@ BUILDIN_FUNC(setmapflag)
 				return SCRIPT_CMD_FAILURE;
 			}
 			break;
-		case MF_NOSAVE:
-			ShowWarning("buildin_setmapflag: Use script command setmapflagnosave to adjust this mapflag.\n");
-			return SCRIPT_CMD_FAILURE;
-		case MF_PVP_NIGHTMAREDROP:
-			ShowWarning("buildin_setmapflag: Unable to set pvp_nightmaredrop mapflag from this script command.\n");
-			return SCRIPT_CMD_FAILURE;
+		case MF_NOSAVE: // Assume setting "SavePoint"
+			args.nosave.map = 0;
+			args.nosave.x = -1;
+			args.nosave.y = -1;
+			break;
+		case MF_PVP_NIGHTMAREDROP: // Assume setting standard drops
+			args.nightmaredrop.drop_id = -1;
+			args.nightmaredrop.drop_per = 300;
+			args.nightmaredrop.drop_type = NMDT_EQUIP;
+			break;
 		default:
 			FETCH(4, args.flag_val);
 			break;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12267,9 +12267,7 @@ BUILDIN_FUNC(getmapflag)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-#ifdef ADJUST_SKILL_DAMAGE
 	FETCH(4, args.flag_val);
-#endif
 
 	script_pushint(st, map_getmapflag_sub(m, static_cast<e_mapflag>(mf), &args));
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12304,7 +12304,7 @@ BUILDIN_FUNC(setmapflag)
 	switch(mf) {
 		case MF_SKILL_DAMAGE:
 			if (script_hasdata(st, 4) && script_hasdata(st, 5))
-				args.rate[script_getnum(st, 5)] = script_getnum(st, 4);
+				args.skill_damage.rate[script_getnum(st, 5)] = script_getnum(st, 4);
 			else {
 				ShowWarning("buildin_setmapflag: Unable to set skill_damage mapflag as flag data is missing.\n");
 				return SCRIPT_CMD_FAILURE;

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -7269,6 +7269,14 @@
 	export_constant(BL_MER);
 	export_constant(BL_ELEM);
 
+	/* skill damage mapflag types */
+	export_constant(SKILLDMG_PC);
+	export_constant(SKILLDMG_MOB);
+	export_constant(SKILLDMG_BOSS);
+	export_constant(SKILLDMG_OTHER);
+	export_constant(SKILLDMG_MAX);
+	export_constant(SKILLDMG_CASTER);
+
 	#undef export_constant
 	#undef export_constant2
 	#undef export_parameter

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -21455,7 +21455,6 @@ static bool skill_parse_row_changematerialdb(char* split[], int columns, int cur
 	return true;
 }
 
-#ifdef ADJUST_SKILL_DAMAGE
 /**
  * Reads skill damage adjustment
  * @author [Lilith]
@@ -21472,17 +21471,16 @@ static bool skill_parse_row_skilldamage(char* split[], int columns, int current)
 
 	id = skill_db_isset(id, __FUNCTION__);
 
-	memset(&skill_db[id]->damage,0,sizeof(struct s_skill_damage));
+	skill_db[id]->damage = {};
 	skill_db[id]->damage.caster |= atoi(split[1]);
 	skill_db[id]->damage.map |= atoi(split[2]);
 
-	for(int offset = 3, int i = 0; i < SKILLDMG_MAX && offset < columns; i++, offset++ ){
+	for(int offset = 3, i = 0; i < SKILLDMG_MAX && offset < columns; i++, offset++ ){
 		skill_db[id]->damage.rate[i] = cap_value(atoi(split[offset]), -100, INT_MAX);
 	}
 
 	return true;
 }
-#endif
 
 /**
  * Init dummy skill db also init Skill DB allocation
@@ -21590,9 +21588,8 @@ static void skill_readdb(void)
 		sv_readdb(dbsubpath1, "skill_improvise_db.txt"      , ',',   2,  2, MAX_SKILL_IMPROVISE_DB, skill_parse_row_improvisedb, i > 0);
 		sv_readdb(dbsubpath1, "skill_changematerial_db.txt" , ',',   5,  5+2*MAX_SKILL_CHANGEMATERIAL_SET, MAX_SKILL_CHANGEMATERIAL_DB, skill_parse_row_changematerialdb, i > 0);
 		sv_readdb(dbsubpath1, "skill_nonearnpc_db.txt"      , ',',   2,  3, -1, skill_parse_row_nonearnpcrangedb, i > 0);
-#ifdef ADJUST_SKILL_DAMAGE
 		sv_readdb(dbsubpath1, "skill_damage_db.txt"         , ',',   4,  3+SKILLDMG_MAX, -1, skill_parse_row_skilldamage, i > 0);
-#endif
+
 		aFree(dbsubpath1);
 		aFree(dbsubpath2);
 	}

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -225,9 +225,7 @@ struct s_skill_db {
 	uint8 unit_nonearnpc_type;	//type of NPC [Cydh]
 
 	// skill_damage_db.txt
-#ifdef ADJUST_SKILL_DAMAGE
 	struct s_skill_damage damage;
-#endif
 
 	// skill_copyable_db.txt
 	struct s_copyable { // [Cydh]


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to a942853.
  * Removed ADJUST_SKILL_DAMAGE define and enabled the mapflag always.
  * Cleaned up atcommand mapinfo and skill_damage mapflag interaction.
  * Cleaned up atcommand mapflag to not allow setting of special mapflags that require extra arguments.