### PR TITLE
Removed jAthena 1082 legacy code regarding castle defense rate.

### DIFF
--- a/conf/battle/guild.conf
+++ b/conf/battle/guild.conf
@@ -20,9 +20,6 @@ guild_max_castles: 0
 // Official setting is 5 minutes (300000 ms), otherwise allow guild leaders to relog to cancel the 5 minute delay.
 guild_skill_relog_delay: 300000
 
-// Damage adjustments for WOE battles against defending Guild monsters (Note 2)
-castle_defense_rate: 100
-
 // Melee damage adjustments (non skills) for WoE battles (Guild Vs Guild) (Note 2)
 gvg_short_attack_damage_rate: 80
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -640,7 +640,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 			if( sd && !(nk&NK_NO_CARDFIX_ATK) ) {
 				cardfix = cardfix * (100 + sd->magic_addrace[tstatus->race] + sd->magic_addrace[RC_ALL] + sd->magic_addrace2[t_race2]) / 100;
 				if( !(nk&NK_NO_ELEFIX) ) { // Affected by Element modifier bonuses
-					cardfix = cardfix * (100 + sd->magic_addele[tstatus->def_ele] + sd->magic_addele[ELE_ALL] + 
+					cardfix = cardfix * (100 + sd->magic_addele[tstatus->def_ele] + sd->magic_addele[ELE_ALL] +
 						sd->magic_addele_script[tstatus->def_ele] + sd->magic_addele_script[ELE_ALL]) / 100;
 					cardfix = cardfix * (100 + sd->magic_atk_ele[rh_ele] + sd->magic_atk_ele[ELE_ALL]) / 100;
 				}
@@ -1709,10 +1709,7 @@ int64 battle_calc_gvg_damage(struct block_list *src,struct block_list *bl,int64 
 
 	if (skill_get_inf2(skill_id)&INF2_NO_GVG_DMG) //Skills with no gvg damage reduction.
 		return damage;
-	/* Uncomment if you want god-mode Emperiums at 100 defense. [Kisuka]
-	if (md && md->guardian_data)
-		damage -= damage * (md->guardian_data->castle->defense/100) * battle_config.castle_defense_rate/100;
-	*/
+
 	if (flag & BF_SKILL) { //Skills get a different reduction than non-skills. [Skotlex]
 		if (flag&BF_WEAPON)
 			damage = damage * battle_config.gvg_weapon_damage_rate / 100;
@@ -6576,7 +6573,7 @@ struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *
 				struct Damage atk = battle_calc_weapon_attack(src, target, skill_id, skill_lv, 0);
 				struct Damage matk = battle_calc_magic_attack(src, target, skill_id, skill_lv, 0);
 				md.damage = 7 * ((atk.damage/skill_lv + matk.damage/skill_lv) * tstatus->vit / 100 );
-	
+
 				// AD benefits from endow/element but damage is forced back to neutral
 				md.damage = battle_attr_fix(src, target, md.damage, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
 			}
@@ -8207,7 +8204,6 @@ static const struct _battle_data {
 	{ "skill_removetrap_type",              &battle_config.skill_removetrap_type,           0,      0,      1,              },
 	{ "disp_experience",                    &battle_config.disp_experience,                 0,      0,      1,              },
 	{ "disp_zeny",                          &battle_config.disp_zeny,                       0,      0,      1,              },
-	{ "castle_defense_rate",                &battle_config.castle_defense_rate,             100,    0,      100,            },
 	{ "bone_drop",                          &battle_config.bone_drop,                       0,      0,      2,              },
 	{ "buyer_name",                         &battle_config.buyer_name,                      1,      0,      1,              },
 	{ "skill_wall_check",                   &battle_config.skill_wall_check,                1,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -368,7 +368,6 @@ struct Battle_Config
 	int skill_removetrap_type;
 	int disp_experience;
 	int disp_zeny;
-	int castle_defense_rate;
 	int backstab_bow_penalty;
 	int hp_rate;
 	int sp_rate;


### PR DESCRIPTION
* **Addressed Issue(s)**: 

https://github.com/rathena/rathena/issues/4399

* **Server Mode**: Both

* **Description of Pull Request**: 

This pull request removes some legacy code and legacy battle flags.

A bit of backstory on this... when investing in your castle's defenses, your Emperium and Guardian's defenses and HP increases resulting in decreased damage taken when enemies attack them.

Back in the day, jAthena's team wasn't really sure to the full extent how to handle this. So they added this battle config, and a few lines of code related to reducing the overall damage taken based on the castle's defense number.

However, this introduced a bug, that when a castle reached 100 defense, the damage taken was reduced to 0, making the Emperium and Guardians unkillable. I commented out this code during eAthena as a hotfix. The correct method was implemented by increasing the defense stats and hp within status.c thus making this battle config option and line of code unnecessary.

It seems that due to some oversight, this battle config and line of commented out code has remained in the codebase for the last 10 years between multiple forks. So... I'm just correcting that in case nobody knew what this was.

The original implemented of the code from jAthena 1082:
eathena/eathena@e8107d0#diff-d96b6365b4bdad78139e676d6e7e3295

The correct implementation already in place:
https://github.com/rathena/rathena/blob/master/src/map/status.cpp#L2874

The battle config was only used for this one specific line of code which has been commented out for 10 years.

Special Thanks to: theultramage, Yommy, Sirius_White for looking into this with me over the last week :)