### PR TITLE
Adjusted death event for Emperium Battleground

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9195,6 +9195,10 @@ The player will also be warped to the default spawn point of the battle group or
 <On Quit Event> refers to an NPC label that attaches to the character and is run when they relog. (Optional)
 <On Death Event> refers to an NPC label that attaches to the character and is run when they die. (Optional)
 
+If "-" is supplied for <map name> then the player will not automatically respawn after the 1 second delay.
+This allows for better manipulation of <On Death Event>. The player will have to be warped to desired location
+at the end of <On Death Event>.
+
 Unlike the prior command, the latter will attach a GROUP in a waiting room to the battleground, and
 sets the array $@arenamembers[0] where 0 holds the IDs of the first group, and 1 holds the IDs of the second.
 
@@ -9214,6 +9218,10 @@ Creates an instance of battleground battle group that can be used with other bat
 <map name>,<x>,<y> refer to where the "respawn" base is, where the player group will respawn when they die.
 <On Quit Event> refers to an NPC label that attaches to the character and is run when they relog. (Optional)
 <On Death Event> refers to an NPC label that attaches to the character and is run when they die. (Optional)
+
+If "-" is supplied for <map name> then the player will not automatically respawn after the 1 second delay.
+This allows for better manipulation of <On Death Event>. The player will have to be warped to desired location
+at the end of <On Death Event>.
 
 Returns battle group ID on success. Returns 0 on failure.
 

--- a/npc/custom/battleground/bg_emp.txt
+++ b/npc/custom/battleground/bg_emp.txt
@@ -1,17 +1,12 @@
 //===== rAthena Script =======================================
 //= Battleground: Emperium
-//===== By: ==================================================
-//= AnnieRuru
-//===== Current Version: =====================================
-//= 1.1
-//===== Compatible With: =====================================
-//= rAthena Project
 //===== Description: =========================================
 //= A simple battleground script:
 //= Destroy the opponent's Emperium to win the match.
-//===== Additional Comments: =================================
-//= 1.0 First version, edited. [Euphy]
+//===== Changelogs: ==========================================
+//= 1.0 First version, edited. [Euphy] [AnnieRuru]
 //= 1.1 Use up to date battleground script commands [AnnieRuru]
+//= 1.2 Fix player can be kill multiple times within 250ms time frame [AnnieRuru]
 //============================================================
 
 -	script	bg_emp#control	-1,{
@@ -26,8 +21,8 @@ OnStart:
 		end;
 
 	// create Battleground and teams
-	.red = waitingroom2bg( "bat_a01", 157,347, strnpcinfo(0)+"::OnRedQuit", strnpcinfo(0)+"::OnRedDead", .rednpcname$ );
-	.blue = waitingroom2bg( "bat_a01", 142,51, strnpcinfo(0)+"::OnBlueQuit", strnpcinfo(0)+"::OnBlueDead", .bluenpcname$ );
+	.red = waitingroom2bg( "-", 0,0, strnpcinfo(0)+"::OnRedQuit", strnpcinfo(0)+"::OnRedDead", .rednpcname$ );
+	.blue = waitingroom2bg( "-", 0,0, strnpcinfo(0)+"::OnBlueQuit", strnpcinfo(0)+"::OnBlueDead", .bluenpcname$ );
 	delwaitingroom .rednpcname$;
 	delwaitingroom .bluenpcname$;
 	setwall "bat_a01", 164,347, 6, 4, 0, "bg_emp_town_red";
@@ -84,9 +79,10 @@ L_EmpDown:
 	end;
 
 // "OnDeath" event
-OnRedDead:
-OnBlueDead:
-	sleep2 1250;
+OnRedDead:  callsub L_Dead, 157,347;
+OnBlueDead: callsub L_Dead, 142,51;
+L_Dead:
+	warp "bat_a01", getarg(0), getarg(1);
 	percentheal 100,100;
 	end;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #3956

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adjusted the death event so players don't have to wait for the 1 second respawn timer before being revived.
Thanks to @AnnieRuru!