### PR TITLE
Corrected script commands containing arrays

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -22430,6 +22430,11 @@ BUILDIN_FUNC(minmax){
 			// Get the session data, if a player is attached
 			sd = st->rid ? map_id2sd(st->rid) : NULL;
 
+			if (not_server_variable(*name) && sd == NULL) {
+				ShowError("buildin_%s: No player attached for player variable '%s'\n", functionname, name);
+				return SCRIPT_CMD_FAILURE;
+			}
+
 			// Try to find the array's source pointer
 			if( !script_array_src( st, sd, name, reference_getref( data ) ) ){
 				ShowError( "buildin_%s: not a array!\n", functionname );

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -8269,6 +8269,10 @@ BUILDIN_FUNC(getpartymember)
 				ShowError("buildin_getpartymember: The array %s is not string type.\n", varname);
 				return SCRIPT_CMD_FAILURE;
 			}
+			if (not_server_variable(*varname)) {
+				ShowError("buildin_getpartymember: Requires a server variable, player variable '%s' is invalid.\n", varname);
+				return SCRIPT_CMD_FAILURE;
+			}
 		}
 
 		for (i = 0; i < MAX_PARTY; i++) {
@@ -11164,6 +11168,12 @@ BUILDIN_FUNC(getunits)
 		id = reference_getid(data);
 		idx = reference_getindex(data);
 		name = reference_getname(data);
+
+		if (not_server_variable(*name)) {
+			st->state = END;
+			ShowError("buildin_%s: Requires a server variable, player variable '%s' is invalid.\n", command, name);
+			return SCRIPT_CMD_FAILURE;
+		}
 	}
 
 	for (bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter))
@@ -17334,6 +17344,11 @@ BUILDIN_FUNC(getunitdata)
 
 	name = reference_getname(data);
 
+	if (not_server_variable(*name)) {
+		ShowError("buildin_getunitdata: Requires a server variable, player variable '%s' is invalid.\n", name);
+		return SCRIPT_CMD_FAILURE;
+	}
+
 #define getunitdata_sub(idx__,var__) setd_sub(st,sd,name,(idx__),(void *)__64BPRTSIZE((int)(var__)),data->ref)
 
 	switch(bl->type) {
@@ -21699,6 +21714,10 @@ BUILDIN_FUNC(getguildmember)
 				ShowError("buildin_getguildmember: The array %s is not string type.\n", varname);
 				return SCRIPT_CMD_FAILURE;
 			}
+			if (not_server_variable(*varname)) {
+				ShowError("buildin_getguildmember: Requires a server variable, player variable '%s' is invalid.\n", varname);
+				return SCRIPT_CMD_FAILURE;
+			}
 		}
 
 		for (i = 0; i < MAX_GUILD; i++) {
@@ -23010,6 +23029,11 @@ BUILDIN_FUNC(channel_setgroup) {
 		if (varname[strlen(varname)-1] == '$') {
 			ShowError("buildin_channel_setgroup: The array %s is not numeric type.\n", varname);
 			script_pushint(st,0);
+			return SCRIPT_CMD_FAILURE;
+		}
+
+		if (not_server_variable(*varname)) {
+			ShowError("buildin_%s: Requires a server variable, player variable '%s' is invalid.\n", funcname, varname);
 			return SCRIPT_CMD_FAILURE;
 		}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -8270,8 +8270,12 @@ BUILDIN_FUNC(getpartymember)
 				return SCRIPT_CMD_FAILURE;
 			}
 			if (not_server_variable(*varname)) {
-				ShowError("buildin_getpartymember: Requires a server variable, player variable '%s' is invalid.\n", varname);
-				return SCRIPT_CMD_FAILURE;
+				struct map_session_data *sd;
+
+				if (!script_rid2sd(sd)) {
+					ShowError("buildin_getpartymember: Cannot use a player variable '%s' if no player is attached.\n", varname);
+					return SCRIPT_CMD_FAILURE;
+				}
 			}
 		}
 
@@ -11169,9 +11173,8 @@ BUILDIN_FUNC(getunits)
 		idx = reference_getindex(data);
 		name = reference_getname(data);
 
-		if (not_server_variable(*name)) {
-			st->state = END;
-			ShowError("buildin_%s: Requires a server variable, player variable '%s' is invalid.\n", command, name);
+		if (not_server_variable(*name) && !script_rid2sd(sd)) {
+			ShowError("buildin_%s: Cannot use a player variable '%s' if no player is attached.\n", command, name);
 			return SCRIPT_CMD_FAILURE;
 		}
 	}
@@ -17344,8 +17347,8 @@ BUILDIN_FUNC(getunitdata)
 
 	name = reference_getname(data);
 
-	if (not_server_variable(*name)) {
-		ShowError("buildin_getunitdata: Requires a server variable, player variable '%s' is invalid.\n", name);
+	if (not_server_variable(*name) && !script_rid2sd(sd)) {
+		ShowError("buildin_getunitdata: Cannot use a player variable '%s' if no player is attached.\n", name);
 		return SCRIPT_CMD_FAILURE;
 	}
 
@@ -21715,8 +21718,12 @@ BUILDIN_FUNC(getguildmember)
 				return SCRIPT_CMD_FAILURE;
 			}
 			if (not_server_variable(*varname)) {
-				ShowError("buildin_getguildmember: Requires a server variable, player variable '%s' is invalid.\n", varname);
-				return SCRIPT_CMD_FAILURE;
+				struct map_session_data *sd;
+
+				if (!script_rid2sd(sd)) {
+					ShowError("buildin_getguildmember: Cannot use a player variable '%s' if no player is attached.\n", varname);
+					return SCRIPT_CMD_FAILURE;
+				}
 			}
 		}
 
@@ -22449,8 +22456,8 @@ BUILDIN_FUNC(minmax){
 			// Get the session data, if a player is attached
 			sd = st->rid ? map_id2sd(st->rid) : NULL;
 
-			if (not_server_variable(*name) && sd == NULL) {
-				ShowError("buildin_%s: No player attached for player variable '%s'\n", functionname, name);
+			if (not_server_variable(*name) && !script_rid2sd(sd)) {
+				ShowError("buildin_%s: Cannot use a player variable '%s' if no player is attached.\n", functionname, name);
 				return SCRIPT_CMD_FAILURE;
 			}
 
@@ -23033,8 +23040,12 @@ BUILDIN_FUNC(channel_setgroup) {
 		}
 
 		if (not_server_variable(*varname)) {
-			ShowError("buildin_%s: Requires a server variable, player variable '%s' is invalid.\n", funcname, varname);
-			return SCRIPT_CMD_FAILURE;
+			struct map_session_data *sd;
+
+			if (!script_rid2sd(sd)) {
+				ShowError("buildin_%s: Cannot use a player variable '%s' if no player is attached.\n", funcname, varname);
+				return SCRIPT_CMD_FAILURE;
+			}
 		}
 
 		n = script_array_highest_key(st, NULL, reference_getname(data), reference_getref(data));


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrects a potential map-server crash with script commands min, max, getpartymember, getguildmember, getunits, getmapunits, getareaunits, getunitdata, and channel_setgroup.
Thanks to @Tokeiburu and @Atemo!