### PR TITLE
Fixed homunculus auto feed for broken luas

### DIFF
--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -71,6 +71,15 @@ feature.achievement: on
 // Requires: 2017-09-20bRagexeRE or later
 feature.homunculus_autofeed: on
 
+// At which rate should homunculus autofeeding trigger? (Note 2)
+// Default: 30
+//
+// NOTE:
+// This setting only applies, if your client side LUAs are bugged.
+// By default the client triggers the feeding packet itself once
+// it reaches the limit that is hardcoded in the client.
+feature.homunculus_autofeed_rate: 30
+
 // Attendance System (Note 1)
 // Requires: 2018-03-07bRagexeRE or later
 feature.attendance: on

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8514,6 +8514,7 @@ static const struct _battle_data {
 	{ "skill_drop_items_full",              &battle_config.skill_drop_items_full,           0,      0,      1,              },
 	{ "switch_remove_edp",                  &battle_config.switch_remove_edp,               2,      0,      3,              },
 	{ "feature.homunculus_autofeed",        &battle_config.feature_homunculus_autofeed,     1,      0,      1,              },
+	{ "feature.homunculus_autofeed_rate",   &battle_config.feature_homunculus_autofeed_rate,30,     0,    100,              },
 	{ "summoner_trait",                     &battle_config.summoner_trait,                  3,      0,      3,              },
 	{ "homunculus_autofeed_always",         &battle_config.homunculus_autofeed_always,      1,      0,      1,              },
 	{ "feature.attendance",                 &battle_config.feature_attendance,              1,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -646,6 +646,7 @@ struct Battle_Config
 	int skill_drop_items_full;
 	int switch_remove_edp;
 	int feature_homunculus_autofeed;
+	int feature_homunculus_autofeed_rate;
 	int summoner_trait;
 	int homunculus_autofeed_always;
 	int feature_attendance;

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -891,6 +891,10 @@ static TIMER_FUNC(hom_hungry){
 		clif_emotion(&hd->bl, ET_OK);
 	}
 
+	if( battle_config.feature_homunculus_autofeed && hd->homunculus.autofeed && hd->homunculus.hunger <= battle_config.feature_homunculus_autofeed_rate ){
+		hom_food( sd, hd );
+	}
+
 	if (hd->homunculus.hunger < 0) {
 		hd->homunculus.hunger = 0;
 		// Delete the homunculus if intimacy <= 100


### PR DESCRIPTION
* **Addressed Issue(s)**: #3318

* **Server Mode**: Renewal

* **Description of Pull Request**: 
This triggers the automatic feeding from server side, if the client itself is broken.

Thanks to @yoonjunho72, @AzarthMZintos and @admkakaroto