### PR TITLE
Fix maintenance and gm_allow_group config

### DIFF
--- a/src/char/char_logif.cpp
+++ b/src/char/char_logif.cpp
@@ -361,8 +361,9 @@ int chlogif_parse_reqaccdata(int fd, struct char_session_data* sd){
 		ARR_FIND( 0, ARRAYLENGTH(map_server), server_id, map_server[server_id].fd > 0 && map_server[server_id].map[0] );
 		// continued from char_auth_ok...
 		if( server_id == ARRAYLENGTH(map_server) || //server not online, bugreport:2359
-			(charserv_config.max_connect_user == 0 && sd->group_id != charserv_config.gm_allow_group) ||
-			( charserv_config.max_connect_user > 0 && char_count_users() >= charserv_config.max_connect_user && sd->group_id != charserv_config.gm_allow_group ) ) {
+			(((charserv_config.max_connect_user == 0 || charserv_config.char_maintenance == 1) ||
+			(charserv_config.max_connect_user > 0 && char_count_users() >= charserv_config.max_connect_user)) &&
+			sd->group_id < charserv_config.gm_allow_group)) {
 			// refuse connection (over populated)
 			chclif_reject(u_fd,0);
 		} else {


### PR DESCRIPTION
Fix maintenance and gm_allow_group config

* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 

char_maintenance
should only allow player wit group id and higher from gm_allow_group

gm_allow_group
before this PR only allow for the group id in it and does not allow for higher
means if it's 10 only 10 are allowed
with this PR if it's 10 > group id 10 or higher can enter the server