### PR TITLE
Fixed STR affecting mob damage in pre-renewal

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -10,6 +10,7 @@
 //--------------------------------------------------------------
 
 // Who should have a baseatk value (makes str affect damage)? (Note 3)
+// Note: Mob is not affected in pre-renewal
 enable_baseatk: 0x29F
 
 // Who can have perfect flee? (Note 3)

--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -10,8 +10,9 @@
 //--------------------------------------------------------------
 
 // Who should have a baseatk value (makes str affect damage)? (Note 3)
-// Note: Mob is not affected in pre-renewal
-enable_baseatk: 0x29F
+// The config has been deprecated and hard coded to the values below.
+//enable_baseatk: 0x9 // Pre-Renewal
+//enable_baseatk: 0x29F // Renewal
 
 // Who can have perfect flee? (Note 3)
 enable_perfect_flee: 1

--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -10,9 +10,8 @@
 //--------------------------------------------------------------
 
 // Who should have a baseatk value (makes str affect damage)? (Note 3)
-// The config has been deprecated and hard coded to the values below.
-//enable_baseatk: 0x9 // Pre-Renewal
-//enable_baseatk: 0x29F // Renewal
+enable_baseatk: 0x9
+enable_baseatk_renewal: 0x29F
 
 // Who can have perfect flee? (Note 3)
 enable_perfect_flee: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7996,7 +7996,6 @@ static const struct _battle_data {
 	{ "enable_critical",                    &battle_config.enable_critical,                 BL_PC,  BL_NUL, BL_ALL,         },
 	{ "mob_critical_rate",                  &battle_config.mob_critical_rate,               100,    0,      INT_MAX,        },
 	{ "critical_rate",                      &battle_config.critical_rate,                   100,    0,      INT_MAX,        },
-	{ "enable_baseatk",                     &battle_config.enable_baseatk,                  BL_CHAR|BL_NPC, BL_NUL, BL_ALL,   },
 	{ "enable_perfect_flee",                &battle_config.enable_perfect_flee,             BL_PC|BL_PET, BL_NUL, BL_ALL,   },
 	{ "casting_rate",                       &battle_config.cast_rate,                       100,    0,      INT_MAX,        },
 	{ "delay_rate",                         &battle_config.delay_rate,                      100,    0,      INT_MAX,        },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7996,6 +7996,8 @@ static const struct _battle_data {
 	{ "enable_critical",                    &battle_config.enable_critical,                 BL_PC,  BL_NUL, BL_ALL,         },
 	{ "mob_critical_rate",                  &battle_config.mob_critical_rate,               100,    0,      INT_MAX,        },
 	{ "critical_rate",                      &battle_config.critical_rate,                   100,    0,      INT_MAX,        },
+	{ "enable_baseatk",                     &battle_config.enable_baseatk,                  BL_CHAR|BL_HOM, BL_NUL, BL_ALL, },
+	{ "enable_baseatk_renewal",             &battle_config.enable_baseatk_renewal,          BL_ALL, BL_NUL, BL_ALL,         },
 	{ "enable_perfect_flee",                &battle_config.enable_perfect_flee,             BL_PC|BL_PET, BL_NUL, BL_ALL,   },
 	{ "casting_rate",                       &battle_config.cast_rate,                       100,    0,      INT_MAX,        },
 	{ "delay_rate",                         &battle_config.delay_rate,                      100,    0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -141,7 +141,6 @@ struct Battle_Config
 	int enable_critical;
 	int mob_critical_rate;
 	int critical_rate;
-	int enable_baseatk;
 	int enable_perfect_flee;
 	int cast_rate, delay_rate;
 	int delay_dependon_dex, delay_dependon_agi;

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -141,6 +141,7 @@ struct Battle_Config
 	int enable_critical;
 	int mob_critical_rate;
 	int critical_rate;
+	int enable_baseatk, enable_baseatk_renewal;
 	int enable_perfect_flee;
 	int cast_rate, delay_rate;
 	int delay_dependon_dex, delay_dependon_agi;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2435,8 +2435,11 @@ unsigned short status_base_atk(const struct block_list *bl, const struct status_
 {
 	int flag = 0, str, dex, dstr;
 
-#ifndef RENEWAL // Deprecated battle_config.enable_baseatk
-	if (!(bl->type&(BL_PC|BL_HOM)))
+#ifdef RENEWAL
+	if (!(bl->type&battle_config.enable_baseatk_renewal))
+		return 0;
+#else
+	if (!(bl->type&battle_config.enable_baseatk))
 		return 0;
 #endif
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2435,12 +2435,10 @@ unsigned short status_base_atk(const struct block_list *bl, const struct status_
 {
 	int flag = 0, str, dex, dstr;
 
-#ifndef RENEWAL // Monster damage is not affected by STR
-	if (bl->type == BL_MOB)
+#ifndef RENEWAL // Deprecated battle_config.enable_baseatk
+	if (!(bl->type&(BL_PC|BL_HOM)))
 		return 0;
 #endif
-	if(!(bl->type&battle_config.enable_baseatk))
-		return 0;
 
 	if (bl->type == BL_PC)
 	switch(((TBL_PC*)bl)->status.weapon) {

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2435,6 +2435,10 @@ unsigned short status_base_atk(const struct block_list *bl, const struct status_
 {
 	int flag = 0, str, dex, dstr;
 
+#ifndef RENEWAL // Monster damage is not affected by STR
+	if (bl->type == BL_MOB)
+		return 0;
+#endif
 	if(!(bl->type&battle_config.enable_baseatk))
 		return 0;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal

* **Description of Pull Request**: 
  * Follow up to fe197bf.
  * STR should not affect monster's damage.
Thanks to @Playtester!