### PR TITLE
Fixed a potential crash on change map events

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -5502,7 +5502,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 	sd->state.workinprogress = WIP_DISABLE_NONE;
 
 	if( sd->state.changemap ) { // Misc map-changing settings
-		unsigned short curr_map_instance_id = map_getmapdata(sd->bl.m)->instance_id, new_map_instance_id = mapdata->instance_id;
+		unsigned short curr_map_instance_id = map_getmapdata(sd->bl.m)->instance_id, new_map_instance_id = (mapdata ? mapdata->instance_id : 0);
 
 		if (curr_map_instance_id != new_map_instance_id) {
 			if (curr_map_instance_id) // Update instance timer for the map on leave


### PR DESCRIPTION
* **Addressed Issue(s)**: #3687

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * When changing to an unknown map (or one on another map-server) the instance checks attempted to check null data.
Thanks to @lelouch22!