### PR TITLE
Corrected possible item loss during char login

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10596,6 +10596,8 @@ static TIMER_FUNC(pc_autosave){
 	iter = mapit_getallusers();
 	for( sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); sd = (TBL_PC*)mapit_next(iter) )
 	{
+		if (!sd->state.pc_loaded) // Player data hasn't fully loaded
+			continue;
 		if(sd->bl.id == last_save_id && save_flag != 1) {
 			save_flag = 1;
 			continue;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolved a rare case if a player logs in and the server hasn't fully initialized all of the player's items that the auto-save timer fires off and saves the player with no items.
Thanks to @Tokeiburu!