### PR TITLE
instance_create missing exception

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19588,6 +19588,12 @@ BUILDIN_FUNC(instance_create)
 	enum instance_mode mode = IM_PARTY;
 	int owner_id = 0;
 
+	if (!instance_searchname_db(script_getstr(st, 2)))
+	{
+		ShowError("buildin_instance_create: Invalid instance name %s\n", script_getstr(st, 2));
+		return SCRIPT_CMD_FAILURE;
+	}
+
 	if (script_hasdata(st, 3)) {
 		mode = static_cast<instance_mode>(script_getnum(st, 3));
 


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 
-
adding exception for if the the instance name is not correct

testing script
```
prontera,152,185,4	script	npcName	444,{
	instance_create("test");
}
```
before
![image](https://user-images.githubusercontent.com/5981261/43350281-2da9a0a6-9206-11e8-81c9-3c30f8dc5f69.png)

after
![image](https://user-images.githubusercontent.com/5981261/43350452-74d23a14-9207-11e8-803f-b8a59870e4bd.png)

i wanted to do this at instance.cpp
```cs
	//nullpo_retr(-1, db);
	if (!db) 
	{
		ShowError("instance_create: Invalid instance name '%s'.\n", name);
		return -5;
	}
```
but don't know what the best (also don't know if removing the `nullpo_retr` is a good thing

