### PR TITLE
Corrected battle config default_fixed_castrate

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16648,12 +16648,13 @@ int skill_vfcastfix(struct block_list *bl, double time, uint16 skill_id, uint16 
 	if (bl->type == BL_MOB || bl->type == BL_NPC)
 		return (int)time;
 
-	if (fixed < 0 || !battle_config.default_fixed_castrate) // no fixed cast time
+	if (fixed < 0) // no fixed cast time
 		fixed = 0;
 	else if (fixed == 0) {
 		fixed = (int)time * battle_config.default_fixed_castrate / 100; // fixed time
 		time = time * (100 - battle_config.default_fixed_castrate) / 100; // variable time
 	}
+	// Else, use fixed cast time from database (when default_fixed_castrate is set to 0)
 
 	// Additive Variable Cast bonus adjustments by items
 	if (sd && !(flag&4)) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #4340

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * When default_fixed_castrate is set to 0, it should not replace the value of the databases' fixed value when greater than 0.
Thanks to @SeravySensei!