### PR TITLE
Corrected Spiritual Sphere Absorption and Cursed Circle interaction

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2141,9 +2141,6 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 			return false;
 		}
 
-		if (flag == 1 && sc->data[SC_CURSEDCIRCLE_TARGET] && skill_id == MO_ABSORBSPIRITS) // Absorb Spirits fails to go through
-			return false;
-
 		if (skill_id != RK_REFRESH && skill_id != SU_GROOMING && sc->opt1 && sc->opt1 != OPT1_BURNING && skill_id != SR_GENTLETOUCH_CURE) { // Stuned/Frozen/etc
 			if (flag != 1) // Can't cast, casted stuff can't damage.
 				return false;


### PR DESCRIPTION
* **Addressed Issue(s)**: #3357

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Revert of 9a009bf.
  * Spiritual Sphere Absorption should still take the spheres from the target even if Cursed Circle is used on the caster.
Thanks to @Raf4h!