### PR TITLE
Fixed CZ_STANDING_RESURRECTION check

### DIFF
--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -87,6 +87,7 @@ groups: (
 	inherit: ( /*empty list*/ )
 	commands: {
 		changedress: true
+		resurrect: true
 	}
 	permissions: {
 		/* without this basic permissions regular players could not 

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -10045,6 +10045,15 @@ ACMD_FUNC(camerainfo){
 	return 0;
 }
 
+ACMD_FUNC(resurrect) {
+	nullpo_retr(-1, sd);
+
+	if (!pc_revive_item(sd))
+		return -1;
+
+	return 0;
+}
+
 #include "../custom/atcommand.inc"
 
 /**
@@ -10345,6 +10354,7 @@ void atcommand_basecommands(void) {
 		ACMD_DEFR(limitedsale, ATCMD_NOCONSOLE|ATCMD_NOAUTOTRADE),
 		ACMD_DEFR(changedress, ATCMD_NOCONSOLE|ATCMD_NOAUTOTRADE),
 		ACMD_DEFR(camerainfo, ATCMD_NOCONSOLE|ATCMD_NOAUTOTRADE),
+		ACMD_DEFR(resurrect, ATCMD_NOCONSOLE),
 	};
 	AtCommandInfo* atcommand;
 	int i;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14940,29 +14940,7 @@ void clif_parse_HomMenu(int fd, struct map_session_data *sd)
 /// 0292
 void clif_parse_AutoRevive(int fd, struct map_session_data *sd)
 {
-	if (sd->sc.data[SC_HELLPOWER]) // Cannot resurrect while under the effect of SC_HELLPOWER.
-		return;
-
-	int16 item_position = itemdb_group_item_exists_pc(sd, IG_TOKEN_OF_SIEGFRIED);
-	uint8 hp = 100, sp = 100;
-
-	if (item_position < 0) {
-		if (sd->sc.data[SC_LIGHT_OF_REGENE]) {
-			hp = sd->sc.data[SC_LIGHT_OF_REGENE]->val2;
-			sp = 0;
-		} else
-			return;
-	}
-
-	if (!status_revive(&sd->bl, hp, sp))
-		return;
-
-	if (item_position < 0)
-		status_change_end(&sd->bl, SC_LIGHT_OF_REGENE, INVALID_TIMER);
-	else
-		pc_delitem(sd, item_position, 1, 0, 1, LOG_TYPE_CONSUME);
-
-	clif_skill_nodamage(&sd->bl, &sd->bl, ALL_RESURRECTION, 4, 1);
+	pc_revive_item(sd);
 }
 
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -727,7 +727,7 @@ struct map_session_data {
 
 	short last_addeditem_index; /// Index of latest item added
 	int autotrade_tid;
-
+	time_t respawn_tid;
 	int bank_vault; ///< Bank Vault
 
 #ifdef PACKET_OBFUSCATION
@@ -1166,6 +1166,7 @@ int pc_skillheal2_bonus(struct map_session_data *sd, uint16 skill_id);
 void pc_damage(struct map_session_data *sd,struct block_list *src,unsigned int hp, unsigned int sp);
 int pc_dead(struct map_session_data *sd,struct block_list *src);
 void pc_revive(struct map_session_data *sd,unsigned int hp, unsigned int sp);
+bool pc_revive_item(struct map_session_data *sd);
 void pc_heal(struct map_session_data *sd,unsigned int hp,unsigned int sp, int type);
 int pc_itemheal(struct map_session_data *sd,int itemid, int hp,int sp);
 int pc_percentheal(struct map_session_data *sd,int,int);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -727,7 +727,7 @@ struct map_session_data {
 
 	short last_addeditem_index; /// Index of latest item added
 	int autotrade_tid;
-	time_t respawn_tid;
+	int respawn_tid;
 	int bank_vault; ///< Bank Vault
 
 #ifdef PACKET_OBFUSCATION


### PR DESCRIPTION
* **Addressed Issue(s)**: -
* **Server Mode**: Both
* **Description of Pull Request**: 
   * Player can force to resurrect as long as they have valid Token of Siegfried even in auto respawn maps
    * Added command `@resurrect` to resurrect using first matched Token of Siegfried item in inventory clients that don't show Resurrect button