### PR TITLE
Corrected item bonuses SkillAtk and SubSkill

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5169,6 +5169,12 @@ static void battle_calc_weapon_final_atk_modifiers(struct Damage* wd, struct blo
 #endif
 	}
 
+	// add any miscellaneous player ATK bonuses
+	if (sd && (skill_damage = pc_skillatk_bonus(sd, skill_id)))
+		ATK_ADDRATE(wd->damage, wd->damage2, skill_damage);
+	if (tsd && (skill_damage = pc_sub_skillatk_bonus(tsd, skill_id)))
+		ATK_ADDRATE(wd->damage, wd->damage2, -skill_damage);
+
 	// Skill damage adjustment
 	if ((skill_damage = battle_skill_damage(src, target, skill_id)) != 0)
 		ATK_ADDRATE(wd->damage, wd->damage2, skill_damage);
@@ -5405,15 +5411,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				ATK_ADD(wd.weaponAtk, wd.weaponAtk2, sstatus->matk_min);
 		}
 #endif
-		// add any miscellaneous player ATK bonuses
-		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
-			ATK_ADDRATE(wd.damage, wd.damage2, i);
-			RE_ALLATK_ADDRATE(&wd, i);
-		}
-		if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id))) {
-			ATK_ADDRATE(wd.damage, wd.damage2, -i);
-			RE_ALLATK_ADDRATE(&wd, -i);
-		}
 
 #ifdef RENEWAL
 		// In Renewal we only cardfix to the weapon and equip ATK


### PR DESCRIPTION
* Fixes #3589.
* Corrected item bonuses SkillAtk and SubSkill granting too much damage.
Thanks to @laziem!

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
