### PR TITLE
Suggestion of 'killedgid'

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -943,8 +943,9 @@ This special label triggers when a player kills another player. The variable
 
 OnNPCKillEvent:
 
-This special label triggers when a player kills a monster without label. The variable
-'killedrid' is set to the Class (mob ID) of the monster killed.
+This special label triggers when a player kills a monster without label.
+The variable 'killedrid' is set to the Class (mob ID) of the monster killed.
+The variable 'killedgid' is set to the ID (unique mob game ID) of the monster killed.
 
 OnPCLoadMapEvent:
 
@@ -6052,8 +6053,9 @@ The only very special thing about this command is an event label, which is an
 optional parameter. This label is written like '<NPC object name>::<label name>'
 and upon the monster being killed, it will execute the script inside of the
 specified NPC object starting from the label given. The RID of the player
-attached at this execution will be the RID of the killing character. The variable
-'killedrid' is set to the Class (mob ID) of the monster killed.
+attached at this execution will be the RID of the killing character.
+The variable 'killedrid' is set to the Class (mob ID) of the monster killed.
+The variable 'killedgid' is set to the ID (unique mob game ID) of the monster killed.
 
 <size> can be:
 	Size_Small	(0)		(default)

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -411,6 +411,7 @@ enum _sp {
 	SP_UPPER,SP_PARTNER,SP_CART,SP_FAME,SP_UNBREAKABLE,	//56-60
 	SP_CARTINFO=99,	// 99
 
+	SP_KILLEDGID=118,
 	SP_BASEJOB=119,	// 100+19 - celest
 	SP_BASECLASS=120,	//Hmm.. why 100+19? I just use the next one... [Skotlex]
 	SP_KILLERRID=121,

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2994,16 +2994,19 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 
 		if( md->npc_event[0] && !md->state.npc_killmonster ) {
 			if( sd && battle_config.mob_npc_event_type ) {
+				pc_setparam(sd, SP_KILLEDGID, md->bl.id);
 				pc_setparam(sd, SP_KILLEDRID, md->mob_id);
 				pc_setparam(sd, SP_KILLERRID, sd->bl.id);
 				npc_event(sd,md->npc_event,0);
 			} else if( mvp_sd ) {
+				pc_setparam(mvp_sd, SP_KILLEDGID, md->bl.id);
 				pc_setparam(mvp_sd, SP_KILLEDRID, md->mob_id);
 				pc_setparam(mvp_sd, SP_KILLERRID, sd?sd->bl.id:0);
 				npc_event(mvp_sd,md->npc_event,0);
 			} else
 				npc_event_do(md->npc_event);
 		} else if( mvp_sd && !md->state.npc_killmonster ) {
+			pc_setparam(mvp_sd, SP_KILLEDGID, md->bl.id);
 			pc_setparam(mvp_sd, SP_KILLEDRID, md->mob_id);
 			npc_script_event(mvp_sd, NPCE_KILLNPC); // PCKillNPC [Lance]
 		}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8116,6 +8116,7 @@ int pc_readparam(struct map_session_data* sd,int type)
 		case SP_FAME:            val = sd->status.fame; break;
 		case SP_KILLERRID:       val = sd->killerrid; break;
 		case SP_KILLEDRID:       val = sd->killedrid; break;
+		case SP_KILLEDGID:       val = sd->killedgid; break;
 		case SP_SITTING:         val = pc_issit(sd)?1:0; break;
 		case SP_CHARMOVE:		 val = sd->status.character_moves; break;
 		case SP_CHARRENAME:		 val = sd->status.rename; break;
@@ -8382,6 +8383,9 @@ bool pc_setparam(struct map_session_data *sd,int type,int val)
 		return true;
 	case SP_KILLEDRID:
 		sd->killedrid = val;
+		return true;
+	case SP_KILLEDGID:
+		sd->killedgid = val;
 		return true;
 	case SP_CHARMOVE:
 		sd->status.character_moves = val;

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -587,7 +587,7 @@ struct map_session_data {
 	size_t duel_group; // duel vars [LuzZza]
 	size_t duel_invite;
 
-	int killerrid, killedrid;
+	int killerrid, killedrid, killedgid;
 
 	int cashPoints, kafraPoints;
 	int rental_timer;

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -511,6 +511,7 @@
 	export_parameter("BaseClass",SP_BASECLASS);
 	export_parameter("killerrid",SP_KILLERRID);
 	export_parameter("killedrid",SP_KILLEDRID);
+	export_parameter("killedgid",SP_KILLEDGID);
 	export_parameter("Sitting",SP_SITTING);
 	export_parameter("CharMoves",SP_CHARMOVE);
 	export_parameter("CharRename",SP_CHARRENAME);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Currently `killedrid` is set to to the Class (mob ID) of the monster killed. I suggest to set `killedgid` - variable containing the monster game ID - as well to easily retrieve the datas of the monster killed.

**Sample 1**
_________________
```
-	script	killedgid test 1	-1,{
	end;
OnNPCKillEvent:
	getunitdata killedgid, .@data;
	announce "monster '" + getunitname(killedgid) + "' died at coordinates x: " + .@data[UMOB_X] + ", y: " + .@data[UMOB_Y],0;
	end;
}
```
**Sample 2**
_________________
```
izlude,125,140,5	script	killedgid test 2	60,{
	monster "izlude",137,141, "poring",1001,5, strnpcinfo(0) + "::OnMobDead";
	monster "izlude",137,141, "coucou",1002,5, strnpcinfo(0) + "::OnMobDead";
	end;
OnMobDead:
	getunitdata killedgid, .@data;
	announce "monster named '" + getunitname(killedgid) + "' died at coordinates x: " + .@data[UMOB_X] + ", y: " + .@data[UMOB_Y],0;
	end;
}
```
**Thought ?**
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
