### PR TITLE
Corrected Cross Slash

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3366,7 +3366,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 		case RL_QD_SHOT:
 			wd->div_ = 1 + (sd ? sd->status.job_level : 1) / 20 + (tsc && tsc->data[SC_C_MARKER] ? 2 : 0);
 			break;
-		case SC_JYUMONJIKIRI:
+		case KO_JYUMONJIKIRI:
 			if( tsc && tsc->data[SC_JYUMONJIKIRI] )
 				wd->div_ = wd->div_ * -1;// needs more info
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixed Kagerou/Oboro Cross Slash div_ check looking for the status change rather than the skill ID.
Thanks to @mrjnumber1!