### PR TITLE
Cleaned up Joint Beat behavior

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3634,10 +3634,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += 40 * skill_lv;
 			break;
 		case LK_JOINTBEAT:
-			i = 10 * skill_lv - 50;
+			skillratio += -100 + 10 * skill_lv - 50;
 			if (wd->miscflag&BREAK_NECK) // The 2x damage is only for the break neck ailment.
-				i *= 2;
-			skillratio += i;
+				skillratio <<= 1;
 			break;
 #ifdef RENEWAL
 		// Renewal: skill ratio applies to entire damage [helvetica]

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3635,7 +3635,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case LK_JOINTBEAT:
 			skillratio += -100 + 10 * skill_lv - 50;
-			if (wd->miscflag&BREAK_NECK) // The 2x damage is only for the break neck ailment.
+			if (wd->miscflag & BREAK_NECK || (tsc && tsc->data[status_skill2sc(skill_id)]->val2 & BREAK_NECK)) // The 2x damage is only for the BREAK_NECK ailment.
 				skillratio <<= 1;
 			break;
 #ifdef RENEWAL

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3635,8 +3635,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case LK_JOINTBEAT:
 			i = 10 * skill_lv - 50;
-			// Although not clear, it's being assumed that the 2x damage is only for the break neck ailment.
-			if (wd->miscflag&BREAK_NECK)
+			if (wd->miscflag&BREAK_NECK) // The 2x damage is only for the break neck ailment.
 				i *= 2;
 			skillratio += i;
 			break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1511,13 +1511,6 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 			sc_start2(src,bl, SC_BLEEDING,50, skill_lv, src->id, skill_get_time2(skill_id,skill_lv));
 		break;
 
-	case LK_JOINTBEAT:
-		status = status_skill2sc(skill_id);
-		if (tsc->jb_flag) {
-			sc_start4(src,bl,status,(5*skill_lv+5),skill_lv,tsc->jb_flag&BREAK_FLAGS,src->id,0,skill_get_time2(skill_id,skill_lv));
-			tsc->jb_flag = 0;
-		}
-		break;
 	case ASC_METEORASSAULT:
 		//Any enemies hit by this skill will receive Stun, Darkness, or external bleeding status ailment with a 5%+5*skill_lv% chance.
 		switch(rnd()%3) {
@@ -4775,18 +4768,28 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		break;
 
 	case LK_JOINTBEAT: // decide the ailment first (affects attack damage and effect)
-		switch( rnd()%6 ){
-		case 0: flag |= BREAK_ANKLE; break;
-		case 1: flag |= BREAK_WRIST; break;
-		case 2: flag |= BREAK_KNEE; break;
-		case 3: flag |= BREAK_SHOULDER; break;
-		case 4: flag |= BREAK_WAIST; break;
-		case 5: flag |= BREAK_NECK; break;
+		switch (rnd() % 6) {
+			case 0:
+				flag |= BREAK_ANKLE;
+				break;
+			case 1:
+				flag |= BREAK_WRIST;
+				break;
+			case 2:
+				flag |= BREAK_KNEE;
+				break;
+			case 3:
+				flag |= BREAK_SHOULDER;
+				break;
+			case 4:
+				flag |= BREAK_WAIST;
+				break;
+			case 5:
+				flag |= BREAK_NECK; // Send this flag through skill_attack for the double damage bonus (if the hit lands)
+				break;
 		}
-		//TODO: is there really no cleaner way to do this?
-		sc = status_get_sc(bl);
-		if (sc) sc->jb_flag = flag;
-		skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
+		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag))
+			sc_start4(src, bl, status_skill2sc(skill_id), 50 + (skill_lv + 1) - 270 * tstatus->str / 100, skill_lv, flag&BREAK_FLAGS, src->id, 0, skill_get_time2(skill_id, skill_lv));
 		break;
 
 	case MO_COMBOFINISH:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4767,27 +4767,25 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag|SD_ANIMATION);
 		break;
 
-	case LK_JOINTBEAT: // decide the ailment first (affects attack damage and effect)
+	case LK_JOINTBEAT:
 		switch (rnd() % 6) {
 			case 0:
-				flag |= BREAK_ANKLE;
+				flag = BREAK_ANKLE;
 				break;
 			case 1:
-				flag |= BREAK_WRIST;
+				flag = BREAK_WRIST;
 				break;
 			case 2:
-				flag |= BREAK_KNEE;
+				flag = BREAK_KNEE;
 				break;
 			case 3:
-				flag |= BREAK_SHOULDER;
+				flag = BREAK_SHOULDER;
 				break;
 			case 4:
-				flag |= BREAK_WAIST;
+				flag = BREAK_WAIST;
 				break;
 			case 5:
-				// Send this flag through skill_attack for the double damage bonus (if the hit lands)
-				// BREAK_NECK does not stack with other breaks
-				flag = BREAK_NECK;
+				flag = BREAK_NECK; // Send this flag through skill_attack for the double damage bonus (if the hit lands)
 				break;
 		}
 		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag))

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4788,6 +4788,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				flag = BREAK_NECK; // Send this flag through skill_attack for the double damage bonus (if the hit lands)
 				break;
 		}
+		if (flag != BREAK_NECK && tsc && tsc->data[status_skill2sc(skill_id)]->val2 & BREAK_NECK)
+			flag = BREAK_NECK; // Target should always receive double damage if neck is already broken
 		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag))
 			sc_start4(src, bl, status_skill2sc(skill_id), 50 + (skill_lv + 1), skill_lv, flag&BREAK_FLAGS, src->id, 0, skill_get_time2(skill_id, skill_lv));
 		break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4785,11 +4785,13 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				flag |= BREAK_WAIST;
 				break;
 			case 5:
-				flag |= BREAK_NECK; // Send this flag through skill_attack for the double damage bonus (if the hit lands)
+				// Send this flag through skill_attack for the double damage bonus (if the hit lands)
+				// BREAK_NECK does not stack with other breaks
+				flag = BREAK_NECK;
 				break;
 		}
 		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag))
-			sc_start4(src, bl, status_skill2sc(skill_id), 50 + (skill_lv + 1) - 270 * tstatus->str / 100, skill_lv, flag&BREAK_FLAGS, src->id, 0, skill_get_time2(skill_id, skill_lv));
+			sc_start4(src, bl, status_skill2sc(skill_id), 50 + (skill_lv + 1), skill_lv, flag&BREAK_FLAGS, src->id, 0, skill_get_time2(skill_id, skill_lv));
 		break;
 
 	case MO_COMBOFINISH:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4768,26 +4768,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		break;
 
 	case LK_JOINTBEAT:
-		switch (rnd() % 6) {
-			case 0:
-				flag = BREAK_ANKLE;
-				break;
-			case 1:
-				flag = BREAK_WRIST;
-				break;
-			case 2:
-				flag = BREAK_KNEE;
-				break;
-			case 3:
-				flag = BREAK_SHOULDER;
-				break;
-			case 4:
-				flag = BREAK_WAIST;
-				break;
-			case 5:
-				flag = BREAK_NECK; // Send this flag through skill_attack for the double damage bonus (if the hit lands)
-				break;
-		}
+		flag = 1 << rnd() % 6;
 		if (flag != BREAK_NECK && tsc && tsc->data[status_skill2sc(skill_id)]->val2 & BREAK_NECK)
 			flag = BREAK_NECK; // Target should always receive double damage if neck is already broken
 		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag))

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8186,6 +8186,10 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 				tick /= 5;
 			sc_def = status->agi*50;
 			break;
+		case SC_JOINTBEAT:
+			sc_def2 = 270 * status->str / 100; // 270 * STR / 100
+			tick_def2 = (status->luk * 50 + status->agi * 200) / 2; // (50 * LUK / 100 + 20 * AGI / 100) / 2
+			break;
 		case SC_DEEPSLEEP:
 			tick_def2 = status_get_base_status(bl)->int_ * 25 + status_get_lv(bl) * 50;
 			break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9526,6 +9526,8 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 					return 0;
 				break;
 			case SC_JOINTBEAT:
+				if (sc && sc->data[type]->val2 & BREAK_NECK)
+					return 0; // BREAK_NECK cannot be stacked until the status is over.
 				val2 |= sce->val2; // Stackable ailments
 			default:
 				if(sce->val1 > val1)

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9527,7 +9527,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				break;
 			case SC_JOINTBEAT:
 				if (sc && sc->data[type]->val2 & BREAK_NECK)
-					return 0; // BREAK_NECK cannot be stacked until the status is over.
+					return 0; // BREAK_NECK cannot be stacked with new breaks until the status is over.
 				val2 |= sce->val2; // Stackable ailments
 			default:
 				if(sce->val1 > val1)

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -1953,15 +1953,14 @@ enum efst_types : short{
 };
 
 /// JOINTBEAT stackable ailments
-enum e_joint_break
-{
-	BREAK_ANKLE	= 0x01, ///< MoveSpeed reduced by 50%
-	BREAK_WRIST	= 0x02, ///< ASPD reduced by 25%
-	BREAK_KNEE	= 0x04, ///< MoveSpeed reduced by 30%, ASPD reduced by 10%
-	BREAK_SHOULDER	= 0x08, ///< DEF reduced by 50%
-	BREAK_WAIST	= 0x10, ///< DEF reduced by 25%, ATK reduced by 25%
-	BREAK_NECK	= 0x20, ///< current attack does 2x damage, inflicts 'bleeding' for 30 seconds
-	BREAK_FLAGS	= BREAK_ANKLE | BREAK_WRIST | BREAK_KNEE | BREAK_SHOULDER | BREAK_WAIST | BREAK_NECK,
+enum e_joint_break : uint8 {
+	BREAK_ANKLE = 0x01,		///< MoveSpeed reduced by 50%
+	BREAK_WRIST = 0x02,		///< ASPD reduced by 25%
+	BREAK_KNEE = 0x04,		///< MoveSpeed reduced by 30%, ASPD reduced by 10%
+	BREAK_SHOULDER = 0x08,	///< DEF reduced by 50%
+	BREAK_WAIST = 0x10,		///< DEF reduced by 25%, ATK reduced by 25%
+	BREAK_NECK = 0x20,		///< Current attack does 2x damage, inflicts 'bleeding' for 30 seconds
+	BREAK_FLAGS = BREAK_ANKLE | BREAK_WRIST | BREAK_KNEE | BREAK_SHOULDER | BREAK_WAIST | BREAK_NECK,
 };
 
 extern short current_equip_item_index;
@@ -2327,7 +2326,6 @@ struct status_change {
 	unsigned short opt2;// health state (bitfield)
 	unsigned char count;
 	//! TODO: See if it is possible to implement the following SC's without requiring extra parameters while the SC is inactive.
-	unsigned char jb_flag; //Joint Beat type flag
 	struct {
 		unsigned char move;
 		unsigned char pickup;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4122

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Added missing rate and duration reduction based on the targets stats.
  * Confirmed that double damage only applies to BREAK_NECK.
  * Cleaned up skill to remove jb_flag from status_change struct.
Thanks to @mrjnumber1!