### PR TITLE
Adjusted pet walk speed

### DIFF
--- a/conf/battle/pet.conf
+++ b/conf/battle/pet.conf
@@ -78,3 +78,9 @@ pet_master_dead: no
 // Send auto-feed notice even if the client setting is OFF (Note 1) 
 // Official: yes
 pet_autofeed_always: yes
+
+// Pet walk speed.
+// 1: Master's walk speed (official)
+// 2: DEFAULT_WALK_SPEED value
+// 3: Mob database walk speed
+pet_walk_speed: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8521,6 +8521,7 @@ static const struct _battle_data {
 	{ "min_shop_buy",                       &battle_config.min_shop_buy,                    1,      0,      INT_MAX,        },
 	{ "min_shop_sell",                      &battle_config.min_shop_sell,                   0,      0,      INT_MAX,        },
 	{ "feature.equipswitch",                &battle_config.feature_equipswitch,             1,      0,      1,              },
+	{ "pet_walk_speed",                     &battle_config.pet_walk_speed,                  1,      1,      3,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -659,6 +659,7 @@ struct Battle_Config
 	int min_shop_buy;
 	int min_shop_sell;
 	int feature_equipswitch;
+	int pet_walk_speed;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -824,7 +824,7 @@ static TIMER_FUNC(pet_hungry){
 
 		if( pd->pet.intimate <= PET_INTIMATE_NONE ) {
 			pd->pet.intimate = PET_INTIMATE_NONE;
-			pd->status.speed = DEFAULT_WALK_SPEED;
+			pd->status.speed = pd->get_pet_walk_speed();
 		}
 
 		status_calc_pet(pd,SCO_NONE);
@@ -1523,7 +1523,7 @@ int pet_food(struct map_session_data *sd, struct pet_data *pd)
 		if (pd->pet.intimate <= PET_INTIMATE_NONE) {
 			pd->pet.intimate = PET_INTIMATE_NONE;
 			pet_stop_attack(pd);
-			pd->status.speed = DEFAULT_WALK_SPEED;
+			pd->status.speed = pd->get_pet_walk_speed();
 		}
 	}
 	else {
@@ -1668,11 +1668,11 @@ static int pet_ai_sub_hard(struct pet_data *pd, struct map_session_data *sd, t_t
 	}
 
 	// Return speed to normal.
-	if (pd->status.speed != DEFAULT_WALK_SPEED) {
+	if (pd->status.speed != pd->get_pet_walk_speed()) {
 		if (pd->ud.walktimer != INVALID_TIMER)
 			return 0; // Wait until the pet finishes walking back to master.
 
-		pd->status.speed = DEFAULT_WALK_SPEED;
+		pd->status.speed = pd->get_pet_walk_speed();
 		pd->ud.state.change_walk_target = pd->ud.state.speed_changed = 1;
 	}
 

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -824,7 +824,7 @@ static TIMER_FUNC(pet_hungry){
 
 		if( pd->pet.intimate <= PET_INTIMATE_NONE ) {
 			pd->pet.intimate = PET_INTIMATE_NONE;
-			pd->status.speed = pd->db->status.speed;
+			pd->status.speed = DEFAULT_WALK_SPEED;
 		}
 
 		status_calc_pet(pd,SCO_NONE);
@@ -1523,7 +1523,7 @@ int pet_food(struct map_session_data *sd, struct pet_data *pd)
 		if (pd->pet.intimate <= PET_INTIMATE_NONE) {
 			pd->pet.intimate = PET_INTIMATE_NONE;
 			pet_stop_attack(pd);
-			pd->status.speed = pd->db->status.speed;
+			pd->status.speed = DEFAULT_WALK_SPEED;
 		}
 	}
 	else {
@@ -1668,11 +1668,11 @@ static int pet_ai_sub_hard(struct pet_data *pd, struct map_session_data *sd, t_t
 	}
 
 	// Return speed to normal.
-	if (pd->status.speed != pd->db->status.speed) {
+	if (pd->status.speed != DEFAULT_WALK_SPEED) {
 		if (pd->ud.walktimer != INVALID_TIMER)
 			return 0; // Wait until the pet finishes walking back to master.
 
-		pd->status.speed = pd->db->status.speed;
+		pd->status.speed = DEFAULT_WALK_SPEED;
 		pd->ud.state.change_walk_target = pd->ud.state.speed_changed = 1;
 	}
 

--- a/src/map/pet.hpp
+++ b/src/map/pet.hpp
@@ -167,6 +167,17 @@ struct pet_data {
 	std::shared_ptr<s_pet_db> get_pet_db() {
 		return pet_db.find(this->pet.class_);
 	}
+
+	int get_pet_walk_speed() {
+		switch (battle_config.pet_walk_speed) {
+			case 1: // Master
+				return this->master->battle_status.speed;
+			case 2: // DEFAULT_WALK_SPEED
+				return DEFAULT_WALK_SPEED;
+			case 3: // Mob database
+				return this->db->status.speed;
+		}
+	}
 };
 
 bool pet_create_egg(struct map_session_data *sd, unsigned short item_id);

--- a/src/map/pet.hpp
+++ b/src/map/pet.hpp
@@ -9,6 +9,9 @@
 #include "../common/mmo.hpp"
 #include "../common/timer.hpp"
 
+#include "battle.hpp"
+#include "mob.hpp"
+#include "pc.hpp"
 #include "script.hpp"
 #include "status.hpp"
 #include "unit.hpp"
@@ -170,6 +173,7 @@ struct pet_data {
 
 	int get_pet_walk_speed() {
 		switch (battle_config.pet_walk_speed) {
+			default:
 			case 1: // Master
 				return this->master->battle_status.speed;
 			case 2: // DEFAULT_WALK_SPEED

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2969,7 +2969,7 @@ void status_calc_pet_(struct pet_data *pd, enum e_status_calc_opt opt)
 		memcpy(&pd->status, &pd->db->status, sizeof(struct status_data));
 		pd->status.mode = MD_CANMOVE; // Pets discard all modes, except walking
 		pd->status.class_ = CLASS_NORMAL;
-		pd->status.speed = pd->db->status.speed;
+		pd->status.speed = DEFAULT_WALK_SPEED;
 
 		if(battle_config.pet_attack_support || battle_config.pet_damage_support) {
 			// Attack support requires the pet to be able to attack

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2969,7 +2969,7 @@ void status_calc_pet_(struct pet_data *pd, enum e_status_calc_opt opt)
 		memcpy(&pd->status, &pd->db->status, sizeof(struct status_data));
 		pd->status.mode = MD_CANMOVE; // Pets discard all modes, except walking
 		pd->status.class_ = CLASS_NORMAL;
-		pd->status.speed = DEFAULT_WALK_SPEED;
+		pd->status.speed = pd->get_pet_walk_speed();
 
 		if(battle_config.pet_attack_support || battle_config.pet_damage_support) {
 			// Attack support requires the pet to be able to attack


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Changed the default pet walk speed from the monster database value to DEFAULT_WALK_SPEED.
  * Resolves some pets walking too slow.