### PR TITLE
Persistent favorites

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -141,3 +141,13 @@ min_shop_buy: 1
 // Minimum sell price of items at a normal shop
 // Officially items can be sold for 0 Zeny
 min_shop_sell: 0
+
+// If enabled, non-equipment items put into the favorites tab will be remembered by ID and
+// automatically added to the favorites tab again if the item was consumed or dropped then rebought.
+persistent_favorites: 1
+
+// If enabled, the above also applies to equipment - all equipment of the same item ID will always be put into the favorites tab.
+// For example, if you put your +15 Kalga mace into favorites and find another Kalga Mace, both will be in the favorites tab.
+// Note : Both options only affect what happens to the item when it is moved to the favorites tab.
+// Disabling the option will not remove the item from favorites even if consumed, until the player manually removes it from the favorites.
+persistent_favorites_equipment: 0

--- a/conf/inter_athena.conf
+++ b/conf/inter_athena.conf
@@ -89,6 +89,7 @@ global_acc_reg_str_table: global_acc_reg_str
 // Char Database Tables
 char_db: char
 hotkey_db: hotkey
+favs_db: favorites
 scdata_db: sc_data
 cart_db: cart_inventory
 inventory_db: inventory

--- a/sql-files/favs.sql
+++ b/sql-files/favs.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS `favorites`;
+CREATE TABLE favorites(
+    char_id INT,
+    itemid INT,
+    PRIMARY KEY (char_id,itemid)
+    );
+	

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -74,6 +74,7 @@ struct Schema_Config {
 	char auction_db[DB_NAME_LEN]; // Auctions System
 	char friend_db[DB_NAME_LEN];
 	char hotkey_db[DB_NAME_LEN];
+	char favs_db[DB_NAME_LEN]; // favorited items
 	char quest_db[DB_NAME_LEN];
 	char homunculus_db[DB_NAME_LEN];
 	char skill_homunculus_db[DB_NAME_LEN];

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -75,6 +75,7 @@
 #define DB_NAME_LEN 256 //max len of dbs
 #define MAX_CLAN 500
 #define MAX_CLANALLIANCE 6
+#define MAX_FAVORITES 128 // Maximum number of different items a player can save in their favorites tab. 
 
 // for produce
 #define MIN_ATTRIBUTE 0
@@ -523,6 +524,8 @@ struct mmo_charstatus {
 #endif
 	bool show_equip,allow_party;
 	short rename;
+
+	int favs[MAX_FAVORITES];
 
 	time_t delete_date;
 	time_t unban_time;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8525,6 +8525,8 @@ static const struct _battle_data {
 	{ "min_shop_buy",                       &battle_config.min_shop_buy,                    1,      0,      INT_MAX,        },
 	{ "min_shop_sell",                      &battle_config.min_shop_sell,                   0,      0,      INT_MAX,        },
 	{ "feature.equipswitch",                &battle_config.feature_equipswitch,             1,      0,      1,              },
+	{ "persistent_favorites",               &battle_config.persistent_favorites,            1,      0,      1, },
+	{ "persistent_favorites_equipment",     &battle_config.persistent_favorites_equipment,  1,      0,      1, },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -655,6 +655,8 @@ struct Battle_Config
 	int min_shop_buy;
 	int min_shop_sell;
 	int feature_equipswitch;
+	int persistent_favorites;
+	int persistent_favorites_equipment;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -18560,9 +18560,12 @@ void clif_parse_MoveItem(int fd, struct map_session_data *sd) {
 	}
 	else if (type == 0) {
 		sd->inventory.u.items_inventory[index].favorite = 1;
-		for (j = 0; (j < MAX_FAVORITES) && (sd->status.favs[j] > 0); j++) { ; }
+		if (battle_config.persistent_favorites)
+			if (!(itemdb_isequip2(sd->inventory_data[index])) || battle_config.persistent_favorites_equipment) {
+			for (j = 0; (j < MAX_FAVORITES) && (sd->status.favs[j] > 0); j++) { ; }
 
-		if (j < MAX_FAVORITES) (sd->status.favs[j] = (sd->inventory.u.items_inventory[index].nameid));
+			if (j < MAX_FAVORITES) (sd->status.favs[j] = (sd->inventory.u.items_inventory[index].nameid));
+		}
 	}
 	else
 		return;/* nothing to do. */

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -18544,6 +18544,7 @@ void clif_parse_MoveItem(int fd, struct map_session_data *sd) {
 	struct s_packet_db* info = &packet_db[RFIFOW(fd,0)];
 	int index = RFIFOW(fd,info->pos[0]) - 2;
 	int type = RFIFOB(fd, info->pos[1]);
+	int j;
 
 	/* can't move while dead. */
 	if(pc_isdead(sd)) {
@@ -18553,10 +18554,16 @@ void clif_parse_MoveItem(int fd, struct map_session_data *sd) {
 	if (index < 0 || index >= MAX_INVENTORY)
 		return;
 
-	if ( sd->inventory.u.items_inventory[index].favorite && type == 1 )
+	if (sd->inventory.u.items_inventory[index].favorite && type == 1) {
 		sd->inventory.u.items_inventory[index].favorite = 0;
-	else if( type == 0 )
+		for (j = 0; j < MAX_FAVORITES; j++) if (sd->status.favs[j] == (sd->inventory.u.items_inventory[index].nameid)) sd->status.favs[j] = 0;
+	}
+	else if (type == 0) {
 		sd->inventory.u.items_inventory[index].favorite = 1;
+		for (j = 0; (j < MAX_FAVORITES) && (sd->status.favs[j] > 0); j++) { ; }
+
+		if (j < MAX_FAVORITES) (sd->status.favs[j] = (sd->inventory.u.items_inventory[index].nameid));
+	}
 	else
 		return;/* nothing to do. */
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -4531,6 +4531,7 @@ short pc_search_inventory(struct map_session_data *sd, unsigned short nameid) {
 char pc_additem(struct map_session_data *sd,struct item *item,int amount,e_log_pick_type log_type) {
 	struct item_data *id;
 	int16 i;
+	int j;
 	unsigned int w;
 
 	nullpo_retr(1, sd);
@@ -4587,6 +4588,10 @@ char pc_additem(struct map_session_data *sd,struct item *item,int amount,e_log_p
 			sd->inventory.u.items_inventory[i].favorite = 0;
 		if( item->equipSwitch )
 			sd->inventory.u.items_inventory[i].equipSwitch = 0;
+
+		for (j = 0; j < MAX_FAVORITES; j++) {
+			if (sd->status.favs[j] == item->nameid) sd->inventory.u.items_inventory[i].favorite = 1;
+		}
 
 		sd->inventory.u.items_inventory[i].amount = amount;
 		sd->inventory_data[i] = id;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
None, this is a new optional feature. 

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Both.

* **Description of Pull Request**: 

When items are put into the favorites tab in the inventory, players expect them to actually stay there. This is not the case for items that get consumed : once you used up your last gemstone, even if you buy more, it'll not be in favorites anymore, so if you rely on favorites to sell or storage everything that's not in favorites, you'll end up going into battle without the items.
This pull request adds a new option to items.conf that allows items to be memorized when put into the favorites tab, so even if the item leaves and reenters the inventory for any reason (dropped, consumed and rebought, etc), it'll stay in the tab where it originally was.
To achieve this, the itemID/charID pairs have to be stored in the database - the root of the current behavior lies in the fact favorites are stored in the actual instance of the inventory item, so it's lost as soon as that item is moved.

Note : I have no idea how RAthena creates the databases when it's first installed - the commands to add the favorites table are in favs.sql, if they need to be moved to a specific file, please move it there.
I've been using this feature to play in the past 2 months without issues, since then the only change I added was to make it optional.
