### PR TITLE
Fixes channel_chat crash

### DIFF
--- a/src/map/channel.cpp
+++ b/src/map/channel.cpp
@@ -504,7 +504,7 @@ struct Channel* channel_name2channel(char *chname, struct map_session_data *sd, 
 	if(channel_chk(chname, NULL, 1))
 		return NULL;
 
-	struct map_data *mapdata = map_getmapdata(sd->bl.m);
+	struct map_data *mapdata = sd ? map_getmapdata(sd->bl.m) : NULL;
 
 	if(sd && strcmpi(chname + 1,channel_config.map_tmpl.name) == 0){
 		if(flag&1 && !mapdata->channel)


### PR DESCRIPTION
* **Addressed Issue(s)**: #3363 

* **Server Mode**: Both

* **Description of Pull Request**: 

  * Fixed map-server crash on `channel_chat` usage
  * Follow up 584fcac43a13381d74374cf8835b2d2b077913b6