### PR TITLE
Cleaned up instance script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -8897,18 +8897,17 @@ The command returns the instance ID upon success, and these values upon failure:
 *instance_destroy {<instance id>};
 
 Destroys instance with the ID <instance id>. If no ID is specified, the instance
-the script is attached to is used. If the script is not attached to an instance,
-the instance of the currently attached player is used (if it is a character, party,
-guild or clan mode). If it is not owned by anyone, no player needs to be attached. If
-that fails, the script will come to a halt. This will also trigger the "OnInstanceDestroy"
-label in all NPCs inside the instance.
+the script is attached to is used. If that fails, the script will come to a halt.
+This will also trigger the "OnInstanceDestroy" label in all NPCs inside the instance.
 
 ---------------------------------------
 
 *instance_enter("<instance name>",{<x>,<y>,<char_id>,<instance id>});
 
-Warps player to the specified instance after the script terminates. The map and
-coordinates are located in 'db/(pre-)re/instance_db.txt'.
+Warps the attached player to the specified <instance id>. If no ID is specified,
+the IM_PARTY instance the invoking player is attached to is used.
+
+The map and coordinates are located in 'db/(pre-)re/instance_db.txt'.
 
 The command returns IE_OK upon success, and these values upon failure:
  IE_NOMEMBER:	Party/Guild/Clan not found (for party/guild/clan modes).
@@ -8922,49 +8921,46 @@ Put -1 for x and y if want to warp player with default entrance coordinates.
 *instance_npcname("<npc name>"{,<instance id>})
 
 Returns the unique name of the instanced script. If no ID is specified,
-the instance the script is attached to is used. If the script is not attached to
-an instance, the instance of the currently attached NPC, player, party, guild
-or clan is used. If that fails, the script will come to a halt.
+the instance the script is attached to is used. If that fails, the script
+will come to a halt.
 
 ---------------------------------------
 
 *instance_mapname("<map name>"{,<instance id>})
 
 Returns the unique name of the instanced map. If no instance ID is specified,
-the instance the script is attached to is used. If the script is not attached to
-an instance, the instance of the currently attached player is used (if it is a
-character, party, guild or clan mode). If it is not owned by anyone, no player needs
-to be attached. If that fails, the command returns an empty string instead.
+the instance the script is attached to is used. If that fails, the command
+returns an empty string instead.
 
 ---------------------------------------
 
-*instance_id()
+*instance_id({<instance mode>})
 
-Returns the unique instance id of the attached script. If the script is not
-attached to an instance, the instance of the currently attached player is
-used (if it is a character, party, guild or clan mode). If it is not owned by anyone, no
-player needs to be attached. If that fails, the function will return 0.
+Returns the unique instance ID of the given mode. By default it returns the
+attached script instance. If <instance mode> is provided then the instance
+of the currently attached player is used. If that fails, the function will return 0.
+
+Instance Mode options:
+ IM_CHAR:	Attached to character.
+ IM_PARTY:	Attached to character's party.
+ IM_GUILD:	Attached to character's guild.
+ IM_CLAN:	Attached to character's clan.
 
 ---------------------------------------
 
 *instance_warpall "<map name>",<x>,<y>{,<instance id>};
 
-Warps all players in the instance <instance id> to <map name> at given
-coordinates. If no ID is specified, the instance the script is attached to
-is used. If the script is not attached to an instance, the instance of the
-currently attached player is used (if it is a character, party, guild or clan
-mode). If it is not owned by anyone, no player needs to be attached. If that
-fails, the script will come to a halt.
+Warps all players in the <instance id> to <map name> to the given coordinates.
+If no ID is specified, the IM_PARTY instance the invoking player is attached
+to is used. If that fails, the script will come to a halt.
 
 ---------------------------------------
 
 *instance_announce <instance id>,"<text>",<flag>{,<fontColor>{,<fontType>{,<fontSize>{,<fontAlign>{,<fontY>}}}}};
 
-Broadcasts a message to all players in the instance <instance id> currently
-residing on an instance map. If 0 is specified for <instance id>, the instance
-the script is attached to is used. If the script is not attached to an instance,
-the instance of the currently attached player is used (if it is a character,
-party, guild or clan mode). If it is not owned by anyone, no player needs to be attached.
+Broadcasts a message to all players in the <instance id> currently residing on
+an instance map. If 0 is specified for <instance id>, the instance the script
+is attached to is used.
 
 For details on the other parameters, see 'announce'.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -477,7 +477,8 @@ nothing  - A permanent variable attached to the character, the default variable
            ('return .@var;' returns a value, not a reference).
 "'"      - An instance variable.
            These are used with the instancing system and are unique to each
-           instance type.
+           instance type. Can be accessed from inside the instance or by calling
+           'getvariableofinstance'.
 "#"      - A permanent local account variable.
            They are stored by char-server in the `acc_reg_num` table and
            `acc_reg_str`.
@@ -9053,6 +9054,20 @@ Example:
 .@name$ = "Endless Tower";
 mes .@name$ + " will be destroyed if no one is in the instance for " + instance_info(.@name$,IIT_IDLETIMEOUT) + " seconds.";
 // Endless Tower will be destroyed if no one is in the instance for 300 seconds.
+
+---------------------------------------
+
+*getvariableofinstance(<variable>,<instance id>);
+
+Returns a reference to an instance variable (' prefix) of the specific instance ID.
+This can only be used to get ' variables.
+
+Examples:
+	// This will set the .@s variable to the value of 'var variable of the specific instance ID.
+	set .@s, getvariableofinstance('var, instance_id(IM_PARTY));
+
+	// This will set the 'var variable of the specific instance ID to 1.
+	set getvariableofinstance('var, instance_id(IM_GUILD)), 1;
 
 ---------------------------------------
 

--- a/npc/re/instances/HorrorToyFactory.txt
+++ b/npc/re/instances/HorrorToyFactory.txt
@@ -153,8 +153,7 @@ xmas,237,303,3	script	Catherine Jet Johnson	4_F_SKULL06GIRL,{
 		}
 		if (select( "Unlock Horror Toy Factory", "Cancel" ) == 1) {
 			mes "Door will be.. opened soon.. Would you wait for a moment?";
-			if (instance_create("Horror Toy Factory") >= 0)
-				'xm_d_map$ = instance_mapname("1@xm_d");
+			instance_create("Horror Toy Factory");
 		}
 		close;
 	case 0:
@@ -1549,6 +1548,8 @@ OnTimer1000:
 	end;
 
 OnInstanceInit:
+	'xm_d_map$ = instance_mapname("1@xm_d");
+
 	// Warps
 	disablenpc instance_npcname("#fac3wp");
 	disablenpc instance_npcname("#fac3wp2");

--- a/npc/re/instances/MorseCave.txt
+++ b/npc/re/instances/MorseCave.txt
@@ -150,8 +150,7 @@ moro_cav,61,69,3	script	Senior Tracker#a1	4_M_JOB_ASSASSIN,{
 		mes "It will only stay open for a while.";
 		mes "You'd better use it";
 		mes "while you can.";
-		if (instance_create("Morse's Cave") >= 0)
-			'party_id = getcharid(1);
+		instance_create("Morse's Cave");
 	}
 	close;
 }
@@ -223,6 +222,7 @@ OnInit:
 OnTouch:
 	// note : party member can also trigger this event
 	disablenpc instance_npcname("#RZ Memorial Start");
+	'party_id = getcharid(1);
 	'soul_name$ = strcharinfo(0);	// name displayed on soul is defined at entrance
 	setpcblock PCBLOCK_NPC, true;
 	sleep2 500;
@@ -1164,18 +1164,6 @@ OnInstanceInit:
 	// Debuff - Battle 1 & 2
 	for ( .@i = 1; .@i <= 15; .@i++ )
 		disablenpc instance_npcname( "#RZ Debuff_" + .@i );
-
-	// reload
-	if ('party_id > 0) {
-		getpartymember 'party_id, 1, .@char_id;
-		getpartymember 'party_id, 2, .@account_id;
-		for ( .@i = 0; .@i < $@partymembercount; .@i++ ) {
-			if (isloggedin(.@account_id[.@i],.@char_id[.@i]) == false)
-				continue;
-			if (strcharinfo(3,.@char_id[.@i]) == 'map_rev$)
-				setpcblock PCBLOCK_MOVE, false, .@account_id[.@i];
-		}
-	}
 	end;
 }
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -378,7 +378,7 @@ static struct linkdb_node *sleep_db; // int oid -> struct script_state *
  *------------------------------------------*/
 const char* parse_subexpr(const char* p,int limit);
 int run_func(struct script_state *st);
-unsigned short script_instancegetid(struct script_state *st, enum instance_mode mode);
+unsigned short script_instancegetid(struct script_state *st, enum instance_mode mode = IM_NONE);
 
 const char* script_op2name(int op)
 {
@@ -2736,7 +2736,7 @@ struct script_data *get_val_(struct script_state* st, struct script_data* data, 
 				break;
 			case '\'':
 				{
-					unsigned short instance_id = script_instancegetid(st, IM_NONE);
+					unsigned short instance_id = script_instancegetid(st);
 					if( instance_id )
 						data->u.str = (char*)i64db_get(instance_data[instance_id].regs.vars,reference_getuid(data));
 					else {
@@ -2794,7 +2794,7 @@ struct script_data *get_val_(struct script_state* st, struct script_data* data, 
 					break;
 				case '\'':
 					{
-						unsigned short instance_id = script_instancegetid(st, IM_NONE);
+						unsigned short instance_id = script_instancegetid(st);
 						if( instance_id )
 							data->u.num = (int)i64db_iget(instance_data[instance_id].regs.vars,reference_getuid(data));
 						else {
@@ -3010,7 +3010,7 @@ struct reg_db *script_array_src(struct script_state *st, struct map_session_data
 			break;
 		case '\'': // instance
 			{
-				unsigned short instance_id = script_instancegetid(st, IM_NONE);
+				unsigned short instance_id = script_instancegetid(st);
 
 				if( instance_id ) {
 					src = &instance_data[instance_id].regs;
@@ -3130,7 +3130,7 @@ int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, con
 				return 1;
 			case '\'':
 				{
-					unsigned short instance_id = script_instancegetid(st, IM_NONE);
+					unsigned short instance_id = script_instancegetid(st);
 					if( instance_id ) {
 						if( str[0] ) {
 							i64db_put(instance_data[instance_id].regs.vars, num, aStrdup(str));
@@ -3193,7 +3193,7 @@ int set_reg(struct script_state* st, struct map_session_data* sd, int64 num, con
 				return 1;
 			case '\'':
 				{
-					unsigned short instance_id = script_instancegetid(st, IM_NONE);
+					unsigned short instance_id = script_instancegetid(st);
 					if( instance_id ) {
 						if( val != 0 ) {
 							i64db_iput(instance_data[instance_id].regs.vars, num, val);
@@ -19843,7 +19843,7 @@ BUILDIN_FUNC(instance_destroy)
 	if( script_hasdata(st,2) )
 		instance_id = script_getnum(st,2);
 	else
-		instance_id = script_instancegetid(st, IM_NONE);
+		instance_id = script_instancegetid(st);
 
 	if( instance_id == 0 ) {
 		ShowError("buildin_instance_destroy: Trying to destroy invalid instance %hu.\n", instance_id);
@@ -19898,7 +19898,7 @@ BUILDIN_FUNC(instance_npcname)
 	if( script_hasdata(st,3) )
 		instance_id = script_getnum(st,3);
 	else
-		instance_id = script_instancegetid(st, IM_NONE);
+		instance_id = script_instancegetid(st);
 
 	if( instance_id && (nd = npc_name2id(str)) != NULL ) {
 		static char npcname[NAME_LENGTH];
@@ -19929,7 +19929,7 @@ BUILDIN_FUNC(instance_mapname)
 	if( script_hasdata(st,3) )
 		instance_id = script_getnum(st,3);
 	else
-		instance_id = script_instancegetid(st, IM_NONE);
+		instance_id = script_instancegetid(st);
 
 	// Check that instance mapname is a valid map
 	if(!instance_id || (m = instance_mapname2mapid(str,instance_id)) < 0)
@@ -19945,10 +19945,10 @@ BUILDIN_FUNC(instance_mapname)
  *------------------------------------------*/
 BUILDIN_FUNC(instance_id)
 {
-	enum instance_mode mode = IM_NONE; // Default to the attached NPC
+	int mode = IM_NONE; // Default to the attached NPC
 
 	if (script_hasdata(st, 2)) {
-		mode = static_cast<instance_mode>(script_getnum(st, 2));
+		mode = script_getnum(st, 2);
 
 		if (mode <= IM_NONE || mode >= IM_MAX) {
 			ShowError("buildin_instance_id: Unknown instance mode %d.\n", mode);
@@ -19957,7 +19957,7 @@ BUILDIN_FUNC(instance_id)
 		}
 	}
 
-	script_pushint(st, script_instancegetid(st, mode));
+	script_pushint(st, script_instancegetid(st, static_cast<instance_mode>(mode)));
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -20048,7 +20048,7 @@ BUILDIN_FUNC(instance_announce) {
 	int i;
 
 	if( instance_id == 0 ) {
-		instance_id = script_instancegetid(st, IM_NONE);
+		instance_id = script_instancegetid(st);
 	}
 
 	if( !instance_id && &instance_data[instance_id] != NULL) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -24185,7 +24185,7 @@ BUILDIN_FUNC(getvariableofinstance)
 	struct script_data* data = script_getdata(st, 2);
 
 	if (!data_isreference(data)) {
-		ShowError("buildin_getvariableofinstance: not a variable.\n");
+		ShowError("buildin_getvariableofinstance: %s is not a variable.\n", script_getstr(st, 2));
 		script_reportdata(data);
 		script_pushnil(st);
 		st->state = END;
@@ -24195,7 +24195,7 @@ BUILDIN_FUNC(getvariableofinstance)
 	const char* name = reference_getname(data);
 
 	if (*name != '\'') {
-		ShowError("buildin_getvariableofinstance: invalid scope (not instance variable).\n");
+		ShowError("buildin_getvariableofinstance: Invalid scope. %s is not an instance variable.\n", name);
 		script_reportdata(data);
 		script_pushnil(st);
 		st->state = END;
@@ -24203,16 +24203,18 @@ BUILDIN_FUNC(getvariableofinstance)
 	}
 
 	unsigned short instance_id = script_getnum(st, 3);
-	if (instance_id <= 0 || instance_id > MAX_INSTANCE_DATA) {
-		ShowError("buildin_getvariableofinstance: invalid instance ID %d.\n", instance_id);
+
+	if (instance_id == 0 || instance_id > MAX_INSTANCE_DATA) {
+		ShowError("buildin_getvariableofinstance: Invalid instance ID %d.\n", instance_id);
 		script_pushnil(st);
 		st->state = END;
 		return SCRIPT_CMD_FAILURE;
 	}
 
 	struct instance_data *im = &instance_data[instance_id];
+
 	if (im->state != INSTANCE_BUSY) {
-		ShowError("buildin_getvariableofinstance: unknown instance ID %d.\n", instance_id);
+		ShowError("buildin_getvariableofinstance: Unknown instance ID %d.\n", instance_id);
 		script_pushnil(st);
 		st->state = END;
 		return SCRIPT_CMD_FAILURE;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Script command instance_id now supports an instance mode argument. If no mode is given it will return the attached script's instance.
  * Script commands instance_destroy, instance_npcname, instance_mapname, instance_announce now attach themselves to the script's instance by default.
  * Script commands instance_enter and instance_warpall attach themselves to the player's IM_PARTY instance by default.
  * Update documentation to match changes.
Thanks to @vykimo and @Atemo!