### PR TITLE
Reduce list field length in ipbanlist table from 255 to 15

### DIFF
--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -731,7 +731,7 @@ CREATE TABLE IF NOT EXISTS `inventory` (
 --
 
 CREATE TABLE IF NOT EXISTS `ipbanlist` (
-  `list` varchar(255) NOT NULL default '',
+  `list` varchar(15) NOT NULL default '',
   `btime` datetime NOT NULL,
   `rtime` datetime NOT NULL,
   `reason` varchar(255) NOT NULL default '',

--- a/sql-files/upgrades/upgrade_20190814.sql
+++ b/sql-files/upgrades/upgrade_20190814.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `ipbanlist`
+	CHANGE COLUMN `list` `list` VARCHAR(15) NOT NULL DEFAULT '' FIRST;

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -100,7 +100,7 @@ TIMER_FUNC(ipban_cleanup){
 	if( !login_config.ipban )
 		return 0;// ipban disabled
 
-	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `ipbanlist` WHERE `rtime` <= NOW()") )
+	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `rtime` <= NOW()", ipban_table) )
 		Sql_ShowDebug(sql_handle);
 
 	return 0;


### PR DESCRIPTION
* **Addressed Issue(s)**: #3093 
* **Server Mode**: Both
* **Description of Pull Request**: 
Since IPv4 is always in format xxx.xxx.xxx.xxx, we can safely use VARCHAR(15) as the data type of the `list` field of `ipbanlist` table.