### PR TITLE
Corrected atcommand reloadscript and NPC dialogs

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -7470,11 +7470,12 @@ This command will display a picture, usually an NPC illustration, also called
 cutin, for the currently attached client. The position parameter determines the
 placement of the illustration and takes following values:
 
-	0 - bottom left corner
-	1 - bottom middle
-	2 - bottom right corner
-	3 - middle of screen in a movable window with an empty title bar
-	4 - middle of screen without the window header, but still movable
+	0	bottom left corner
+	1	bottom middle
+	2	bottom right corner
+	3	middle of screen in a movable window with an empty title bar
+	4	middle of screen without the window header, but still movable
+	255	clear all displayed cutins
 
 The picture is read from data\texture\유저인터페이스\illust, from both the GRF archive
 and data folder, and is required to be a bitmap. The file extension .bmp can be

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -3911,7 +3911,7 @@ ACMD_FUNC(reload) {
 
 		iter = mapit_getallusers();
 		for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) )
-			pc_close_npc(pl_sd,2);
+			pc_close_npc(pl_sd,1);
 		mapit_free(iter);
 
 		flush_fifos();

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -3910,8 +3910,10 @@ ACMD_FUNC(reload) {
 		//atcommand_broadcast( fd, sd, "@broadcast", "You will feel a bit of lag at this point !" );
 
 		iter = mapit_getallusers();
-		for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) )
+		for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) ){
 			pc_close_npc(pl_sd,1);
+			clif_cutin(pl_sd, "", 255);
+		}
 		mapit_free(iter);
 
 		flush_fifos();

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2388,6 +2388,7 @@ void clif_viewpoint(struct map_session_data *sd, int npc_id, int type, int x, in
 ///     2 = bottom right corner
 ///     3 = middle of screen, inside a movable window
 ///     4 = middle of screen, movable with a close button, chrome-less
+///   255 = clear all displayed cutins
 void clif_cutin(struct map_session_data* sd, const char* image, int type)
 {
 	int fd;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7684,10 +7684,12 @@ TIMER_FUNC(pc_close_npc_timer){
 	if(sd) pc_close_npc(sd,data);
 	return 0;
 }
-/*
- *  Method to properly close npc for player and clear anything related
- * @flag == 1 : produce close button
- * @flag == 2 : directly close it
+/**
+ * Method to properly close a NPC for player and clear anything related.
+ * @param sd: Player attached
+ * @param flag: Method of closure
+ *   1: Produce a close button and end the NPC
+ *   2: End the NPC (best for no dialog windows)
  */
 void pc_close_npc(struct map_session_data *sd,int flag)
 {
@@ -7713,15 +7715,17 @@ void pc_close_npc(struct map_session_data *sd,int flag)
 #ifdef SECURE_NPCTIMEOUT
 		sd->npc_idle_timer = INVALID_TIMER;
 #endif
-		if (sd->st && sd->st->state == CLOSE) {
-			clif_scriptclose(sd, sd->npc_id);
-			clif_scriptclear(sd, sd->npc_id); // [Ind/Hercules]
-			sd->st->state = END; // Force to end now
-		}
-		if(sd->st && sd->st->state == END ) {// free attached scripts that are waiting
-			script_free_state(sd->st);
-			sd->st = NULL;
-			sd->npc_id = 0;
+		if (sd->st) {
+			if (sd->st->state == CLOSE) {
+				clif_scriptclose(sd, sd->npc_id);
+				clif_scriptclear(sd, sd->npc_id); // [Ind/Hercules]
+				sd->st->state = END; // Force to end now
+			}
+			if (sd->st->state == END) { // free attached scripts that are waiting
+				script_free_state(sd->st);
+				sd->st = NULL;
+				sd->npc_id = 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: #3637

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Force atcommand reloadscript to send a close button if a NPC dialog is active to any attached players.
Thanks to @kukuasir1!