### PR TITLE
setunitdata script command monster stat recaulculation fixes

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -17034,7 +17034,8 @@ BUILDIN_FUNC(getmonsterinfo)
 		case MOB_JOBEXP:	script_pushint(st,mob->job_exp); break;
 		case MOB_ATK1:		script_pushint(st,mob->status.rhw.atk); break;
 		case MOB_ATK2:		script_pushint(st,mob->status.rhw.atk2); break;
-		case MOB_DEF:		script_pushint(st,mob->status.def); break;
+		case MOB_MATK:		script_pushint(st,mob->status.rhw.matk); break;
+		case MOB_DEF:		script_pushint(st, mob->status.def); break;
 		case MOB_MDEF:		script_pushint(st,mob->status.mdef); break;
 		case MOB_STR:		script_pushint(st,mob->status.str); break;
 		case MOB_AGI:		script_pushint(st,mob->status.agi); break;
@@ -17767,6 +17768,7 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_ATKMAX: md->base_status->rhw.atk2 = (unsigned short)value; calc_status = true; break;
 			case UMOB_MATKMIN: md->base_status->matk_min = (unsigned short)value; calc_status = true; break;
 			case UMOB_MATKMAX: md->base_status->matk_max = (unsigned short)value; calc_status = true; break;
+			case UMOB_MATK: md->base_status->rhw.matk = (unsigned short)value; calc_status = true; break;
 			case UMOB_DEF: md->base_status->def = (defType)value; calc_status = true; break;
 			case UMOB_MDEF: md->base_status->mdef = (defType)value; calc_status = true; break;
 			case UMOB_HIT: md->base_status->hit = (short)value; calc_status = true; break;

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -368,7 +368,8 @@ enum monsterinfo_types {
 	MOB_RACE,
 	MOB_ELEMENT,
 	MOB_MODE,
-	MOB_MVPEXP
+	MOB_MVPEXP,
+	MOB_MATK
 };
 
 enum petinfo_types {
@@ -468,6 +469,7 @@ enum unitdata_mobtypes {
 	UMOB_ADELAY,
 	UMOB_DMOTION,
 	UMOB_TARGETID,
+	UMOB_MATK,
 };
 
 enum unitdata_homuntypes {

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -3815,6 +3815,7 @@
 	export_constant(MOB_ELEMENT);
 	export_constant(MOB_MODE);
 	export_constant(MOB_MVPEXP);
+	export_constant(MOB_MATK);
 
 	/* petinfo types */
 	export_constant(PETINFO_ID);
@@ -3997,6 +3998,7 @@
 	export_constant(UMOB_ADELAY);
 	export_constant(UMOB_DMOTION);
 	export_constant(UMOB_TARGETID);
+	export_constant(UMOB_MATK);
 
 	/* unit control - homunculus */
 	export_constant(UHOM_SIZE);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -4878,10 +4878,11 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 			ud->state.change_walk_target = ud->state.speed_changed = 1;
 	}
 
-	if((!(bl->type&BL_REGEN)) && (!sc || !sc->count)) { // No difference.
+	// This breaks monster stat change scripts!!
+	/*	if((!(bl->type&BL_REGEN)) && (!sc || !sc->count)) { // No difference.
 		status_cpy(status, b_status);
 		return;
-	}
+	} */
 
 	if(flag&SCB_STR) {
 		status->str = status_calc_str(bl, sc, b_status->str);
@@ -4976,6 +4977,9 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 			status->watk2 = status_calc_watk(bl, sc, b_status->watk2);
 		}
 		else status->watk = status_calc_watk(bl, sc, b_status->watk);
+		// Monsters still use these in renewal so they are necessary
+		status->rhw.atk = status_calc_watk(bl, sc, b_status->rhw.atk);
+		status->rhw.atk2 = status_calc_watk(bl, sc, b_status->rhw.atk2);
 #endif
 	}
 
@@ -5170,6 +5174,8 @@ void status_calc_bl_main(struct block_list *bl, /*enum scb_flag*/int flag)
 		 * MATK = (sMATK + wMATK + eMATK) * Multiplicative Modifiers
 		 **/
 		int lv = status_get_lv(bl);
+		// We are using status instead of base_status to include INT changes, but base MATK isn't yet in status so copy it.
+		status->rhw.matk = b_status->rhw.matk;
 		status->matk_min = status_base_matk_min(bl, status, lv);
 		status->matk_max = status_base_matk_max(bl, status, lv);
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
--> https://github.com/rathena/rathena/issues/3015
https://github.com/rathena/rathena/issues/2866
maybe more

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Renewal

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Today I tried to make a script raise monster stats and ran into several problems. This commit fixes the following problems I had to deal with :
-Monster stat recalculation is cut short and doesn't happen at all if the unit recalculated has no regen (monsters don't) and no status active on it (scripts changing stats with setunitdata do not cause status changes). I commented out this code until there is a more appropriate solution, as it outright makes setunitdata not function at all - according to the docs folder, it is supposed to trigger a recalculation and wouldn't be meaningful otherwise anyway. While it sounds correct to simply copy the base_status to status, it is not : this results in a monster who has correct rhw.matk but incorrect min and max matk, as that is being calculated within the base_status itself.
-When MATK is calculated, rhk.matk from status is used instead of base_status. This makes changes in base_status have no effect at all on calculated matk values, and scripts change base_status, not sure what else. 
-Monsters have their attack min and max stored in rhw.atk and rhw.atk2 as far as I see when running in debug and watching data in memory. The script command setunitdata also sets these values.  Commit https://github.com/rathena/rathena/commit/fe197bfa120aef5fd31c6896122b35fdc06774b4 removed the recalculation for them, which means monster attack no longer moves from base_status to status and no longer has effects applied to it. I restored these 2 lines which made setunitdata for them function correctly. I suspect this one is responsible for the linked NPC_POWERUP issue.
-There is no MOB_MATK for scripts. Now that monster matk is no longer their ATK2 stat, it need to be added.
-There is no UMOB_MATK. A min and max version does exist, but those are calculated values, setting them is meaningless and should get lost as soon as a recalculation of stats happen (note the first problem blocked recalculations on monsters, suppressing this problem as well). 

Note, I'm a noob who has no idea about how things are done here. Feel free to deny this and make your own pull request if it's not correctly formatted, or you are more experienced with how monster stat recalculations work. If you are wondering what's this whole weird mess of stuff, I just wanted to have a script command raise my monster's MATK by a percentage. It's not my fault I ran into 5 separate problems trying to get something that simple done. I also have no idea if the described problems affect unit types other than monsters (if they use rhw.atk, atk2, matk then most likely yes), in which case some of those might also get fixed. This aims to be an emergency fix to what I consider a critcial set of problems, it's by no means a well tested and perfect solutions. Also, I haven't yet tested setunitdata on other monster stats. There might be more similar bugs lurking around.