### PR TITLE
Corrected Fame Points for level 3 weapons

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -244,7 +244,7 @@ fame_taekwon_mission: 1
 // Refined own forged weapon to +10
 fame_refine_lv1: 1
 fame_refine_lv2: 25
-fame_refine_lv3: 10000
+fame_refine_lv3: 1000
 // Success to forge a lv3 weapon with 3 additional ingredients
 fame_forge: 10
 // Success to prepare 'n' Condensed Potions in a row


### PR DESCRIPTION
* **Addressed Issue(s)**: #4346

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Level 3 forged weapons should give 1,000 fame points instead of 10,000.
Thanks to @Indigo000!