### PR TITLE
MD5 emails protection

### DIFF
--- a/conf/login_athena.conf
+++ b/conf/login_athena.conf
@@ -106,9 +106,10 @@ vip_char_increase: -1
 // 0 or more: new accounts automatically expire after the given value, in seconds
 start_limited_time: -1
 
-// Store passwords as MD5 hashes instead of plain text?
-// NOTE: Will not work with clients that use <passwordencrypt>
+// Store passwords/emails as MD5 hashes instead of plain text?
+// NOTE: use_MD5_passwords will not work with clients that use <passwordencrypt>
 use_MD5_passwords: no
+use_MD5_emails: no
 
 // Ipban features
 ipban_enable: yes

--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../common/md5calc.hpp"
 #include "../common/malloc.hpp"
 #include "../common/mapindex.hpp"
 #include "../common/mmo.hpp"
@@ -541,14 +542,20 @@ int chclif_parse_char_delete2_req(int fd, struct char_session_data* sd) {
  **/
 bool chclif_delchar_check(struct char_session_data *sd, char *delcode, uint8 flag) {
 	// E-Mail check
-	if (flag&CHAR_DEL_EMAIL && (
-			!stricmp(delcode, sd->email) || //email does not match or
+	if (flag&CHAR_DEL_EMAIL) {
+
+		/* TODO : In case of md5 mails
+		if( login_config.use_md5_emails )
+			MD5_String(delcode, delcode);
+		*/
+		if (!stricmp(delcode, sd->email) || //email does not match or
 			(
 				!stricmp("a@a.com", sd->email) && //it is default email and
 				!strcmp("", delcode) //user sent an empty email
-			))) {
+			)) {
 			ShowInfo("" CL_RED "Char Deleted" CL_RESET " " CL_GREEN "(E-Mail)" CL_RESET ".\n");
 			return true;
+		}
 	}
 	// Birthdate (YYMMDD)
 	if (flag&CHAR_DEL_BIRTHDATE && (

--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -7,6 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "login.hpp"
+
+#include "../common/md5calc.hpp"
 #include "../common/malloc.hpp"
 #include "../common/mmo.hpp"
 #include "../common/showmsg.hpp"
@@ -318,6 +321,9 @@ static bool account_db_sql_create(AccountDB* self, struct mmo_account* acc) {
 	if( account_id > END_ACCOUNT_NUM )
 		return false;
 
+	if( login_config.use_md5_emails )
+		MD5_String(acc->email,acc->email);	
+	
 	// insert the data into the database
 	acc->account_id = account_id;
 	return mmo_auth_tosql(db, acc, true);
@@ -533,7 +539,7 @@ static bool mmo_auth_fromsql(AccountDB_SQL* db, struct mmo_account* acc, uint32 
 	Sql_GetData(sql_handle, 17, &data, NULL); acc->old_group = atoi(data);
 #endif
 	Sql_FreeResult(sql_handle);
-
+	
 	return true;
 }
 

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -582,6 +582,8 @@ bool login_config_read(const char* cfgName, bool normal) {
 			login_config.start_limited_time = atoi(w2);
 		else if(!strcmpi(w1, "use_MD5_passwords"))
 			login_config.use_md5_passwds = (bool)config_switch(w2);
+		else if(!strcmpi(w1, "use_MD5_emails"))
+			login_config.use_md5_emails = (bool)config_switch(w2);
 		else if(!strcmpi(w1, "group_id_to_connect"))
 			login_config.group_id_to_connect = atoi(w2);
 		else if(!strcmpi(w1, "min_group_id_to_connect"))
@@ -684,6 +686,7 @@ void login_set_defaults() {
 	login_config.new_account_flag = true;
 	login_config.new_acc_length_limit = true;
 	login_config.use_md5_passwds = false;
+	login_config.use_md5_emails = false;
 	login_config.group_id_to_connect = -1;
 	login_config.min_group_id_to_connect = -1;
 

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -77,6 +77,7 @@ struct Login_Config {
 	bool new_account_flag,new_acc_length_limit;     /// autoregistration via _M/_F ? / if yes minimum length is 4?
 	int start_limited_time;                         /// new account expiration time (-1: unlimited)
 	bool use_md5_passwds;                           /// work with password hashes instead of plaintext passwords?
+	bool use_md5_emails;                            /// work with emails hashes instead of plaintext emails? [Vykimo]
 	int group_id_to_connect;                        /// required group id to connect
 	int min_group_id_to_connect;                    /// minimum group id to connect
 


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/3626
* **Server Mode**: BOTH
* **Description of Pull Request**: Protect emails stored in DB by allowing administrator to store emails in MD5 or not.
It's a partial answer to the issue concerning user personal data protection (next step is pincode).
_TODO :_ In case of old clients which ask for mail to delete character, add md5 support.
