### PR TITLE
Fixed invalid item errors in achievements

### DIFF
--- a/src/map/achievement.cpp
+++ b/src/map/achievement.cpp
@@ -260,7 +260,7 @@ uint64 AchievementDatabase::parseBodyNode(const YAML::Node &node){
 				return 0;
 			}
 
-			achievement->rewards.nameid = amount;
+			achievement->rewards.amount = amount;
 		}
 
 		if( this->nodeExists( rewardNode, "Script" ) ){


### PR DESCRIPTION
* **Addressed Issue(s)**: #4236

* **Server Mode**: Both

* **Description of Pull Request**: 
The reward amount was getting stored into the wrong field of the achievement structure.

Thanks to @RadianFord
