### PR TITLE
Corrected a potential overflow in item bonuses

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -485,8 +485,8 @@ struct map_session_data {
 
 		short splash_range, splash_add_range;
 		short add_steal_rate;
-		short add_heal_rate, add_heal2_rate;
-		short sp_gain_value, hp_gain_value, magic_sp_gain_value, magic_hp_gain_value;
+		int add_heal_rate, add_heal2_rate;
+		int sp_gain_value, hp_gain_value, magic_sp_gain_value, magic_hp_gain_value;
 		short sp_vanish_rate, hp_vanish_rate;
 		short sp_vanish_per, hp_vanish_per;
 		unsigned short unbreakable;	// chance to prevent ANY equipment breaking [celest]


### PR DESCRIPTION
* **Addressed Issue(s)**: #3703

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixed bHealPower, bHealPower2, bSPGainValue, bHPGainValue, bMagicSPGainValue, and bMagicHPGainValue having a chance to potentially overflow from signed short limit.
Thanks to @Everade!