### PR TITLE
Corrected warping and OnTouch events

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12795,7 +12795,7 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 	if(opt_flag&4) // Out of hiding, invoke on place.
 		skill_unit_move(bl,gettick(),1);
 
-	if(opt_flag&2 && sd && map_getcell(bl->m,bl->x,bl->y,CELL_CHKNPC))
+	if(opt_flag&2 && sd && !sd->state.warping && map_getcell(bl->m,bl->x,bl->y,CELL_CHKNPC))
 		npc_touch_areanpc(sd,bl->m,bl->x,bl->y); // Trigger on-touch event.
 
 	ers_free(sc_data_ers, sce);


### PR DESCRIPTION
* **Addressed Issue(s)**: #1658, #3620

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixed script command warp2 or OnTouch NPC attempting to trigger OnTouch events a second time for players in a hidden state while warping to the destination map resulting in them being sent to an invalid location.
Thanks to @exneval, @mgksrt8, @admkakaroto, and @Zeloss!