### PR TITLE
Corrected pet bonuses not applying

### DIFF
--- a/conf/battle/pet.conf
+++ b/conf/battle/pet.conf
@@ -22,6 +22,7 @@ pet_friendly_rate: 100
 pet_hungry_delay_rate: 100
 
 // Does the pet need its equipment before it does its skill? (Note 1)
+// These bonuses are unofficial and found in the import/pet_db.yml
 pet_equip_required: yes
 
 // When the master attacks a monster, whether or not the pet will also attack. (Note 1)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8091,7 +8091,6 @@ static const struct _battle_data {
 	{ "pet_attack_support",                 &battle_config.pet_attack_support,              0,      0,      1,              },
 	{ "pet_damage_support",                 &battle_config.pet_damage_support,              0,      0,      1,              },
 	{ "pet_support_min_friendly",           &battle_config.pet_support_min_friendly,        900,    0,      950,            },
-	{ "pet_equip_min_friendly",             &battle_config.pet_equip_min_friendly,          900,    0,      950,            },
 	{ "pet_support_rate",                   &battle_config.pet_support_rate,                100,    0,      INT_MAX,        },
 	{ "pet_attack_exp_to_master",           &battle_config.pet_attack_exp_to_master,        0,      0,      1,              },
 	{ "pet_attack_exp_rate",                &battle_config.pet_attack_exp_rate,             100,    0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -226,7 +226,6 @@ struct Battle_Config
 	int pet_attack_support;
 	int pet_damage_support;
 	int pet_support_min_friendly;	//[Skotlex]
-	int pet_equip_min_friendly;
 	int pet_support_rate;
 	int pet_attack_exp_to_master;
 	int pet_attack_exp_rate;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -600,17 +600,13 @@ int pet_hungry_val(struct pet_data *pd)
  */
 void pet_set_intimate(struct pet_data *pd, int value)
 {
-	int intimate;
-	struct map_session_data *sd;
-
 	nullpo_retv(pd);
-
-	intimate = pd->pet.intimate;
-	sd = pd->master;
 
 	pd->pet.intimate = min(value, PET_INTIMATE_MAX);
 
-	if( sd && ((intimate >= battle_config.pet_equip_min_friendly && pd->pet.intimate < battle_config.pet_equip_min_friendly) || (intimate < battle_config.pet_equip_min_friendly && pd->pet.intimate >= battle_config.pet_equip_min_friendly)) )
+	struct map_session_data *sd = pd->master;
+
+	if (sd)
 		status_calc_pc(sd,SCO_NONE);
 }
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3831,9 +3831,10 @@ int status_calc_pc_sub(struct map_session_data* sd, enum e_status_calc_opt opt)
 	if( sd->pd ) { // Pet Bonus
 		struct pet_data *pd = sd->pd;
 		std::shared_ptr<s_pet_db> pet_db_ptr = pd->get_pet_db();
-		if( pet_db_ptr != nullptr && pet_db_ptr->pet_bonus_script && pd->pet.intimate >= battle_config.pet_equip_min_friendly )
+
+		if (pet_db_ptr != nullptr && pet_db_ptr->pet_bonus_script)
 			run_script(pet_db_ptr->pet_bonus_script,0,sd->bl.id,0);
-		if( pet_db_ptr != nullptr && pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus )
+		if (pet_db_ptr != nullptr && pd->pet.intimate > 0 && (!battle_config.pet_equip_required || pd->pet.equip > 0) && pd->state.skillbonus == 1 && pd->bonus)
 			pc_bonus(sd,pd->bonus->type, pd->bonus->val);
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #4283

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrected pet bonuses not applying on intimacy changes.
  * Removed pet_equip_min_friendly battle config as bonuses are determined on intimacy in the bonus script.
Thanks to @teededung!