### PR TITLE
Corrected Card/Enchant Combos

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9771,7 +9771,7 @@ int pc_load_combo(struct map_session_data *sd) {
 		if(!itemdb_isspecial(sd->inventory.u.items_inventory[idx].card[0])) {
 			struct item_data *data;
 			int j;
-			for( j = 0; j < id->slot; j++ ) {
+			for( j = 0; j < MAX_SLOTS; j++ ) {
 				if (!sd->inventory.u.items_inventory[idx].card[j])
 					continue;
 				if ( ( data = itemdb_exists(sd->inventory.u.items_inventory[idx].card[j]) ) != NULL ) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #3644

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrected the loop that counts card/enchant combos at login being limited to the number of slots on the main item instead of MAX_SLOTS.
Thanks to @Badarosk0!