### PR TITLE
Updated Acid Terror damage modifier for renewal

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3604,7 +3604,11 @@ static int battle_calc_attack_skill_ratio(struct Damage wd, struct block_list *s
 			skillratio += 20 * skill_lv;
 			break;
 		case AM_ACIDTERROR:
+#ifdef RENEWAL
+			skillratio += 200 + 80 * skill_lv;
+#else
 			skillratio += 40 * skill_lv;
+#endif
 			break;
 		case MO_FINGEROFFENSIVE:
 			skillratio += 50 * skill_lv;


### PR DESCRIPTION
* **Server Mode**: Both
* **Description of Pull Request**: 
Modifies damage modifier of Acid Terror according to the following links as reference:
Renewal damage modifier: https://irowiki.org/wiki/Acid_Terror
Pre-renewal damage modifier: https://irowiki.org/classic/Acid_Terror
