### PR TITLE
fix getareaunits coordinates

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11385,7 +11385,7 @@ BUILDIN_FUNC(getunits)
 
 	for (bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter))
 	{
-		if (!m || (m == bl->m && !x0 && !y0 && !x1 && !y1) || (bl->m == m && (bl->x >= x0 && bl->y <= y0) && (bl->x <= x1 && bl->y >= y1)))
+		if (!m || (m == bl->m && !x0 && !y0 && !x1 && !y1) || (bl->m == m && (bl->x >= x0 && bl->y >= y0) && (bl->x <= x1 && bl->y <= y1)))
 		{
 			if (data)
 				set_reg(st, sd, reference_uid(id, idx + size), name, (is_string_variable(name) ? (void*)status_get_name(bl) : (void*)__64BPRTSIZE(bl->id)), reference_getref(data));

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11350,10 +11350,10 @@ BUILDIN_FUNC(getunits)
 			ShowWarning("buildin_%s: Unknown map '%s'.\n", command, str);
 			return SCRIPT_CMD_FAILURE;
 		}
-		x0 = script_getnum(st, 4);
-		y0 = script_getnum(st, 5);
-		x1 = script_getnum(st, 6);
-		y1 = script_getnum(st, 7);
+		x0 = min(script_getnum(st, 4), script_getnum(st, 6));
+		y0 = min(script_getnum(st, 5), script_getnum(st, 7));
+		x1 = max(script_getnum(st, 4), script_getnum(st, 6));
+		y1 = max(script_getnum(st, 5), script_getnum(st, 7));
 
 		if (script_hasdata(st, 8))
 			data = script_getdata(st, 8);


### PR DESCRIPTION
Co-Authored-By: AnnieRuru <annieruru@users.noreply.github.com>

* **Server Mode**: both

* **Description of Pull Request**: 
thanks to @AnnieRuru she warned me about it time ago and i didn't think about the issue much
test script:
```cs
-	script	getareaunits	-1,{
OnInit:
	for(.@i = 152;.@i<156;.@i++){
		for(.@m = 162;.@m<166;.@m++){
			monster "prontera",.@i,.@m,"--en--",1084,1;
		}
	}
	//start :	152,162
	//end	:	156,166
	debugmes "==============================================";
	debugmes "Wrong way of typing it:";
	debugmes "" + getareaunits(BL_MOB,"prontera",152,166,156,162);
	debugmes "==============================================";
	debugmes "Right way of typing it:";
	debugmes "" + getareaunits(BL_MOB,"prontera",152,162,156,166);
	debugmes "==============================================";
end;
}
```
Before:
![image](https://user-images.githubusercontent.com/5981261/57486731-fd3cb180-72ae-11e9-8267-e09573b9bb0a.png)

After:
![image](https://user-images.githubusercontent.com/5981261/57486775-1f363400-72af-11e9-8c88-a0d94bf82224.png)

Edit:
now the command should accept both ways , so it would be backward compatible and work the right way thanks to @Atemo
![image](https://user-images.githubusercontent.com/5981261/57493438-223c1f00-72c5-11e9-97ba-f2edaa483c5e.png)
