### PR TITLE
Fixed the upgrade script for pet evolution

### DIFF
--- a/sql-files/upgrades/upgrade_20190309.sql
+++ b/sql-files/upgrades/upgrade_20190309.sql
@@ -1,2 +1,12 @@
 ALTER TABLE `pet`
 	ADD COLUMN `autofeed` tinyint(2) NOT NULL default '0' AFTER `incubate`;
+
+UPDATE `inventory` `i`
+INNER JOIN `char` `c`
+ON `i`.`char_id` = `c`.`char_id` AND `c`.`pet_id` <> '0'
+SET `i`.`attribute` = '1'
+WHERE
+	`i`.`card0` = '256'
+AND
+	( `i`.`card1` | ( `i`.`card2` << 16 ) ) = `c`.`pet_id`
+;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4075

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixed being unable to return pets to their eggs.
Deleting all pet data is not the right choice here.

Thanks to @mazvi
