### PR TITLE
Changed equippable jobs for some items in pre-re/item_db.txt

### DIFF
--- a/db/pre-re/item_db.txt
+++ b/db/pre-re/item_db.txt
@@ -542,24 +542,24 @@
 1189,Krasnaya,Krasnaya,5,20,,3800,200,,2,3,0x00004082,2,2,34,2,50,1,3,{ if(readparam(bStr)>=95) { bonus bBaseAtk,20; } },{},{}
 1190,Claymore_C,Claymore,5,0,,0,220,,1,0,0x00004080,7,2,34,3,1,0,3,{ bonus2 bAddSize,Size_All,40; },{},{}
 // Daggers
-1201,Knife,Knife,5,50,,400,17,,1,3,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1202,Knife_,Knife,5,50,,400,17,,1,4,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1203,Knife__,Knife,5,50,,400,17,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1204,Cutter,Cutter,5,1250,,500,30,,1,3,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1205,Cutter_,Cutter,5,1250,,500,30,,1,4,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1206,Cutter__,Cutter,5,1250,,500,30,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1207,Main_Gauche,Main Gauche,5,2400,,600,43,,1,3,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1208,Main_Gauche_,Main Gauche,5,2400,,600,43,,1,4,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1209,Main_Gauche__,Main Gauche,5,2400,,600,43,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{},{},{}
-1210,Dirk,Dirk,5,8500,,500,59,,1,2,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1211,Dirk_,Dirk,5,8500,,500,59,,1,3,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1212,Dirk__,Dirk,5,8500,,500,59,,1,0,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1213,Dagger,Dagger,5,14000,,600,73,,1,2,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1214,Dagger_,Dagger,5,14000,,600,73,,1,3,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1215,Dagger__,Dagger,5,14000,,600,73,,1,0,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1216,Stiletto,Stiletto,5,19500,,700,87,,1,2,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1217,Stiletto_,Stiletto,5,19500,,700,87,,1,3,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
-1218,Stiletto__,Stiletto,5,19500,,700,87,,1,0,0xFE9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1201,Knife,Knife,5,50,,400,17,,1,3,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1202,Knife_,Knife,5,50,,400,17,,1,4,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1203,Knife__,Knife,5,50,,400,17,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1204,Cutter,Cutter,5,1250,,500,30,,1,3,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1205,Cutter_,Cutter,5,1250,,500,30,,1,4,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1206,Cutter__,Cutter,5,1250,,500,30,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1207,Main_Gauche,Main Gauche,5,2400,,600,43,,1,3,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1208,Main_Gauche_,Main Gauche,5,2400,,600,43,,1,4,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1209,Main_Gauche__,Main Gauche,5,2400,,600,43,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{},{},{}
+1210,Dirk,Dirk,5,8500,,500,59,,1,2,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1211,Dirk_,Dirk,5,8500,,500,59,,1,3,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1212,Dirk__,Dirk,5,8500,,500,59,,1,0,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1213,Dagger,Dagger,5,14000,,600,73,,1,2,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1214,Dagger_,Dagger,5,14000,,600,73,,1,3,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1215,Dagger__,Dagger,5,14000,,600,73,,1,0,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1216,Stiletto,Stiletto,5,19500,,700,87,,1,2,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1217,Stiletto_,Stiletto,5,19500,,700,87,,1,3,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
+1218,Stiletto__,Stiletto,5,19500,,700,87,,1,0,0x3E9F7EEF,7,2,2,2,12,1,1,{},{},{}
 1219,Gladius,Gladius,5,43000,,700,105,,1,2,0x028F5EEE,7,2,2,3,24,1,1,{},{},{}
 1220,Gladius_,Gladius,5,43000,,700,105,,1,3,0x028F5EEE,7,2,2,3,24,1,1,{},{},{}
 1221,Gladius__,Gladius,5,43000,,700,105,,1,0,0x028F5EEE,7,2,2,3,24,1,1,{},{},{}
@@ -588,9 +588,9 @@
 1244,Holy_Dagger,Holy Dagger,5,20,,800,100,,1,0,0x02021040,7,2,2,4,55,1,1,{ bonus bAtkEle,Ele_Holy; bonus bDex,1; },{},{}
 1245,Cinquedea,Cinquedea,5,40000,,700,110,,1,1,0x00000001,7,2,2,3,30,1,1,{},{},{}
 1246,Cinquedea_,Cinquedea,5,40000,,700,110,,1,2,0x00000001,7,2,2,3,30,1,1,{},{},{}
-1247,Kindling_Dagger,Kindle Dagger,5,10000,,600,39,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Fire; },{},{}
-1248,Obsidian_Dagger,Obsidian Dagger,5,10000,,600,39,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Earth; },{},{}
-1249,Fisherman's_Dagger,Fisherman's Dagger,5,10000,,600,39,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Water; },{},{}
+1247,Kindling_Dagger,Kindle Dagger,5,10000,,600,39,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Fire; },{},{}
+1248,Obsidian_Dagger,Obsidian Dagger,5,10000,,600,39,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Earth; },{},{}
+1249,Fisherman's_Dagger,Fisherman's Dagger,5,10000,,600,39,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Water; },{},{}
 // Katars
 1250,Jur,Jur,5,19500,,800,125,,1,2,0x00001000,7,2,34,2,18,1,16,{},{},{}
 1251,Jur_,Jur,5,19500,,800,125,,1,3,0x00001000,7,2,34,2,18,1,16,{},{},{}
@@ -5331,9 +5331,9 @@
 // More Weapons
 //===================================================================
 // Daggers and Ninja Weapons
-13000,Jujube_Dagger,Jujube Dagger,5,10000,,600,39,,1,0,0xFE9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Wind; },{},{}
-13001,Dragon_Killer,Dragon Killer,5,20,,900,110,,1,0,0xFE9F7EEF,7,2,2,4,60,1,1,{ bonus bIgnoreDefRace,RC_Dragon; bonus2 bExpAddRace,RC_Dragon,10; },{},{}
-13002,Ginnungagap,Ginnungagap,5,20,,700,148,,1,0,0xFE9F7EEF,7,2,2,4,70,1,1,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Blind,500; bonus2 bAddEff2,Eff_Blind,50; },{},{}
+13000,Jujube_Dagger,Jujube Dagger,5,10000,,600,39,,1,0,0x3E9F7EEF,7,2,2,1,1,1,1,{ bonus bAtkEle,Ele_Wind; },{},{}
+13001,Dragon_Killer,Dragon Killer,5,20,,900,110,,1,0,0x3E9F7EEF,7,2,2,4,60,1,1,{ bonus bIgnoreDefRace,RC_Dragon; bonus2 bExpAddRace,RC_Dragon,10; },{},{}
+13002,Ginnungagap,Ginnungagap,5,20,,700,148,,1,0,0x3E9F7EEF,7,2,2,4,70,1,1,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Blind,500; bonus2 bAddEff2,Eff_Blind,50; },{},{}
 13003,Coward,Cowardice Blade,5,52000,,700,80,,1,1,0x02021040,7,2,2,3,55,1,1,{ bonus bDef,5; },{},{}
 13004,Coward_,Cowardice Blade,5,52000,,700,80,,1,2,0x02021040,7,2,2,3,55,1,1,{ bonus bDef,5; },{},{}
 13005,Angelwing_Short_Sword,Angelic Wing Dagger,5,20,,600,120,,1,2,0x00000001,7,2,2,4,50,1,1,{},{},{}
@@ -5350,7 +5350,7 @@
 13016,Poison_Knife_,Poison Knife,5,20,,800,64,,1,2,0x028F5EEE,7,2,2,3,65,1,1,{ bonus bAtkEle,Ele_Poison; bonus2 bAddEff,Eff_Poison,3000; },{},{}
 13017,House_Auger_,Ice Pick,5,20,,600,70,,1,1,0x028F5EEE,7,2,2,4,36,1,1,{ bonus bDefRatioAtkClass,Class_All; },{},{}
 13018,Sucsamad_,Sucsamad,5,20,,800,140,,1,1,0x028F5EEE,7,2,2,4,36,1,1,{ bonus2 bAddEle,Ele_Earth,10; bonus2 bAddEle,Ele_Wind,10; bonus bUnbreakableWeapon; },{},{}
-13019,Ginnungagap_,Ginnungagap,5,20,,700,148,,1,1,0xFE9F7EEF,7,2,2,4,70,1,1,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Blind,500; bonus2 bAddEff2,Eff_Blind,50; },{},{}
+13019,Ginnungagap_,Ginnungagap,5,20,,700,148,,1,1,0x3E9F7EEF,7,2,2,4,70,1,1,{ bonus bAtkEle,Ele_Dark; bonus2 bAddEff,Eff_Blind,500; bonus2 bAddEff2,Eff_Blind,50; },{},{}
 13020,Warrior_Balmung_,Warrior's Balmung,5,20,,1000,170,,1,0,0xFFFFFFFF,7,2,2,4,48,1,1,{ bonus bAllStats,5; },{},{}
 13021,Combat_Knife_C,Combat Knife,5,1,,0,129,,1,0,0x028F5EEE,7,2,2,4,1,0,1,{ bonus bIgnoreDefRace,RC_DemiHuman; bonus bIgnoreDefRace,RC_Player; bonus2 bSubRace,RC_DemiHuman,10; bonus2 bSubRace,RC_Player,10; bonus2 bSubRace,RC_Demon,-10; bonus bMaxSPrate,10; bonus bSPDrainValue,3; },{},{}
 13022,Counter_Dagger_C,Dagger of Counter,5,1,,0,209,,1,0,0x00810204,7,2,2,4,1,0,1,{ bonus bCritical,90; },{},{}
@@ -5361,19 +5361,19 @@
 13027,Scalpel,Scalpel,5,20,,500,120,,1,3,0x028F5EEE,2,2,2,4,55,1,1,{ bonus2 bAddEff,Eff_Bleeding,500; },{},{}
 13028,Tooth_Blade,Tooth Blade,5,20,,700,130,,1,1,0x028F5EEE,2,2,2,4,55,1,1,{ if(getrefine()>=9){ bonus3 bAutoSpell,"NPC_SLOWCAST",2,70; } else bonus3 bAutoSpell,"NPC_SLOWCAST",1,50; },{},{}
 13029,Prinsence_Knife,Prinsense Knife,5,20,,0,120,,1,0,0x028F5EEE,7,2,2,1,0,0,1,{ bonus2 bAddClass,Class_All,50; },{},{}
-13030,Dragon_Killer_,Dragon Killer,5,20,,900,110,,1,2,0xFE9F7EEF,7,2,2,4,60,1,1,{ bonus bIgnoreDefRace,RC_Dragon; bonus2 bExpAddRace,RC_Dragon,10; },{},{}
+13030,Dragon_Killer_,Dragon Killer,5,20,,900,110,,1,2,0x3E9F7EEF,7,2,2,4,60,1,1,{ bonus bIgnoreDefRace,RC_Dragon; bonus2 bExpAddRace,RC_Dragon,10; },{},{}
 13031,Sword_Breaker_,Swordbreaker,5,20,,1000,70,,1,3,0x028F5EEE,7,2,2,4,36,1,1,{ bonus bBreakWeaponRate,500; },{},{}
 13032,Mail_Breaker_,Mailbreaker,5,20,,1000,70,,1,3,0x028F5EEE,7,2,2,4,36,1,1,{ bonus bBreakArmorRate,500; },{},{}
 13033,Assasin_Dagger_,Assassin Dagger,5,20,,600,140,,1,1,0x00001000,7,2,2,4,36,1,1,{ bonus bMaxHPrate,20; bonus bMaxSPrate,15; bonus bAspdRate,2; bonus bAtkEle,Ele_Dark; },{},{}
 13034,Twilight_Desert,Desert Twilight,5,20,,600,130,,1,2,0x00001000,2,2,2,2,70,1,1,{},{},{}
 13035,Sandstorm,Sandstorm,5,20,,600,50,,1,4,0x00001000,2,2,2,2,70,1,1,{},{},{}
-13036,BF_Dagger1,Brave Assassin's Damascus,5,20,,0,120,,1,0,0xFE9F7EEF,7,2,2,3,80,1,1,{ bonus bStr,1; bonus bAgi,1; bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus2 bIgnoreDefRaceRate,RC_DemiHuman,20; bonus2 bIgnoreDefRaceRate,RC_Player,20; bonus bUnbreakableWeapon; if(Class==Job_Ninja||Class==Job_Rogue||Class==Job_Stalker) bonus bMatkRate,15; },{},{}
-13037,BF_Dagger2,Valorous Assassin's Damascus,5,20,,0,120,,1,0,0xFE9F7EEF,7,2,2,3,80,1,1,{ bonus bStr,1; bonus bAgi,1; bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus bUnbreakableWeapon; autobonus "{ bonus bDefRatioAtkClass,Class_All; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }"; if(Class==Job_Ninja||Class==Job_Rogue||Class==Job_Stalker) bonus bMatkRate,15; },{},{}
+13036,BF_Dagger1,Brave Assassin's Damascus,5,20,,0,120,,1,0,0x3E9F7EEF,7,2,2,3,80,1,1,{ bonus bStr,1; bonus bAgi,1; bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus2 bIgnoreDefRaceRate,RC_DemiHuman,20; bonus2 bIgnoreDefRaceRate,RC_Player,20; bonus bUnbreakableWeapon; if(Class==Job_Ninja||Class==Job_Rogue||Class==Job_Stalker) bonus bMatkRate,15; },{},{}
+13037,BF_Dagger2,Valorous Assassin's Damascus,5,20,,0,120,,1,0,0x3E9F7EEF,7,2,2,3,80,1,1,{ bonus bStr,1; bonus bAgi,1; bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus bUnbreakableWeapon; autobonus "{ bonus bDefRatioAtkClass,Class_All; }",10,6000,BF_WEAPON,"{ specialeffect2 EF_HASTEUP; }"; if(Class==Job_Ninja||Class==Job_Rogue||Class==Job_Stalker) bonus bMatkRate,15; },{},{}
 13038,Dagger_Of_Hunter,Dagger of Hunter,5,20,,700,120,,1,3,0x00020000,2,2,2,3,70,1,1,{ bonus bStr,1; bonus bAgi,2; bonus bDex,1; bonus4 bAutoSpellOnSkill,"RG_BACKSTAP","SM_BASH",10,100; bonus2 bSkillAtk,"RG_BACKSTAP",20; },{},{}
 13039,Ivory_Knife,Ivory Knife,5,20,,700,130,,1,2,0x028F5EEE,2,2,2,3,50,1,1,{ bonus bAgi,2; bonus bAspdRate,3; bonus2 bAddEff,Eff_Bleeding,300; bonus3 bAutoSpell,"NPC_CRITICALWOUND",1,30; },{},{}
-13040,N_Cutter,Novice Cutter,5,0,,0,50,,1,3,0xFE9F7EEF,7,2,2,1,1,0,1,{},{},{}
-13041,N_Main_Gauche,Novice Main Gauche,5,0,,0,63,,1,3,0xFE9F7EEF,7,2,2,1,1,0,1,{},{},{}
-13042,Krieger_Dagger1,Glorious Gladius,5,20,,0,120,,1,0,0xFE9F7EEF,7,2,2,4,80,1,1,{ bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus2 bIgnoreDefRaceRate,RC_DemiHuman,20; bonus2 bIgnoreDefRaceRate,RC_Player,20; bonus3 bAutoSpell,"PR_LEXDIVINA",1,20; bonus bUnbreakableWeapon; if(getrefine()>5) { bonus2 bAddRace,RC_DemiHuman,(getrefine()-4)*(getrefine()-4); bonus2 bAddRace,RC_Player,(getrefine()-4)*(getrefine()-4); bonus2 bIgnoreDefRaceRate,RC_DemiHuman,5; bonus2 bIgnoreDefRaceRate,RC_Player,5; } if(getrefine()>8) bonus4 bAutoSpellOnSkill,"RG_RAID","NPC_WIDEBLEEDING",1,250; },{},{}
+13040,N_Cutter,Novice Cutter,5,0,,0,50,,1,3,0x3E9F7EEF,7,2,2,1,1,0,1,{},{},{}
+13041,N_Main_Gauche,Novice Main Gauche,5,0,,0,63,,1,3,0x3E9F7EEF,7,2,2,1,1,0,1,{},{},{}
+13042,Krieger_Dagger1,Glorious Gladius,5,20,,0,120,,1,0,0x3E9F7EEF,7,2,2,4,80,1,1,{ bonus2 bAddRace,RC_DemiHuman,75; bonus2 bAddRace,RC_Player,75; bonus2 bIgnoreDefRaceRate,RC_DemiHuman,20; bonus2 bIgnoreDefRaceRate,RC_Player,20; bonus3 bAutoSpell,"PR_LEXDIVINA",1,20; bonus bUnbreakableWeapon; if(getrefine()>5) { bonus2 bAddRace,RC_DemiHuman,(getrefine()-4)*(getrefine()-4); bonus2 bAddRace,RC_Player,(getrefine()-4)*(getrefine()-4); bonus2 bIgnoreDefRaceRate,RC_DemiHuman,5; bonus2 bIgnoreDefRaceRate,RC_Player,5; } if(getrefine()>8) bonus4 bAutoSpellOnSkill,"RG_RAID","NPC_WIDEBLEEDING",1,250; },{},{}
 13043,Fortune_Sword_I,Fortune Sword,5,0,,0,120,,1,0,0x028F5EEE,7,2,2,4,0,0,1,{ bonus bLuk,5; },{},{}
 13044,House_Auger_I,Ice Pick,5,0,,0,105,,1,0,0x028F5EEE,7,2,2,4,0,0,1,{},{},{}
 13045,Kamaitachi_I,Kamaitachi,5,0,,0,155,,2,0,0x02000000,7,2,2,4,0,0,1,{},{},{}


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #3733 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: pre-re

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
* Rebellion and Summoner job shouldn't be able to equip these items
Thanks to @RadianFord!

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
