### PR TITLE
Announce Accept Char id

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6799,7 +6799,7 @@ as soon as the progress bar activates.
 //
 ---------------------------------------
 
-*announce "<text>",<flag>{,<fontColor>{,<fontType>{,<fontSize>{,<fontAlign>{,<fontY>}}}}};
+*announce "<text>",<flag>{,<fontColor>{,<fontType>{,<fontSize>{,<fontAlign>{,<fontY>{,<char_id>}}}}}};
 
 This command will broadcast a message to all or most players, similar to
 @kami/@kamib GM commands.
@@ -6819,7 +6819,7 @@ Target flags:
 You cannot use more than one target flag.
 
 Source flags:
-- bc_pc: Broadcast source is the attached player (default).
+- bc_pc: Broadcast source is the attached player or the char id if it's provided (default).
 - bc_npc: Broadcast source is the NPC, not the player attached to the script
   (useful when a player is not attached or the message should be sent to those
   nearby the NPC).

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6858,7 +6858,7 @@ but it can be used instead in NPCs to "preview" an announce.
 	announce "This is my message just for you people here",bc_npc|bc_area;
 
 	// This will be a private message to the player with character id 150000
-	announce "This is my message just for char id 150000",bc_self,0xFFF618,FW_NORMAL,12,NULL,NULL,150000;
+	announce "This is my message just for char id 150000",bc_self,0xFFF618,FW_NORMAL,12,0,0,150000;
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6815,11 +6815,12 @@ Target flags:
 - bc_all: Broadcast message is sent server-wide (default).
 - bc_map: Message is sent to everyone in the same map as the source of the broadcast (see below).
 - bc_area: Message is sent to players in the vicinity of the source.
-- bc_self: Message is sent only to current player.
+- bc_self: Message is sent only to current player , if the source flag is bc_pc it also can
+			be used to send the Message to the character id if it's provided.
 You cannot use more than one target flag.
 
 Source flags:
-- bc_pc: Broadcast source is the attached player or the char id if it's provided (default).
+- bc_pc: Broadcast source is the attached player or the character id if it's provided (default).
 - bc_npc: Broadcast source is the NPC, not the player attached to the script
   (useful when a player is not attached or the message should be sent to those
   nearby the NPC).
@@ -6855,6 +6856,9 @@ but it can be used instead in NPCs to "preview" an announce.
 
 	// This will be shown on everyones screen that is in sight of the NPC.
 	announce "This is my message just for you people here",bc_npc|bc_area;
+
+	// This will be a private message to the player with character id 150000
+	announce "This is my message just for char id 150000",bc_self,0xFFF618,FW_NORMAL,12,NULL,NULL,150000;
 
 ---------------------------------------
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11103,10 +11103,10 @@ BUILDIN_FUNC(announce)
 		}else{
 			struct map_session_data* sd;
 
-			if (!script_charid2sd(9, sd))
-				bl = NULL;
-			else
+			if(script_charid2sd(9, sd))
 				bl = &sd->bl;
+			else
+				bl = NULL;
 		}
 		
 		if (bl == NULL)

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11103,10 +11103,10 @@ BUILDIN_FUNC(announce)
 		}else{
 			struct map_session_data* sd;
 
-			if( script_rid2sd(sd) )
-				bl = &sd->bl;
-			else
+			if (!script_charid2sd(9, sd))
 				bl = NULL;
+			else
+				bl = &sd->bl;
 		}
 		
 		if (bl == NULL)
@@ -24600,7 +24600,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(attachnpctimer,"?"), // attached the player id to the npc timer [Celest]
 	BUILDIN_DEF(detachnpctimer,"?"), // detached the player id from the npc timer [Celest]
 	BUILDIN_DEF(playerattached,""), // returns id of the current attached player. [Skotlex]
-	BUILDIN_DEF(announce,"si?????"),
+	BUILDIN_DEF(announce,"si??????"),
 	BUILDIN_DEF(mapannounce,"ssi?????"),
 	BUILDIN_DEF(areaannounce,"siiiisi?????"),
 	BUILDIN_DEF(getusers,"i"),


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/3901

* **Server Mode**: both

* **Description of Pull Request**: 
the original idea is to make a new GID like `GID_GROUP` and hook it to vector of players
but instead of making things complicated
this will allow `<char_id>` in the `announce` command as it already accept attached char on `bc_self`

* with this PR we can do this:
```cs
OnInit:
	bindatcmd("listenpvp",strnpcinfo(3)+"::Onlistenpvp",0,99);
end;

Onlistenpvp:
	.@ndx = inarray($pvplisteners,getcharid(0));
	if(.@ndx == -1){
		$pvplisteners[getarraysize($pvplisteners)] = getcharid(0);
		dispbottom "PVP Announcement : ON";
	}else{
		deletearray $pvplisteners[.@ndx],1;
		dispbottom "PVP Announcement : OFF";
	}
end;
OnSomethingHappen:
	for(.@i=0;.@i<getarraysize($pvplisteners);.@i++){
		announce "Something happen in PVP!",bc_self,0xFFF618,FW_NORMAL,12,NULL,NULL,$pvplisteners[.@i];
	}
end;
```

* **test script**:
```cs
//with both online char id 150000 , 150003
prontera,157,170,4	script	announce_to_id	444,{
	announce "this for the char id 150000",bc_self,0xFFF618,FW_NORMAL,12,NULL,NULL,150000;
	announce "this for the char id 150003",bc_self,0xFFF618,FW_NORMAL,12,NULL,NULL,150003;
}
```
