### PR TITLE
gvg warning

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12610,7 +12610,7 @@ BUILDIN_FUNC(gvgon3)
 		return SCRIPT_CMD_FAILURE;
 	}
 	if (!map_getmapflag(m, MF_GVG_TE))
-		map_setmapflag(m, MF_GVG, true);
+		map_setmapflag(m, MF_GVG_TE, true);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12627,7 +12627,7 @@ BUILDIN_FUNC(gvgoff3)
 		return SCRIPT_CMD_FAILURE;
 	}
 	if (map_getmapflag(m, MF_GVG_TE))
-		map_setmapflag(m, MF_GVG, false);
+		map_setmapflag(m, MF_GVG_TE, false);
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12537,10 +12537,12 @@ BUILDIN_FUNC(pvpon)
 
 	m = map_mapname2mapid(str);
 
-	if (m < 0 || map_getmapflag(m, MF_PVP))
+	if (m < 0) {
+		ShowWarning("buildin_pvpon: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
-
-	map_setmapflag(m, MF_PVP, true);
+	}
+	if (!map_getmapflag(m, MF_PVP))
+		map_setmapflag(m, MF_PVP, true);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12552,10 +12554,12 @@ BUILDIN_FUNC(pvpoff)
 
 	m = map_mapname2mapid(str);
 
-	if(m < 0 || !map_getmapflag(m, MF_PVP))
+	if (m < 0) {
+		ShowWarning("buildin_pvpoff: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
-
-	map_setmapflag(m, MF_PVP, false);
+	}
+	if (map_getmapflag(m, MF_PVP))
+		map_setmapflag(m, MF_PVP, false);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12567,10 +12571,12 @@ BUILDIN_FUNC(gvgon)
 
 	m = map_mapname2mapid(str);
 
-	if (m < 0 || map_getmapflag(m, MF_GVG))
+	if (m < 0) {
+		ShowWarning("buildin_gvgon: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
-
-	map_setmapflag(m, MF_GVG, true);
+	}
+	if (!map_getmapflag(m, MF_GVG))
+		map_setmapflag(m, MF_GVG, true);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12582,8 +12588,11 @@ BUILDIN_FUNC(gvgoff)
 
 	m = map_mapname2mapid(str);
 
-	if (m < 0 || !map_getmapflag(m, MF_GVG))
+	if (m < 0) {
+		ShowWarning("buildin_gvgoff: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
+	}
+	if (map_getmapflag(m, MF_GVG))
 		map_setmapflag(m, MF_GVG, false);
 
 	return SCRIPT_CMD_SUCCESS;
@@ -12596,10 +12605,12 @@ BUILDIN_FUNC(gvgon3)
 
 	m = map_mapname2mapid(str);
 
-	if (m < 0 || map_getmapflag(m, MF_GVG_TE))
+	if (m < 0) {
+		ShowWarning("buildin_gvgon3: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
-
-	map_setmapflag(m, MF_GVG_TE, true);
+	}
+	if (!map_getmapflag(m, MF_GVG_TE))
+		map_setmapflag(m, MF_GVG, true);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12611,10 +12622,12 @@ BUILDIN_FUNC(gvgoff3)
 
 	m = map_mapname2mapid(str);
 
-	if (m < 0 || !map_getmapflag(m, MF_GVG_TE))
+	if (m < 0) {
+		ShowWarning("buildin_gvgoff3: Unknown map '%s'.\n", str);
 		return SCRIPT_CMD_FAILURE;
-
-	map_setmapflag(m, MF_GVG_TE, false);
+	}
+	if (map_getmapflag(m, MF_GVG_TE))
+		map_setmapflag(m, MF_GVG, false);
 
 	return SCRIPT_CMD_SUCCESS;
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: NA

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
## Before
- pvpon, pvpoff, gvgon, gvgoff, gvgon3, gvgoff3 scripts commands currently display a debug when the map arg doesn't exist / the flag is already in the state of the command.
## After
- The commands now display a proper message when the map doesn't exist.
- The command don't return SCRIPT_CMD_FAILURE anymore when the flag is already in the state of the command.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
