### PR TITLE
fix several issues with pets

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8035,9 +8035,9 @@ int pc_dead(struct map_session_data *sd,struct block_list *src)
 	if(sd->status.pet_id > 0 && sd->pd) {
 		struct pet_data *pd = sd->pd;
 		if( !mapdata->flag[MF_NOEXPPENALTY] ) {
-			pet_set_intimate(pd, pd->pet.intimate + pd->get_pet_db()->die);
-			if( pd->pet.intimate < 0 )
-				pd->pet.intimate = 0;
+			pet_set_intimate(pd, pd->pet.intimate - pd->get_pet_db()->die);
+			if( pd->pet.intimate <= PET_INTIMATE_NONE )
+				pet_set_intimate(pd, PET_INTIMATE_NONE);
 			clif_send_petdata(sd,sd->pd,1,pd->pet.intimate);
 		}
 		if( sd->pd->target_id ) // Unlock all targets...

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8035,7 +8035,7 @@ int pc_dead(struct map_session_data *sd,struct block_list *src)
 	if(sd->status.pet_id > 0 && sd->pd) {
 		struct pet_data *pd = sd->pd;
 		if( !mapdata->flag[MF_NOEXPPENALTY] ) {
-			pet_set_intimate(pd, pd->pet.intimate - pd->get_pet_db()->die);
+			pet_set_intimate(pd, pd->pet.intimate + pd->get_pet_db()->die);
 			if( pd->pet.intimate <= PET_INTIMATE_NONE )
 				pet_set_intimate(pd, PET_INTIMATE_NONE);
 			clif_send_petdata(sd,sd->pd,1,pd->pet.intimate);

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -606,6 +606,9 @@ void pet_set_intimate(struct pet_data *pd, int value)
 
 	struct map_session_data *sd = pd->master;
 
+	if(pd->pet.intimate <= PET_INTIMATE_NONE)
+		pc_delitem(sd, pet_egg_search(sd, pd->pet.pet_id), 1, 0, 0, LOG_TYPE_OTHER);
+
 	if (sd)
 		status_calc_pc(sd,SCO_NONE);
 }
@@ -819,7 +822,7 @@ static TIMER_FUNC(pet_hungry){
 		pet_set_intimate(pd, pd->pet.intimate + pet_db_ptr->hungry_intimacy_dec);
 
 		if( pd->pet.intimate <= PET_INTIMATE_NONE ) {
-			pd->pet.intimate = PET_INTIMATE_NONE;
+			pet_set_intimate(pd, PET_INTIMATE_NONE);
 			pd->status.speed = pd->get_pet_walk_speed();
 		}
 
@@ -1147,6 +1150,11 @@ int pet_select_egg(struct map_session_data *sd,short egg_index)
 
 	if(egg_index < 0 || egg_index >= MAX_INVENTORY)
 		return 0; //Forged packet!
+
+	if(sd->trade_partner){	//The player have trade in progress.
+		clif_displaymessage(sd->fd, "You need to complete the trade first.");
+		return 0;
+	}
 
 	if(sd->inventory.u.items_inventory[egg_index].card[0] == CARD0_PET)
 		intif_request_petdata(sd->status.account_id, sd->status.char_id, MakeDWord(sd->inventory.u.items_inventory[egg_index].card[1], sd->inventory.u.items_inventory[egg_index].card[2]) );
@@ -1524,7 +1532,7 @@ int pet_food(struct map_session_data *sd, struct pet_data *pd)
 	if (pd->pet.hungry > PET_HUNGRY_SATISFIED) {
 		pet_set_intimate(pd, pd->pet.intimate + pet_db_ptr->r_full);
 		if (pd->pet.intimate <= PET_INTIMATE_NONE) {
-			pd->pet.intimate = PET_INTIMATE_NONE;
+			pet_set_intimate(pd, PET_INTIMATE_NONE);
 			pet_stop_attack(pd);
 			pd->status.speed = pd->get_pet_walk_speed();
 		}
@@ -2210,7 +2218,7 @@ void pet_evolution(struct map_session_data *sd, int16 pet_id) {
 	// Prepare the new pet
 	sd->pd->pet.class_ = pet_id;
 	sd->pd->pet.egg_id = new_data->EggID;
-	sd->pd->pet.intimate = new_data->intimate;
+	pet_set_intimate(sd->pd, new_data->intimate);
 	if( !sd->pd->pet.rename_flag ){
 		struct mob_db* mdb = mob_db( pet_id );
 

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1151,10 +1151,8 @@ int pet_select_egg(struct map_session_data *sd,short egg_index)
 	if(egg_index < 0 || egg_index >= MAX_INVENTORY)
 		return 0; //Forged packet!
 
-	if(sd->trade_partner){	//The player have trade in progress.
-		clif_displaymessage(sd->fd, "You need to complete the trade first.");
+	if(sd->trade_partner)	//The player have trade in progress.
 		return 0;
-	}
 
 	if(sd->inventory.u.items_inventory[egg_index].card[0] == CARD0_PET)
 		intif_request_petdata(sd->status.account_id, sd->status.char_id, MakeDWord(sd->inventory.u.items_inventory[egg_index].card[1], sd->inventory.u.items_inventory[egg_index].card[2]) );

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1154,6 +1154,12 @@ int pet_select_egg(struct map_session_data *sd,short egg_index)
 	if(sd->trade_partner)	//The player have trade in progress.
 		return 0;
 
+	std::shared_ptr<s_pet_db> pet = pet_db_search(sd->inventory.u.items_inventory[egg_index].nameid, PET_EGG);
+	if (!pet) {
+		ShowError("pet does not exist, egg id %d\n", sd->inventory.u.items_inventory[egg_index].nameid);
+		return 0;
+	}
+
 	if(sd->inventory.u.items_inventory[egg_index].card[0] == CARD0_PET)
 		intif_request_petdata(sd->status.account_id, sd->status.char_id, MakeDWord(sd->inventory.u.items_inventory[egg_index].card[1], sd->inventory.u.items_inventory[egg_index].card[2]) );
 	else


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/4406

* **Server Mode**: both

* **Description of Pull Request**: 
Thansk to @teededung 

1. fix where you can hatch egg while you are trading.
2. fix where egg not deleted after the pet is lost.

for test:
1. `@item 9005` , `@hatch` , trade with another player and put the egg in the trade window , before finalize the trade after the ok in both sides , complete hatching the pet , that complete the trade.

2. `@item 9005` , `@hatch` and hatch the pet , `@petfriendly 1` `@pethungry 1` and wait
also `@item 9005` `@petfriendly 0`

3. put in the item db `60110,Test_Egg,Test Egg,7,20,,0,,,,,,,,,,,,,{},{},{}` , get the item , and try hatching it without adding the pet in the pet db (thanks to @admkakaroto).

Side Note: there is an issue where the player can't hatch new pet after the old pet is lost unless he relogin , it need to set `sd->status.pet_id = 0` , however this break the random walk behavior

