### PR TITLE
Prevent duplicate npc

### DIFF
--- a/npc/re/other/dimensional_gap.txt
+++ b/npc/re/other/dimensional_gap.txt
@@ -126,6 +126,7 @@ dali,115,85,5	script	Party Leader#dali	2_M_SWORDMASTER,{
 dali,115,85,0	script	#dalichat	-1,{
 	end;
 OnInit:
+	hideonnpc "Party Leader#dali2";
 	disablenpc "#dalichat";
 	end;
 OnEnable:


### PR DESCRIPTION
Hide second "chatting" NPC at initialization.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/3677
* **Server Mode**: RE
* **Description of Pull Request**: NPC Party Leader is duplicated because one is for "chatting scene" and the other one launch "chat mode". The "chat mode" one has to be hidden OnInit.