### PR TITLE
prevent manhole Battle/GvG/MD_STATUS_IMMUNE monsters

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9054,7 +9054,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		switch (type) {
 		case SC_COMA:
 		// continue list...
-		    return 0;
+			return 0;
 		}
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2127,10 +2127,6 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 				&& (src->type != BL_PC || ((TBL_PC*)src)->skillitem != skill_id))
 				return false;
 			break;
-		case SC_MANHOLE:
-			// Skill is disabled against special racial grouped monsters(GvG and Battleground)
-			if (target && ( status_get_race2(target) == RC2_GVG || status_get_race2(target) == RC2_BATTLEFIELD ) )
-				return false;
 		default:
 			break;
 	}
@@ -9048,15 +9044,25 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			case SC_SV_ROOTTWIST:
 			case SC_BITESCAR:
 			case SC_FRESHSHRIMP:
+			case SC__MANHOLE:
 				return 0;
 		}
 	}
+
 	// Check for mvp resistance // atm only those who OS
 	if(status_has_mode(status,MD_MVP) && !(flag&SCSTART_NOAVOID)) {
-		 switch (type) {
-		 case SC_COMA:
+		switch (type) {
+		case SC_COMA:
 		// continue list...
-		     return 0;
+		    return 0;
+		}
+	}
+
+	//Check for GVG and Battleground Race2 Monsters.
+	if (status_get_race2(bl) == RC2_GVG || status_get_race2(bl) == RC2_BATTLEFIELD) {
+		switch (type) {
+		case SC__MANHOLE:
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: related to https://github.com/rathena/rathena/issues/1977


* **Server Mode**: renewal

* **Description of Pull Request**: manhole effect should not work on gvg/battle/MD_STATUS_IMMUNE monsters

as the skill is not targeted , the only way is to not apply the effect

i don't have idea about the MD_STATUS_IMMUNE 
but the skill does not work on normal maps , and rn if you spawn mvp or boss in the right map , you can just spam it and don't let anyone kill it , **i don't think** this could happen in the official server 
