### PR TITLE
Made mob sprite column unique

### DIFF
--- a/sql-files/mob_db.sql
+++ b/sql-files/mob_db.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `mob_db`;
 CREATE TABLE `mob_db` (
   `ID` mediumint(9) unsigned NOT NULL default '0',
-  `Sprite` text NOT NULL,
+  `Sprite` varchar(24) NOT NULL,
   `kName` text NOT NULL,
   `iName` text NOT NULL,
   `LV` tinyint(6) unsigned NOT NULL default '0',
@@ -61,7 +61,7 @@ CREATE TABLE `mob_db` (
   `Drop9per` smallint(9) unsigned NOT NULL default '0',
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ID`)
+  PRIMARY KEY  (`ID`),
   UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 

--- a/sql-files/mob_db.sql
+++ b/sql-files/mob_db.sql
@@ -62,6 +62,7 @@ CREATE TABLE `mob_db` (
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
   PRIMARY KEY  (`ID`)
+  UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 
 # Monster Database

--- a/sql-files/mob_db2.sql
+++ b/sql-files/mob_db2.sql
@@ -62,6 +62,7 @@ CREATE TABLE `mob_db2` (
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
   PRIMARY KEY  (`ID`)
+  UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 
 # Monster Additional Database

--- a/sql-files/mob_db2.sql
+++ b/sql-files/mob_db2.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `mob_db2`;
 CREATE TABLE `mob_db2` (
   `ID` mediumint(9) unsigned NOT NULL default '0',
-  `Sprite` text NOT NULL,
+  `Sprite` varchar(24) NOT NULL,
   `kName` text NOT NULL,
   `iName` text NOT NULL,
   `LV` tinyint(6) unsigned NOT NULL default '0',
@@ -61,7 +61,7 @@ CREATE TABLE `mob_db2` (
   `Drop9per` smallint(9) unsigned NOT NULL default '0',
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ID`)
+  PRIMARY KEY  (`ID`),
   UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 

--- a/sql-files/mob_db2_re.sql
+++ b/sql-files/mob_db2_re.sql
@@ -62,6 +62,7 @@ CREATE TABLE `mob_db2_re` (
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
   PRIMARY KEY  (`ID`)
+  UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 
 # Monsters Additional Database

--- a/sql-files/mob_db2_re.sql
+++ b/sql-files/mob_db2_re.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `mob_db2_re`;
 CREATE TABLE `mob_db2_re` (
   `ID` mediumint(9) unsigned NOT NULL default '0',
-  `Sprite` text NOT NULL,
+  `Sprite` varchar(24) NOT NULL,
   `kName` text NOT NULL,
   `iName` text NOT NULL,
   `LV` tinyint(6) unsigned NOT NULL default '0',
@@ -61,7 +61,7 @@ CREATE TABLE `mob_db2_re` (
   `Drop9per` smallint(9) unsigned NOT NULL default '0',
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ID`)
+  PRIMARY KEY  (`ID`),
   UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 

--- a/sql-files/mob_db_re.sql
+++ b/sql-files/mob_db_re.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `mob_db_re`;
 CREATE TABLE `mob_db_re` (
   `ID` mediumint(9) unsigned NOT NULL default '0',
-  `Sprite` text NOT NULL,
+  `Sprite` varchar(24) NOT NULL,
   `kName` text NOT NULL,
   `iName` text NOT NULL,
   `LV` tinyint(6) unsigned NOT NULL default '0',
@@ -61,7 +61,7 @@ CREATE TABLE `mob_db_re` (
   `Drop9per` smallint(9) unsigned NOT NULL default '0',
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`ID`)
+  PRIMARY KEY  (`ID`),
   UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 

--- a/sql-files/mob_db_re.sql
+++ b/sql-files/mob_db_re.sql
@@ -62,6 +62,7 @@ CREATE TABLE `mob_db_re` (
   `DropCardid` smallint(5) unsigned NOT NULL default '0',
   `DropCardper` smallint(9) unsigned NOT NULL default '0',
   PRIMARY KEY  (`ID`)
+  UNIQUE KEY (`Sprite`)
 ) ENGINE=MyISAM;
 
 # Monster Database

--- a/sql-files/upgrades/upgrade_20190628.sql
+++ b/sql-files/upgrades/upgrade_20190628.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `mob_db`
+	ADD UNIQUE KEY (`Sprite`)
+
+ALTER TABLE `mob_db_re`
+	ADD UNIQUE KEY (`Sprite`)
+
+ALTER TABLE `mob_db2`
+	ADD UNIQUE KEY (`Sprite`)
+
+ALTER TABLE `mob_db2_re`
+	ADD UNIQUE KEY (`Sprite`)

--- a/sql-files/upgrades/upgrade_20190628.sql
+++ b/sql-files/upgrades/upgrade_20190628.sql
@@ -1,11 +1,19 @@
 ALTER TABLE `mob_db`
+	MODIFY `Sprite` varchar(24) NOT NULL,
 	ADD UNIQUE KEY (`Sprite`)
+;
 
 ALTER TABLE `mob_db_re`
+	MODIFY `Sprite` varchar(24) NOT NULL,
 	ADD UNIQUE KEY (`Sprite`)
+;
 
 ALTER TABLE `mob_db2`
+	MODIFY `Sprite` varchar(24) NOT NULL,
 	ADD UNIQUE KEY (`Sprite`)
+;
 
 ALTER TABLE `mob_db2_re`
+	MODIFY `Sprite` varchar(24) NOT NULL,
 	ADD UNIQUE KEY (`Sprite`)
+;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4223

* **Server Mode**: Both

* **Description of Pull Request**: 
Changes the type of the sprite column to varchar, because text cannot be used in a unique key, because it's size might be too big. After changing the type a unique key will be added, since inside the server code the sprite name is treated as unique as well.
