### PR TITLE
Fix HomSkill (MH_OVERED_BOOST)

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12559,7 +12559,7 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 						struct homun_data *hd = BL_CAST(BL_HOM,bl);
 
 						if( hd )
-							hd->homunculus.hunger = max(1,hd->homunculus.hunger - 50);
+							hd->homunculus.hunger = max(1,hd->homunculus.hunger / 2);
 					}
 					break;
 				case BL_PC:


### PR DESCRIPTION
* **Addressed Issue(s)**: #4217 

* **Server Mode**: Renewal

* **Description of Pull Request**: 

https://www.divine-pride.net/database/skill/8023
Following skill database from divine-pride, Homunculus Hungry Rate should be decrease by half.
