### PR TITLE
Threshold for blacksmith refine fame points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ Thumbs.db
 /libmysql.dll
 /pcre8.dll
 /zlib.dll
+
+# CMakeFiles
+/CMakeFiles/

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -247,6 +247,8 @@ fame_refine_lv2: 25
 fame_refine_lv3: 1000
 // Success to forge a lv3 weapon with 3 additional ingredients
 fame_forge: 10
+// Refine threshold for giving point for refining forged weapon to +10
+blacksmith_fame_refine_threshold: 10
 // Success to prepare 'n' Condensed Potions in a row
 fame_pharmacy_3: 1
 fame_pharmacy_5: 3

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8527,6 +8527,7 @@ static const struct _battle_data {
 	{ "min_shop_sell",                      &battle_config.min_shop_sell,                   0,      0,      INT_MAX,        },
 	{ "feature.equipswitch",                &battle_config.feature_equipswitch,             1,      0,      1,              },
 	{ "pet_walk_speed",                     &battle_config.pet_walk_speed,                  1,      1,      3,              },
+	{ "blacksmith_fame_refine_threshold",   &battle_config.blacksmith_fame_refine_threshold,10,     1,      MAX_REFINE,     },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -658,6 +658,7 @@ struct Battle_Config
 	int min_shop_sell;
 	int feature_equipswitch;
 	int pet_walk_speed;
+	int blacksmith_fame_refine_threshold;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -9085,7 +9085,7 @@ BUILDIN_FUNC(successrefitem) {
 		pc_equipitem(sd,i,ep);
 		clif_misceffect(&sd->bl,3);
 		achievement_update_objective(sd, AG_REFINE_SUCCESS, 2, sd->inventory_data[i]->wlv, sd->inventory.u.items_inventory[i].refine);
-		if (sd->inventory.u.items_inventory[i].refine == MAX_REFINE &&
+		if (sd->inventory.u.items_inventory[i].refine == battle_config.blacksmith_fame_refine_threshold &&
 			sd->inventory.u.items_inventory[i].card[0] == CARD0_FORGE &&
 			sd->status.char_id == (int)MakeDWord(sd->inventory.u.items_inventory[i].card[2],sd->inventory.u.items_inventory[i].card[3]))
 		{ // Fame point system [DracoRPG]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #4408

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adjusted default threshold to +10 for both pre-renewal and renewal. Also made it configurable.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
