### PR TITLE
Bugfix disable npc

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -4619,7 +4619,7 @@ void clif_getareachar_unit(struct map_session_data* sd,struct block_list *bl)
 	/**
 	* Hide NPC from maya purple card.
 	**/
-	if(bl->type == BL_NPC && !((TBL_NPC*)bl)->chat_id && (((TBL_NPC*)bl)->sc.option&OPTION_INVISIBLE))
+	if(bl->type == BL_NPC && (((TBL_NPC*)bl)->sc.option&OPTION_INVISIBLE))
 		return;
 
 	ud = unit_bl2ud(bl);


### PR DESCRIPTION
Bugfix disable npc

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/3102

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: BOTH

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fix the bug addressed in issue 3102. Normal behavior is that maya purple can't see NPCs disabled but only hidden npc. 
OPTION_INVISIBLE is associated to disabled npc (OPTION_HIDE for hidden npc), so invisible NPCs must be skipped when changing map/refreshing even if they have a chat room. 
With this modification, hidden npc with a chatroom will still display it (for Roleplay purpose and players with maya purple card will see black npc form ) but disabled npc will not (and packet won't be send).

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
