### PR TITLE
Corrected Fire Charm and Exploding Dragon damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5927,7 +5927,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case NJ_BAKUENRYU:
 						skillratio += 50 + 150 * skill_lv;
 						if(sd && sd->spiritcharm_type == CHARM_TYPE_FIRE && sd->spiritcharm > 0)
-							skillratio += 45 * sd->spiritcharm;
+							skillratio += 15 * sd->spiritcharm;
 						break;
 					case NJ_HYOUSENSOU:
 #ifdef RENEWAL


### PR DESCRIPTION
* **Addressed Issue(s)**: #3695

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fire Charm was granting too much bonus damage when used with Exploding Dragon.
Thanks to @Balferian!