### PR TITLE
Corrected Enchant Arms for older clients

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5995,6 +5995,11 @@ void clif_status_change_sub(struct block_list *bl, int id, int type, int flag, t
 
 	nullpo_retv(bl);
 
+#if PACKETVER < 20151104
+	if (type == EFST_WEAPONPROPERTY)
+		type = EFST_ATTACK_PROPERTY_NOTHING + val1; // Assign status icon for older clients
+#endif
+
 #if PACKETVER >= 20120618
 	if (flag && battle_config.display_status_timers)
 		WBUFW(buf,0) = 0x983;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10325,6 +10325,10 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				val1 = val1%ELE_ALL;
 			else if (val1 < 0)
 				val1 = rnd()%ELE_ALL;
+
+#ifdef PACKETVER < 20151104
+			StatusIconChangeTable[type] = EFST_ATTACK_PROPERTY_NOTHING + val1; // Assign status icon for older clients
+#endif
 			break;
 		case SC_CRITICALWOUND:
 			val2 = 20*val1; // Heal effectiveness decrease

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10325,10 +10325,6 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				val1 = val1%ELE_ALL;
 			else if (val1 < 0)
 				val1 = rnd()%ELE_ALL;
-
-#if PACKETVER < 20151104
-			StatusIconChangeTable[type] = EFST_ATTACK_PROPERTY_NOTHING + val1; // Assign status icon for older clients
-#endif
 			break;
 		case SC_CRITICALWOUND:
 			val2 = 20*val1; // Heal effectiveness decrease

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10326,7 +10326,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			else if (val1 < 0)
 				val1 = rnd()%ELE_ALL;
 
-#ifdef PACKETVER < 20151104
+#if PACKETVER < 20151104
 			StatusIconChangeTable[type] = EFST_ATTACK_PROPERTY_NOTHING + val1; // Assign status icon for older clients
 #endif
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes Enchant Arms displaying an incorrect status icon for clients older than 2015-11-04.
Thanks to @Daegaladh!