### PR TITLE
Ensure the mysql server host support full length domain

### DIFF
--- a/src/char/inter.cpp
+++ b/src/char/inter.cpp
@@ -45,7 +45,7 @@ InterServerDatabase interServerDb;
 Sql* sql_handle = NULL;	///Link to mysql db, connection FD
 
 int char_server_port = 3306;
-char char_server_ip[32] = "127.0.0.1";
+char char_server_ip[64] = "127.0.0.1";
 char char_server_id[32] = "ragnarok";
 char char_server_pw[32] = ""; // Allow user to send empty password (bugreport:7787)
 char char_server_db[32] = "ragnarok";

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -16,7 +16,7 @@
 #include "loginlog.hpp"
 
 // login sql settings
-static char   ipban_db_hostname[32] = "127.0.0.1";
+static char   ipban_db_hostname[64] = "127.0.0.1";
 static uint16 ipban_db_port = 3306;
 static char   ipban_db_username[32] = "ragnarok";
 static char   ipban_db_password[32] = "";

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -55,7 +55,7 @@ using namespace rathena;
 char default_codepage[32] = "";
 
 int map_server_port = 3306;
-char map_server_ip[32] = "127.0.0.1";
+char map_server_ip[64] = "127.0.0.1";
 char map_server_id[32] = "ragnarok";
 char map_server_pw[32] = "";
 char map_server_db[32] = "ragnarok";
@@ -90,7 +90,7 @@ char roulette_table[32] = "db_roulette";
 char guild_storage_log_table[32] = "guild_storage_log";
 
 // log database
-char log_db_ip[32] = "127.0.0.1";
+char log_db_ip[64] = "127.0.0.1";
 int log_db_port = 3306;
 char log_db_id[32] = "ragnarok";
 char log_db_pw[32] = "ragnarok";


### PR DESCRIPTION
* **Server Mode**:  Both

* **Description of Pull Request**: 

rAthena is support use the domain to connect mysql server, but some cloud services (like RDS in ALIYUN from China), they will provide a supper long domain for you (far more than 32 bytes), our mysql server host ip buffer is too small, use the RDS domain will be truncated.

So I think we can extend it for support full length domain.