### PR TITLE
Corrected White Imprison and reflected damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6842,6 +6842,9 @@ int64 battle_calc_return_damage(struct block_list* bl, struct block_list *src, i
 	sc = status_get_sc(bl);
 	ssc = status_get_sc(src);
 
+	if (sc->data[SC_WHITEIMPRISON])
+		return 0; // White Imprison does not reflect any damage
+
 	if (flag & BF_SHORT) {//Bounces back part of the damage.
 		if ( (skill_get_inf2(skill_id)&INF2_TRAP || !status_reflect) && sd && sd->bonus.short_weapon_damage_return ) {
 			rdamage += damage * sd->bonus.short_weapon_damage_return / 100;


### PR DESCRIPTION
* **Addressed Issue(s)**: #3634

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Targets in White Imprison using reflect equipment or skills should not send damage back to those outside.
Thanks to @admkakaroto!