### PR TITLE
Switched supported client to Ragexe

### DIFF
--- a/src/config/packets.hpp
+++ b/src/config/packets.hpp
@@ -17,8 +17,9 @@
 #endif
 
 #ifndef PACKETVER_RE
-	/// From this point on only kRO RE clients are supported
-	#if PACKETVER > 20151104
+	/// From November 2015 only RagexeRE are supported.
+	/// After July 2018 only Ragexe are supported.
+	#if PACKETVER > 20151104 && PACKETVER < 20180704
 		#define PACKETVER_RE
 	#endif
 #endif


### PR DESCRIPTION
* **Addressed Issue(s)**: #3376

* **Server Mode**: Both

* **Description of Pull Request**: 
This adds support for clients after July 2018.
Since no unpacked RagexeRE exist anymore, we need to switch back over to Ragexe.
This should work without problems until 2018-11-21.
After this there are further changes required.

Thanks to @Haikenz
