### PR TITLE
Updates inf3 in skill_db

### DIFF
--- a/db/pre-re/skill_db.txt
+++ b/db/pre-re/skill_db.txt
@@ -54,26 +54,28 @@
 // 14 attack type (none, weapon, magic, misc)
 // 15 Blowcount (amount of tiles skill knockbacks)
 // 16 inf3 (skill information 3):
-//    0x00001 - skill ignores land protector
-//    0x00002 - free
-//    0x00004 - usable skills while hiding
-//    0x00008 - skill that can be use while in dancing state
-//    0x00010 - skill that could hit emperium
-//    0x00020 - skill ignores SC_STASIS
-//    0x00040 - skill blocked by kagehumi
-//    0x00080 - skill range affected by AC_VULTURE
-//    0x00100 - skill range affected by GS_SNAKEEYE
-//    0x00200 - skill range affected by NJ_SHADOWJUMP
-//    0x00400 - skill range affected by WL_RADIUS
-//    0x00800 - skill range affected by RA_RESEARCHTRAP
-//    0x01000 - skill that does not affect user that has NC_HOVERING active
-//    0x02000 - skill that can be using while riding warg
-//    0x04000 - skill that can be used while on Madogear
-//    0x08000 - skill that can be used to target while under SC__MANHOLE effect
-//    0x10000 - skill that affects hidden targets
-//    0x20000 - skill that affects SC_GLOOMYDAY_SK
-//    0x40000 - skill that is affected by SC_DANCEWITHWUG
-//    0x80000 - skill blocked by RA_WUGBITE
+//    0x000001 - skill ignores land protector
+//    0x000002 - free
+//    0x000004 - usable skills while hiding
+//    0x000008 - skill that can be use while in dancing state
+//    0x000010 - skill that could hit emperium
+//    0x000020 - skill ignores SC_STASIS
+//    0x000040 - skill blocked by kagehumi
+//    0x000080 - skill range affected by AC_VULTURE
+//    0x000100 - skill range affected by GS_SNAKEEYE
+//    0x000200 - skill range affected by NJ_SHADOWJUMP
+//    0x000400 - skill range affected by WL_RADIUS
+//    0x000800 - skill range affected by RA_RESEARCHTRAP
+//    0x001000 - skill that does not affect user that has NC_HOVERING active
+//    0x002000 - skill that can be using while riding warg
+//    0x004000 - skill that can be used while on Madogear
+//    0x008000 - skill that can be used to target while under SC__MANHOLE effect
+//    0x010000 - skill that affects hidden targets
+//    0x020000 - skill that affects SC_GLOOMYDAY_SK
+//    0x040000 - skill that is affected by SC_DANCEWITHWUG
+//    0x080000 - skill blocked by RA_WUGBITE
+//    0x100000 - skill is not blocked by SC_AUTOGUARD (physical-skill only)
+//    0x200000 - skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 // 17 Name
 // 18 Description
 1,0,0,0,0,0,0,9,0,no,0,0,0,none,0,0x0,		NV_BASIC,Basic Skill
@@ -352,8 +354,8 @@
 226,0,0,0,0,0,0,10,0,no,0,0,0,weapon,0,0x0,		AM_AXEMASTERY,Axe Mastery
 227,0,0,0,0,0,0,10,0,no,0,0,0,none,0,0x0,		AM_LEARNINGPOTION,Potion Research
 228,0,6,4,0,0x1,0,10,0,no,0,0,0,none,0,0x0,		AM_PHARMACY,Prepare Potion
-229,9,6,2,3,0x9,0,5,1,yes,0,0,0,weapon,0,0x0,	AM_DEMONSTRATION,Bomb
-230,9,6,1,0,0x48,0,5,1,yes,0,0,0,weapon,0,0x0,	AM_ACIDTERROR,Acid Terror
+229,9,6,2,3,0x9,0,5,1,yes,0,0,0,weapon,0,0x300000,	AM_DEMONSTRATION,Bomb
+230,9,6,1,0,0x48,0,5,1,yes,0,0,0,weapon,0,0x300000,	AM_ACIDTERROR,Acid Terror
 231,9,6,16,0,0x1,0,5,1,yes,0,0xC00,0,none,0,0x0,	AM_POTIONPITCHER,Aid Potion
 232,4,6,2,0,0x1,0,5,1,no,0,0,5,none,0,0x0,		AM_CANNIBALIZE,Summon Flora
 233,1,6,2,0,0x1,0,5,1,no,0,0,3,none,0,0x0,		AM_SPHEREMINE,Summon Marine Sphere
@@ -530,7 +532,7 @@
 //****
 // Paladin
 367,9,8,1,0,0xD0,0,5,1,no,0,0x18000,0,misc,0,0x0,		PA_PRESSURE,Gloria Domini
-368,0,6,4,0,0x61,0,5,1,yes,0,0,0,weapon,0,0x0,	PA_SACRIFICE, Martyr's Reckoning
+368,0,6,4,0,0x61,0,5,1,yes,0,0,0,weapon,0,0x300000,	PA_SACRIFICE, Martyr's Reckoning
 369,0,6,4,0,0x41,0,10,1,yes,0,0,0,misc,0,0x0,	PA_GOSPEL,Battle Chant
 
 //****
@@ -607,7 +609,7 @@
 
 //****
 // Assassin Cross
-406,0,6,4,-1,0xA,2,10,1,no,0,0x40000,0,weapon,0,0x0,	ASC_METEORASSAULT,Meteor Assault
+406,0,6,4,-1,0xA,2,10,1,no,0,0x40000,0,weapon,0,0x300000,	ASC_METEORASSAULT,Meteor Assault
 407,0,6,4,0,0x1,0,1,0,no,0,0,0,none,0,0x0,		ASC_CDP,Create Deadly Poison
 
 //****
@@ -731,7 +733,7 @@
 500,0,6,4,0,0x41,0,5,1,no,0,0,0,misc,0,0x0,		GS_GLITTERING,Flip the Coin
 501,9,6,1,-1,0x50,0,1,1,no,0,0,0,misc,0,0x0,		GS_FLING,Fling
 502,-9,8,1,-1,0,0,1,3,no,0,0,0,weapon,0,0x0,		GS_TRIPLEACTION,Triple Action
-503,-9,6,1,-1,0x8,0,1,1,no,0,0,0,weapon,0,0x0,	GS_BULLSEYE,Bulls Eye
+503,-9,6,1,-1,0x8,0,1,1,no,0,0,0,weapon,0,0x300000,	GS_BULLSEYE,Bulls Eye
 504,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_MADNESSCANCEL,Madness Canceller
 505,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_ADJUSTMENT,AdJustment
 506,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_INCREASING,Increasing Accuracy
@@ -899,7 +901,7 @@
 1001,14,6,1,-1,0,0,1,1,no,0,0x1,0,weapon,0,0x0,	KN_CHARGEATK,Charge Attack
 1002,0,6,4,0,0x1,0,1,0,no,0,0x1,0,weapon,2,0x0,	CR_SHRINK,Shrink
 1003,0,0,0,0,0,0,1,0,no,0,0x1,0,weapon,0,0x0,	AS_SONICACCEL,Sonic Acceleration
-1004,9,8,1,0,0x8,0,1,1,no,0,0x1,0,weapon,0,0x0,	AS_VENOMKNIFE,Throw Venom Knife
+1004,9,8,1,0,0x8,0,1,1,no,0,0x1,0,weapon,0,0x300000,	AS_VENOMKNIFE,Throw Venom Knife
 1005,1,6,1,0,0x1,0,1,1,no,0,0x1,0,weapon,0,0x0,	RG_CLOSECONFINE,Close Confine
 1006,0,6,4,3,0,1,1,1,yes,0,0x40001,0,magic,3,0x0,	WZ_SIGHTBLASTER,Sight Blaster
 1007,0,6,4,0,0x1,0,1,0,no,0,0x1,0,none,0,0x0,	SA_CREATECON,Create Elemental Converter
@@ -1032,8 +1034,8 @@
 2240,0,6,4,0,0,0,1,1,no,0,0,0,none,0,0x0,		RA_WUGMASTERY,Warg Mastery
 2241,0,6,4,0,0,0,3,1,no,0,0,0,none,0,0x2000,		RA_WUGRIDER,Warg Rider
 2242,0,6,4,-1,0x42,1,1,1,no,0,0,0,weapon,0,0x42000,	RA_WUGDASH,Warg Dash
-2243,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x42000,	RA_WUGSTRIKE,Warg Strike
-2244,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x40080,	RA_WUGBITE,Warg Bite
+2243,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x342000,	RA_WUGSTRIKE,Warg Strike
+2244,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x340080,	RA_WUGBITE,Warg Bite
 2245,0,0,0,0,0,0,10,0,no,0,0,0,none,0,0x0,		RA_TOOTHOFWUG,Tooth of Warg
 2246,0,6,4,0,0x2,3:4:5:6:7,5,1,no,0,0x40000,0,weapon,0,0x0,	RA_SENSITIVEKEEN,Sensitive Keen
 2247,0,6,4,0,0x1,0,5,1,no,0,0,0,none,0,0x80040,		RA_CAMOUFLAGE,Camouflage
@@ -1059,7 +1061,7 @@
 2264,0,6,4,0,0x1,0,1,1,no,0,0,0,none,7,0x4000,		NC_F_SIDESLIDE,Front-Side Slide
 2265,0,6,4,0,0x1,0,1,1,no,0,0,0,none,7,0x4000,		NC_B_SIDESLIDE,Back-Side Slide
 2266,0,0,0,0,0,0,4,0,no,0,0,0,none,0,0x0,		NC_MAINFRAME,Mainframe Restructure
-2267,0,6,4,0,0xCA,2:3:4,3,1,no,0,0x40000,0,weapon,5,0x4000,	NC_SELFDESTRUCTION,Self Destruction
+2267,0,6,4,0,0xCA,2:3:4,3,1,no,0,0x40000,0,weapon,5,0x304000,	NC_SELFDESTRUCTION,Self Destruction
 2268,0,6,4,0,0x1,0,4,1,yes,0,0,0,none,0,0x4000,	NC_SHAPESHIFT,Shape Shift
 2269,0,6,4,0,0x1,0,1,1,no,0,0,0,none,0,0x4000,		NC_EMERGENCYCOOL,Emergency Cool
 2270,0,6,4,0,0x3,7,1,1,yes,0,0,0,none,0,0x4000,	NC_INFRAREDSCAN,Infrared Scan
@@ -1232,7 +1234,7 @@
 2479,9,6,2,0,0,0,5,1,yes,0,0x80,3,misc,0,0x0,	GN_THORNS_TRAP,Thorn Trap
 2480,11,6,1,0,0x1,0,5,1,yes,0,0,3,misc,0,0x0,		GN_BLOOD_SUCKER,Blood Sucker //CHECK Data says its a magic attack. Hmmmm....
 2481,11,6,1,-1,0x2,1:2:3:4:5,5,1,yes,0,0,0,weapon,0,0x0,	GN_SPORE_EXPLOSION,Spore Explosion //CHECK Data says its element is set to neutral. Need to confirm.
-2482,11,6,2,0,0x8,0,5,1,yes,0,0,1,weapon,2,0x0,	GN_WALLOFTHORN,Wall of Thorns
+2482,11,6,2,0,0x8,0,5,1,yes,0,0,1,weapon,2,0x300000,	GN_WALLOFTHORN,Wall of Thorns
 2483,11,6,2,0,0x3,4,10,1,yes,0,0x0,0,weapon,0,0x1,	GN_CRAZYWEED,Crazy Weed
 2484,0,6,2,2,0x2,2,10,1,no,0,0x40000,0,weapon,0,0x1,	GN_CRAZYWEED_ATK,Crazy Weed Attack
 2485,9,6,2,3,0,0,5,1,yes,0,0,1,magic,0,0x0,		GN_DEMONIC_FIRE,Demonic Fire

--- a/db/re/skill_db.txt
+++ b/db/re/skill_db.txt
@@ -54,26 +54,28 @@
 // 14 attack type (none, weapon, magic, misc)
 // 15 Blowcount (amount of tiles skill knockbacks)
 // 16 inf3 (skill information 3):
-//    0x00001 - skill ignores land protector
-//    0x00002 - free
-//    0x00004 - usable skills while hiding
-//    0x00008 - skill that can be use while in dancing state
-//    0x00010 - skill that could hit emperium
-//    0x00020 - skill ignores SC_STASIS
-//    0x00040 - skill blocked by kagehumi
-//    0x00080 - skill range affected by AC_VULTURE
-//    0x00100 - skill range affected by GS_SNAKEEYE
-//    0x00200 - skill range affected by NJ_SHADOWJUMP
-//    0x00400 - skill range affected by WL_RADIUS
-//    0x00800 - skill range affected by RA_RESEARCHTRAP
-//    0x01000 - skill that does not affect user that has NC_HOVERING active
-//    0x02000 - skill that can be using while riding warg
-//    0x04000 - skill that can be used while on Madogear
-//    0x08000 - skill that can be used to target while under SC__MANHOLE effect
-//    0x10000 - skill that affects hidden targets
-//    0x20000 - skill that affects SC_GLOOMYDAY_SK
-//    0x40000 - skill that is affected by SC_DANCEWITHWUG
-//    0x80000 - skill blocked by RA_WUGBITE
+//    0x000001 - skill ignores land protector
+//    0x000002 - free
+//    0x000004 - usable skills while hiding
+//    0x000008 - skill that can be use while in dancing state
+//    0x000010 - skill that could hit emperium
+//    0x000020 - skill ignores SC_STASIS
+//    0x000040 - skill blocked by kagehumi
+//    0x000080 - skill range affected by AC_VULTURE
+//    0x000100 - skill range affected by GS_SNAKEEYE
+//    0x000200 - skill range affected by NJ_SHADOWJUMP
+//    0x000400 - skill range affected by WL_RADIUS
+//    0x000800 - skill range affected by RA_RESEARCHTRAP
+//    0x001000 - skill that does not affect user that has NC_HOVERING active
+//    0x002000 - skill that can be using while riding warg
+//    0x004000 - skill that can be used while on Madogear
+//    0x008000 - skill that can be used to target while under SC__MANHOLE effect
+//    0x010000 - skill that affects hidden targets
+//    0x020000 - skill that affects SC_GLOOMYDAY_SK
+//    0x040000 - skill that is affected by SC_DANCEWITHWUG
+//    0x080000 - skill blocked by RA_WUGBITE
+//    0x100000 - skill is not blocked by SC_AUTOGUARD (physical-skill only)
+//    0x200000 - skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 // 17 Name
 // 18 Description
 1,0,0,0,0,0,0,9,0,no,0,0,0,none,0,0x0,		NV_BASIC,Basic Skill
@@ -352,8 +354,8 @@
 226,0,0,0,0,0,0,10,0,no,0,0,0,weapon,0,0x0,		AM_AXEMASTERY,Axe Mastery
 227,0,0,0,0,0,0,10,0,no,0,0,0,none,0,0x0,		AM_LEARNINGPOTION,Potion Research
 228,0,6,4,0,0x1,0,10,0,no,0,0,0,none,0,0x0,		AM_PHARMACY,Prepare Potion
-229,9,6,2,3,0x9,0,5,1,yes,0,0,0,weapon,0,0x0,	AM_DEMONSTRATION,Bomb
-230,9,6,1,0,0x48,0,5,1,yes,0,0,0,weapon,0,0x0,	AM_ACIDTERROR,Acid Terror
+229,9,6,2,3,0x9,0,5,1,yes,0,0,0,weapon,0,0x300000,	AM_DEMONSTRATION,Bomb
+230,9,6,1,0,0x48,0,5,1,yes,0,0,0,weapon,0,0x300000,	AM_ACIDTERROR,Acid Terror
 231,9,6,16,0,0x1,0,5,1,yes,0,0xC00,0,none,0,0x0,	AM_POTIONPITCHER,Aid Potion
 232,4,6,2,0,0x1,0,5,1,no,0,0,5,none,0,0x0,		AM_CANNIBALIZE,Summon Flora
 233,1,6,2,0,0x1,0,5,1,no,0,0,3,none,0,0x0,		AM_SPHEREMINE,Summon Marine Sphere
@@ -530,7 +532,7 @@
 //****
 // Paladin
 367,9,8,1,0,0xD0,0,5,1,no,0,0x18000,0,misc,0,0x0,		PA_PRESSURE,Gloria Domini
-368,0,6,4,0,0x69,0,5,1,yes,0,0,0,weapon,0,0x0,	PA_SACRIFICE, Martyr's Reckoning
+368,0,6,4,0,0x69,0,5,1,yes,0,0,0,weapon,0,0x300000,	PA_SACRIFICE, Martyr's Reckoning
 369,0,6,4,0,0x41,0,10,1,yes,0,0,0,misc,0,0x0,	PA_GOSPEL,Battle Chant
 
 //****
@@ -607,7 +609,7 @@
 
 //****
 // Assassin Cross
-406,0,6,4,-1,0xA,2,10,1,no,0,0x40000,0,weapon,0,0x0,	ASC_METEORASSAULT,Meteor Assault
+406,0,6,4,-1,0xA,2,10,1,no,0,0x40000,0,weapon,0,0x300000,	ASC_METEORASSAULT,Meteor Assault
 407,0,6,4,0,0x1,0,1,0,no,0,0,0,none,0,0x0,		ASC_CDP,Create Deadly Poison
 
 //****
@@ -731,7 +733,7 @@
 500,0,6,4,0,0x41,0,5,1,no,0,0,0,misc,0,0x0,		GS_GLITTERING,Flip the Coin
 501,9,6,1,-1,0x50,0,1,1,no,0,0,0,misc,0,0x0,		GS_FLING,Fling
 502,-9,8,1,-1,0,0,1,3,no,0,0,0,weapon,0,0x0,		GS_TRIPLEACTION,Triple Action
-503,-9,6,1,-1,0x8,0,1,1,no,0,0,0,weapon,0,0x0,	GS_BULLSEYE,Bulls Eye
+503,-9,6,1,-1,0x8,0,1,1,no,0,0,0,weapon,0,0x300000,	GS_BULLSEYE,Bulls Eye
 504,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_MADNESSCANCEL,Madness Canceller
 505,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_ADJUSTMENT,AdJustment
 506,0,6,4,0,0x1,0,1,1,no,0,0,0,weapon,0,0x0,		GS_INCREASING,Increasing Accuracy
@@ -905,7 +907,7 @@
 1001,14,6,1,-1,0,0,1,1,no,0,0x1,0,weapon,0,0x0,	KN_CHARGEATK,Charge Attack
 1002,0,6,4,0,0x1,0,1,0,no,0,0x1,0,weapon,2,0x0,	CR_SHRINK,Shrink
 1003,0,0,0,0,0,0,1,0,no,0,0x1,0,weapon,0,0x0,	AS_SONICACCEL,Sonic Acceleration
-1004,9,8,1,0,0x8,0,1,1,no,0,0x1,0,weapon,0,0x0,	AS_VENOMKNIFE,Throw Venom Knife
+1004,9,8,1,0,0x8,0,1,1,no,0,0x1,0,weapon,0,0x300000,	AS_VENOMKNIFE,Throw Venom Knife
 1005,1,6,1,0,0x1,0,1,1,no,0,0x1,0,weapon,0,0x0,	RG_CLOSECONFINE,Close Confine
 1006,0,6,4,3,0,1,1,1,yes,0,0x40001,0,magic,3,0x0,	WZ_SIGHTBLASTER,Sight Blaster
 1007,0,6,4,0,0x1,0,1,0,no,0,0x1,0,none,0,0x0,	SA_CREATECON,Create Elemental Converter
@@ -1038,8 +1040,8 @@
 2240,0,6,4,0,0,0,1,1,no,0,0,0,none,0,0x0,		RA_WUGMASTERY,Warg Mastery
 2241,0,6,4,0,0,0,3,1,no,0,0,0,none,0,0x2000,		RA_WUGRIDER,Warg Rider
 2242,0,6,4,-1,0x42,1,1,1,no,0,0,0,weapon,0,0x42000,	RA_WUGDASH,Warg Dash
-2243,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x42000,	RA_WUGSTRIKE,Warg Strike
-2244,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x40080,	RA_WUGBITE,Warg Bite
+2243,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x342000,	RA_WUGSTRIKE,Warg Strike
+2244,9,6,1,0,0x98,0,5,1,no,0,0,0,weapon,0,0x340080,	RA_WUGBITE,Warg Bite
 2245,0,0,0,0,0,0,10,0,no,0,0,0,none,0,0x0,		RA_TOOTHOFWUG,Tooth of Warg
 2246,0,6,4,0,0x2,3:4:5:6:7,5,1,no,0,0x40000,0,weapon,0,0x0,	RA_SENSITIVEKEEN,Sensitive Keen
 2247,0,6,4,0,0x1,0,5,1,no,0,0,0,none,0,0x80040,		RA_CAMOUFLAGE,Camouflage
@@ -1065,7 +1067,7 @@
 2264,0,6,4,0,0x1,0,1,1,no,0,0,0,none,7,0x4000,		NC_F_SIDESLIDE,Front-Side Slide
 2265,0,6,4,0,0x1,0,1,1,no,0,0,0,none,7,0x4000,		NC_B_SIDESLIDE,Back-Side Slide
 2266,0,0,0,0,0,0,4,0,no,0,0,0,none,0,0x0,		NC_MAINFRAME,Mainframe Restructure
-2267,0,6,4,0,0xCA,2:3:4,3,1,no,0,0x40000,0,weapon,5,0x4000,	NC_SELFDESTRUCTION,Self Destruction
+2267,0,6,4,0,0xCA,2:3:4,3,1,no,0,0x40000,0,weapon,5,0x304000,	NC_SELFDESTRUCTION,Self Destruction
 2268,0,6,4,0,0x1,0,4,1,yes,0,0,0,none,0,0x4000,	NC_SHAPESHIFT,Shape Shift
 2269,0,6,4,0,0x1,0,1,1,no,0,0,0,none,0,0x4000,		NC_EMERGENCYCOOL,Emergency Cool
 2270,0,6,4,0,0x3,7,1,1,yes,0,0,0,none,0,0x4000,	NC_INFRAREDSCAN,Infrared Scan
@@ -1238,7 +1240,7 @@
 2479,9,6,2,0,0,0,5,1,yes,0,0x80,3,misc,0,0x0,	GN_THORNS_TRAP,Thorn Trap
 2480,11,6,1,0,0x1,0,5,1,yes,0,0,3,misc,0,0x0,		GN_BLOOD_SUCKER,Blood Sucker //CHECK Data says its a magic attack. Hmmmm....
 2481,11,6,1,-1,0x2,1:2:3:4:5,5,1,yes,0,0,0,weapon,0,0x0,	GN_SPORE_EXPLOSION,Spore Explosion //CHECK Data says its element is set to neutral. Need to confirm.
-2482,11,6,2,0,0x8,0,5,1,yes,0,0,1,weapon,2,0x0,	GN_WALLOFTHORN,Wall of Thorns
+2482,11,6,2,0,0x8,0,5,1,yes,0,0,1,weapon,2,0x300000,	GN_WALLOFTHORN,Wall of Thorns
 2483,11,6,2,0,0x3,4,10,1,yes,0,0x0,0,weapon,0,0x1,	GN_CRAZYWEED,Crazy Weed
 2484,0,6,2,2,0x2,2,10,1,no,0,0x40000,0,weapon,0,0x1,	GN_CRAZYWEED_ATK,Crazy Weed Attack
 2485,9,6,2,3,0,0,5,1,yes,0,0,1,magic,0,0x0,		GN_DEMONIC_FIRE,Demonic Fire

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1135,7 +1135,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			return 0;
 		}
 
-		if( (sce = sc->data[SC_AUTOGUARD]) && flag&BF_WEAPON && !(skill_get_nk(skill_id)&NK_NO_CARDFIX_ATK) && rnd()%100 < sce->val2 ) {
+		if( (sce = sc->data[SC_AUTOGUARD]) && flag&BF_WEAPON && !(skill_get_inf3(skill_id)&INF3_NO_EFF_AUTOGUARD) && rnd()%100 < sce->val2) {
 			int delay;
 			struct status_change_entry *sce_d = sc->data[SC_DEVOTION];
 			struct block_list *d_bl = NULL;
@@ -1227,7 +1227,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			return 0;
 		}
 
-		if (((sce = sc->data[SC_UTSUSEMI]) || sc->data[SC_BUNSINJYUTSU]) && flag&BF_WEAPON && !(skill_get_nk(skill_id)&NK_NO_CARDFIX_ATK)) {
+		if (((sce = sc->data[SC_UTSUSEMI]) || sc->data[SC_BUNSINJYUTSU]) && flag&BF_WEAPON && !(skill_get_inf3(skill_id)&INF3_NO_EFF_CICADA)) {
 			skill_additional_effect (src, bl, skill_id, skill_lv, flag, ATK_BLOCK, gettick() );
 			if (!status_isdead(src))
 				skill_counter_additional_effect( src, bl, skill_id, skill_lv, flag, gettick() );

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -85,26 +85,28 @@ enum e_skill_inf2 {
 
 /// Skill info type 3
 enum e_skill_inf3 {
-	INF3_NOLP             = 0x00001, // Skill that can ignore Land Protector
-	INF3_FREE             = 0x00002, // Free
-	INF3_USABLE_HIDING    = 0x00004, // Skill that can be use in hiding
-	INF3_USABLE_DANCE     = 0x00008, // Skill that can be use while in dancing state
-	INF3_HIT_EMP          = 0x00010, // Skill that could hit emperium
-	INF3_STASIS_BL        = 0x00020, // Skill that can ignore SC_STASIS
-	INF3_KAGEHUMI_BL      = 0x00040, // Skill blocked by kagehumi
-	INF3_EFF_VULTURE      = 0x00080, // Skill range affected by AC_VULTURE
-	INF3_EFF_SNAKEEYE     = 0x00100, // Skill range affected by GS_SNAKEEYE
-	INF3_EFF_SHADOWJUMP   = 0x00200, // Skill range affected by NJ_SHADOWJUMP
-	INF3_EFF_RADIUS       = 0x00400, // Skill range affected by WL_RADIUS
-	INF3_EFF_RESEARCHTRAP = 0x00800, // Skill range affected by RA_RESEARCHTRAP
-	INF3_NO_EFF_HOVERING  = 0x01000, // Skill that does not affect user that has SC_HOVERING active
-	INF3_USABLE_WARG      = 0x02000, // Skill that can be use while riding warg
-	INF3_USABLE_MADO      = 0x04000, // Skill that can be used while on Madogear
-	INF3_USABLE_MANHOLE   = 0x08000, // Skill that can be used to target while under SC__MANHOLE effect
-	INF3_HIT_HIDING       = 0x10000, // Skill that affects hidden targets
-	INF3_SC_GLOOMYDAY_SK  = 0x20000, // Skill that affects SC_GLOOMYDAY_SK
-	INF3_SC_DANCEWITHWUG  = 0x40000, // Skill that is affected by SC_DANCEWITHWUG
-	INF3_BITE_BLOCK       = 0x80000, // Skill blocked by RA_WUGBITE
+	INF3_NOLP             = 0x000001, // Skill that can ignore Land Protector
+	INF3_FREE             = 0x000002, // Free
+	INF3_USABLE_HIDING    = 0x000004, // Skill that can be use in hiding
+	INF3_USABLE_DANCE     = 0x000008, // Skill that can be use while in dancing state
+	INF3_HIT_EMP          = 0x000010, // Skill that could hit emperium
+	INF3_STASIS_BL        = 0x000020, // Skill that can ignore SC_STASIS
+	INF3_KAGEHUMI_BL      = 0x000040, // Skill blocked by kagehumi
+	INF3_EFF_VULTURE      = 0x000080, // Skill range affected by AC_VULTURE
+	INF3_EFF_SNAKEEYE     = 0x000100, // Skill range affected by GS_SNAKEEYE
+	INF3_EFF_SHADOWJUMP   = 0x000200, // Skill range affected by NJ_SHADOWJUMP
+	INF3_EFF_RADIUS       = 0x000400, // Skill range affected by WL_RADIUS
+	INF3_EFF_RESEARCHTRAP = 0x000800, // Skill range affected by RA_RESEARCHTRAP
+	INF3_NO_EFF_HOVERING  = 0x001000, // Skill that does not affect user that has SC_HOVERING active
+	INF3_USABLE_WARG      = 0x002000, // Skill that can be use while riding warg
+	INF3_USABLE_MADO      = 0x004000, // Skill that can be used while on Madogear
+	INF3_USABLE_MANHOLE   = 0x008000, // Skill that can be used to target while under SC__MANHOLE effect
+	INF3_HIT_HIDING       = 0x010000, // Skill that affects hidden targets
+	INF3_SC_GLOOMYDAY_SK  = 0x020000, // Skill that affects SC_GLOOMYDAY_SK
+	INF3_SC_DANCEWITHWUG  = 0x040000, // Skill that is affected by SC_DANCEWITHWUG
+	INF3_BITE_BLOCK       = 0x080000, // Skill blocked by RA_WUGBITE
+	INF3_NO_EFF_AUTOGUARD = 0x100000, // Skill is not blocked by SC_AUTOGUARD (physical-skill only)
+	INF3_NO_EFF_CICADA    = 0x200000, // Skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 };
 
 /// Walk intervals at which chase-skills are attempted to be triggered.


### PR DESCRIPTION
* **Addressed Issue(s)**: #3487
* **Server Mode**: Both
#### **Description of Pull Request**: 
* Added inf3 0x100000 for skill is not blocked by SC_AUTOGUARD (physical-skill only)
* Added inf3 0x200000 for skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
* Changed `NK_NO_CARDFIX_ATK` check to the flag above
* Applied those new inf3 flags for skills which are `weapon`-type and have `0x8`-nk