### PR TITLE
Max Walkpath Fix

### DIFF
--- a/src/map/path.cpp
+++ b/src/map/path.cpp
@@ -48,7 +48,7 @@ static BHEAP_STRUCT_VAR(node_heap, g_open_set);	// use static heap for all path 
 /// Comparator for binary heap of path nodes (minimum cost at top)
 #define NODE_MINTOPCMP(i,j) ((i)->f_cost - (j)->f_cost)
 
-#define calc_index(x,y) (((x)+(y)*MAX_WALKPATH) & (MAX_WALKPATH*MAX_WALKPATH-1))
+#define calc_index(x,y) (((MAX_WALKPATH+x)+(MAX_WALKPATH+y)*(MAX_WALKPATH*2+1)) % ((MAX_WALKPATH*2+1)*(MAX_WALKPATH*2+1)))
 
 /// Estimates the cost from (x0,y0) to (x1,y1).
 /// This is inadmissible (overestimating) heuristic used by game client.
@@ -329,7 +329,7 @@ bool path_search(struct walkpath_data *wpd, int16 m, int16 x0, int16 y0, int16 x
 		// FIXME: This array is too small to ensure all paths shorter than MAX_WALKPATH
 		// can be found without node collision: calc_index(node1) = calc_index(node2).
 		// Figure out more proper size or another way to keep track of known nodes.
-		struct path_node tp[MAX_WALKPATH * MAX_WALKPATH];
+		struct path_node tp[(2 * MAX_WALKPATH + 1) * (2 * MAX_WALKPATH + 1)];
 		struct path_node *current, *it;
 		int xs = mapdata->xs - 1;
 		int ys = mapdata->ys - 1;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/3974
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Probably both, tested in renewal
* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Attempted to make the declared array large enough to have no index conflicts, as instructed by the comment. Tested for MAX_WALKPATH values of 3 and 17, both seems to work as intended, while they did not work before. 
If this solution does work, I suggest removing the fixme comment and replacing the "if e return false" part with outputting an error message, as it should never actually happen anymore. (In fact if that was known to be an exit from the function due to a bug, it should have done that in the first place instead of merely returning a "no can't walk there" result.)