### PR TITLE
Fixed reloadmobdb status calculation

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -5352,6 +5352,9 @@ static int mob_reload_sub( struct mob_data *md, va_list args ){
 	// Relink the mob to the new database entry
 	md->db = mob_db(md->mob_id);
 
+	// Recalculate the monster status based on the new data
+	status_calc_mob(md, SCO_NONE);
+
 	// If the view data was not overwritten manually
 	if( !md->vd_changed ){
 		// Get the new view data from the mob database


### PR DESCRIPTION
* **Addressed Issue(s)**: #3783

* **Server Mode**: Both

* **Description of Pull Request**: 
Adds a status recalculation for each active monster on monster database reload.

Thanks to @Everade
