### PR TITLE
fix getunits commands for mapindex[0]

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11288,7 +11288,7 @@ BUILDIN_FUNC(getunits)
 	int type = script_getnum(st, 2);
 	int size = 0;
 	int32 idx, id;
-	int16 m = 0, x0 = 0, y0 = 0, x1 = 0, y1 = 0;
+	int16 m = -1, x0 = 0, y0 = 0, x1 = 0, y1 = 0;
 	struct s_mapiterator *iter = mapit_alloc(MAPIT_NORMAL, bl_type(type));
 
 	if (!strcmp(command, "getmapunits"))
@@ -11347,7 +11347,7 @@ BUILDIN_FUNC(getunits)
 
 	for (bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter))
 	{
-		if (!m || (m == bl->m && !x0 && !y0 && !x1 && !y1) || (bl->m == m && (bl->x >= x0 && bl->y >= y0) && (bl->x <= x1 && bl->y <= y1)))
+		if (m == -1 || (m == bl->m && !x0 && !y0 && !x1 && !y1) || (bl->m == m && (bl->x >= x0 && bl->y >= y0) && (bl->x <= x1 && bl->y <= y1)))
 		{
 			if (data)
 				set_reg(st, sd, reference_uid(id, idx + size), name, (is_string_variable(name) ? (void*)status_get_name(bl) : (void*)__64BPRTSIZE(bl->id)), reference_getref(data));


### PR DESCRIPTION
* **Addressed Issue(s)**:  https://github.com/rathena/rathena/issues/4416

* **Server Mode**: Both

* **Description of Pull Request**: 
at the first map in the maps list (currently is `alb_ship`) the commands skip the map as it check for !m , and it should check for m == -1

test script:
```cs
-	script	get_unit_test	-1,{
	switch(select("map:area:all")){
		case 1:
			mes "" + getmapunits(BL_PC,strnpcinfo(4),.@array);
			mes "" + getarraysize(.@array);
			break;
		case 2:
			mes "the number of cells around the npc?";
			input .@i;
			getmapxy(.@m$, .@x, .@y, BL_NPC);
			mes "" + getareaunits(BL_PC,.@m$,(.@x + .@i),(.@y + .@i),(.@x - .@i),(.@y - .@i),.@array);
			mes "" + getarraysize(.@array);
			break;
		case 3:
			mes "" + getunits(BL_PC);
			break;
	}
end;
}
prontera,155,182,0	duplicate(get_unit_test)	get_unit_test_1	444
alb_ship,166,173,0	duplicate(get_unit_test)	get_unit_test_2	444
```
