### PR TITLE
Added unsigned rate support for yaml

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -237,6 +237,34 @@ bool YamlDatabase::asString(const YAML::Node &node, const std::string &name, std
 	return asType<std::string>(node, name, out);
 }
 
+bool YamlDatabase::asUInt16Rate( const YAML::Node& node, const std::string& name, uint16& out, uint16 maximum ){
+	if( this->asUInt16( node, name, out ) ){
+		if( out > maximum ){
+			this->invalidWarning( node[name], "Node \"%s\" with value %" PRIu16 " exceeds maximum of %" PRIu16 ".\n", name.c_str(), out, maximum );
+
+			return false;
+		}else{
+			return true;
+		}
+	}else{
+		return false;
+	}
+}
+
+bool YamlDatabase::asUInt32Rate( const YAML::Node& node, const std::string& name, uint32& out, uint32 maximum ){
+	if( this->asUInt32( node, name, out ) ){
+		if( out > maximum ){
+			this->invalidWarning( node[name], "Node \"%s\" with value %" PRIu32 " exceeds maximum of %" PRIu32 ".\n", name.c_str(), out, maximum );
+
+			return false;
+		}else{
+			return true;
+		}
+	}else{
+		return false;
+	}
+}
+
 void YamlDatabase::invalidWarning( const YAML::Node &node, const char* fmt, ... ){
 	va_list ap;
 

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -46,6 +46,8 @@ protected:
 	bool asFloat(const YAML::Node &node, const std::string &name, float &out);
 	bool asDouble(const YAML::Node &node, const std::string &name, double &out);
 	bool asString(const YAML::Node &node, const std::string &name, std::string &out);
+	bool asUInt16Rate(const YAML::Node& node, const std::string& name, uint16& out, uint16 maximum=10000);
+	bool asUInt32Rate(const YAML::Node& node, const std::string& name, uint32& out, uint32 maximum=10000);
 
 public:
 	YamlDatabase( const std::string type_, uint16 version_, uint16 minimumVersion_ ){


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: Added core functions to supported reading unsigned rates.
By default rates are values between 0 and 10000, if no other maximum is defined.
