### PR TITLE
Corrected Reins of Mount interaction with hiding

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -20656,6 +20656,9 @@ BUILDIN_FUNC(setmounting) {
 	if( sd->sc.option&(OPTION_WUGRIDER|OPTION_RIDING|OPTION_DRAGON|OPTION_MADOGEAR) ) {
 		clif_msg(sd, NEED_REINS_OF_MOUNT);
 		script_pushint(st,0); //can't mount with one of these
+	} else if (sd->sc.data[SC_CLOAKING] || sd->sc.data[SC_CHASEWALK] || sd->sc.data[SC_CLOAKINGEXCEED] || sd->sc.data[SC_CAMOUFLAGE] || sd->sc.data[SC_STEALTHFIELD] || sd->sc.data[SC__FEINTBOMB]) {
+		// SC_HIDING, SC__INVISIBILITY, SC__SHADOWFORM, SC_SUHIDE already disable item usage
+		script_pushint(st, 0); // Silent failure
 	} else {
 		if( sd->sc.data[SC_ALL_RIDING] )
 			status_change_end(&sd->bl, SC_ALL_RIDING, INVALID_TIMER); //release mount


### PR DESCRIPTION
* **Addressed Issue(s)**: #3614

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Reins of Mount should not be applied to players who are in some sort of hidden state.
  * Item delay is still applied.
Thanks to @admkakaroto and @cydh!