### PR TITLE
Corrected Gentle Touch skills

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9314,11 +9314,10 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		status_change_end(bl, SC_PRESTIGE, INVALID_TIMER);
 		break;
 	case SC_GT_CHANGE:
+		status_change_end(bl, SC_GT_REVITALIZE, INVALID_TIMER);
+		break;
 	case SC_GT_REVITALIZE:
-		if( type != SC_GT_REVITALIZE )
-			status_change_end(bl, SC_GT_REVITALIZE, INVALID_TIMER);
-		if( type != SC_GT_CHANGE )
-			status_change_end(bl, SC_GT_CHANGE, INVALID_TIMER);
+		status_change_end(bl, SC_GT_CHANGE, INVALID_TIMER);
 		break;
 	case SC_WARMER:
 		status_change_end(bl, SC_CRYSTALIZE, INVALID_TIMER);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9313,6 +9313,13 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	case SC_BANDING:
 		status_change_end(bl, SC_PRESTIGE, INVALID_TIMER);
 		break;
+	case SC_GT_CHANGE:
+	case SC_GT_REVITALIZE:
+		if( type != SC_GT_REVITALIZE )
+			status_change_end(bl, SC_GT_REVITALIZE, INVALID_TIMER);
+		if( type != SC_GT_CHANGE )
+			status_change_end(bl, SC_GT_CHANGE, INVALID_TIMER);
+		break;
 	case SC_WARMER:
 		status_change_end(bl, SC_CRYSTALIZE, INVALID_TIMER);
 		status_change_end(bl, SC_FREEZING, INVALID_TIMER);


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to 24c4c49.
  * Gentle Touch - Convert and Gentle Touch - Revitalize should not be able to be stacked with one another; only Gentle Touch - Energy Gain can stack with them.
Thanks to @teededung!