### PR TITLE
Add optional argument {<instance mode>} to instance_id()

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8885,13 +8885,20 @@ to be attached. If that fails, the command returns an empty string instead.
 
 ---------------------------------------
 
-*instance_id()
+*instance_id({<instance mode>})
 
 Returns the unique instance id of the attached script. If the script is not
 attached to an instance, the instance of the currently attached player is
 used (if it is a character, party, guild or clan mode). If it is not owned by anyone, no
 player needs to be attached. If that fails, the function will return 0.
 
+When a player is attached, you can search id related to a particular mode.
+Instance Mode options:
+ IM_CHAR: Attached to the character.
+ IM_PARTY: Attached to the player's party.
+ IM_GUILD: Attached to the player's guild.
+ IM_CLAN: Attached to the player's clan.
+ 
 ---------------------------------------
 
 *instance_warpall "<map name>",<x>,<y>{,<instance id>};

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19929,7 +19929,7 @@ BUILDIN_FUNC(instance_id)
 			ShowError("buildin_instance_create: Unknown instance mode %d for '%s'\n", mode, script_getstr(st, 2));
 			return SCRIPT_CMD_FAILURE;
 		}
-		script_pushint(st, script_instancegetid(st, true, mode));
+		script_pushint(st, script_instancegetid(st, mode));
 	} else
 		script_pushint(st, script_instancegetid(st));
 	return SCRIPT_CMD_SUCCESS;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -378,7 +378,7 @@ static struct linkdb_node *sleep_db; // int oid -> struct script_state *
  *------------------------------------------*/
 const char* parse_subexpr(const char* p,int limit);
 int run_func(struct script_state *st);
-unsigned short script_instancegetid(struct script_state *st, bool use_mode = false, enum instance_mode mode = IM_PARTY);
+unsigned short script_instancegetid(struct script_state *st, enum instance_mode mode = IM_NONE);
 
 const char* script_op2name(int op)
 {
@@ -19705,7 +19705,7 @@ BUILDIN_FUNC(bg_get_data)
  *------------------------------------------*/
 //Returns an Instance ID
 //Checks NPC first, then if player is attached we check
-unsigned short script_instancegetid(struct script_state* st, bool use_mode, enum instance_mode mode)
+unsigned short script_instancegetid(struct script_state* st, enum instance_mode mode)
 {
 	unsigned short instance_id = 0;
 	struct npc_data *nd;
@@ -19719,7 +19719,7 @@ unsigned short script_instancegetid(struct script_state* st, bool use_mode, enum
 		struct clan *cd = NULL;
 
 		if ((sd = map_id2sd(st->rid))) {
-			if(use_mode) {
+			if(mode != IM_NONE) {
 				switch(mode) {
 					case IM_CHAR:
 						if (sd->instance_id)


### PR DESCRIPTION
* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Modification of instance_id({<instance mode>}) :
- Optional argument {<instance mode>} added
You can specify the instance mode because else, instance_id will check instances in this order : single, party, guild, then clan. So this pull request allows npc to select the right instance id attached to the player. (in case of different instances opened at the same time but not attached at the same mode).
+ Documentation in script_command.txt

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
