### PR TITLE
Add missing unit type documentation

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Who should have a baseatk value (makes str affect damage)? (Note 3)

--- a/conf/battle/battleground.conf
+++ b/conf/battle/battleground.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Melee damage adjustments (non skills) for Battleground maps (Note 2)

--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -4,7 +4,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Buying store (Note 1)

--- a/conf/battle/homunc.conf
+++ b/conf/battle/homunc.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Homunculus setting (Note 3)

--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // The highest value at which an item can be sold via the merchant vend skill. (in zeny)

--- a/conf/battle/misc.conf
+++ b/conf/battle/misc.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // PK Server Mode.  Turns entire server pvp(excluding towns). Experience loss is doubled if killed by another player.

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // The HP rate of MVPs. (Note 2)

--- a/conf/battle/pet.conf
+++ b/conf/battle/pet.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Rate for catching pets (Note 2)

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Players' maximum HP rate? (Default is 100)

--- a/conf/battle/status.conf
+++ b/conf/battle/status.conf
@@ -6,7 +6,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Should skill casting be cancelled when inflicted by curse/stun/sleep/etc (includes silence) (Note 3)?

--- a/conf/log_athena.conf
+++ b/conf/log_athena.conf
@@ -4,7 +4,7 @@
 // Note 1: Value is a config switch (on/off, yes/no or 1/0)
 // Note 2: Value is in percents (100 means 100%)
 // Note 3: Value is a bit field. If no description is given,
-//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun)
+//         assume unit types (1: Pc, 2: Mob, 4: Pet, 8: Homun, 16: Mercenary, 128: NPC, 512: Elemental)
 //--------------------------------------------------------------
 
 // Enable Logs? (Note 3)


### PR DESCRIPTION
The value `enable_baseatk` which has a default value set to 0x29F is represented in bit like this: `0010 1001 1111`.
The bit fields in the "Note 3" documentation only includes a description for the bit fields from 1 to 16. As we see from the code and from the default value this field can affect more unit types which were added with this commit.

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/3869

* **Server Mode**: 
Renewal

* **Description of Pull Request**: 
This adds the missing documentation.
