### PR TITLE
Implemented official buy/sell amount restrictions

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -133,3 +133,11 @@ broadcast_hide_name: 2
 
 // Enable to sell rental item to NPC shop? (Note 1)
 rental_transaction: yes
+
+// Minimum purchase price of items at a normal Shop
+// Officially items cannot be purchased for less than 1 Zeny
+min_shop_buy: 1
+
+// Minimum sell price of items at a normal shop
+// Officially items can be sold for 0 Zeny
+min_shop_sell: 0

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8511,6 +8511,8 @@ static const struct _battle_data {
 	{ "feature.attendance",                 &battle_config.feature_attendance,              1,      0,      1,              },
 	{ "feature.privateairship",             &battle_config.feature_privateairship,          1,      0,      1,              },
 	{ "rental_transaction",                 &battle_config.rental_transaction,              1,      0,      1,              },
+	{ "min_shop_buy",                       &battle_config.min_shop_buy,                    1,      0,      INT_MAX,        },
+	{ "min_shop_sell",                      &battle_config.min_shop_sell,                   0,      0,      INT_MAX,        },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -651,6 +651,8 @@ struct Battle_Config
 	int feature_attendance;
 	int feature_privateairship;
 	int rental_transaction;
+	int min_shop_buy;
+	int min_shop_sell;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -4294,8 +4294,8 @@ int pc_modifybuyvalue(struct map_session_data *sd,int orig_value)
 	if(rate1 < rate2) rate1 = rate2;
 	if(rate1)
 		val = (int)((double)orig_value*(double)(100-rate1)/100.);
-	if(val < 0) val = 0;
-	if(orig_value > 0 && val < 1) val = 1;
+	if(val < battle_config.min_shop_buy)
+		val = battle_config.min_shop_buy;
 
 	return val;
 }
@@ -4310,8 +4310,8 @@ int pc_modifysellvalue(struct map_session_data *sd,int orig_value)
 		rate = 5+skill*2-((skill==10)? 1:0);
 	if(rate)
 		val = (int)((double)orig_value*(double)(100+rate)/100.);
-	if(val < 0) val = 0;
-	if(orig_value > 0 && val < 1) val = 1;
+	if (val < battle_config.min_shop_sell)
+		val = battle_config.min_shop_sell;
 
 	return val;
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: #3666

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * When purchasing items from a NPC shop, the minimum purchase price is always 1 Zeny.
  * When selling items to a NPC shop, the minimum sell price is always 0 Zeny.
Thanks to @Balferian and @dastgirp!