### PR TITLE
Fixed Escape not working with bNoKnockback

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -12338,7 +12338,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 
 	case SC_ESCAPE:
 		skill_unitsetting(src, skill_id, skill_lv, x, y, 0);
-		skill_blown(src, src, skill_get_blewcount(skill_id, skill_lv), unit_getdir(src), BLOWN_NONE);
+		skill_blown(src, src, skill_get_blewcount(skill_id, skill_lv), unit_getdir(src), BLOWN_IGNORE_NO_KNOCKBACK); // Don't stop the caster from backsliding if special_state.no_knockback is active
 		clif_skill_nodamage(src,src,skill_id,skill_lv,1);
 		flag |= 1;
 		break;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4344

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolved Escape not letting the player backslide when wearing items that give bNoKnockback bonus.
Thanks to @Badarosk0!