### PR TITLE
Implementing atcommand_disable_npc config

### DIFF
--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -37,4 +37,5 @@ atcommand_levelup_events: no
 
 // Disable atcommand while the player is attached to npc (default: 1)
 // this can be changed per npc via script commands 'enable_command' and 'disable_command'
+// You can bypass this by using 'command_enable' permission at the 'group.conf'.
 atcommand_disable_npc: 1

--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -35,7 +35,8 @@ atcommand_mobinfo_type: 1
 // Default: no
 atcommand_levelup_events: no
 
-// Disable atcommand while the player is attached to npc (default: 1)
-// this can be changed per npc via script commands 'enable_command' and 'disable_command'
-// You can bypass this by using 'command_enable' permission at the 'group.conf'.
-atcommand_disable_npc: 1
+// Disable atcommands while a player is attached to a npc? (Note 1)
+// This can be changed by script commands 'enable_command' and 'disable_command'.
+// Anyone with the 'command_enable' permission in the 'conf/group.conf' can bypass this.
+// Default: yes
+atcommand_disable_npc: yes

--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -35,6 +35,6 @@ atcommand_mobinfo_type: 1
 // Default: no
 atcommand_levelup_events: no
 
-//this will allow group id to use atcommand while it's attached to an npc
-//(default: 0) all groups can use atcommand wile attached to an npc.
-atcommand_while_npc_attach: 0
+// Disable atcommand while the player is attached to npc (default: 1)
+// this can be changed per npc via script commands 'enable_command' and 'disable_command'
+atcommand_disable_npc: 1

--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -37,4 +37,4 @@ atcommand_levelup_events: no
 
 //this will allow group id to use atcommand while it's attached to an npc
 //(default: 0) all groups can use atcommand wile attached to an npc.
-atcommand_while_npc_attach: 10
+atcommand_while_npc_attach: 0

--- a/conf/battle/gm.conf
+++ b/conf/battle/gm.conf
@@ -34,3 +34,7 @@ atcommand_mobinfo_type: 1
 // This option is for @baselevelup and @joblevelup
 // Default: no
 atcommand_levelup_events: no
+
+//this will allow group id to use atcommand while it's attached to an npc
+//(default: 0) all groups can use atcommand wile attached to an npc.
+atcommand_while_npc_attach: 10

--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -93,7 +93,6 @@ groups: (
 		trade or party */
 		can_trade: true
 		can_party: true
-		command_enable: true
 		attendance: true
 	}
 },
@@ -284,6 +283,7 @@ groups: (
 	permissions: {
 		can_trade: true
 		can_party: true
+		command_enable: true
 		all_skill: false
 		all_equipment: false
 		skill_unconditional: false

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5354,7 +5354,7 @@ Example:
 
 These commands toggle the ability to use atcommand while interacting with an NPC.
 
-The default setting, 'atcommand_enable_npc', is defined in 'conf/battle/gm.conf'.
+The default setting, 'atcommand_disable_npc', is defined in 'conf/battle/gm.conf'.
 
 ---------------------------------------
 //

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -10482,6 +10482,10 @@ bool is_atcommand(const int fd, struct map_session_data* sd, const char* message
 	if ( !message || !*message )
 		return false;
 
+	//ignore atcommand if the player with gruop id is attached to npc
+	if (sd->npc_id && battle_config.atcommand_while_npc_attach > sd->group_id)
+		return false;
+
 	//If cannot use atcomamnd while talking with NPC [Kichi]
 	if (type == 1 && sd->npc_id && sd->state.disable_atcommand_on_npc)
 		return false;

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -10482,10 +10482,6 @@ bool is_atcommand(const int fd, struct map_session_data* sd, const char* message
 	if ( !message || !*message )
 		return false;
 
-	//ignore atcommand if the player with gruop id is attached to npc
-	if (sd->npc_id && battle_config.atcommand_while_npc_attach > sd->group_id)
-		return false;
-
 	//If cannot use atcomamnd while talking with NPC [Kichi]
 	if (type == 1 && sd->npc_id && sd->state.disable_atcommand_on_npc)
 		return false;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8488,6 +8488,7 @@ static const struct _battle_data {
 	{ "mvp_exp_reward_message",             &battle_config.mvp_exp_reward_message,          0,      0,      1,              },
 	{ "can_damage_skill",                   &battle_config.can_damage_skill,                1,      0,      BL_ALL,         },
 	{ "atcommand_levelup_events",			&battle_config.atcommand_levelup_events,		0,		0,		1,				},
+	{ "atcommand_while_npc_attach",			&battle_config.atcommand_while_npc_attach,		0,		0,		99,				},
 	{ "block_account_in_same_party",		&battle_config.block_account_in_same_party,		1,		0,		1,				},
 	{ "tarotcard_equal_chance",             &battle_config.tarotcard_equal_chance,          0,      0,      1,              },
 	{ "change_party_leader_samemap",        &battle_config.change_party_leader_samemap,     1,      0,      1,              },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8488,7 +8488,7 @@ static const struct _battle_data {
 	{ "mvp_exp_reward_message",             &battle_config.mvp_exp_reward_message,          0,      0,      1,              },
 	{ "can_damage_skill",                   &battle_config.can_damage_skill,                1,      0,      BL_ALL,         },
 	{ "atcommand_levelup_events",			&battle_config.atcommand_levelup_events,		0,		0,		1,				},
-	{ "atcommand_while_npc_attach",			&battle_config.atcommand_while_npc_attach,		0,		0,		99,				},
+	{ "atcommand_disable_npc",				&battle_config.atcommand_disable_npc,			1,		0,		1,				},
 	{ "block_account_in_same_party",		&battle_config.block_account_in_same_party,		1,		0,		1,				},
 	{ "tarotcard_equal_chance",             &battle_config.tarotcard_equal_chance,          0,      0,      1,              },
 	{ "change_party_leader_samemap",        &battle_config.change_party_leader_samemap,     1,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -623,7 +623,7 @@ struct Battle_Config
 	int mvp_exp_reward_message;
 	int can_damage_skill; //Which BL types can damage traps
 	int atcommand_levelup_events;
-	int atcommand_while_npc_attach;
+	int atcommand_disable_npc;
 	int block_account_in_same_party;
 	int tarotcard_equal_chance; //Official or equal chance for each card
 	int change_party_leader_samemap;

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -623,6 +623,7 @@ struct Battle_Config
 	int mvp_exp_reward_message;
 	int can_damage_skill; //Which BL types can damage traps
 	int atcommand_levelup_events;
+	int atcommand_while_npc_attach;
 	int block_account_in_same_party;
 	int tarotcard_equal_chance; //Official or equal chance for each card
 	int change_party_leader_samemap;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4235,7 +4235,7 @@ void script_attach_state(struct script_state* st){
 		sd->st = st;
 		sd->npc_id = st->oid;
 		sd->npc_item_flag = st->npc_item_flag; // load default.
-		sd->state.disable_atcommand_on_npc = (!pc_has_permission(sd, PC_PERM_ENABLE_COMMAND));
+		sd->state.disable_atcommand_on_npc = battle_config.atcommand_disable_npc;
 #ifdef SECURE_NPCTIMEOUT
 		if( sd->npc_idle_timer == INVALID_TIMER )
 			sd->npc_idle_timer = add_timer(gettick() + (SECURE_NPCTIMEOUT_INTERVAL*1000),npc_secure_timeout_timer,sd->bl.id,0);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4235,7 +4235,7 @@ void script_attach_state(struct script_state* st){
 		sd->st = st;
 		sd->npc_id = st->oid;
 		sd->npc_item_flag = st->npc_item_flag; // load default.
-		sd->state.disable_atcommand_on_npc = battle_config.atcommand_disable_npc;
+		sd->state.disable_atcommand_on_npc = battle_config.atcommand_disable_npc && (!pc_has_permission(sd, PC_PERM_ENABLE_COMMAND));
 #ifdef SECURE_NPCTIMEOUT
 		if( sd->npc_idle_timer == INVALID_TIMER )
 			sd->npc_idle_timer = add_timer(gettick() + (SECURE_NPCTIMEOUT_INTERVAL*1000),npc_secure_timeout_timer,sd->bl.id,0);


### PR DESCRIPTION
ignore atcmmand if player with group id is attached to npc

* **Addressed Issue(s)**: none 

* **Server Mode**: both

* **Description of Pull Request**: 

* most of the warning where `sd->npc_id != npc_id`
this can happen when the player is attached to npc (uses sleep or timer) that use @refresh or other command like script commands from bindatcmd and it deattach the player from the npc

* ps: the player can use atcommand by making it as shortcut on the (Alt+M) menu ingame and this patch will ignore the atcommand using this trick
some npcs after it do x use sleep to do y > if player deattach before y than it's bug
ofc the player can disconnect from the server , while i don't know how to prevent that i can prevent the atcommands

I defaulted it to 0 cuz players are used to using @refresh and @load etc while stuck on npc
i think the official should be 99 as normal players does not have @commands enabled

* this PR is not done yet
as it should allow `*atcommand "<command>";` command script to progress
i will add support for that if the developers agree about it


* Update:
while checking , i found this
https://github.com/rathena/rathena/blob/9f4a569ecc0af179e6926c2b31062b2fff3bd771/doc/script_commands.txt#L5357
however it's not implemented in the src
maybe it would be a better idea ?