### PR TITLE
Adjusted some NPC names

### DIFF
--- a/npc/jobs/1-1e/ninja.txt
+++ b/npc/jobs/1-1e/ninja.txt
@@ -74,9 +74,9 @@ alberta,30,65,3	script	Akagi	730,{
 	}
 }
 
-que_ng,30,65,3	script	Cougar#nq	730,{
+que_ng,30,65,3	script	Kuuga#nq	730,{
 	if (Upper == 2) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "I... I've never";
 		mes "seen a baby as";
 		mes "powerful as you!";
@@ -86,7 +86,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 	}
 	if (Class == Job_Novice) {
 		if (JobLevel < 10) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Hm? Have you come to";
 			mes "learn how to be a Ninja?";
 			mes "You're not quite experienced";
@@ -100,7 +100,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "Excuse me.";
 			mes "H-hello?";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "...............................";
 			mes "How did you do that?";
 			next;
@@ -108,7 +108,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "Do what? I didn't";
 			mes "do anything, I don't think...";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "H-How are you able to";
 			mes "see me? I'm supposed to";
 			mes "be invisible to the naked eye.";
@@ -121,7 +121,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "Calm down, there's no";
 			mes "need to get violent!";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "What...?";
 			mes "How did you dodge";
 			mes "all of my attacks?";
@@ -134,7 +134,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "to change my job";
 			mes "to a Ninja.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "...Oh. Is that all?";
 			mes "Hmm, you've got great";
 			mes "potential, but I can't help";
@@ -142,14 +142,14 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "enemies, and I can't let my";
 			mes "guard down for even a second.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "That Wildcat Joe is";
 			mes "completely ruthless...!";
 			mes "He could strike at any time!";
 			mes "He'll do anything to achieve";
 			mes "victory over his enemies!";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Wait, wait, I just";
 			mes "thought of something.";
 			mes "Maybe you can help me out.";
@@ -158,7 +158,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "really want to be a Ninja.";
 			next;
 			if(select("Sure.:No, thanks.") == 2) {
-				mes "[Cougar]";
+				mes "[Kuuga]";
 				mes "Hm? Well, alright.";
 				mes "Still, I don't see";
 				mes "why we can't help";
@@ -166,7 +166,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 				mes "little predicament...";
 				close;
 			}
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Great! Now, I wanted to";
 			mes "ask Wildcat Joe if he'd";
 			mes "agree to a temporary truce.";
@@ -174,7 +174,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "are out of weapons, so we";
 			mes "should get well equipped first.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Please take this letter,";
 			mes "and deliver it to Wildcat";
 			mes "Joe in Einbroch. He's a master";
@@ -182,7 +182,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "eye out for him. Ah, and look";
 			mes "for him in a high place.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Yeah, Wildcat Joe";
 			mes "always did have a thing";
 			mes "for hiding in high places.";
@@ -194,7 +194,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 1) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Even if this task";
 			mes "isn't that urgent,";
 			mes "please hurry over to";
@@ -203,7 +203,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 2) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Did you deliver that";
 			mes "letter to Wildcat Joe?";
 			mes "I still need to know his";
@@ -213,14 +213,14 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 3) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Ah, you've returned.";
 			mes "So did Wildcat Joe send";
 			mes "you back here with his";
 			mes "response? Great, great,";
 			mes "please let me read it.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "What...?! How could he";
 			mes "reject my proposal for";
 			mes "a truce?! This can only";
@@ -228,14 +228,14 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "Kunai. Nuts! I have to catch";
 			mes "up to him, or I'm a goner!";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Listen, you've got to help";
 			mes "me out again! I need you to";
 			mes "gather some materials so that";
 			mes "I can craft my own Kunai to fight Wildcat Joe. Then, I'll go ahead";
 			mes "and change your job to a Ninja.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "All you need";
 			mes "to bring me is";
 			mes "^3355FF5 Cyfars^000000 and";
@@ -249,7 +249,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "asked me to gather";
 			mes "those same materials.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Curses! Then that means...";
 			mes "You actually helped Joe";
 			mes "in crafting his Kunai! No!";
@@ -262,7 +262,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 		}
 		else if (NINJ_Q == 4) {
 			if (countitem(7053) < 5 || countitem(1010) < 1) {
-				mes "[Cougar]";
+				mes "[Kuuga]";
 				mes "Hurry and bring";
 				mes "^3355FF5 Cyfars^000000 and";
 				mes "^3355FF1 Phracon^000000 to me,";
@@ -272,7 +272,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 				close;
 			}
 			if (SkillPoint != 0) {
-				mes "[Cougar]";
+				mes "[Kuuga]";
 				mes "Whoa, whoa...";
 				mes "You still have some";
 				mes "leftover Skill Points.";
@@ -281,7 +281,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 				mes "change jobs, right?";
 				close;
 			}
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Ah, you're back with";
 			mes "everything that I need.";
 			mes "You've come earlier than";
@@ -289,14 +289,14 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "as promised, I'll turn";
 			mes "you into a Ninja.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Let me formally introduce";
-			mes "myself. I am High Ninja Cougar";
+			mes "myself. I am High Ninja Kuuga";
 			mes "in the Touga Ninja Corps, and";
 			mes "I'm in charge of the search";
 			mes "party to find Sir Kazma.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Sir Kazma is the chief";
 			mes "of my village, but he's";
 			mes "run away. This has resulted";
@@ -304,7 +304,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "the Ninja Corps. Things are";
 			mes "pretty unstable right now...";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "I initially didn't want to";
 			mes "accept you as a Ninja because";
 			mes "of this complicated situation.";
@@ -312,14 +312,14 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "you're truly worthy of joining";
 			mes "the Ninja ranks.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "According to his letter, even";
 			mes "Joe thinks highly of you. Just";
 			mes "remember that, as a Ninja, your";
 			mes "mission is your highest priority. But don't let mission objectives";
 			mes "supercede your conscience.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "''Secrecy above all else.''";
 			mes "To keep our secrets in the";
 			mes "shadows, you can only buy";
@@ -327,7 +327,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "authorized dealers. Please";
 			mes "keep that in mind.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "As of today, you are";
 			mes "now a proud member of the";
 			mes "Touga Ninja Corps. Be as";
@@ -342,7 +342,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			close;
 		}
 		else {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "How have you been?";
 			mes "Train hard: you want";
 			mes "to be able to vanish";
@@ -353,7 +353,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 		}
 	} else {
 		if (BaseClass == Job_Ninja) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "How have you been?";
 			mes "Train hard: you want";
 			mes "to be able to vanish";
@@ -362,7 +362,7 @@ que_ng,30,65,3	script	Cougar#nq	730,{
 			mes "the respect of any Ninja~";
 			close;
 		} else {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "What...?";
 			mes "How were you able";
 			mes "to find me hidden";
@@ -459,7 +459,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "?????!!";
 		next;
 		mes "[Suspicious Man]";
-		mes "Why? Didn't you bring Cougar's letter for me?";
+		mes "Why? Didn't you bring Kuuga's letter for me?";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Are you...";
@@ -468,7 +468,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Suspicious Man]";
 		mes "...Yes, but I prefer to";
 		mes "be called Red Leopard Joe.";
-		mes "Cougar sent you to me, right?";
+		mes "Kuuga sent you to me, right?";
 		mes "He's the only one who calls";
 		mes "me that. So you want to be";
 		mes "a Ninja, eh? Hmm, alright.";
@@ -494,7 +494,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Red Leopard Joe]";
 		mes "For now, let me read";
 		mes "this letter. Let's see...";
-		mes "Hm. I thought that Cougar";
+		mes "Hm. I thought that Kuuga";
 		mes "would want to challenge me";
 		mes "again, but he actually wants";
 		mes "a temporary truce? Hah!";
@@ -521,7 +521,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Red Leopard Joe]";
 		mes "Here you go.";
 		mes "Please bring this";
-		mes "letter to Cougar.";
+		mes "letter to Kuuga.";
 		mes "It'll take a while to";
 		mes "return to Amatsu, so let";
 		mes "me send you there directly...";
@@ -538,7 +538,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "Eh? I'm not sure what";
 		mes "happened, but it seems";
 		mes "that you haven't delivered";
-		mes "my response to Cougar yet.";
+		mes "my response to Kuuga yet.";
 		mes "Shall I directly send you";
 		mes "to Amatsu right now?";
 		next;
@@ -558,7 +558,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 	}
 	else if (NINJ_Q == 4) {
 		mes "[Red Leopard Joe]";
-		mes "Cougar asked you to";
+		mes "Kuuga asked you to";
 		mes "gather some materials";
 		mes "too? Oh well, I suppose";
 		mes "that I can't blame him.";

--- a/npc/jobs/1-1e/ninja.txt
+++ b/npc/jobs/1-1e/ninja.txt
@@ -74,9 +74,9 @@ alberta,30,65,3	script	Akagi	730,{
 	}
 }
 
-que_ng,30,65,3	script	Kuuga#nq	730,{
+que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 	if (Upper == 2) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "I... I've never";
 		mes "seen a baby as";
 		mes "powerful as you!";
@@ -86,7 +86,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 	}
 	if (Class == Job_Novice) {
 		if (JobLevel < 10) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Hm? Have you come to";
 			mes "learn how to be a Ninja?";
 			mes "You're not quite experienced";
@@ -100,7 +100,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "Excuse me.";
 			mes "H-hello?";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "...............................";
 			mes "How did you do that?";
 			next;
@@ -108,7 +108,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "Do what? I didn't";
 			mes "do anything, I don't think...";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "H-How are you able to";
 			mes "see me? I'm supposed to";
 			mes "be invisible to the naked eye.";
@@ -121,7 +121,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "Calm down, there's no";
 			mes "need to get violent!";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "What...?";
 			mes "How did you dodge";
 			mes "all of my attacks?";
@@ -134,7 +134,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "to change my job";
 			mes "to a Ninja.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "...Oh. Is that all?";
 			mes "Hmm, you've got great";
 			mes "potential, but I can't help";
@@ -142,14 +142,14 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "enemies, and I can't let my";
 			mes "guard down for even a second.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "That Wildcat Joe is";
 			mes "completely ruthless...!";
 			mes "He could strike at any time!";
 			mes "He'll do anything to achieve";
 			mes "victory over his enemies!";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Wait, wait, I just";
 			mes "thought of something.";
 			mes "Maybe you can help me out.";
@@ -158,7 +158,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "really want to be a Ninja.";
 			next;
 			if(select("Sure.:No, thanks.") == 2) {
-				mes "[Kuuga]";
+				mes "[Kuuga Gai]";
 				mes "Hm? Well, alright.";
 				mes "Still, I don't see";
 				mes "why we can't help";
@@ -166,7 +166,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 				mes "little predicament...";
 				close;
 			}
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Great! Now, I wanted to";
 			mes "ask Wildcat Joe if he'd";
 			mes "agree to a temporary truce.";
@@ -174,7 +174,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "are out of weapons, so we";
 			mes "should get well equipped first.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Please take this letter,";
 			mes "and deliver it to Wildcat";
 			mes "Joe in Einbroch. He's a master";
@@ -182,7 +182,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "eye out for him. Ah, and look";
 			mes "for him in a high place.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Yeah, Wildcat Joe";
 			mes "always did have a thing";
 			mes "for hiding in high places.";
@@ -194,7 +194,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 1) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Even if this task";
 			mes "isn't that urgent,";
 			mes "please hurry over to";
@@ -203,7 +203,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 2) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Did you deliver that";
 			mes "letter to Wildcat Joe?";
 			mes "I still need to know his";
@@ -213,14 +213,14 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			close;
 		}
 		else if (NINJ_Q == 3) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Ah, you've returned.";
 			mes "So did Wildcat Joe send";
 			mes "you back here with his";
 			mes "response? Great, great,";
 			mes "please let me read it.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "What...?! How could he";
 			mes "reject my proposal for";
 			mes "a truce?! This can only";
@@ -228,14 +228,14 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "Kunai. Nuts! I have to catch";
 			mes "up to him, or I'm a goner!";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Listen, you've got to help";
 			mes "me out again! I need you to";
 			mes "gather some materials so that";
 			mes "I can craft my own Kunai to fight Wildcat Joe. Then, I'll go ahead";
 			mes "and change your job to a Ninja.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "All you need";
 			mes "to bring me is";
 			mes "^3355FF5 Cyfars^000000 and";
@@ -249,7 +249,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "asked me to gather";
 			mes "those same materials.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Curses! Then that means...";
 			mes "You actually helped Joe";
 			mes "in crafting his Kunai! No!";
@@ -262,7 +262,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 		}
 		else if (NINJ_Q == 4) {
 			if (countitem(7053) < 5 || countitem(1010) < 1) {
-				mes "[Kuuga]";
+				mes "[Kuuga Gai]";
 				mes "Hurry and bring";
 				mes "^3355FF5 Cyfars^000000 and";
 				mes "^3355FF1 Phracon^000000 to me,";
@@ -272,7 +272,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 				close;
 			}
 			if (SkillPoint != 0) {
-				mes "[Kuuga]";
+				mes "[Kuuga Gai]";
 				mes "Whoa, whoa...";
 				mes "You still have some";
 				mes "leftover Skill Points.";
@@ -281,7 +281,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 				mes "change jobs, right?";
 				close;
 			}
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Ah, you're back with";
 			mes "everything that I need.";
 			mes "You've come earlier than";
@@ -289,14 +289,14 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "as promised, I'll turn";
 			mes "you into a Ninja.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Let me formally introduce";
-			mes "myself. I am High Ninja Kuuga";
+			mes "myself. I am High Ninja Kuuga Gai";
 			mes "in the Touga Ninja Corps, and";
 			mes "I'm in charge of the search";
 			mes "party to find Sir Kazma.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Sir Kazma is the chief";
 			mes "of my village, but he's";
 			mes "run away. This has resulted";
@@ -304,7 +304,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "the Ninja Corps. Things are";
 			mes "pretty unstable right now...";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "I initially didn't want to";
 			mes "accept you as a Ninja because";
 			mes "of this complicated situation.";
@@ -312,14 +312,14 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "you're truly worthy of joining";
 			mes "the Ninja ranks.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "According to his letter, even";
 			mes "Joe thinks highly of you. Just";
 			mes "remember that, as a Ninja, your";
 			mes "mission is your highest priority. But don't let mission objectives";
 			mes "supercede your conscience.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "''Secrecy above all else.''";
 			mes "To keep our secrets in the";
 			mes "shadows, you can only buy";
@@ -327,7 +327,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "authorized dealers. Please";
 			mes "keep that in mind.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "As of today, you are";
 			mes "now a proud member of the";
 			mes "Touga Ninja Corps. Be as";
@@ -342,7 +342,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			close;
 		}
 		else {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "How have you been?";
 			mes "Train hard: you want";
 			mes "to be able to vanish";
@@ -353,7 +353,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 		}
 	} else {
 		if (BaseClass == Job_Ninja) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "How have you been?";
 			mes "Train hard: you want";
 			mes "to be able to vanish";
@@ -362,7 +362,7 @@ que_ng,30,65,3	script	Kuuga#nq	730,{
 			mes "the respect of any Ninja~";
 			close;
 		} else {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "What...?";
 			mes "How were you able";
 			mes "to find me hidden";
@@ -459,7 +459,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "?????!!";
 		next;
 		mes "[Suspicious Man]";
-		mes "Why? Didn't you bring Kuuga's letter for me?";
+		mes "Why? Didn't you bring Kuuga Gai's letter for me?";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Are you...";
@@ -468,7 +468,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Suspicious Man]";
 		mes "...Yes, but I prefer to";
 		mes "be called Red Leopard Joe.";
-		mes "Kuuga sent you to me, right?";
+		mes "Kuuga Gai sent you to me, right?";
 		mes "He's the only one who calls";
 		mes "me that. So you want to be";
 		mes "a Ninja, eh? Hmm, alright.";
@@ -494,7 +494,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Red Leopard Joe]";
 		mes "For now, let me read";
 		mes "this letter. Let's see...";
-		mes "Hm. I thought that Kuuga";
+		mes "Hm. I thought that Kuuga Gai";
 		mes "would want to challenge me";
 		mes "again, but he actually wants";
 		mes "a temporary truce? Hah!";
@@ -521,7 +521,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "[Red Leopard Joe]";
 		mes "Here you go.";
 		mes "Please bring this";
-		mes "letter to Kuuga.";
+		mes "letter to Kuuga Gai.";
 		mes "It'll take a while to";
 		mes "return to Amatsu, so let";
 		mes "me send you there directly...";
@@ -538,7 +538,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "Eh? I'm not sure what";
 		mes "happened, but it seems";
 		mes "that you haven't delivered";
-		mes "my response to Kuuga yet.";
+		mes "my response to Kuuga Gai yet.";
 		mes "Shall I directly send you";
 		mes "to Amatsu right now?";
 		next;
@@ -558,7 +558,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 	}
 	else if (NINJ_Q == 4) {
 		mes "[Red Leopard Joe]";
-		mes "Kuuga asked you to";
+		mes "Kuuga Gai asked you to";
 		mes "gather some materials";
 		mes "too? Oh well, I suppose";
 		mes "that I can't blame him.";

--- a/npc/jobs/1-1e/ninja.txt
+++ b/npc/jobs/1-1e/ninja.txt
@@ -112,12 +112,12 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "H-How are you able to";
 			mes "see me? I'm supposed to";
 			mes "be invisible to the naked eye.";
-			mes "Ah, now I get it. Wildcat Joe";
+			mes "Ah, now I get it. Red Leopard Joe";
 			mes "must have sent you to kill me! I won't fall for your tricks! Die!";
 			next;
 			mes "["+strcharinfo(0)+"]";
 			mes "W-wait! I-I don't even";
-			mes "know who Wildcat Joe is!";
+			mes "know who Red Leopard Joe is!";
 			mes "Calm down, there's no";
 			mes "need to get violent!";
 			next;
@@ -143,7 +143,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "guard down for even a second.";
 			next;
 			mes "[Kuuga Gai]";
-			mes "That Wildcat Joe is";
+			mes "That Red Leopard Joe is";
 			mes "completely ruthless...!";
 			mes "He could strike at any time!";
 			mes "He'll do anything to achieve";
@@ -168,7 +168,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			}
 			mes "[Kuuga Gai]";
 			mes "Great! Now, I wanted to";
-			mes "ask Wildcat Joe if he'd";
+			mes "ask Red Leopard Joe if he'd";
 			mes "agree to a temporary truce.";
 			mes "I'm aware that both of us";
 			mes "are out of weapons, so we";
@@ -183,7 +183,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "for him in a high place.";
 			next;
 			mes "[Kuuga Gai]";
-			mes "Yeah, Wildcat Joe";
+			mes "Yeah, Red Leopard Joe";
 			mes "always did have a thing";
 			mes "for hiding in high places.";
 			mes "Anyway, after you give him";
@@ -199,13 +199,13 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "isn't that urgent,";
 			mes "please hurry over to";
 			mes "Einbroch and deliver";
-			mes "my letter to Wildcat Joe.";
+			mes "my letter to Red Leopard Joe.";
 			close;
 		}
 		else if (NINJ_Q == 2) {
 			mes "[Kuuga Gai]";
 			mes "Did you deliver that";
-			mes "letter to Wildcat Joe?";
+			mes "letter to Red Leopard Joe?";
 			mes "I still need to know his";
 			mes "response to my proposal";
 			mes "for a truce. Anyway, see";
@@ -215,7 +215,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 		else if (NINJ_Q == 3) {
 			mes "[Kuuga Gai]";
 			mes "Ah, you've returned.";
-			mes "So did Wildcat Joe send";
+			mes "So did Red Leopard Joe send";
 			mes "you back here with his";
 			mes "response? Great, great,";
 			mes "please let me read it.";
@@ -232,7 +232,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "Listen, you've got to help";
 			mes "me out again! I need you to";
 			mes "gather some materials so that";
-			mes "I can craft my own Kunai to fight Wildcat Joe. Then, I'll go ahead";
+			mes "I can craft my own Kunai to fight Red Leopard Joe. Then, I'll go ahead";
 			mes "and change your job to a Ninja.";
 			next;
 			mes "[Kuuga Gai]";
@@ -245,7 +245,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			next;
 			mes "["+strcharinfo(0)+"]";
 			mes "Huh? That's funny,";
-			mes "Wildcat Joe actually";
+			mes "Red Leopard Joe actually";
 			mes "asked me to gather";
 			mes "those same materials.";
 			next;
@@ -268,7 +268,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 				mes "^3355FF1 Phracon^000000 to me,";
 				mes "so that I can craft";
 				mes "my own Kunai to use";
-				mes "against Wildcat Joe!";
+				mes "against Red Leopard Joe!";
 				close;
 			}
 			if (SkillPoint != 0) {
@@ -388,14 +388,14 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "Oh, are you from";
 		mes "Amatsu? I'm looking";
 		mes "for someone named";
-		mes "Wildcat Joe from there.";
+		mes "Red Leopard Joe from there.";
 		next;
 		mes "[Suspicious Man]";
 		mes "...No. No, I'm actually";
 		mes "from Izlude, and I'm only";
 		mes "here in Einbroch for some";
 		mes "minerals. Tell me, why are";
-		mes "you looking for this Wildcat Joe?";
+		mes "you looking for this Red Leopard Joe?";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Well, I need to deliver";
@@ -408,7 +408,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "about it, I do think that I've";
 		mes "run once or twice into him";
 		mes "in this town. Though, he prefers to be called ''Red Leopard Joe,''";
-		mes "instead of ''Wildcat Joe.''";
+		mes "instead of ''Red Leopard Joe.''";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "I really want to help you";
@@ -463,7 +463,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Are you...";
-		mes "Are you Wildcat Joe?";
+		mes "Are you Red Leopard Joe?";
 		next;
 		mes "[Suspicious Man]";
 		mes "...Yes, but I prefer to";

--- a/npc/jobs/1-1e/ninja.txt
+++ b/npc/jobs/1-1e/ninja.txt
@@ -112,12 +112,12 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "H-How are you able to";
 			mes "see me? I'm supposed to";
 			mes "be invisible to the naked eye.";
-			mes "Ah, now I get it. Red Leopard Joe";
+			mes "Ah, now I get it. Wildcat Joe";
 			mes "must have sent you to kill me! I won't fall for your tricks! Die!";
 			next;
 			mes "["+strcharinfo(0)+"]";
 			mes "W-wait! I-I don't even";
-			mes "know who Red Leopard Joe is!";
+			mes "know who Wildcat Joe is!";
 			mes "Calm down, there's no";
 			mes "need to get violent!";
 			next;
@@ -143,7 +143,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "guard down for even a second.";
 			next;
 			mes "[Kuuga Gai]";
-			mes "That Red Leopard Joe is";
+			mes "That Wildcat Joe is";
 			mes "completely ruthless...!";
 			mes "He could strike at any time!";
 			mes "He'll do anything to achieve";
@@ -168,7 +168,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			}
 			mes "[Kuuga Gai]";
 			mes "Great! Now, I wanted to";
-			mes "ask Red Leopard Joe if he'd";
+			mes "ask Wildcat Joe if he'd";
 			mes "agree to a temporary truce.";
 			mes "I'm aware that both of us";
 			mes "are out of weapons, so we";
@@ -183,7 +183,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "for him in a high place.";
 			next;
 			mes "[Kuuga Gai]";
-			mes "Yeah, Red Leopard Joe";
+			mes "Yeah, Wildcat Joe";
 			mes "always did have a thing";
 			mes "for hiding in high places.";
 			mes "Anyway, after you give him";
@@ -199,13 +199,13 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "isn't that urgent,";
 			mes "please hurry over to";
 			mes "Einbroch and deliver";
-			mes "my letter to Red Leopard Joe.";
+			mes "my letter to Wildcat Joe.";
 			close;
 		}
 		else if (NINJ_Q == 2) {
 			mes "[Kuuga Gai]";
 			mes "Did you deliver that";
-			mes "letter to Red Leopard Joe?";
+			mes "letter to Wildcat Joe?";
 			mes "I still need to know his";
 			mes "response to my proposal";
 			mes "for a truce. Anyway, see";
@@ -215,7 +215,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 		else if (NINJ_Q == 3) {
 			mes "[Kuuga Gai]";
 			mes "Ah, you've returned.";
-			mes "So did Red Leopard Joe send";
+			mes "So did Wildcat Joe send";
 			mes "you back here with his";
 			mes "response? Great, great,";
 			mes "please let me read it.";
@@ -232,7 +232,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			mes "Listen, you've got to help";
 			mes "me out again! I need you to";
 			mes "gather some materials so that";
-			mes "I can craft my own Kunai to fight Red Leopard Joe. Then, I'll go ahead";
+			mes "I can craft my own Kunai to fight Wildcat Joe. Then, I'll go ahead";
 			mes "and change your job to a Ninja.";
 			next;
 			mes "[Kuuga Gai]";
@@ -245,7 +245,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 			next;
 			mes "["+strcharinfo(0)+"]";
 			mes "Huh? That's funny,";
-			mes "Red Leopard Joe actually";
+			mes "Wildcat Joe actually";
 			mes "asked me to gather";
 			mes "those same materials.";
 			next;
@@ -268,7 +268,7 @@ que_ng,30,65,3	script	Kuuga Gai#nq	730,{
 				mes "^3355FF1 Phracon^000000 to me,";
 				mes "so that I can craft";
 				mes "my own Kunai to use";
-				mes "against Red Leopard Joe!";
+				mes "against Wildcat Joe!";
 				close;
 			}
 			if (SkillPoint != 0) {
@@ -388,14 +388,14 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "Oh, are you from";
 		mes "Amatsu? I'm looking";
 		mes "for someone named";
-		mes "Red Leopard Joe from there.";
+		mes "Wildcat Joe from there.";
 		next;
 		mes "[Suspicious Man]";
 		mes "...No. No, I'm actually";
 		mes "from Izlude, and I'm only";
 		mes "here in Einbroch for some";
 		mes "minerals. Tell me, why are";
-		mes "you looking for this Red Leopard Joe?";
+		mes "you looking for this Wildcat Joe?";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Well, I need to deliver";
@@ -408,7 +408,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		mes "about it, I do think that I've";
 		mes "run once or twice into him";
 		mes "in this town. Though, he prefers to be called ''Red Leopard Joe,''";
-		mes "instead of ''Red Leopard Joe.''";
+		mes "instead of ''Wildcat Joe.''";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "I really want to help you";
@@ -463,7 +463,7 @@ einbroch,184,194,3	script	Suspicious Man#nq	 	881,{
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Are you...";
-		mes "Are you Red Leopard Joe?";
+		mes "Are you Wildcat Joe?";
 		next;
 		mes "[Suspicious Man]";
 		mes "...Yes, but I prefer to";

--- a/npc/quests/quests_nameless.txt
+++ b/npc/quests/quests_nameless.txt
@@ -36,8 +36,8 @@
 //= - Variable in use: rumour_nd (Max: 22)
 //===== Additional Comments: ================================= 
 //= 1.0 First version. [L0ne_W0lf]
-//= 1.1 Made quest accessable to "Failed" gaebolg quest. [L0ne_W0lf]
-//= 1.1a Touch up to other Gaebolg fail-points. [L0ne_W0lf]
+//= 1.1 Made quest accessable to "Failed" Geoborg quest. [L0ne_W0lf]
+//= 1.1a Touch up to other Geoborg fail-points. [L0ne_W0lf]
 //= 1.2 Some final tuning to Nameless Island quest. [Koca]
 //= 1.3 Should fix any more issues with "Creature" npc. [L0ne_W0lf]
 //= 1.4 Changed the way Out_from_Monastery works slightly. [L0ne_W0lf]
@@ -1003,7 +1003,7 @@ nameless_i,127,207,0	script	Dead Crow#Aru	111,{
 		mes "^3355FFThis grass must be the";
 		mes "main ingredient of the";
 		mes "poison used to kill the";
-		mes "Gaebolg family princes.^000000";
+		mes "Geoborg family princes.^000000";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Looks like I just hit";

--- a/npc/quests/quests_prontera.txt
+++ b/npc/quests/quests_prontera.txt
@@ -4,7 +4,7 @@
 //= Collection of Prontera-based quests.
 //= * Culvert Access
 //= * Ph.D Hat Quest
-//= * Gaebolg Family Curse
+//= * Geoborg Family Curse
 //===== Comments: ============================================
 //= Culvert Access:
 //= - [Official Conversion]
@@ -12,7 +12,7 @@
 //= Ph.D Hat Quest:
 //= - [Official Conversion]
 //= - n/a
-//= Gaebolg Family Curse:
+//= Geoborg Family Curse:
 //= - [Official Conversion]
 //= - Variable in use: prt_curse (max 61)
 //===== Changelogs: ==========================================
@@ -22,7 +22,7 @@
 //= 1.3 Removed Duplicates [Silent]
 //= 1.4 Moved Culvert from cities/prontera.txt [Evera]
 //= 1.5 Culvert has been rescripted from the ground up. [L0ne_W0lf]
-//= 1.6 Added Gaebolg Family Curse quest. [L0ne_W0lf]
+//= 1.6 Added Geoborg Family Curse quest. [L0ne_W0lf]
 //= 1.6a Fixed a couple spelling mistakes. [L0ne_W0lf]
 //= 1.7 Updated "Ph.D Quest" Dialogs. [Samuray22]
 //= 1.7b Fixed some minor typos. [SinSloth]
@@ -34,7 +34,7 @@
 //= 2.0b Corrected a Typo error. (bugreport:950) [Samuray22]
 //= 2.1 Added missing checkweights. [L0ne_W0lf]
 //= 2.2 Added Nameless Island quest addition. [L0ne_W0lf]
-//= 2.3 Bamph will now talk to those who failed the Gaebolg quest. [L0ne_W0lf]
+//= 2.3 Bamph will now talk to those who failed the Geoborg quest. [L0ne_W0lf]
 //= 2.3a Touch up to Bamph fo other fail-points. [L0ne_W0lf]
 //= 2.3b Hopefully the last change needed for Nameless quest. [L0ne_W0lf]
 //= 2.4 Updated Headgear Quest. [L0ne_W0lf]
@@ -245,7 +245,7 @@ prt_in,38,108,4	script	Teacher	53,{
 	}
 }
 
-// Gaebolg Family Curse :: prt_curse
+// Geoborg Family Curse :: prt_curse
 //============================================================
 prontera,248,212,3	script	Busy Boy#prt	706,3,3,{
 	callsub S_CheckWeight; //Check Player's weight
@@ -800,7 +800,7 @@ yuno,311,195,3	script	Historian#prt01	754,{
 		mes "With the return of peace,";
 		mes "the 7 warriors established";
 		mes "the Rune-Midgarts Kingdom,";
-		mes "choosing Tristram Gaebolg III";
+		mes "choosing Tristram Geoborg III";
 		mes "as the kingdom's first ruler. ";
 		next;
 		mes "[Historian]";
@@ -1197,7 +1197,7 @@ morocc_in,45,126,3	script	Historian#prt02	702,{
 		mes "^333333(As a historian, Rodafrian";
 		mes "might be able to help me in";
 		mes "investigating the curse of the";
-		mes "Gaebolgs. The priests told me";
+		mes "Geoborgs. The priests told me";
 		mes "not to tell anybody, though.";
 		mes "Should I take this risk?)^000000";
 		next;
@@ -1230,7 +1230,7 @@ morocc_in,45,126,3	script	Historian#prt02	702,{
 			next;
 			mes "[Historian Rodafrian]";
 			mes "Anyway, your report about";
-			mes "the Gaebolg family will be";
+			mes "the Geoborg family will be";
 			mes "greatly appreciated by the";
 			mes "Rekenber Historical Research";
 			mes "Group. But first, I need to";
@@ -1239,7 +1239,7 @@ morocc_in,45,126,3	script	Historian#prt02	702,{
 			mes "[Historian Rodafrian]";
 			mes "Anyway, keep this information";
 			mes "a secret between me and you";
-			mes "for now. Then, when I reveal the secret curse of the Gaebolg royal";
+			mes "for now. Then, when I reveal the secret curse of the Geoborg royal";
 			mes "family, I'll finally outshine that Karlomoff! Bwahahahahaha!";
 			next;
 			mes "["+strcharinfo(0)+"]";
@@ -2293,7 +2293,7 @@ prt_church,185,106,3	script	Father Bamph	60,{
 		next;
 		mes "[Father Bamph]";
 		mes "Finally, the first Tristram of";
-		mes "the Gaebolg family defeated";
+		mes "the Geoborg family defeated";
 		mes "Jormungand together with 6";
 		mes "other warriors, but only after";
 		mes "it killed his beloved father.";
@@ -2308,7 +2308,7 @@ prt_church,185,106,3	script	Father Bamph	60,{
 		mes "[Father Bamph]";
 		mes "To this day...";
 		mes "^FF0000Every first prince of";
-		mes "the Gaebolg family dies";
+		mes "the Geoborg family dies";
 		mes "at a young age^000000. That is";
 		mes "Jormungand's curse and";
 		mes "the royal family's secret.";
@@ -2431,7 +2431,7 @@ prt_church,185,106,3	script	Father Bamph	60,{
 		mes "Oh, my. I learned the song";
 		mes "when I was a young boy from";
 		mes "my father. However, your version seems to reveal the secret curse";
-		mes "of the Gaebolgs. Please tell me, where did you hear that song?";
+		mes "of the Geoborgs. Please tell me, where did you hear that song?";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Well, I first heard this";
@@ -3072,7 +3072,7 @@ prt_church,16,114,4	script	Father Bamph#tomb	60,{
 	if (prt_curse == 18) {
 		mes "[Father Bamph]";
 		mes "There are the bodies";
-		mes "of the Gaebolg princes";
+		mes "of the Geoborg princes";
 		mes "that were killed during";
 		mes "the exorcism. Please take";
 		mes "a look at the body to the left.";
@@ -3550,13 +3550,13 @@ OnTouch:
 		mes "["+strcharinfo(0)+"]";
 		mes "Long ago, the giant serpent";
 		mes "Jormungand threatened mankind.";
-		mes "7 warriors defeated Jormungand, led by Tristram III of the Gaebolg";
-		mes "family, but Jormungand cursed the Gaebolg bloodline in its defeat.";
+		mes "7 warriors defeated Jormungand, led by Tristram III of the Geoborg";
+		mes "family, but Jormungand cursed the Geoborg bloodline in its defeat.";
 		next;
 		mes "["+strcharinfo(0)+"]";
 		mes "Ever since, the curse kills";
 		mes "the first born prince of the";
-		mes "Gaebolg family at an early age.";
+		mes "Geoborg family at an early age.";
 		mes "However, all of the princes of";
 		mes "this generation were killed.";
 		next;

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -99,7 +99,7 @@ que_ng,21,76,0	script	Wall with a Drawing#ko	844,{
 
 job_ko,25,115,4	script	Old Man#ko	588,{
 	if (MaxWeight - Weight < 1000 || checkweight(1201,1) == 0) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "You don't need to carry so many things."; //custom translation
 		close;
 	}
@@ -107,7 +107,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "You are not in the Family of the Ninja.";
 		close2;
 		warp "amatsu",147,136;
@@ -755,12 +755,12 @@ L_StartTest:
 
 // Test of Knowledge
 //============================================================
-job_ko,81,124,4	script	Cougar#ko	730,{
+job_ko,81,124,4	script	Kuuga#ko	730,{
 	if (BaseJob != Job_Ninja) {
 		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "Sorry, your family is not same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
@@ -770,61 +770,61 @@ job_ko,81,124,4	script	Cougar#ko	730,{
 		goto L_Kick;
 	}
 	if (MaxWeight - Weight < 1000 || checkweight(1201,1) == 0) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "This is a test of knowledge, so why did you bring so many things?"; //custom translation
 		close;
 	}
 	set .@ko_test_01, isbegin_quest(5136);
 	set .@ko_test_01_1, isbegin_quest(5139);
 	if (.@ko_test_01 == 1 && .@ko_test_01_1 == 0) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "It's been a while.";
 		next;
 		select("Aren't you...");
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "I remember you from before looking for the way of the ninja.";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "You've grown this strong already?";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "Ha ha ha-";
 		mes "A truly determined youth! I like that.";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "Good! The test you are about to take is the ^339CCCTest of Knowledge^000000.";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "I hope you haven't been lazy with your studies while focusing on getting stronger?";
 		next;
 		switch(select("Yes:No")) {
 		case 1:
 			setquest 5139;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "That's a relief. Let me know when you are ready to start the test.";
 			close;
 		case 2:
 			setquest 5139;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "So you were all talk? Well, let me know when you are ready then.";
 			close;
 		}
 	} else if (.@ko_test_01 == 1 && .@ko_test_01_1 == 1) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "I'm ready at my end. Are you ready for the test?";
 		next;
 		if(select("Yes:No") == 2) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Well, what can I do but wait for you.";
 			close;
 		}
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "This isn't your first test, is it?";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "You only need to choose the correct answer to my questions.";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "Let's start.";
 		next;
 
@@ -844,9 +844,9 @@ job_ko,81,124,4	script	Cougar#ko	730,{
 		deletearray .@n[10],getarraysize(.@n) - .@questions;
 		freeloop(0);
 
-		set @job_ko_cougar,0;
+		set @job_ko_Kuuga,0;
 		for (set .@i,1; .@i<=.@questions; set .@i,.@i+1) {
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes (.@i < .@questions)?"Question number "+.@i+":":"Last question:";
 			switch (.@n[.@i-1]) {
 				case 1: callsub L_Question,"What is the DEX + LUK total for a Job Master?",2,"8:10:12:14"; break;
@@ -900,67 +900,67 @@ job_ko,81,124,4	script	Cougar#ko	730,{
 				case 49: callsub L_Question,"Which of the following blacksmiths do not create ninja items?",2,"Khaibara:Aiku:Tetsu:Toshu"; break;
 				case 50: callsub L_Question,"What is the name of the suspicious man you can meet during the Ninja job change quest?",3,"Red Leopard Jack:Black Leopard Jack:Red Leopard Joe:Black Leopard Joe"; break;
 				default:
-					mes "[Cougar]";
+					mes "[Kuuga]";
 					mes "An unknown error has occurred.";
 					mes "Please contact customer service.";
 					close;
 			}
 		}
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "You're through all 10 questions. Wasn't so bad! The important part starts now.";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "... ... ...";
 		next;
-		if (@job_ko_cougar < 90) {
-			mes "[Cougar]";
+		if (@job_ko_Kuuga < 90) {
+			mes "[Kuuga]";
 			mes "You fool!!";
 			mes "You couldn't even solve these?";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Can't believe someone who is taking a new path can be so pathetic.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "I'll give you another chance.";
 			mes "You will take the test again with new questions. Better pass it this time.";
 		} else {
-			mes "[Cougar]";
-			mes "Hmm. " + (@job_ko_cougar) + "?";
+			mes "[Kuuga]";
+			mes "Hmm. " + (@job_ko_Kuuga) + "?";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Well, looks like you weren't lazy with your studies.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "What? Proud of yourself for solving these questions?";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "You still have a long way to go and this is only a small fraction of it.";
 			next;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "Well... I'm curious how far your strong will can take you through other tests.";
 			next;
 			completequest 5136;
 			erasequest 5139;
-			mes "[Cougar]";
+			mes "[Kuuga]";
 			mes "I'll let you go now so go report back to Guide Gion with your results.";
 			close2;
 			warp "job_ko",16,113;
 			end;
 		}
-		set @job_ko_cougar,0;
+		set @job_ko_Kuuga,0;
 		close;
 	} else if (.@ko_test_01 == 2 && .@ko_test_01_1 == 0) {
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "I'll let you go now so go report back to Guide Gion with your results.";
 		close2;
 		warp "job_ko",16,113;
 		end;
 	} else {  //custom translation
 	L_Kick:
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "How did you get here?";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "It's my duty to get rid of you.";
 		mes "^000099(He's a short, silent man.)^000000";
 		mes "This will push you back!";
@@ -975,7 +975,7 @@ L_Question:
 	mes getarg(0);
 	next;
 	if(select(getarg(2)) == getarg(1))
-		set @job_ko_cougar, @job_ko_cougar + 10;
+		set @job_ko_Kuuga, @job_ko_Kuuga + 10;
 	return;
 }
 
@@ -1961,7 +1961,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		next;
 		select("Long time indeed, Joe.");
 		mes "[Red Leopard Joe]";
-		mes "You aren't surprised I'm here. Did you meet ^0237FDCougar^000000 before coming here?";
+		mes "You aren't surprised I'm here. Did you meet ^0237FDKuuga^000000 before coming here?";
 		next;
 		mes "[Red Leopard Joe]";
 		mes "Don't like it that I'm not the first one you visited but that is not important.";
@@ -2577,24 +2577,24 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 		mes "[Someone's Voice]";
 		mes "Wait for a while, Gion.";
 		next;
-		donpcevent "Cougar#ko2::OnEnable";
+		donpcevent "Kuuga#ko2::OnEnable";
 		donpcevent "Red Leopard Joe#ko2::OnEnable";
 		cutin "job_ko04",2;
 		mes "[Guide Gion]";
 		mes "I'm sorry I almost forgot about you two. Do you have anything to share with " + strcharinfo(0) + "?";
 		next;
 		cutin "",255;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "Hmm... Embarrassing... to speak so suddenly...";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes strcharinfo(0) + ", you are now a proud member of our family. Always hold your head high and...";
 		next;
-		mes "[Cougar]";
+		mes "[Kuuga]";
 		mes "^777777(Gai's voice fades out.)^000000.";
 		mes "I'm sorry I strangled you when we first met.";
 		next;
-		donpcevent "Cougar#ko2::OnDisable";
+		donpcevent "Kuuga#ko2::OnDisable";
 		mes "[Red Leopard Joe]";
 		mes "Puhahaha! Gai is all talk. I know I was know valuable to you than that Gai.";
 		next;
@@ -2656,16 +2656,16 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 	}
 }
 
-job_ko,151,47,4	script	Cougar#ko2	730,{
-	mes "[Cougar]";
+job_ko,151,47,4	script	Kuuga#ko2	730,{
+	mes "[Kuuga]";
 	mes "Congratulation for choosing the road of development!";
 	close;
 OnInit:
 OnDisable:
-	disablenpc "Cougar#ko2";
+	disablenpc "Kuuga#ko2";
 	end;
 OnEnable:
-	enablenpc "Cougar#ko2";
+	enablenpc "Kuuga#ko2";
 	end;
 }
 

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -99,7 +99,7 @@ que_ng,21,76,0	script	Wall with a Drawing#ko	844,{
 
 job_ko,25,115,4	script	Old Man#ko	588,{
 	if (MaxWeight - Weight < 1000 || checkweight(1201,1) == 0) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "You don't need to carry so many things."; //custom translation
 		close;
 	}
@@ -107,7 +107,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "You are not in the Family of the Ninja.";
 		close2;
 		warp "amatsu",147,136;
@@ -755,12 +755,12 @@ L_StartTest:
 
 // Test of Knowledge
 //============================================================
-job_ko,81,124,4	script	Kuuga#ko	730,{
+job_ko,81,124,4	script	Kuuga Gai#ko	730,{
 	if (BaseJob != Job_Ninja) {
 		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "Sorry, your family is not same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
@@ -770,61 +770,61 @@ job_ko,81,124,4	script	Kuuga#ko	730,{
 		goto L_Kick;
 	}
 	if (MaxWeight - Weight < 1000 || checkweight(1201,1) == 0) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "This is a test of knowledge, so why did you bring so many things?"; //custom translation
 		close;
 	}
 	set .@ko_test_01, isbegin_quest(5136);
 	set .@ko_test_01_1, isbegin_quest(5139);
 	if (.@ko_test_01 == 1 && .@ko_test_01_1 == 0) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "It's been a while.";
 		next;
 		select("Aren't you...");
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "I remember you from before looking for the way of the ninja.";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "You've grown this strong already?";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "Ha ha ha-";
 		mes "A truly determined youth! I like that.";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "Good! The test you are about to take is the ^339CCCTest of Knowledge^000000.";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "I hope you haven't been lazy with your studies while focusing on getting stronger?";
 		next;
 		switch(select("Yes:No")) {
 		case 1:
 			setquest 5139;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "That's a relief. Let me know when you are ready to start the test.";
 			close;
 		case 2:
 			setquest 5139;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "So you were all talk? Well, let me know when you are ready then.";
 			close;
 		}
 	} else if (.@ko_test_01 == 1 && .@ko_test_01_1 == 1) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "I'm ready at my end. Are you ready for the test?";
 		next;
 		if(select("Yes:No") == 2) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Well, what can I do but wait for you.";
 			close;
 		}
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "This isn't your first test, is it?";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "You only need to choose the correct answer to my questions.";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "Let's start.";
 		next;
 
@@ -846,7 +846,7 @@ job_ko,81,124,4	script	Kuuga#ko	730,{
 
 		set @job_ko_Kuuga,0;
 		for (set .@i,1; .@i<=.@questions; set .@i,.@i+1) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes (.@i < .@questions)?"Question number "+.@i+":":"Last question:";
 			switch (.@n[.@i-1]) {
 				case 1: callsub L_Question,"What is the DEX + LUK total for a Job Master?",2,"8:10:12:14"; break;
@@ -900,48 +900,48 @@ job_ko,81,124,4	script	Kuuga#ko	730,{
 				case 49: callsub L_Question,"Which of the following blacksmiths do not create ninja items?",2,"Khaibara:Aiku:Tetsu:Toshu"; break;
 				case 50: callsub L_Question,"What is the name of the suspicious man you can meet during the Ninja job change quest?",3,"Red Leopard Jack:Black Leopard Jack:Red Leopard Joe:Black Leopard Joe"; break;
 				default:
-					mes "[Kuuga]";
+					mes "[Kuuga Gai]";
 					mes "An unknown error has occurred.";
 					mes "Please contact customer service.";
 					close;
 			}
 		}
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "You're through all 10 questions. Wasn't so bad! The important part starts now.";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "... ... ...";
 		next;
 		if (@job_ko_Kuuga < 90) {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "You fool!!";
 			mes "You couldn't even solve these?";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Can't believe someone who is taking a new path can be so pathetic.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "I'll give you another chance.";
 			mes "You will take the test again with new questions. Better pass it this time.";
 		} else {
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Hmm. " + (@job_ko_Kuuga) + "?";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Well, looks like you weren't lazy with your studies.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "What? Proud of yourself for solving these questions?";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "You still have a long way to go and this is only a small fraction of it.";
 			next;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "Well... I'm curious how far your strong will can take you through other tests.";
 			next;
 			completequest 5136;
 			erasequest 5139;
-			mes "[Kuuga]";
+			mes "[Kuuga Gai]";
 			mes "I'll let you go now so go report back to Guide Gion with your results.";
 			close2;
 			warp "job_ko",16,113;
@@ -950,17 +950,17 @@ job_ko,81,124,4	script	Kuuga#ko	730,{
 		set @job_ko_Kuuga,0;
 		close;
 	} else if (.@ko_test_01 == 2 && .@ko_test_01_1 == 0) {
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "I'll let you go now so go report back to Guide Gion with your results.";
 		close2;
 		warp "job_ko",16,113;
 		end;
 	} else {  //custom translation
 	L_Kick:
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "How did you get here?";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "It's my duty to get rid of you.";
 		mes "^000099(He's a short, silent man.)^000000";
 		mes "This will push you back!";
@@ -1961,7 +1961,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		next;
 		select("Long time indeed, Joe.");
 		mes "[Red Leopard Joe]";
-		mes "You aren't surprised I'm here. Did you meet ^0237FDKuuga^000000 before coming here?";
+		mes "You aren't surprised I'm here. Did you meet ^0237FDKuuga Gai^000000 before coming here?";
 		next;
 		mes "[Red Leopard Joe]";
 		mes "Don't like it that I'm not the first one you visited but that is not important.";
@@ -2577,24 +2577,24 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 		mes "[Someone's Voice]";
 		mes "Wait for a while, Gion.";
 		next;
-		donpcevent "Kuuga#ko2::OnEnable";
+		donpcevent "Kuuga Gai#ko2::OnEnable";
 		donpcevent "Red Leopard Joe#ko2::OnEnable";
 		cutin "job_ko04",2;
 		mes "[Guide Gion]";
 		mes "I'm sorry I almost forgot about you two. Do you have anything to share with " + strcharinfo(0) + "?";
 		next;
 		cutin "",255;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "Hmm... Embarrassing... to speak so suddenly...";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes strcharinfo(0) + ", you are now a proud member of our family. Always hold your head high and...";
 		next;
-		mes "[Kuuga]";
+		mes "[Kuuga Gai]";
 		mes "^777777(Gai's voice fades out.)^000000.";
 		mes "I'm sorry I strangled you when we first met.";
 		next;
-		donpcevent "Kuuga#ko2::OnDisable";
+		donpcevent "Kuuga Gai#ko2::OnDisable";
 		mes "[Red Leopard Joe]";
 		mes "Puhahaha! Gai is all talk. I know I was know valuable to you than that Gai.";
 		next;
@@ -2656,16 +2656,16 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 	}
 }
 
-job_ko,151,47,4	script	Kuuga#ko2	730,{
-	mes "[Kuuga]";
+job_ko,151,47,4	script	Kuuga Gai#ko2	730,{
+	mes "[Kuuga Gai]";
 	mes "Congratulation for choosing the road of development!";
 	close;
 OnInit:
 OnDisable:
-	disablenpc "Kuuga#ko2";
+	disablenpc "Kuuga Gai#ko2";
 	end;
 OnEnable:
-	enablenpc "Kuuga#ko2";
+	enablenpc "Kuuga Gai#ko2";
 	end;
 }
 

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -108,7 +108,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Kuuga Gai]";
-		mes "You are not in the Family of the Ninja.";
+		mes "You are not in the Clan of the Ninja.";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -135,28 +135,28 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "^1A95E6He keeps talking and doesn't stop to answer your question.^1A95E6";
 		next;
 		mes "[Old Man]";
-		mes "There once was a quiet family living in ancient Amatsu times that is never mentioned in history books or stories.";
+		mes "There once was a quiet Clan living in ancient Amatsu times that is never mentioned in history books or stories.";
 		next;
 		mes "[Old Man]";
 		mes "They lived beneath shadows but always yearned for the bright sun, like a sunflower.";
 		next;
 		mes "[Old Man]";
-		mes "A family that was loyal to their lord who they served as their bright sun.";
+		mes "A Clan that was loyal to their lord who they served as their bright sun.";
 		next;
 		mes "[Old Man]";
-		mes "...a very trustworthy family...";
+		mes "...a very trustworthy Clan...";
 		next;
 		mes "[Old Man]";
 		mes "....loyal to their core...";
 		next;
 		mes "[Old Man]";
-		mes "...a family of integrity...";
+		mes "...a Clan of integrity...";
 		next;
 		select("What happened to them?");
 		mes "^1A95E6The old man looks at you with a melancholy face.^1A95E6";
 		next;
 		mes "[Old Man]";
-		mes "Why are you interested in a family that was abandoned by their lord and disappeared from history itself?";
+		mes "Why are you interested in a Clan that was abandoned by their lord and disappeared from history itself?";
 		next;
 		if(select("I'm a Ninja.:I'm bored.") == 2) {
 			mes "[Old Man]";
@@ -167,13 +167,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		}
 		cutin "job_ko02",2;
 		mes "[Old Man]";
-		mes "Ninja! There was a time when the family was called ninjas, too.";
+		mes "Ninja! There was a time when the Clan was called ninjas, too.";
 		next;
 		erasequest 5131;
 		setquest 5132;
 		set job_kagero,2;
 		mes "[Old Man]";
-		mes "You'll have to lend me your ear for I have so much to tell you about the family story.";
+		mes "You'll have to lend me your ear for I have so much to tell you about the Clan story.";
 		close2;
 		cutin "",255;
 		end;
@@ -185,13 +185,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "This goes way back to ancient times and nobody in Amatsu remembers about it.";
 		next;
 		mes "[Old Man]";
-		mes "The family worked behind the scenes and basically lived their lives for their lord.";
+		mes "The Clan worked behind the scenes and basically lived their lives for their lord.";
 		next;
 		mes "[Old Man]";
 		mes "They were very loyal doing whatever deed their lord asked for.";
 		next;
 		mes "[Old Man]";
-		mes "Ninja, the family was known as the dark family but that doesn't mean they wanted to be hidden in the darkness.";
+		mes "Ninja, the Clan was known as the dark Clan but that doesn't mean they wanted to be hidden in the darkness.";
 		next;
 		mes "[Old Man]";
 		mes "They were loyal enough to be satisfied as the lord's servants but their loyalty became the problem.";
@@ -201,13 +201,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "They are a secret organization that even the lord didn't know much about.";
 		next;
 		mes "[Old Man]";
-		mes "The few that knew about the family's existence, tried to investigate them but nobody was able to reveal their true identity.";
+		mes "The few that knew about the Clan's existence, tried to investigate them but nobody was able to reveal their true identity.";
 		next;
 		mes "[Old Man]";
-		mes "That is why this family has grown from loyal servants to a group feared for its secrets.";
+		mes "That is why this Clan has grown from loyal servants to a group feared for its secrets.";
 		next;
 		mes "[Old Man]";
-		mes "The lord shunned the family and didn't call them for their service any more but they never betrayed him.";
+		mes "The lord shunned the Clan and didn't call them for their service any more but they never betrayed him.";
 		next;
 		select("They were really loyal people.");
 		cutin "job_ko03",2;
@@ -224,12 +224,12 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 	} else if (job_kagero == 3) {
 		cutin "job_ko03",2;
 		mes "[Old Man]";
-		mes "The family has been living in hiding for so long since the old days. The current lord didn't even know of their existence.";
+		mes "The Clan has been living in hiding for so long since the old days. The current lord didn't even know of their existence.";
 		next;
 		select(".........");
 		cutin "job_ko01",2;
 		mes "[Old Man]";
-		mes "I'm Leader Gion, the last of the dark ninja family.";
+		mes "I'm Leader Gion, the last of the dark ninja Clan.";
 		next;
 		if(select("I think your time has ended.:I need your teaching.") == 1) {
 			cutin "job_ko04",2;
@@ -237,7 +237,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Are you an assassin to end this old man's life?";
 			next;
 			mes "[Leader Gion]";
-			mes "So that is why you've shown interest in my family. I won't give up easily.";
+			mes "So that is why you've shown interest in my Clan. I won't give up easily.";
 			next;
 			percentheal -99,0;
 			mes "Pow!!";
@@ -334,7 +334,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				break;
 			case 3:
 				mes "[Leader Gion]";
-				mes "My family was famous for using unique weapons that we created.";
+				mes "My Clan was famous for using unique weapons that we created.";
 				next;
 				mes "[Leader Gion]";
 				mes "You would be considered blessed if you created your own unique weapon.";
@@ -400,11 +400,11 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Since I felt happy like this. I feel young and energetic seeing young people like you challenge themselves with a new path.";
 			next;
 			mes "[Leader Gion]";
-			mes "We're done with explaining about the tests, now should I tell you my family story?";
+			mes "We're done with explaining about the tests, now should I tell you my Clan story?";
 			next;
 			cutin "job_ko01",2;
 			mes "[Leader Gion]";
-			mes "My family started from two warriors.";
+			mes "My Clan started from two warriors.";
 			next;
 			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
@@ -420,7 +420,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "There was a time there was an enmity between both warriors.";
 			next;
 			mes "[Leader Gion]";
-			mes "But it didn't take long for them to become one as a family.";
+			mes "But it didn't take long for them to become one as a Clan.";
 			next;
 			select("How did it go afterwards?");
 			cutin "job_ko02",2;
@@ -457,7 +457,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				mes "I wonder if Joe is satisfied with your performance.";
 				next;
 			}
-			select("Please continue with the family story.");
+			select("Please continue with the Clan story.");
 			cutin "job_ko02",2;
 			mes "[Leader Gion]";
 			mes "Looks like you are pretty eager to hear more. Where did I leave off... Ah! I remember.";
@@ -541,7 +541,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Maybe current generations like me are the ancestors of the current Amatsu lord? But this is only an assumption.";
 			next;
 			mes "[Leader Gion]";
-			mes "I'm almost at the end of my family story. Come back after you've passed the third test and I will tell you the rest.";
+			mes "I'm almost at the end of my Clan story. Come back after you've passed the third test and I will tell you the rest.";
 			next;
 			callsub L_StartTest,.@last_test,3;
 			end;
@@ -584,7 +584,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Yes, he was. And his efforts didn't go in vain since the two warriors eventually got acquainted and married.";
 			next;
 			mes "[Leader Gion]";
-			mes "This is how the family started.";
+			mes "This is how the Clan started.";
 			next;
 			select("What happened after?");
 			mes "[Leader Gion]";
@@ -654,7 +654,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "Now! No more small talk. I'll let you know what the target is for the Test of Battle.";
 		next;
 		mes "[Leader Gion]";
-		mes "The target is a monster called the ^FF0000Family Secret^000000.";
+		mes "The target is a monster called the ^FF0000Clan Secret^000000.";
 		next;
 		mes "[Leader Gion]";
 		mes "You will have to be careful because there are many similiar shaped and named monsters in test site.";
@@ -761,7 +761,7 @@ job_ko,81,124,4	script	Kuuga Gai#ko	730,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Kuuga Gai]";
-		mes "Sorry, your family is not same as ours, is there something wrong?";
+		mes "Sorry, your Clan is not same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -1936,7 +1936,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Red Leopard Joe]";
-		mes "Sorry, your family is not the same as ours, is there something wrong?";
+		mes "Sorry, your Clan is not the same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -1968,10 +1968,10 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		next;
 		mes "[Red Leopard Joe]";
 		mes "Alright, " + strcharinfo(0) + "!";
-		mes "Welcome to the workshop where weapons are created for the family.";
+		mes "Welcome to the workshop where weapons are created for the Clan.";
 		next;
 		mes "[Red Leopard Joe]";
-		mes "Our family has been creating and using unique weapons to serve our secret missions since ancient times.";
+		mes "Our Clan has been creating and using unique weapons to serve our secret missions since ancient times.";
 		next;
 		select("Really? At Einbroch?");
 		mes "[Red Leopard Joe]";
@@ -1981,7 +1981,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		mes "Yes. Einbroch is known as an industrial city, the city of great blacksmiths create new technology.";
 		next;
 		mes "[Red Leopard Joe]";
-		mes "My mission is to analyze their technology and report back to the family.";
+		mes "My mission is to analyze their technology and report back to the Clan.";
 		next;
 		mes "[Red Leopard Joe]";
 		mes "I spoke more than I intended to.";
@@ -2525,7 +2525,7 @@ job_ko,148,46,4	script	Leader Gion#ko2	588,{
 		mes "Looks like you haven't taken care of the target yet.";
 		next;
 		mes "[Leader Gion]";
-		mes "I'll tell you once more. The target is the ^FF0000Family Secret^000000.";
+		mes "I'll tell you once more. The target is the ^FF0000Clan Secret^000000.";
 		next;
 		mes "[Leader Gion]";
 		mes "Of course the path will be difficult, so continue searching!"; //custom translation
@@ -2588,7 +2588,7 @@ job_ko,148,46,4	script	Leader Gion#ko2	588,{
 		mes "Hmm... Embarrassing... to speak so suddenly...";
 		next;
 		mes "[Kuuga Gai]";
-		mes strcharinfo(0) + ", you are now a proud member of our family. Always hold your head high and...";
+		mes strcharinfo(0) + ", you are now a proud member of our Clan. Always hold your head high and...";
 		next;
 		mes "[Kuuga Gai]";
 		mes "^777777(Gai's voice fades out.)^000000.";
@@ -2699,7 +2699,7 @@ OnEnable:
 		case 6: set .@mob,1049; break;
 		case 7: set .@mob,1050; break;
 	}
-	areamonster "job_ko",120,30,160,70,"Family Secret",.@mob,1,"Summon Target#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan Secret",.@mob,1,"Summon Target#ko::OnMyMobDead";
 	end;
 OnDisable:
 	initnpctimer;
@@ -2721,25 +2721,25 @@ OnInit:
 	donpcevent "Summon Fake#ko::OnEnable";
 	end;
 OnEnable:
-	areamonster "job_ko",120,30,160,70,"Family's Legacy",1002,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Legacy",1002,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Memory",1002,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Memory",1002,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Mistake",1031,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Mistake",1031,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Mistake",1031,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Mistake",1031,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Memory",1113,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Memory",1113,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Past",1113,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Past",1113,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Legacy",1063,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Legacy",1063,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Legacy",1063,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Legacy",1063,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Mistake",1010,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Mistake",1010,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Memory",1010,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Memory",1010,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Past",1049,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Past",1049,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Mistake",1049,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Mistake",1049,5,"Summon Fake#ko::OnMyMobDead";
-	areamonster "job_ko",120,30,160,70,"Family's Memory",1050,5,"Summon Fake#ko::OnMyMobDead";
+	areamonster "job_ko",120,30,160,70,"Clan's Memory",1050,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Oboro's Past",1050,5,"Summon Fake#ko::OnMyMobDead";
 	areamonster "job_ko",120,30,160,70,"Kagerou's Past",1050,5,"Summon Fake#ko::OnMyMobDead";
 	end;

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -229,14 +229,14 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		select(".........");
 		cutin "job_ko01",2;
 		mes "[Old Man]";
-		mes "I'm Guide Gion, the last of the dark ninja family.";
+		mes "I'm Leader Gion, the last of the dark ninja family.";
 		next;
 		if(select("I think your time has ended.:I need your teaching.") == 1) {
 			cutin "job_ko04",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Are you an assassin to end this old man's life?";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "So that is why you've shown interest in my family. I won't give up easily.";
 			next;
 			percentheal -99,0;
@@ -247,50 +247,50 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			end;
 		}
 		cutin "job_ko02",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Teaching...";
 		mes "Been a long time since I last heard that word.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I guess this little visit was not by coincidence but a start of a connection.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Sorry I am not a teacher. But!";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I can help you on the path you've chosen, the ^33CC71"+((Sex == SEX_MALE)?"Kagerou":"Oboro")+"^000000 path.";
 		next;
-		mes "^1A95E6You hear Guide Gion's voice faintly as you slip away.^1A95E6";
+		mes "^1A95E6You hear Leader Gion's voice faintly as you slip away.^1A95E6";
 		next;
 		erasequest 5133;
 		setquest 5134;
 		set job_kagero,4;
-		mes "[Guide Gion]";
-		mes "If you are prepared to follow me, Guide Gion, on the "+((Sex == SEX_MALE)?"Kagerou":"Oboro")+" path, we will meet again.";
+		mes "[Leader Gion]";
+		mes "If you are prepared to follow me, Leader Gion, on the "+((Sex == SEX_MALE)?"Kagerou":"Oboro")+" path, we will meet again.";
 		close2;
 		warp "amatsu",147,136;
 		end;
 	} else if (job_kagero == 4) {
 		cutin "job_ko02",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I thought you were afraid of the ^33CC71path of the "+((Sex == SEX_MALE)?"Kagerou":"Oboro")+"^33CC71 and wouldn't come back.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "But from the look of your eyes, I guess I misjudged you.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You will have to train your mind and body to walk steadily in the unknown world and never fall into temptation to stay on the path.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Our ancestors had 4 tests to train our people.";
 		next;
 		select("4 tests?");
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Yes, there are 4 tests.";
 		mes "My ancestors trained my people with 4 tests that involve ^087FF8knowledge^000000, ^087FF8survival^000000, ^087FF8weapons^000000, and ^087FF8battle^000000.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I know you are curious what these tests are. Let me explain one by one.";
 		next;
 		while(1) {
@@ -298,75 +298,75 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			set .@test, .@test | (1<<(.@i-1));
 			switch (.@i) {
 			case 1:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "We need to be knowledgeable in order to assist the lord. This test is for this purpose.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "You can pass the test if you successfully solve more than 9 out of 10 questions.";
 				next;
 				if (.@test != 15) {
-					mes "[Guide Gion]";
+					mes "[Leader Gion]";
 					mes "The test will be easy to pass if you've been steady in your studies. Now what other test are you curious about?";
 					next;
 				}
 				break;
 			case 2:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Missions aren't always easy and safe. That is why survival instincts are vital to us.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "My ancestors call this test the dice test. It is a test to advance forward depending on the dice results.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Think of it as the simple dice games people play.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "But never let your guard down during the test because it isn't called the survival test for nothing.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "There will be blocks that help you while there are blocks that will interrupt you.";
 				next;
 				if (.@test != 15) {
-					mes "[Guide Gion]";
+					mes "[Leader Gion]";
 					mes "If you deal with various situations wisely, you will be able to pass the test. Now what other test are you curious about?";
 					next;
 				}
 				break;
 			case 3:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "My family was famous for using unique weapons that we created.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "You would be considered blessed if you created your own unique weapon.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Creating a weapon for yourself and refining it is the purpose of this test.";
 				next;
 				if (.@test != 15) {
-					mes "[Guide Gion]";
+					mes "[Leader Gion]";
 					mes "I hope you will be blessed and find the best weapon for yourself. Now what other test are you curious about?";
 					next;
 				}
 				break;
 			case 4:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Missions are not always done alone. You will often work in teams of 2 or 3 for a common goal.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "The battle test is only for those that pass that knowledge, survival and weapon tests. So! It is the very last test.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Unlike the other three tests that are done alone, you will have to compete with others in this final test.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "There is only one target!!";
 				mes "And only the first to get to the target passes the test.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "You'll be lucky if you have no competitors during your test.";
 				next;
 				if (.@test != 15) {
-					mes "[Guide Gion]";
+					mes "[Leader Gion]";
 					mes "A challenge is better than explaining it a hundred times. It's the actual experience that makes you better.";
 					next;
 				}
@@ -375,13 +375,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			if (.@test == 15) break;
 		}
 		cutin "job_ko02",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Seeing is believing, so go on and take the challenge."; //custom translation
 		next;
 		erasequest 5134;
 		setquest 5135;
 		set job_kagero,5;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Let's start right away after you are done with preparations.";
 		close2;
 		cutin "",255;
@@ -393,110 +393,110 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		set .@ko_test, .@ko_test_01 + .@ko_test_02 + .@ko_test_03;
 		if (.@ko_test == 0) {
 			cutin "job_ko03",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "It's been a while.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Since I felt happy like this. I feel young and energetic seeing young people like you challenge themselves with a new path.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "We're done with explaining about the tests, now should I tell you my family story?";
 			next;
 			cutin "job_ko01",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "My family started from two warriors.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Oboro, a warrior like the misty moonlight.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The Sun and the Moon.";
 			mes "The sunlight that lights up the world and the moonlight that lights up the night. Both were very similar but different warriors.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "There was a time there was an enmity between both warriors.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "But it didn't take long for them to become one as a family.";
 			next;
 			select("How did it go afterwards?");
 			cutin "job_ko02",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Ha ha ha. It is never fun to listen to the whole story all at once, no? Come back after passing a test and I'll continue my story.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Which test will you select as your first test?";
 			next;
 			callsub L_StartTest,select("Test of Knowledge:Test of Survival:Test of Weaponry"),1;
 			end;
 		} else if (.@ko_test == 2) {
 			cutin "job_ko01",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			if (.@ko_test_01 == 2) {
 				set .@menu$,":Test of Survival:Test of Weaponry";
 				mes "You've passed the Test of Knowledge.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "My friend doesn't approve of others that easily but I guess he liked you.";
 				next;
 			} else if (.@ko_test_02 == 2) {
 				set .@menu$,"Test of Knowledge::Test of Weaponry";
 				mes "You've passed the Test of Survival.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "Looks like you went through hell with this test.";
 				next;
 			} else if (.@ko_test_03 == 2) {
 				set .@menu$,"Test of Knowledge:Test of Survival:";
 				mes "You've passed the Test of Weaponry.";
 				next;
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "I wonder if Joe is satisfied with your performance.";
 				next;
 			}
 			select("Please continue with the family story.");
 			cutin "job_ko02",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Looks like you are pretty eager to hear more. Where did I leave off... Ah! I remember.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Oboro, a warrior like the misty moonlight.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Both warriors weren't close at first, because personality and everything else was completely opposite of each other.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The first place they met was the battlefield. And you know how enemies greet each other on a battlefield.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "They ended up injuring each other badly.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "But what can you do? War is a war.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The friend you've laughed with yesterday is a foe that you have to fight with in a war today.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "So nobody can get along with anyone during a war.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "I'll continue the story after you pass another test.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Which test will you choose for the second test?";
 			next;
 			callsub L_StartTest,select(.@menu$),2;
 			end;
 		} else if (.@ko_test == 4) {
 			cutin "job_ko04",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			if (.@ko_test_01 == 2 && .@ko_test_02 == 2) {
 				set .@last_test,3;
 				mes "You've passed the ^339CCCTests of Knowledge and Survival^000000!";
@@ -508,96 +508,96 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				mes "You've passed the ^339CCCTests of Survival and Weaponry^000000!";
 			}
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "You are already done with two tests. Hope you've learned a lot from them.";
 			next;
 			cutin "job_ko01",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Shall we continue with the story?";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Oboro, a warrior like the misty moonlight.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "I think I left off when the two warriors met at the battlefield as enemies.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The long war ended eventually but the wounds and pain of those that survived had just started.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "So these two warriors started to embrace and heal the war wounds together and became one.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "There is a backstory of a man appearing in front of them and winning the loyalty from both warriors.";
 			next;
 			select("Who is this man?");
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "There isn't much known about this man. Only a short mentioning of the two warriors pledging their allegiance.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Maybe current generations like me are the ancestors of the current Amatsu lord? But this is only an assumption.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "I'm almost at the end of my family story. Come back after you've passed the third test and I will tell you the rest.";
 			next;
 			callsub L_StartTest,.@last_test,3;
 			end;
 		} else if (.@ko_test == 6) {
 			cutin "job_ko01",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "You've gone through three tests leaving only one to pass.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "As I've told you before, the last test is different because you have to compete against others.";
 			next;
 			select("Will you continue the story?");
 			cutin "job_ko02",2;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Ha ha ha. I will finish the story.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Oboro, a warrior like the misty moonlight.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "It is told that the man that earned the loyalty of the two warriors was a humorous person.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "He like the jokes and conversations better than quarrels and he liked women over men.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Hmm... I don't know why this part of the story was kept alive all these years but this man wanted to bring these two warriors together.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Both warriors did travel together after the war but kept an awkward distance from each other.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "They must have had their reasons but their lord would send them out to a difficult mission together, put them in a secret room together and all sorts of situations together.";
 			next;
 			select("Sounds like an odd person.");
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Yes, he was. And his efforts didn't go in vain since the two warriors eventually got acquainted and married.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "This is how the family started.";
 			next;
 			select("What happened after?");
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Sadly, the next part of story was purposely discontinued.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "I think it's because someone wanted us to let go of the past and move forward.";
 			next;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "That's that. Now shouldn't you be preparing for the last test?";
 			next;
 			set job_kagero,6;
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "But you must be tired from all the tests so far. Take a rest.";
 			close2;
 			cutin "",255;
@@ -610,12 +610,12 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				set .@test_ko$, "Survival";
 			else if (.@ko_test_03 == 1)
 				set .@test_ko$, "Weaponry";
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Weren't you taking the Test of " + .@test_ko$ + " just now?"; //custom translation
 			next;
 			switch(select("I want to go back to test site.:Ah... no.")) {
 			case 1:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "The Test of " + .@test_ko$ + " site is over here."; //custom translation(?)
 				close2;
 				if (.@ko_test_01 == 1)
@@ -626,7 +626,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 					warp "job_ko",121,129;
 				end;
 			case 2:
-				mes "[Guide Gion]";
+				mes "[Leader Gion]";
 				mes "The village is over here.";
 				close2;
 				warp "amatsu",147,136;
@@ -635,39 +635,39 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		}
 	} else if (job_kagero == 6) {
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You've come back already? You could have rested more. Is there a reason to hurry?";
 		next;
 		input .@inputstr$;
 		cutin "job_ko03",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Because of ^B24E59" + .@inputstr$ + "^000000?";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I have to admit, I don't understand you now.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "But since you've gone through much, I'm sure you will do good with the final test.";
 		next;
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Now! No more small talk. I'll let you know what the target is for the Test of Battle.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "The target is a monster called the ^FF0000Family Secret^000000.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You will have to be careful because there are many similiar shaped and named monsters in test site.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "And if you are lucky, there will be others targeting the monster.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "May the blessings of '" + ((Sex == SEX_MALE)?"Kagerou, dancing sun":"Oboro, misty moonlight") + "' be with you.";
 		next;
 		setquest 5146;
 		set job_kagero,7;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Then let's go to the battle test field.";
 		close2;
 		switch(rand(3)) {
@@ -678,12 +678,12 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		end;
 	} else if (job_kagero == 7 || job_kagero == 8) {
 		cutin "job_ko03",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I see you are in the middle of the ^339CCCTest of Battle^000000. Will you go back to the test site?";
 		next;
 		switch(select("Go back to the test site.:Visit the village.")) {
 		case 1:
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The test site is over here."; //custom translation(?)
 			close2;
 			switch(rand(3)) {
@@ -693,7 +693,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			}
 			end;
 		case 2:
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "The village is over here.";
 			close2;
 			cutin "",255;
@@ -701,7 +701,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		}
 	} else {
 		cutin "job_ko03",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You should not be here. Leave!";
 		close2;
 		warp "amatsu",147,136;
@@ -716,14 +716,14 @@ L_StartTest:
 		case 2: set .@str$,"You are taking the ^339CCCTest of %s^000000 as the second test? "; break; //custom translation
 		case 3: set .@str$,"Your third test is the ^339CCCTest of %s^000000! "; break;
 	}
-	mes "[Guide Gion]";
+	mes "[Leader Gion]";
 	switch (getarg(0)) {
 	case 1:
 		mes sprintf(.@str$ + "Then I will get to see a familiar face after so long...","Knowledge");
 		next;
 		select("Familiar face?");
 		setquest 5136;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Ha ha ha. You'll know when we get there. The Test of Knowledge is taken over here.";
 		close2;
 		warp "job_ko",72,128;
@@ -732,7 +732,7 @@ L_StartTest:
 		mes sprintf(.@str$ + "It's a lonesome test that you have to face alone.","Survival");
 		next;
 		setquest 5137;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "But I believe you can handle it. The Test of Survival is taken over here.";
 		close2;
 		warp "job_ko",62,16;
@@ -745,7 +745,7 @@ L_StartTest:
 		getitem 1010,1; //Phracon
 		mes "You receive 5 Iron Ore and 1 Phracon.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You will find these useful. The Test of Weaponry is taken over here.";
 		close2;
 		warp "job_ko",121,129;
@@ -942,7 +942,7 @@ job_ko,81,124,4	script	Kuuga Gai#ko	730,{
 			completequest 5136;
 			erasequest 5139;
 			mes "[Kuuga Gai]";
-			mes "I'll let you go now so go report back to Guide Gion with your results.";
+			mes "I'll let you go now so go report back to Leader Gion with your results.";
 			close2;
 			warp "job_ko",16,113;
 			end;
@@ -951,7 +951,7 @@ job_ko,81,124,4	script	Kuuga Gai#ko	730,{
 		close;
 	} else if (.@ko_test_01 == 2 && .@ko_test_01_1 == 0) {
 		mes "[Kuuga Gai]";
-		mes "I'll let you go now so go report back to Guide Gion with your results.";
+		mes "I'll let you go now so go report back to Leader Gion with your results.";
 		close2;
 		warp "job_ko",16,113;
 		end;
@@ -2513,48 +2513,48 @@ job_ko,127,121,0	duplicate(Refinement Tools#ko_01)	Refinement Tools#ko_02	844
 
 // Test of Battle
 //============================================================
-job_ko,148,46,4	script	Guide Gion#ko2	588,{
+job_ko,148,46,4	script	Leader Gion#ko2	588,{
 	if (MaxWeight - Weight < 2000 || checkweight(1201,1) == 0) {
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You don't need so many things now!"; //custom translation
 		close;
 	}
 	if (job_kagero == 7) {
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Looks like you haven't taken care of the target yet.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I'll tell you once more. The target is the ^FF0000Family Secret^000000.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Of course the path will be difficult, so continue searching!"; //custom translation
 		close2;
 		cutin "",255;
 		end;
 	} else if (job_kagero == 8) {
 		cutin "job_ko02",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "Looks like you've taken care of the target. Hmm.";
 		next;
 
 		//custom translations
 		if (ismounting()) {
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "But please get down from your frog. Otherwise I can't continue!";
 			close2;
 			cutin "",255;
 			end;
 		}
 		if (BaseLevel < 99 || JobLevel < 70) {
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "How did you get weaker? Come back once you've regained your previous levels.";
 			close2;
 			cutin "",255;
 			end;
 		}
 		if (SkillPoint != 0) {
-			mes "[Guide Gion]";
+			mes "[Leader Gion]";
 			mes "Please come back after using all your Skill Points.";
 			close2;
 			cutin "",255;
@@ -2563,15 +2563,15 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 
 		mapannounce "job_ko","[Gion] Interrupting the Test of Battle.",bc_map;
 		cutin "job_ko04",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "The Test of Battle will be put off for a while. Don't worry because this does not have affect to other tests.";
 		next;
 		mapannounce "job_ko","[Gion] My Friend " + strcharinfo(0) + " made it to " + ((Sex == SEX_MALE)?"Kagerou":"Oboro") + " Path. Congratulations!!",bc_map;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "My friend " + strcharinfo(0) + " made it to " + ((Sex == SEX_MALE)?"Kagerou":"Oboro") + " Path. Congratulations!!";
 		next;
 		cutin "job_ko02",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "It is pleasant to meet a youth that is walking through a new path.";
 		next;
 		mes "[Someone's Voice]";
@@ -2580,7 +2580,7 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 		donpcevent "Kuuga Gai#ko2::OnEnable";
 		donpcevent "Red Leopard Joe#ko2::OnEnable";
 		cutin "job_ko04",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I'm sorry I almost forgot about you two. Do you have anything to share with " + strcharinfo(0) + "?";
 		next;
 		cutin "",255;
@@ -2615,17 +2615,17 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 		mes "I named your weapons on my own but I know you'll like the name.";
 		next;
 		mes "[Red Leopard Joe]";
-		mes "Guide Gion, please continue.";
+		mes "Leader Gion, please continue.";
 		next;
 		cutin "job_ko01",2;
 		donpcevent "Red Leopard Joe#ko2::OnDisable";
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I don't have much to add because Gai and Joe said it all.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I'm just sorry that the environment of all these tests could have been better for our later generation.";
 		next;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You only need to look forward and never turn back.";
 		next;
 		for (set .@i,5131; .@i<=5146; set .@i,.@i+1)
@@ -2634,21 +2634,21 @@ job_ko,148,46,4	script	Guide Gion#ko2	588,{
 		getnameditem .@item,strcharinfo(0);
 		jobchange (Sex == SEX_MALE)?Job_Kagerou:Job_Oboro;
 		donpcevent "Summon Target#ko::OnEnable";
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I hope the blessings of Kagerou, dancing sun and Oboro, misty moonlight will be with you on your journey ahead.";
 		close2;
 		warp "que_ng",21,71;
 		end;
 	} else if (job_kagero == 9) {
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "I hope the blessings of Kagerou, dancing sun and Oboro, misty moonlight will be with you on your journey ahead.";
 		close2;
 		warp "que_ng",21,71;
 		end;
 	} else {
 		cutin "job_ko01",2;
-		mes "[Guide Gion]";
+		mes "[Leader Gion]";
 		mes "You should not be here. Please leave!"; //custom translation
 		close2;
 		warp "amatsu",147,136;

--- a/npc/re/jobs/2e/kagerou_oboro.txt
+++ b/npc/re/jobs/2e/kagerou_oboro.txt
@@ -108,7 +108,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Kuuga Gai]";
-		mes "You are not in the Clan of the Ninja.";
+		mes "You are not in the clan of the Ninja.";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -135,28 +135,28 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "^1A95E6He keeps talking and doesn't stop to answer your question.^1A95E6";
 		next;
 		mes "[Old Man]";
-		mes "There once was a quiet Clan living in ancient Amatsu times that is never mentioned in history books or stories.";
+		mes "There once was a quiet clan living in ancient Amatsu times that is never mentioned in history books or stories.";
 		next;
 		mes "[Old Man]";
 		mes "They lived beneath shadows but always yearned for the bright sun, like a sunflower.";
 		next;
 		mes "[Old Man]";
-		mes "A Clan that was loyal to their lord who they served as their bright sun.";
+		mes "A clan that was loyal to their lord who they served as their bright sun.";
 		next;
 		mes "[Old Man]";
-		mes "...a very trustworthy Clan...";
+		mes "...a very trustworthy clan...";
 		next;
 		mes "[Old Man]";
 		mes "....loyal to their core...";
 		next;
 		mes "[Old Man]";
-		mes "...a Clan of integrity...";
+		mes "...a clan of integrity...";
 		next;
 		select("What happened to them?");
 		mes "^1A95E6The old man looks at you with a melancholy face.^1A95E6";
 		next;
 		mes "[Old Man]";
-		mes "Why are you interested in a Clan that was abandoned by their lord and disappeared from history itself?";
+		mes "Why are you interested in a clan that was abandoned by their lord and disappeared from history itself?";
 		next;
 		if(select("I'm a Ninja.:I'm bored.") == 2) {
 			mes "[Old Man]";
@@ -167,13 +167,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		}
 		cutin "job_ko02",2;
 		mes "[Old Man]";
-		mes "Ninja! There was a time when the Clan was called ninjas, too.";
+		mes "Ninja! There was a time when the clan was called ninjas, too.";
 		next;
 		erasequest 5131;
 		setquest 5132;
 		set job_kagero,2;
 		mes "[Old Man]";
-		mes "You'll have to lend me your ear for I have so much to tell you about the Clan story.";
+		mes "You'll have to lend me your ear for I have so much to tell you about the clan story.";
 		close2;
 		cutin "",255;
 		end;
@@ -185,13 +185,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "This goes way back to ancient times and nobody in Amatsu remembers about it.";
 		next;
 		mes "[Old Man]";
-		mes "The Clan worked behind the scenes and basically lived their lives for their lord.";
+		mes "The clan worked behind the scenes and basically lived their lives for their lord.";
 		next;
 		mes "[Old Man]";
 		mes "They were very loyal doing whatever deed their lord asked for.";
 		next;
 		mes "[Old Man]";
-		mes "Ninja, the Clan was known as the dark Clan but that doesn't mean they wanted to be hidden in the darkness.";
+		mes "Ninja, the clan was known as the dark clan but that doesn't mean they wanted to be hidden in the darkness.";
 		next;
 		mes "[Old Man]";
 		mes "They were loyal enough to be satisfied as the lord's servants but their loyalty became the problem.";
@@ -201,13 +201,13 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 		mes "They are a secret organization that even the lord didn't know much about.";
 		next;
 		mes "[Old Man]";
-		mes "The few that knew about the Clan's existence, tried to investigate them but nobody was able to reveal their true identity.";
+		mes "The few that knew about the clan's existence, tried to investigate them but nobody was able to reveal their true identity.";
 		next;
 		mes "[Old Man]";
-		mes "That is why this Clan has grown from loyal servants to a group feared for its secrets.";
+		mes "That is why this clan has grown from loyal servants to a group feared for its secrets.";
 		next;
 		mes "[Old Man]";
-		mes "The lord shunned the Clan and didn't call them for their service any more but they never betrayed him.";
+		mes "The lord shunned the clan and didn't call them for their service any more but they never betrayed him.";
 		next;
 		select("They were really loyal people.");
 		cutin "job_ko03",2;
@@ -224,12 +224,12 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 	} else if (job_kagero == 3) {
 		cutin "job_ko03",2;
 		mes "[Old Man]";
-		mes "The Clan has been living in hiding for so long since the old days. The current lord didn't even know of their existence.";
+		mes "The clan has been living in hiding for so long since the old days. The current lord didn't even know of their existence.";
 		next;
 		select(".........");
 		cutin "job_ko01",2;
 		mes "[Old Man]";
-		mes "I'm Leader Gion, the last of the dark ninja Clan.";
+		mes "I'm Leader Gion, the last of the dark ninja clan.";
 		next;
 		if(select("I think your time has ended.:I need your teaching.") == 1) {
 			cutin "job_ko04",2;
@@ -237,7 +237,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Are you an assassin to end this old man's life?";
 			next;
 			mes "[Leader Gion]";
-			mes "So that is why you've shown interest in my Clan. I won't give up easily.";
+			mes "So that is why you've shown interest in my clan. I won't give up easily.";
 			next;
 			percentheal -99,0;
 			mes "Pow!!";
@@ -334,7 +334,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				break;
 			case 3:
 				mes "[Leader Gion]";
-				mes "My Clan was famous for using unique weapons that we created.";
+				mes "My clan was famous for using unique weapons that we created.";
 				next;
 				mes "[Leader Gion]";
 				mes "You would be considered blessed if you created your own unique weapon.";
@@ -400,11 +400,11 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Since I felt happy like this. I feel young and energetic seeing young people like you challenge themselves with a new path.";
 			next;
 			mes "[Leader Gion]";
-			mes "We're done with explaining about the tests, now should I tell you my Clan story?";
+			mes "We're done with explaining about the tests, now should I tell you my clan story?";
 			next;
 			cutin "job_ko01",2;
 			mes "[Leader Gion]";
-			mes "My Clan started from two warriors.";
+			mes "My clan started from two warriors.";
 			next;
 			mes "[Leader Gion]";
 			mes "Kagerou, a warrior like the dancing flames of the sun.";
@@ -420,7 +420,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "There was a time there was an enmity between both warriors.";
 			next;
 			mes "[Leader Gion]";
-			mes "But it didn't take long for them to become one as a Clan.";
+			mes "But it didn't take long for them to become one as a clan.";
 			next;
 			select("How did it go afterwards?");
 			cutin "job_ko02",2;
@@ -457,7 +457,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 				mes "I wonder if Joe is satisfied with your performance.";
 				next;
 			}
-			select("Please continue with the Clan story.");
+			select("Please continue with the clan story.");
 			cutin "job_ko02",2;
 			mes "[Leader Gion]";
 			mes "Looks like you are pretty eager to hear more. Where did I leave off... Ah! I remember.";
@@ -541,7 +541,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Maybe current generations like me are the ancestors of the current Amatsu lord? But this is only an assumption.";
 			next;
 			mes "[Leader Gion]";
-			mes "I'm almost at the end of my Clan story. Come back after you've passed the third test and I will tell you the rest.";
+			mes "I'm almost at the end of my clan story. Come back after you've passed the third test and I will tell you the rest.";
 			next;
 			callsub L_StartTest,.@last_test,3;
 			end;
@@ -584,7 +584,7 @@ job_ko,25,115,4	script	Old Man#ko	588,{
 			mes "Yes, he was. And his efforts didn't go in vain since the two warriors eventually got acquainted and married.";
 			next;
 			mes "[Leader Gion]";
-			mes "This is how the Clan started.";
+			mes "This is how the clan started.";
 			next;
 			select("What happened after?");
 			mes "[Leader Gion]";
@@ -761,7 +761,7 @@ job_ko,81,124,4	script	Kuuga Gai#ko	730,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Kuuga Gai]";
-		mes "Sorry, your Clan is not same as ours, is there something wrong?";
+		mes "Sorry, your clan is not same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -1936,7 +1936,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 			if (isbegin_quest(.@i)) erasequest .@i;
 		set job_kagero,0;
 		mes "[Red Leopard Joe]";
-		mes "Sorry, your Clan is not the same as ours, is there something wrong?";
+		mes "Sorry, your clan is not the same as ours, is there something wrong?";
 		close2;
 		warp "amatsu",147,136;
 		end;
@@ -1968,10 +1968,10 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		next;
 		mes "[Red Leopard Joe]";
 		mes "Alright, " + strcharinfo(0) + "!";
-		mes "Welcome to the workshop where weapons are created for the Clan.";
+		mes "Welcome to the workshop where weapons are created for the clan.";
 		next;
 		mes "[Red Leopard Joe]";
-		mes "Our Clan has been creating and using unique weapons to serve our secret missions since ancient times.";
+		mes "Our clan has been creating and using unique weapons to serve our secret missions since ancient times.";
 		next;
 		select("Really? At Einbroch?");
 		mes "[Red Leopard Joe]";
@@ -1981,7 +1981,7 @@ job_ko,127,125,4	script	Red Leopard Joe#ko	730,{
 		mes "Yes. Einbroch is known as an industrial city, the city of great blacksmiths create new technology.";
 		next;
 		mes "[Red Leopard Joe]";
-		mes "My mission is to analyze their technology and report back to the Clan.";
+		mes "My mission is to analyze their technology and report back to the clan.";
 		next;
 		mes "[Red Leopard Joe]";
 		mes "I spoke more than I intended to.";
@@ -2588,7 +2588,7 @@ job_ko,148,46,4	script	Leader Gion#ko2	588,{
 		mes "Hmm... Embarrassing... to speak so suddenly...";
 		next;
 		mes "[Kuuga Gai]";
-		mes strcharinfo(0) + ", you are now a proud member of our Clan. Always hold your head high and...";
+		mes strcharinfo(0) + ", you are now a proud member of our clan. Always hold your head high and...";
 		next;
 		mes "[Kuuga Gai]";
 		mes "^777777(Gai's voice fades out.)^000000.";

--- a/npc/re/merchants/renters.txt
+++ b/npc/re/merchants/renters.txt
@@ -153,110 +153,110 @@ prontera,125,208,5	script	Peco Peco Remover	105,{
 	close;
 }
 
-// Magic Gear Renter :: madogear
+// Mado Gear Renter :: madogear
 //============================================================
 -	script	::mgm	-1,{
-	mes "[Mado Gear Armourer]";
+	mes "[Mado Gear Armorer]";
 	if (Class == Job_Mechanic || Class == Job_Mechanic_T || Class == Job_Baby_Mechanic) {
 		mes "Welcome, Mechanic.";
 		mes "Would you like to rent a Pushcart or";
-		mes "ride a Magic Gear?";
+		mes "ride a Mado Gear?";
 		next;
-		switch(select("Rent a Pushcart:Ride a Magic Gear:Buy Emergency Magic Gear:Upgrade Cooling Device:Cancel")) {
+		switch(select("Rent a Pushcart:Ride a Mado Gear:Buy Emergency Mado Gear:Upgrade Cooling Device:Cancel")) {
 		case 1:
 			if (checkcart()) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I'm sorry, but you already";
 				mes "have a Pushcart.";
 				close;
 			}
 			setcart;
-			mes "[Mado Gear Armourer]";
+			mes "[Mado Gear Armorer]";
 			mes "There you go!";
 			close;
 		case 2:
 			if (checkmadogear()) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I'm sorry, but you're already";
-				mes "riding a Magic Gear.";
+				mes "riding a Mado Gear.";
 				close;
 			}
 			else if (!getskilllv("NC_MADOLICENCE")) {
-				mes "[Mado Gear Armourer]";
-				mes "Please learn the skill to get the Magic Gear License first.";
+				mes "[Mado Gear Armorer]";
+				mes "Please learn the skill to get the Mado Gear License first.";
 				close;
 			}
 			else if(ismounting()) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "Please remove your cash mount.";
 				close;
 			}
 			setmadogear;
-			mes "[Mado Gear Armourer]";
+			mes "[Mado Gear Armorer]";
 			mes "Have fun, and please come again!";
 			close;
 		case 3:
-			mes "[Mado Gear Armourer]";
-			mes "Emergency Magic Gear is really useful for emergency situations and it is sold at 1,000,000 Zeny.";
+			mes "[Mado Gear Armorer]";
+			mes "Emergency Mado Gear is really useful for emergency situations and it is sold at 1,000,000 Zeny.";
 			next;
 			if (select("Purchase:Cancel") == 2) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I see. Please feel free to ask me";
 				mes "if you change your mind.";
 				close;
 			}
 			if (countitem(23277) > 0) {
-				mes "[Mado Gear Armourer]";
-				mes "I'm sorry, but you already have an Emergency Magic Gear.";
+				mes "[Mado Gear Armorer]";
+				mes "I'm sorry, but you already have an Emergency Mado Gear.";
 				close;
 			}
 			if (Zeny < 1000000) {
-				mes "[Mado Gear Armourer]";
-				mes "I'm sorry, but you don't have enough Zeny to purchase the Emergency Magic Gear.";
+				mes "[Mado Gear Armorer]";
+				mes "I'm sorry, but you don't have enough Zeny to purchase the Emergency Mado Gear.";
 				close;
 			}
 			Zeny -= 1000000;
 			getitem 23277,1; //Mado_Box
-			mes "[Mado Gear Armourer]";
+			mes "[Mado Gear Armorer]";
 			mes "There you go!";
 			close;
 		case 4:
-			mes "[Mado Gear Armourer]";
+			mes "[Mado Gear Armorer]";
 			mes "Which device do you want to upgrade?";
 			next;
 			if (select("Cooling Device:High Quality Cooler") == 1) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "Upgrading Cooling Device to High Quality Cooler needs 1 Cooling Device and 2,000,000 Zeny.";
 				next;
 				.@itemid = 2804;
 				.@cost = 2000000;
 			} else {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "Upgrading High Quality Cooler to Special Cooler needs 1 High Quality Cooler and 4,000,000 Zeny.";
 				next;
 				.@itemid = 2809;
 				.@cost = 4000000;
 			}
 			if (select("Upgrade:Cancel") == 2) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I see. Please feel free to ask me";
 				mes "if you change your mind.";
 				close;
 			}
 			if (!countitem(.@itemid)) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I'm sorry, but you don't have the " + getitemname(.@itemid) + ".";
 				close;
 			}
 			if (Zeny < .@cost) {
-				mes "[Mado Gear Armourer]";
+				mes "[Mado Gear Armorer]";
 				mes "I'm sorry, but you don't have enough Zeny to upgrade the device.";
 				close;
 			}
 			Zeny -= .@cost;
 			delitem .@itemid,1;
 			getitem (.@itemid == 2804 ? 2809 : 2810),1; //High_Quality_Cooler,Special_Cooler
-			mes "[Mado Gear Armourer]";
+			mes "[Mado Gear Armorer]";
 			mes "Here you are! Your very own " + getitemname(.@itemid) + ".";
 			close;
 		case 5:
@@ -264,16 +264,16 @@ prontera,125,208,5	script	Peco Peco Remover	105,{
 		}
 	}
 	mes "How may I help you?";
-	mes "Magic Gears are only available for Mechanics.";
+	mes "Mado Gears are only available for Mechanics.";
 	close;
 }
-prontera,163,178,3	duplicate(mgm)	Mado Gear Armourer#prt	105
-geffen,103,55,5	duplicate(mgm)	Mado Gear Armourer#gef	105
-payon,166,106,5	duplicate(mgm)	Mado Gear Armourer#pay	105
-aldebaran,133,112,5	duplicate(mgm)	Mado Gear Armourer#alde	105
-yuno,167,187,3	duplicate(mgm)	Mado Gear Armourer#yuno	105
-rachel,106,134,5	duplicate(mgm)	Mado Gear Armourer#ra	105
-dicastes01,187,207,3	duplicate(mgm)	Mado Gear Armourer#dic	105
-manuk,273,212,5	duplicate(mgm)	Mado Gear Armourer#man	105
-splendide,180,174,5	duplicate(mgm)	Mado Gear Armourer#spl	105
-mid_camp,242,243,3	duplicate(mgm)	Mado Gear Armourer#mid	105
+prontera,163,178,3	duplicate(mgm)	Mado Gear Armorer#prt	105
+geffen,103,55,5	duplicate(mgm)	Mado Gear Armorer#gef	105
+payon,166,106,5	duplicate(mgm)	Mado Gear Armorer#pay	105
+aldebaran,133,112,5	duplicate(mgm)	Mado Gear Armorer#alde	105
+yuno,167,187,3	duplicate(mgm)	Mado Gear Armorer#yuno	105
+rachel,106,134,5	duplicate(mgm)	Mado Gear Armorer#ra	105
+dicastes01,187,207,3	duplicate(mgm)	Mado Gear Armorer#dic	105
+manuk,273,212,5	duplicate(mgm)	Mado Gear Armorer#man	105
+splendide,180,174,5	duplicate(mgm)	Mado Gear Armorer#spl	105
+mid_camp,242,243,3	duplicate(mgm)	Mado Gear Armorer#mid	105


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This pull request changed some NPC names and dialogues based on kRO client's quest and navi file.

1. Original kRO name for iRO version of "Cougar" is "쿠우가", which should be translated to "Kuuga"
2. Fixes https://github.com/rathena/rathena/issues/3854
3. A follow up of https://github.com/rathena/rathena/pull/3224 which misses some dialogues.
