### PR TITLE
Added correct allocation info to strlib

### DIFF
--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -1067,36 +1067,36 @@ bool sv_readdb(const char* directory, const char* filename, char delim, int minc
 // @author MouseJstr (original)
 
 /// Allocates a StringBuf
-StringBuf* StringBuf_Malloc()
+StringBuf* _StringBuf_Malloc(const char *file, int line, const char *func)
 {
 	StringBuf* self;
-	CREATE(self, StringBuf, 1);
-	StringBuf_Init(self);
+	self = (StringBuf *)_mcalloc(1, sizeof(StringBuf), file, line, func);
+	_StringBuf_Init(file, line, func, self);
 	return self;
 }
 
 /// Initializes a previously allocated StringBuf
-void StringBuf_Init(StringBuf* self)
+void _StringBuf_Init(const char *file, int line, const char *func,StringBuf* self)
 {
 	self->max_ = 1024;
-	self->ptr_ = self->buf_ = (char*)aMalloc(self->max_ + 1);
+	self->ptr_ = self->buf_ = (char*)_mmalloc(self->max_ + 1, file, line, func);
 }
 
 /// Appends the result of printf to the StringBuf
-int StringBuf_Printf(StringBuf* self, const char* fmt, ...)
+int _StringBuf_Printf(const char *file, int line, const char *func,StringBuf* self, const char* fmt, ...)
 {
 	int len;
 	va_list ap;
 
 	va_start(ap, fmt);
-	len = StringBuf_Vprintf(self, fmt, ap);
+	len = _StringBuf_Vprintf(file,line,func,self, fmt, ap);
 	va_end(ap);
 
 	return len;
 }
 
 /// Appends the result of vprintf to the StringBuf
-int StringBuf_Vprintf(StringBuf* self, const char* fmt, va_list ap)
+int _StringBuf_Vprintf(const char *file, int line, const char *func,StringBuf* self, const char* fmt, va_list ap)
 {
 	for(;;)
 	{
@@ -1116,13 +1116,13 @@ int StringBuf_Vprintf(StringBuf* self, const char* fmt, va_list ap)
 		/* Else try again with more space. */
 		self->max_ *= 2; // twice the old size
 		off = (int)(self->ptr_ - self->buf_);
-		self->buf_ = (char*)aRealloc(self->buf_, self->max_ + 1);
+		self->buf_ = (char*)_mrealloc(self->buf_, self->max_ + 1, file, line, func);
 		self->ptr_ = self->buf_ + off;
 	}
 }
 
 /// Appends the contents of another StringBuf to the StringBuf
-int StringBuf_Append(StringBuf* self, const StringBuf* sbuf)
+int _StringBuf_Append(const char *file, int line, const char *func,StringBuf* self, const StringBuf* sbuf)
 {
 	int available = self->max_ - (self->ptr_ - self->buf_);
 	int needed = (int)(sbuf->ptr_ - sbuf->buf_);
@@ -1131,7 +1131,7 @@ int StringBuf_Append(StringBuf* self, const StringBuf* sbuf)
 	{
 		int off = (int)(self->ptr_ - self->buf_);
 		self->max_ += needed;
-		self->buf_ = (char*)aRealloc(self->buf_, self->max_ + 1);
+		self->buf_ = (char*)_mrealloc(self->buf_, self->max_ + 1, file, line, func);
 		self->ptr_ = self->buf_ + off;
 	}
 
@@ -1141,7 +1141,7 @@ int StringBuf_Append(StringBuf* self, const StringBuf* sbuf)
 }
 
 // Appends str to the StringBuf
-int StringBuf_AppendStr(StringBuf* self, const char* str)
+int _StringBuf_AppendStr(const char *file, int line, const char *func,StringBuf* self, const char* str)
 {
 	int available = self->max_ - (self->ptr_ - self->buf_);
 	int needed = (int)strlen(str);
@@ -1150,7 +1150,7 @@ int StringBuf_AppendStr(StringBuf* self, const char* str)
 	{// not enough space, expand the buffer (minimum expansion = 1024)
 		int off = (int)(self->ptr_ - self->buf_);
 		self->max_ += max(needed, 1024);
-		self->buf_ = (char*)aRealloc(self->buf_, self->max_ + 1);
+		self->buf_ = (char*)_mrealloc(self->buf_, self->max_ + 1, file, line, func);
 		self->ptr_ = self->buf_ + off;
 	}
 

--- a/src/common/strlib.hpp
+++ b/src/common/strlib.hpp
@@ -7,6 +7,7 @@
 #include <stdarg.h>
 
 #include "cbasetypes.hpp"
+#include "malloc.hpp"
 
 #if !defined(__USE_GNU)
 #define __USE_GNU  // required to enable strnlen on some platforms
@@ -147,12 +148,18 @@ struct StringBuf
 };
 typedef struct StringBuf StringBuf;
 
-StringBuf* StringBuf_Malloc(void);
-void StringBuf_Init(StringBuf* self);
-int StringBuf_Printf(StringBuf* self, const char* fmt, ...);
-int StringBuf_Vprintf(StringBuf* self, const char* fmt, va_list args);
-int StringBuf_Append(StringBuf* self, const StringBuf *sbuf);
-int StringBuf_AppendStr(StringBuf* self, const char* str);
+StringBuf* _StringBuf_Malloc(const char *file, int line, const char *func);
+#define StringBuf_Malloc() _StringBuf_Malloc(ALC_MARK)
+void _StringBuf_Init(const char *file, int line, const char *func, StringBuf* self);
+#define StringBuf_Init(self) _StringBuf_Init(ALC_MARK,self)
+int _StringBuf_Printf(const char *file, int line, const char *func, StringBuf* self, const char* fmt, ...);
+#define StringBuf_Printf(self,fmt,...) _StringBuf_Printf(ALC_MARK,self,fmt,__VA_ARGS__)
+int _StringBuf_Vprintf(const char *file, int line, const char *func,StringBuf* self, const char* fmt, va_list args);
+#define StringBuf_Vprintf(self,fmt,args) _StringBuf_Vprintf(ALC_MARK,self,fmt,args)
+int _StringBuf_Append(const char *file, int line, const char *func, StringBuf* self, const StringBuf *sbuf);
+#define StringBuf_Append(self,sbuf) _StringBuf_Append(ALC_MARK,self,sbuf)
+int _StringBuf_AppendStr(const char *file, int line, const char *func, StringBuf* self, const char* str);
+#define StringBuf_AppendStr(self,str) _StringBuf_AppendStr(ALC_MARK,self,str)
 int StringBuf_Length(StringBuf* self);
 char* StringBuf_Value(StringBuf* self);
 void StringBuf_Clear(StringBuf* self);

--- a/src/common/strlib.hpp
+++ b/src/common/strlib.hpp
@@ -153,7 +153,7 @@ StringBuf* _StringBuf_Malloc(const char *file, int line, const char *func);
 void _StringBuf_Init(const char *file, int line, const char *func, StringBuf* self);
 #define StringBuf_Init(self) _StringBuf_Init(ALC_MARK,self)
 int _StringBuf_Printf(const char *file, int line, const char *func, StringBuf* self, const char* fmt, ...);
-#define StringBuf_Printf(self,fmt,...) _StringBuf_Printf(ALC_MARK,self,fmt,__VA_ARGS__)
+#define StringBuf_Printf(self,fmt,...) _StringBuf_Printf(ALC_MARK,self,fmt, ## __VA_ARGS__)
 int _StringBuf_Vprintf(const char *file, int line, const char *func,StringBuf* self, const char* fmt, va_list args);
 #define StringBuf_Vprintf(self,fmt,args) _StringBuf_Vprintf(ALC_MARK,self,fmt,args)
 int _StringBuf_Append(const char *file, int line, const char *func, StringBuf* self, const StringBuf *sbuf);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2330 as one example.

* **Server Mode**: Both

* **Description of Pull Request**: 
This way you can really see where your memory leaks from StringBuf, SQL Queries or other functions that use this really come from.
