### PR TITLE
Corrected status attack's element

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3038,7 +3038,7 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 	wd->statusAtk += battle_calc_status_attack(sstatus, EQI_HAND_R);
 	wd->statusAtk2 += battle_calc_status_attack(sstatus, EQI_HAND_L);
 
-	if (skill_id || (sd && sd->sc.data[SC_SEVENWIND])) { // Mild Wind applies element to status ATK as well as weapon ATK [helvetica]
+	if (sd && sd->sc.data[SC_SEVENWIND]) { // Mild Wind applies element to status ATK as well as weapon ATK [helvetica]
 		wd->statusAtk = battle_attr_fix(src, target, wd->statusAtk, right_element, tstatus->def_ele, tstatus->ele_lv);
 		wd->statusAtk2 = battle_attr_fix(src, target, wd->statusAtk, left_element, tstatus->def_ele, tstatus->ele_lv);
 	} else { // status atk is considered neutral on normal attacks [helvetica]


### PR DESCRIPTION
* **Addressed Issue(s)**: #3861

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Status attacks should always be forced to neutral.
Thanks to @Tokeiburu!