### PR TITLE
Corrected server info display

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -18823,7 +18823,7 @@ void clif_display_pinfo(struct map_session_data *sd, int cmdtype) {
 		}
 		//1:Premium
 		if (pc_isvip(sd)) {
-			details_bexp[1] = battle_config.vip_base_exp_increase;
+			details_bexp[1] = battle_config.vip_base_exp_increase * 10;
 			if (details_bexp[1] < 0)
 				details_bexp[1] = 0 - details_bexp[1];
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: #3431

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrected the VIP EXP bonus amount being displayed incorrectly for the personal information packet.
Thanks to @hendra814!