### PR TITLE
Fixed unitwalk with the same event name

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -416,6 +416,9 @@ static TIMER_FUNC(unit_walktoxy_timer){
 			// Copying is required in case someone uses unitwalkto inside the event code
 			safestrncpy(walk_done_event, ud->walk_done_event, EVENT_NAME_LENGTH);
 
+			//Clear the event
+			ud->walk_done_event[0] = 0;
+
 			ud->state.walk_script = true;
 
 			// Execute the event
@@ -434,11 +437,6 @@ static TIMER_FUNC(unit_walktoxy_timer){
 				return 0;
 			}
 
-			// Check if another event was set
-			if( !strcmp(ud->walk_done_event,walk_done_event) ){
-				// If not remove it
-				ud->walk_done_event[0] = 0;
-			}
 		}
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/4118

* **Server Mode**: both

* **Description of Pull Request**: 
with this PR `unitwalk` now allow looping with the same event after the unit reached the given coordinates

* **test script**:
```cs
//@warp prontera 160 175 @reloadscript
-	script	unitwalk_test	-1,{
OnInit:
	monster "prontera",155,176,"--en--",1002,1;
	.gid = $@mobid[0];
	unitwalk .gid,155,(176 - 5),strnpcinfo(3) + "::OnDone";
end;
OnDone:
	getunitdata(.gid,.@g);
	unitwalk .gid,155,(.@g[UMOB_Y] - 5),strnpcinfo(3) + "::OnDone";
end;;
}
```
