### PR TITLE
autopot script improvment

### DIFF
--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -157,10 +157,10 @@ OnCommand:
 end;
 
 OnStart:
-	if (!getstatus(SC_BERSERK) || !getstatus(SC_SATURDAYNIGHTFEVER) || !getstatus(SC_GRAVITATION) ||
-	    !getstatus(SC_TRICKDEAD) || !getstatus(SC_HIDING) || !getstatus(SC__SHADOWFORM) || !getstatus(SC__INVISIBILITY) ||
-	    !getstatus(SC__MANHOLE) || !getstatus(SC_KAGEHUMI) || !getstatus(SC_HEAT_BARREL_AFTER) ||
-		!getstatus(SC_STONE) || !getstatus(SC_FREEZE) || !getstatus(SC_STUN) || !getstatus(SC_SLEEP))
+	if (!getstatus(SC_BERSERK) && !getstatus(SC_SATURDAYNIGHTFEVER) && !getstatus(SC_GRAVITATION) &&
+	    !getstatus(SC_TRICKDEAD) && !getstatus(SC_HIDING) && !getstatus(SC__SHADOWFORM) && !getstatus(SC__INVISIBILITY) &&
+	    !getstatus(SC__MANHOLE) && !getstatus(SC_KAGEHUMI) && !getstatus(SC_HEAT_BARREL_AFTER) &&
+		!getstatus(SC_STONE) && !getstatus(SC_FREEZE) && !getstatus(SC_STUN) && !getstatus(SC_SLEEP))
 		{
 		if(Hp){
 			if(@autopot_hp_Active && Hp * 100 / MaxHp < @autopot_hp_Min) {

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -15,7 +15,7 @@
 -	script	#autopot	-1,{
 OnInit:
 	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand");
-	.MinDelay = 250;	//Minimum Delay Alowed (Default and Recomanded: 250)[lower values will increase server strain]
+	.MinDelay = 100;	//Minimum Delay Alowed (Default and Recomanded: 100)[lower values will increase server strain]
 	setarray .blackList[0],0;	//Array of Black Listed Item's IDs
 end;
 
@@ -49,7 +49,7 @@ L_Start:
 		@autopot_delay = getarg(3);
 
 	if (getd("@autopot_" + .@type$ + "_Min")   < 1  || getd("@autopot_" + .@type$ + "_Min") > 100)  setd "@autopot_" + .@type$ + "_Min",90;
-	if (@autopot_delay < 100 || @autopot_delay > 1000) @autopot_delay = .MinDelay;
+	if (@autopot_delay < 50 || @autopot_delay > 1000) @autopot_delay = .MinDelay;
 	if (getiteminfo(.@potion,2) != IT_HEALING) {
 		dispbottom getitemname(.@potion) + " is not a healing item.";
 		end;
@@ -62,6 +62,7 @@ L_Start:
 		message strcharinfo(0), "Your base level is too low to use '" + getitemname(.@potion) + "'.";
 		end;
 	}
+	setd "@autopot_" + .@type$ + "_ID",.@potion;
 	setd "@autopot_" + .@type$ + "_Active",true;
 	addtimer .@delay,strnpcinfo(3) + "::OnStart";
 	message strcharinfo(0), "Auto-Potion " + strtoupper(.@type$) + " enabled.";
@@ -113,6 +114,7 @@ OnCommand:
 				.@select = select(.@menu$ + "   ^777777Cancel^000000") - 1;
 				if (.@select != .@count)
 					callsub L_Start,.@command$[0],.@items[.@select];
+				callsub L_Info;
 				close2;
 			}else{
 				message strcharinfo(0), "There are no healing items in your inventory.";
@@ -124,6 +126,7 @@ OnCommand:
 		.@delay = atoi(.@atcmd_parameters$[3]);
 		if(getitemname(.@potion) != "null"){
 			callsub L_Start,.@command$[0],.@potion,.@percent,.@delay;
+			callsub L_Info;
 			end;
 		}
 		message strcharinfo(0), "Auto-Potion : something went wrong!";
@@ -163,18 +166,20 @@ OnStart:
 	    !getstatus(SC__MANHOLE) || !getstatus(SC_KAGEHUMI) || !getstatus(SC_HEAT_BARREL_AFTER) ||
 		!getstatus(SC_STONE) || !getstatus(SC_FREEZE) || !getstatus(SC_STUN) || !getstatus(SC_SLEEP))
 		{
-		if(@autopot_hp_Active && Hp && Hp * 100 / MaxHp < @autopot_hp_Min) {
-			if (countitem(@autopot_hp_ID)) {
-				delitem @autopot_hp_ID,1;
-				consumeitem @autopot_hp_ID;
-				specialeffect2 207;
+		if(Hp){
+			if(@autopot_hp_Active && Hp * 100 / MaxHp < @autopot_hp_Min) {
+				if (countitem(@autopot_hp_ID)) {
+					delitem @autopot_hp_ID,1;
+					consumeitem @autopot_hp_ID;
+					specialeffect2 207;
+				}
 			}
-		}
-		if(@autopot_sp_Active && Sp && Sp * 100 / MaxSp < @autopot_sp_Min) {
-			if (countitem(@autopot_sp_ID)) {
-				delitem @autopot_sp_ID,1;
-				consumeitem @autopot_sp_ID;
-				specialeffect2 208;
+			if(@autopot_sp_Active && Sp * 100 / MaxSp < @autopot_sp_Min) {
+				if (countitem(@autopot_sp_ID)) {
+					delitem @autopot_sp_ID,1;
+					consumeitem @autopot_sp_ID;
+					specialeffect2 208;
+				}
 			}
 		}
 	}

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -1,29 +1,37 @@
 //===== rAthena Script =======================================
 //= Auto-Potion
-//===== By: ==================================================
-//= Euphy
-//===== Current Version: =====================================
-//= 2.0
-//===== Compatible With: =====================================
-//= rAthena Project
 //===== Description: =========================================
 //= Provides an @autopot command to automatically use potions.
-//===== Additional Comments: =================================
+//===== Changelogs: ==========================================
 //= 1.0 First version. [Euphy]
 //= 2.0 rewrite and adding SP option. [sader1992]
 //============================================================
 -	script	#autopot	-1,{
 OnInit:
+	.HP_Option = true;	//Allow HP option
+	.SP_Option = true;	//Allow SP option
+	.MinDelay = 100;	//Minimum Delay Allowed (Default and Recommended: 100) [lower values will increase server strain]
+	setarray .blackList[0],0;	//Array of black listed item ID
+
+	if(!.HP_Option && !.SP_Option){
+		debugmes "Warning: @autopot both hp and sp are Disabled";
+		debugmes "Warning: @autopot script has been Disabled!";
+		end;
+	}
 	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand",0,99);
-	.MinDelay = 100;	//Minimum Delay Alowed (Default and Recomanded: 100)[lower values will increase server strain]
-	setarray .blackList[0],0;	//Array of Black Listed Item's IDs
 end;
 
 L_Help:
 	dispbottom "Available commands:";
-	dispbottom "    @autopot <hp|sp> <item id> {<min hp % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
-	dispbottom "    @autopot <hp|sp> list";
-	dispbottom "    @autopot <hp|sp> <on|off>";
+	if(.HP_Option && .SP_Option){
+		dispbottom "    @autopot <hp|sp> <item id> {<min hp|sp % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
+		dispbottom "    @autopot <hp|sp> list";
+		dispbottom "    @autopot <hp|sp> <on|off>";
+	}else{
+		dispbottom "    @autopot <" + (.HP_Option?"hp":"sp") + "> <item id> {<min " + (.HP_Option?"hp":"sp") + " % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
+		dispbottom "    @autopot <" + (.HP_Option?"hp":"sp") + "> list";
+		dispbottom "    @autopot <" + (.HP_Option?"hp":"sp") + "> <on|off>";
+	}
 	dispbottom "    @autopot info";
 	dispbottom "    @autopot help";
 	dispbottom "    @autopot blacklist";
@@ -31,10 +39,14 @@ L_Help:
 
 L_Info:
 	dispbottom "----------Auto-Potion Information-----------";
-	dispbottom "HP POTION:  " + getitemname(@autopot_hp_ID) + " (" + @autopot_hp_ID + ")";
-	dispbottom "MIN HP:   " + @autopot_hp_Min + " %";
-	dispbottom "SP POTION:  " + getitemname(@autopot_sp_ID) + " (" + @autopot_sp_ID + ")";
-	dispbottom "MIN SP:   " + @autopot_sp_Min + " %";
+	if(.HP_Option){
+		dispbottom "HP POTION:  " + getitemname(@autopot_hp_ID) + " (" + @autopot_hp_ID + ")";
+		dispbottom "MIN HP:   " + @autopot_hp_Min + " %";
+	}
+	if(.SP_Option){
+		dispbottom "SP POTION:  " + getitemname(@autopot_sp_ID) + " (" + @autopot_sp_ID + ")";
+		dispbottom "MIN SP:   " + @autopot_sp_Min + " %";
+	}
 	dispbottom "DELAY:    " + @autopot_delay + " ms";
 	dispbottom "---------------------------------------------";
 	return;
@@ -53,7 +65,7 @@ L_Start:
 		end;
 	}
 	if(inarray(.blackList[0],.@potion) != -1){
-		mes  "'" + getitemname(.@potion) + "' is in the Black List, and connot be used.";
+		mes  "'" + getitemname(.@potion) + "' is black listed and cannot be used.";
 		end;
 	}
 	if (BaseLevel < getiteminfo(.@potion,12)) {
@@ -77,13 +89,17 @@ OnCommand:
 	.@command$[1] = strtolower(.@atcmd_parameters$[1]);
 	
 	if(.@command$[0] == "hp" || .@command$[0] == "sp"){
+		if((!.HP_Option && .@command$[0] == "hp") || (!.SP_Option && .@command$[0] == "sp")){
+			message strcharinfo(0), "Auto-Potion " + strtoupper(.@command$[0]) + " is Disabled from The Server.";
+			end;
+		}
 		if(.@command$[1] == "on"){
 			if(getd("@autopot_" + .@command$[0] + "_Active")){
 				message strcharinfo(0), "Auto-Potion " + strtoupper(.@command$[0]) + " is already on.";
 				end;
 			}
 			if(!getd("@autopot_" + .@command$[0] + "_ID")){
-				dispbottom "You need to setup " + strtoupper(.@command$[0]) + " Potion to be use.";
+				dispbottom "You need to set a " + strtoupper(.@command$[0]) + " Potion to be used.";
 				callsub L_Help;
 				end;
 			}

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -3,24 +3,25 @@
 //===== By: ==================================================
 //= Euphy
 //===== Current Version: =====================================
-//= 1.0
+//= 2.0
 //===== Compatible With: =====================================
 //= rAthena Project
 //===== Description: =========================================
-//= Provides an @autopot command to automatically use potions
-//= when hit (i.e. 'autobonus2').
+//= Provides an @autopot command to automatically use potions.
 //===== Additional Comments: =================================
 //= 1.0 First version. [Euphy]
+//= 2.0 improve. [sader1992]
 //============================================================
-
 -	script	#autopot	-1,{
 OnInit:
 	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand");
+	.MinDelay = 100;	//Minimum Delay Alowed
+	setarray .blackList[0],0;	//Array of Potion IDs Black List
 	end;
 
 L_Help:
 	dispbottom "Available commands:";
-	dispbottom "    @autopot <item id> {<min hp % [1..100]> {<delay [50..1000]>}}";
+	dispbottom "    @autopot <item id> {<min hp % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
 	dispbottom "    @autopot <on|off>";
 	dispbottom "    @autopot list";
 	dispbottom "    @autopot info";
@@ -40,7 +41,7 @@ L_Start:
 	.@min    = getarg(1);
 	.@delay  = getarg(2);
 	if (.@min   < 1  || .@min   > 100)  .@min   = 90;
-	if (.@delay < 50 || .@delay > 1000) .@delay = 50;  // lower values will increase server strain
+	if (.@delay < .MinDelay || .@delay > 1000) .@delay = .MinDelay;  // lower values will increase server strain
 	switch (.@potion) {
 		case 501:
 		case 507:
@@ -79,9 +80,8 @@ L_Start:
 	@autopot_min   = .@min;
 	@autopot_delay = .@delay;
 	@autopot_eff   = .@effect;
-	@autopot_none  = 0;
-	bonus_script "{ callfunc \"start_autopot\"; }",86400,8,0,EFST_HEALPLUS;
-
+	@autopot_active = true;
+	addtimer @autopot_delay,strnpcinfo(3) + "::OnStart";
 	message strcharinfo(0), "Auto-Potion started.";
 	callsub L_Info;
 	return;
@@ -96,37 +96,43 @@ OnCommand:
 	.@command$ = strtolower(.@atcmd_parameters$[0]);
 
 	if (.@command$ == "on") {
-		if (@autopot_min)
+		if(@autopot_active){
 			message strcharinfo(0), "Auto-Potion is already on.";
-		else if (@autopot_min_) {
-			@autopot_min  = @autopot_min_;
-			@autopot_min_ = 0;
-			message strcharinfo(0), "Auto-Potion enabled.";
-			callsub L_Info;
-		} else {
-			message strcharinfo(0), "Auto-Potion has not been set.";
-			callsub L_Help;
+			end;
 		}
+		if(!@autopot_id){
+			dispbottom "You need to setup a Potion to use.";
+			callsub L_Help;
+			end;
+		}
+		message strcharinfo(0), "Auto-Potion enabled.";
+		callsub L_Start, @autopot_id,0,0;
 		end;
 	} else if (.@command$ == "off") {
-		if (!@autopot_min)
+		if (!@autopot_active)
 			message strcharinfo(0), "Auto-Potion is already off.";
 		else {
-			@autopot_min_ = @autopot_min;
-			@autopot_min  = 0;
+			@autopot_active = false;
 			message strcharinfo(0), "Auto-Potion disabled.";
 		}
 		end;
 	} else if (.@command$ == "list") {  // credits to AnnieRuru
+		if(@autopot_active){
+			message strcharinfo(0), "Auto-Potion is on.";
+			message strcharinfo(0), "You need to stop Auto-Potion to use the list command.";
+			end;
+		}
 		getinventorylist;
 		for (; .@i < @inventorylist_count; .@i++) {
 			if (getiteminfo(@inventorylist_id[.@i],2) == IT_HEALING) {
-				.@items[.@count] = @inventorylist_id[.@i];
-				.@menu$ = .@menu$ + sprintf("~ ^0055FF%s^000000 (%dx):", getitemname(@inventorylist_id[.@i]), countitem(@inventorylist_id[.@i]));
-				.@count++;
+				if(inarray(.blackList[0],@inventorylist_id[.@i]) == -1){
+					.@items[.@count] = @inventorylist_id[.@i];
+					.@menu$ = .@menu$ + sprintf("~ ^0055FF%s^000000 (%dx):", getitemname(@inventorylist_id[.@i]), countitem(@inventorylist_id[.@i]));
+					.@count++;
+				}
 			}
 		}
-		if (.@count) {	// 'mes' window needed if player is hit during selection
+		if (.@count) {
 			mes "[ Auto-Potion ]";
 			mes "Select a healing item.";
 			.@select = select(.@menu$ + "   ^777777Cancel^000000") - 1;
@@ -137,7 +143,7 @@ OnCommand:
 			message strcharinfo(0), "There are no healing items in your inventory.";
 		end;
 	} else if (.@command$ == "info") {
-		if (@autopot_min) {
+		if (@autopot_active) {
 			message strcharinfo(0), "Auto-Potion information is displayed below.";
 			callsub L_Info;
 		} else
@@ -149,40 +155,34 @@ OnCommand:
 		end;
 	} else {
 		.@potion = atoi(.@atcmd_parameters$[0]);
+		if(inarray(.blackList[0],.@potion) != -1){
+			dispbottom getitemname(.@potion) + " is not allowed.";
+			end;
+		}
 		if (getiteminfo(.@potion,2) != IT_HEALING) {
-			message strcharinfo(0), getitemname(.@potion) + " is not a healing item.";
+			dispbottom getitemname(.@potion) + " is not a healing item.";
 			end;
 		}
 		callsub L_Start, .@potion, atoi(.@atcmd_parameters$[1]), atoi(.@atcmd_parameters$[2]);
 		end;
 	}
-}
+end;
 
-function	script	start_autopot	{
-	if (@autopot_active) end;
-	@autopot_active = 1;
-	while (Hp && Hp * 100 / MaxHp < @autopot_min) {
-		if (!countitem(@autopot_id)) {
-			if (@autopot_none <= gettimetick(2)) {
-				@autopot_none = gettimetick(2) + 10;
-				dispbottom "There are no '" + getitemname(@autopot_id) + "' in your inventory.";
+OnStart:
+	if(Hp && Hp * 100 / MaxHp < @autopot_min) {
+		if (!getstatus(SC_BERSERK) || !getstatus(SC_SATURDAYNIGHTFEVER) || !getstatus(SC_GRAVITATION) ||
+		    !getstatus(SC_TRICKDEAD) || !getstatus(SC_HIDING) || !getstatus(SC__SHADOWFORM) || !getstatus(SC__INVISIBILITY) ||
+		    !getstatus(SC__MANHOLE) || !getstatus(SC_KAGEHUMI) || !getstatus(SC_HEAT_BARREL_AFTER) ||
+			!getstatus(SC_STONE) || !getstatus(SC_FREEZE) || !getstatus(SC_STUN) || !getstatus(SC_SLEEP))
+			{
+			if (countitem(@autopot_id)) {
+				delitem @autopot_id,1;
+				consumeitem @autopot_id;
+				specialeffect2 @autopot_eff;
 			}
-			break;
 		}
-		if (getstatus(SC_BERSERK) || getstatus(SC_SATURDAYNIGHTFEVER) || getstatus(SC_GRAVITATION) ||
-		    getstatus(SC_TRICKDEAD) || getstatus(SC_HIDING) || getstatus(SC__SHADOWFORM) || getstatus(SC__INVISIBILITY) ||
-		    getstatus(SC__MANHOLE) || getstatus(SC_KAGEHUMI) || getstatus(SC_HEAT_BARREL_AFTER))
-			break;
-		if (getstatus(SC_STONE) || getstatus(SC_FREEZE) || getstatus(SC_STUN) || getstatus(SC_SLEEP))
-			;
-		else {
-			delitem @autopot_id,1;
-			consumeitem @autopot_id;
-			specialeffect2 @autopot_eff;
-		}
-		sleep2 @autopot_delay;
 	}
-	@autopot_active = 0;
-	autobonus2 "{}",10000,1,BF_WEAPON|BF_MAGIC;
-	end;
+	if(@autopot_active)
+		addtimer @autopot_delay,strnpcinfo(3) + "::OnStart";
+end;
 }

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -10,7 +10,7 @@
 OnInit:
 	.HP_Option = true;	//Allow HP option
 	.SP_Option = true;	//Allow SP option
-	.MinDelay = 100;	//Minimum Delay Allowed (Default and Recommended: 100) [lower values will increase server strain]
+	.MinDelay = 100;	//Minimum Delay Allowed in milliseconds (Default and Recommended: 100) [lower values will increase server strain]
 	setarray .blackList[0],0;	//Array of black listed item ID
 
 	if(!.HP_Option && !.SP_Option){
@@ -65,7 +65,7 @@ L_Start:
 		end;
 	}
 	if(inarray(.blackList[0],.@potion) != -1){
-		mes  "'" + getitemname(.@potion) + "' is black listed and cannot be used.";
+		message strcharinfo(0), "'" + getitemname(.@potion) + "' is black listed and cannot be used.";
 		end;
 	}
 	if (BaseLevel < getiteminfo(.@potion,12)) {

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -10,79 +10,61 @@
 //= Provides an @autopot command to automatically use potions.
 //===== Additional Comments: =================================
 //= 1.0 First version. [Euphy]
-//= 2.0 improve. [sader1992]
+//= 2.0 rewrite and adding SP option. [sader1992]
 //============================================================
 -	script	#autopot	-1,{
 OnInit:
 	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand");
-	.MinDelay = 100;	//Minimum Delay Alowed
-	setarray .blackList[0],0;	//Array of Potion IDs Black List
-	end;
+	.MinDelay = 250;	//Minimum Delay Alowed (Default and Recomanded: 250)[lower values will increase server strain]
+	setarray .blackList[0],0;	//Array of Black Listed Item's IDs
+end;
 
 L_Help:
 	dispbottom "Available commands:";
-	dispbottom "    @autopot <item id> {<min hp % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
-	dispbottom "    @autopot <on|off>";
-	dispbottom "    @autopot list";
+	dispbottom "    @autopot <hp|sp> <item id> {<min hp % [1..100]> {<delay [" + .MinDelay + "..1000]>}}";
+	dispbottom "    @autopot <hp|sp> list";
+	dispbottom "    @autopot <hp|sp> <on|off>";
 	dispbottom "    @autopot info";
 	dispbottom "    @autopot help";
+	dispbottom "    @autopot blacklist";
 	return;
 
 L_Info:
-	dispbottom "------ Auto-Potion Information ------";
-	dispbottom "POTION:  " + getitemname(@autopot_id) + " (" + @autopot_id + ")";
-	dispbottom "MIN HP:   " + @autopot_min + " %";
+	dispbottom "----------Auto-Potion Information-----------";
+	dispbottom "HP POTION:  " + getitemname(@autopot_hp_ID) + " (" + @autopot_hp_ID + ")";
+	dispbottom "MIN HP:   " + @autopot_hp_Min + " %";
+	dispbottom "SP POTION:  " + getitemname(@autopot_sp_ID) + " (" + @autopot_sp_ID + ")";
+	dispbottom "MIN SP:   " + @autopot_sp_Min + " %";
 	dispbottom "DELAY:    " + @autopot_delay + " ms";
 	dispbottom "---------------------------------------------";
 	return;
 
 L_Start:
-	.@potion = getarg(0);
-	.@min    = getarg(1);
-	.@delay  = getarg(2);
-	if (.@min   < 1  || .@min   > 100)  .@min   = 90;
-	if (.@delay < .MinDelay || .@delay > 1000) .@delay = .MinDelay;  // lower values will increase server strain
-	switch (.@potion) {
-		case 501:
-		case 507:
-		case 545:
-		case 569: .@effect = EF_POTION1; break;
-		case 502: .@effect = EF_POTION2; break;
-		case 503:
-		case 508:
-		case 546:
-		case 579:
-		case 11500: .@effect = EF_POTION3; break;
-		case 504:
-		case 509:
-		case 547:
-		case 11501:
-		case 11503:
-		case 11548: .@effect = EF_POTION4; break;
-		case 512:
-		case 513:
-		case 515:
-		case 516:
-		case 548:
-		case 549:
-		case 550:
-		case 582:
-		case 607: .@effect = EF_POTION7; break;
-		default: .@effect = EF_EXIT; break;
-	}
+	deltimer strnpcinfo(3) + "::OnStart";
+	.@type$  = getarg(0);
+	.@potion = getarg(1);
+	if(getarg(2))
+		setd "@autopot_" + .@type$ + "_Min",getarg(2);
+	if(getarg(3))
+		@autopot_delay = getarg(3);
 
+	if (getd("@autopot_" + .@type$ + "_Min")   < 1  || getd("@autopot_" + .@type$ + "_Min") > 100)  setd "@autopot_" + .@type$ + "_Min",90;
+	if (@autopot_delay < 100 || @autopot_delay > 1000) @autopot_delay = .MinDelay;
+	if (getiteminfo(.@potion,2) != IT_HEALING) {
+		dispbottom getitemname(.@potion) + " is not a healing item.";
+		end;
+	}
+	if(inarray(.blackList[0],.@potion) != -1){
+		mes  "'" + getitemname(.@potion) + "' is in the Black List, and connot be used.";
+		end;
+	}
 	if (BaseLevel < getiteminfo(.@potion,12)) {
 		message strcharinfo(0), "Your base level is too low to use '" + getitemname(.@potion) + "'.";
 		end;
 	}
-
-	@autopot_id    = .@potion;
-	@autopot_min   = .@min;
-	@autopot_delay = .@delay;
-	@autopot_eff   = .@effect;
-	@autopot_active = true;
-	addtimer @autopot_delay,strnpcinfo(3) + "::OnStart";
-	message strcharinfo(0), "Auto-Potion started.";
+	setd "@autopot_" + .@type$ + "_Active",true;
+	addtimer .@delay,strnpcinfo(3) + "::OnStart";
+	message strcharinfo(0), "Auto-Potion " + strtoupper(.@type$) + " enabled.";
 	callsub L_Info;
 	return;
 
@@ -92,97 +74,109 @@ OnCommand:
 		callsub L_Help;
 		end;
 	}
-
-	.@command$ = strtolower(.@atcmd_parameters$[0]);
-
-	if (.@command$ == "on") {
-		if(@autopot_active){
-			message strcharinfo(0), "Auto-Potion is already on.";
+	.@command$[0] = strtolower(.@atcmd_parameters$[0]);
+	.@command$[1] = strtolower(.@atcmd_parameters$[1]);
+	
+	if(.@command$[0] == "hp" || .@command$[0] == "sp"){
+		if(.@command$[1] == "on"){
+			if(getd("@autopot_" + .@command$[0] + "_Active")){
+				message strcharinfo(0), "Auto-Potion " + strtoupper(.@command$[0]) + " is already on.";
+				end;
+			}
+			if(!getd("@autopot_" + .@command$[0] + "_ID")){
+				dispbottom "You need to setup " + strtoupper(.@command$[0]) + " Potion to be use.";
+				callsub L_Help;
+				end;
+			}
+			callsub L_Start,.@command$[0],getd("@autopot_" + .@command$[0] + "_ID");
 			end;
 		}
-		if(!@autopot_id){
-			dispbottom "You need to setup a Potion to use.";
-			callsub L_Help;
+		if(.@command$[1] == "off"){
+			message strcharinfo(0), "Auto-Potion " + strtoupper(.@command$[0]) + " disabled.";
+			setd "@autopot_" + .@command$[0] + "_Active",false;
 			end;
 		}
-		message strcharinfo(0), "Auto-Potion enabled.";
-		callsub L_Start, @autopot_id,0,0;
-		end;
-	} else if (.@command$ == "off") {
-		if (!@autopot_active)
-			message strcharinfo(0), "Auto-Potion is already off.";
-		else {
-			@autopot_active = false;
-			message strcharinfo(0), "Auto-Potion disabled.";
-		}
-		end;
-	} else if (.@command$ == "list") {  // credits to AnnieRuru
-		if(@autopot_active){
-			message strcharinfo(0), "Auto-Potion is on.";
-			message strcharinfo(0), "You need to stop Auto-Potion to use the list command.";
-			end;
-		}
-		getinventorylist;
-		for (; .@i < @inventorylist_count; .@i++) {
-			if (getiteminfo(@inventorylist_id[.@i],2) == IT_HEALING) {
-				if(inarray(.blackList[0],@inventorylist_id[.@i]) == -1){
+		if(.@command$[1] == "list"){
+			getinventorylist;
+			for(.@i = 0;.@i < @inventorylist_count;.@i++){
+				if (getiteminfo(@inventorylist_id[.@i],2) == IT_HEALING) {
 					.@items[.@count] = @inventorylist_id[.@i];
-					.@menu$ = .@menu$ + sprintf("~ ^0055FF%s^000000 (%dx):", getitemname(@inventorylist_id[.@i]), countitem(@inventorylist_id[.@i]));
+					.@menu$ = .@menu$ + sprintf("~ ^0055FF%s^000000 (%dx)" + (inarray(.blackList[0],@inventorylist_id[.@i]) != -1? " ^364022Black Listed^000000":"") + (BaseLevel < getiteminfo(@inventorylist_id[.@i],12)? " ^E82C0CNeed Higher Level^000000":"") + ":", getitemname(@inventorylist_id[.@i]), countitem(@inventorylist_id[.@i]));
 					.@count++;
 				}
 			}
+			if(.@count){
+				mes "[ Auto-Potion ]";
+				mes "Select a " + strtoupper(.@command$[0]) + " item.";
+				.@select = select(.@menu$ + "   ^777777Cancel^000000") - 1;
+				if (.@select != .@count)
+					callsub L_Start,.@command$[0],.@items[.@select];
+				close2;
+			}else{
+				message strcharinfo(0), "There are no healing items in your inventory.";
+			}
+			end;
 		}
-		if (.@count) {
-			mes "[ Auto-Potion ]";
-			mes "Select a healing item.";
-			.@select = select(.@menu$ + "   ^777777Cancel^000000") - 1;
-			if (.@select != .@count)
-				callsub L_Start, .@items[.@select], 0, 0;
-			close2;
-		} else
-			message strcharinfo(0), "There are no healing items in your inventory.";
+		.@potion = atoi(.@command$[1]);
+		.@percent = atoi(.@atcmd_parameters$[2]);
+		.@delay = atoi(.@atcmd_parameters$[3]);
+		if(getitemname(.@potion) != "null"){
+			callsub L_Start,.@command$[0],.@potion,.@percent,.@delay;
+			end;
+		}
+		message strcharinfo(0), "Auto-Potion : something went wrong!";
+		callsub L_Help;
 		end;
-	} else if (.@command$ == "info") {
-		if (@autopot_active) {
+	}
+	if(.@command$[0] == "blacklist"){
+		dispbottom "--------------Black Listed Items--------------";
+		for(.@i=0;.@i<getarraysize(.blackList);.@i++){
+			dispbottom "    " + getitemname(.blackList[.@i]) + " (" + .blackList[.@i] + ")";
+		}
+		dispbottom "---------------------------------------------";
+		end;
+	}
+	if(.@command$[0] == "info"){
+		if(@autopot_hp_Active || @autopot_sp_Active){
 			message strcharinfo(0), "Auto-Potion information is displayed below.";
 			callsub L_Info;
-		} else
+		}else{
 			message strcharinfo(0), "Auto-Potion is not enabled.";
+		}
 		end;
-	} else if (.@command$ == "help") {
+	}
+	if(.@command$[0] == "help"){
 		message strcharinfo(0), "List of commands is displayed below.";
 		callsub L_Help;
 		end;
-	} else {
-		.@potion = atoi(.@atcmd_parameters$[0]);
-		if(inarray(.blackList[0],.@potion) != -1){
-			dispbottom getitemname(.@potion) + " is not allowed.";
-			end;
-		}
-		if (getiteminfo(.@potion,2) != IT_HEALING) {
-			dispbottom getitemname(.@potion) + " is not a healing item.";
-			end;
-		}
-		callsub L_Start, .@potion, atoi(.@atcmd_parameters$[1]), atoi(.@atcmd_parameters$[2]);
-		end;
 	}
+	
+	message strcharinfo(0), "Invalid syntax.";
+	callsub L_Help;
 end;
 
 OnStart:
-	if(Hp && Hp * 100 / MaxHp < @autopot_min) {
-		if (!getstatus(SC_BERSERK) || !getstatus(SC_SATURDAYNIGHTFEVER) || !getstatus(SC_GRAVITATION) ||
-		    !getstatus(SC_TRICKDEAD) || !getstatus(SC_HIDING) || !getstatus(SC__SHADOWFORM) || !getstatus(SC__INVISIBILITY) ||
-		    !getstatus(SC__MANHOLE) || !getstatus(SC_KAGEHUMI) || !getstatus(SC_HEAT_BARREL_AFTER) ||
-			!getstatus(SC_STONE) || !getstatus(SC_FREEZE) || !getstatus(SC_STUN) || !getstatus(SC_SLEEP))
-			{
-			if (countitem(@autopot_id)) {
-				delitem @autopot_id,1;
-				consumeitem @autopot_id;
-				specialeffect2 @autopot_eff;
+	if (!getstatus(SC_BERSERK) || !getstatus(SC_SATURDAYNIGHTFEVER) || !getstatus(SC_GRAVITATION) ||
+	    !getstatus(SC_TRICKDEAD) || !getstatus(SC_HIDING) || !getstatus(SC__SHADOWFORM) || !getstatus(SC__INVISIBILITY) ||
+	    !getstatus(SC__MANHOLE) || !getstatus(SC_KAGEHUMI) || !getstatus(SC_HEAT_BARREL_AFTER) ||
+		!getstatus(SC_STONE) || !getstatus(SC_FREEZE) || !getstatus(SC_STUN) || !getstatus(SC_SLEEP))
+		{
+		if(@autopot_hp_Active && Hp && Hp * 100 / MaxHp < @autopot_hp_Min) {
+			if (countitem(@autopot_hp_ID)) {
+				delitem @autopot_hp_ID,1;
+				consumeitem @autopot_hp_ID;
+				specialeffect2 207;
+			}
+		}
+		if(@autopot_sp_Active && Sp && Sp * 100 / MaxSp < @autopot_sp_Min) {
+			if (countitem(@autopot_sp_ID)) {
+				delitem @autopot_sp_ID,1;
+				consumeitem @autopot_sp_ID;
+				specialeffect2 208;
 			}
 		}
 	}
-	if(@autopot_active)
+	if(@autopot_hp_Active || @autopot_sp_Active)
 		addtimer @autopot_delay,strnpcinfo(3) + "::OnStart";
 end;
 }

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -14,7 +14,7 @@
 //============================================================
 -	script	#autopot	-1,{
 OnInit:
-	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand");
+	bindatcmd("autopot",strnpcinfo(0)+"::OnCommand",0,99);
 	.MinDelay = 100;	//Minimum Delay Alowed (Default and Recomanded: 100)[lower values will increase server strain]
 	setarray .blackList[0],0;	//Array of Black Listed Item's IDs
 end;
@@ -41,12 +41,10 @@ L_Info:
 
 L_Start:
 	deltimer strnpcinfo(3) + "::OnStart";
-	.@type$  = getarg(0);
-	.@potion = getarg(1);
-	if(getarg(2))
-		setd "@autopot_" + .@type$ + "_Min",getarg(2);
-	if(getarg(3))
-		@autopot_delay = getarg(3);
+	.@type$  = getarg(0,0);
+	.@potion = getarg(1,0);
+	setd "@autopot_" + .@type$ + "_Min",getarg(2,0);
+	@autopot_delay = getarg(3,0);
 
 	if (getd("@autopot_" + .@type$ + "_Min")   < 1  || getd("@autopot_" + .@type$ + "_Min") > 100)  setd "@autopot_" + .@type$ + "_Min",90;
 	if (@autopot_delay < 50 || @autopot_delay > 1000) @autopot_delay = .MinDelay;
@@ -114,7 +112,6 @@ OnCommand:
 				.@select = select(.@menu$ + "   ^777777Cancel^000000") - 1;
 				if (.@select != .@count)
 					callsub L_Start,.@command$[0],.@items[.@select];
-				callsub L_Info;
 				close2;
 			}else{
 				message strcharinfo(0), "There are no healing items in your inventory.";
@@ -126,7 +123,6 @@ OnCommand:
 		.@delay = atoi(.@atcmd_parameters$[3]);
 		if(getitemname(.@potion) != "null"){
 			callsub L_Start,.@command$[0],.@potion,.@percent,.@delay;
-			callsub L_Info;
 			end;
 		}
 		message strcharinfo(0), "Auto-Potion : something went wrong!";

--- a/npc/custom/etc/autopot.txt
+++ b/npc/custom/etc/autopot.txt
@@ -94,6 +94,8 @@ OnCommand:
 		if(.@command$[1] == "off"){
 			message strcharinfo(0), "Auto-Potion " + strtoupper(.@command$[0]) + " disabled.";
 			setd "@autopot_" + .@command$[0] + "_Active",false;
+			if(!@autopot_hp_Active || !@autopot_sp_Active)
+				deltimer strnpcinfo(3) + "::OnStart";
 			end;
 		}
 		if(.@command$[1] == "list"){


### PR DESCRIPTION
* **Addressed Issue(s)**: none
* **Server Mode**: both
* **Description of Pull Request**: 

while the original script sometimes work, but after testing it does not work all the time
or it does not work as the players normally want to.

**the rewrite info:**

1. the script now hook the player to an event with timer
2. the timer = the delay
3. adding minimum delay as config to the script
4. adding blacklist items so if someone don't want an item to work with the script
5. adding sp option
6. changing the commands as following
7. this is a down but the effect is white for hp and blue for sp (before was switching between some effects)
```
@autopot <hp|sp> <item id> {<min hp % [1..100]> {<delay [minimum delay ..1000]>}}
@autopot <hp|sp> list
@autopot <hp|sp> <on|off>
@autopot info
@autopot help
@autopot blacklist
```
for test
```
@str 9999
@item 502 500
@autopot hp 502
@monster orc_lord
```

ofc i would like to get feedback