### PR TITLE
Corrected skills that give bonuses while sitting

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11188,7 +11188,7 @@ void clif_parse_ActionRequest_sub(struct map_session_data *sd, int action_type, 
 			sd->idletime = last_tick;
 
 		pc_setsit(sd);
-		skill_sit(sd, 1);
+		skill_sit(sd, true);
 		clif_sitting(&sd->bl);
 		break;
 	case 0x03: // standup
@@ -11204,7 +11204,7 @@ void clif_parse_ActionRequest_sub(struct map_session_data *sd, int action_type, 
 		if (pc_setstand(sd, false)) {
 			if (battle_config.idletime_option&IDLE_SIT)
 				sd->idletime = last_tick;
-			skill_sit(sd, 0);
+			skill_sit(sd, false);
 			clif_standing(&sd->bl);
 		}
 		break;

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -493,7 +493,7 @@ int skill_unit_move(struct block_list *bl,t_tick tick,int flag);
 void skill_unit_move_unit_group( struct skill_unit_group *group, int16 m,int16 dx,int16 dy);
 void skill_unit_move_unit(struct block_list *bl, int dx, int dy);
 
-int skill_sit (struct map_session_data *sd, int type);
+int skill_sit(struct map_session_data *sd, bool sitting);
 void skill_repairweapon(struct map_session_data *sd, int idx);
 void skill_identify(struct map_session_data *sd,int idx);
 void skill_weaponrefine(struct map_session_data *sd,int idx); // [Celest]

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9910,7 +9910,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_TENSIONRELAX:
 			if (sd) {
 				pc_setsit(sd);
-				skill_sit(sd, 1);
+				skill_sit(sd, true);
 				clif_sitting(&sd->bl);
 			}
 			val2 = 12; // SP cost
@@ -10655,7 +10655,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_BANANA_BOMB_SITDOWN:
 			if( sd && !pc_issit(sd) ) {
 				pc_setsit(sd);
-				skill_sit(sd, 1);
+				skill_sit(sd, true);
 				clif_sitting(bl);
 			}
 			break;
@@ -12507,7 +12507,7 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 		case SC_SITDOWN_FORCE:
 		case SC_BANANA_BOMB_SITDOWN:
 			if( sd && pc_issit(sd) && pc_setstand(sd, false) )
-				skill_sit(sd,0);
+				skill_sit(sd, false);
 			break;
 		case SC_KYOUGAKU:
 			clif_status_load(bl, EFST_KYOUGAKU, 0); // Avoid client crash
@@ -13582,7 +13582,7 @@ TIMER_FUNC(status_change_timer){
 			status_charge(bl,0,sce->val2);	// Reduce 8 every 10 seconds.
 			if( sd && !pc_issit(sd) ) { // Force to sit every 10 seconds.
 				pc_setsit(sd);
-				skill_sit(sd, 1);
+				skill_sit(sd, true);
 				clif_sitting(bl);
 			}
 			sc_timer_next(10000 + tick);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2977,7 +2977,7 @@ int unit_remove_map_(struct block_list *bl, clr_type clrtype, const char* file, 
 				duel_leave(sd->duel_group, sd);
 
 			if(pc_issit(sd) && pc_setstand(sd, false))
-				skill_sit(sd,0);
+				skill_sit(sd, false);
 
 			party_send_dot_remove(sd);// minimap dot fix [Kevin]
 			guild_send_dot_remove(sd);


### PR DESCRIPTION
* **Addressed Issue(s)**: #3611

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrected Gangster's Paradise not releasing the monster invulnerability state when standing up around multiple Rogue's that know Gangster's Paradise.
  * Same fix goes for Taekwon's Peaceful Break and Happy Break.
  * Cleaned up some various parts of these functions as well.
Thanks to @Indigo000!