### PR TITLE
Allow redo MorseCave after the cooldown

### DIFF
--- a/npc/re/instances/MorseCave.txt
+++ b/npc/re/instances/MorseCave.txt
@@ -166,11 +166,6 @@ moro_cav,57,69,3	script	Red Flower#a1	CLEAR_NPC,{
 		mes "to Morocc's lair.";
 		close;
 	}
-	if (isbegin_quest(9318) == 1) {
-		mes "- The Red Flower is closed.";
-		mes "You cannot enter it yet. -";
-		close;
-	}
 	switch( checkquest(9319,PLAYTIME) ) {
 	case -1:
 		break;


### PR DESCRIPTION
Allow redo MorseCave after the cooldown

* **Addressed Issue(s)**: none

* **Server Mode**: renewal

* **Description of Pull Request**: 

player should be able to redo MorseCave after the cooldown is finished
