### PR TITLE
Fixed missing login date for guild members

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -273,8 +273,8 @@ void guild_makemember(struct guild_member *m,struct map_session_data *sd) {
 //	m->exp_payper	= 0;
 	m->online		= 1;
 	m->position		= MAX_GUILDPOSITION-1;
-	memcpy(m->name,sd->status.name,NAME_LENGTH);
-	return;
+	safestrncpy(m->name,sd->status.name,NAME_LENGTH);
+	m->last_login	= (uint32)time(NULL);
 }
 
 /**


### PR DESCRIPTION
* **Addressed Issue(s)**: #3743

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixes missing dates on guild creation or when new members join by setting it to the current date.
