### PR TITLE
Added MS support for the function macro

### DIFF
--- a/src/common/cbasetypes.hpp
+++ b/src/common/cbasetypes.hpp
@@ -62,7 +62,8 @@
 // debug function name
 #ifndef __NETBSD__
 #if __STDC_VERSION__ < 199901L
-#	if __GNUC__ >= 2
+// Microsoft also supports this since C++11
+#	if __GNUC__ >= 2 || defined(_MSC_VER)
 #		define __func__ __FUNCTION__
 #	else
 #		define __func__ ""


### PR DESCRIPTION
* **Addressed Issue(s)**: #3855

* **Server Mode**: Both

* **Description of Pull Request**: 
Added a check for MSC, because we are not at C++11 and this already supports the `__FUNCTION__` macro correctly.
See https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2017
