### PR TITLE
Corrected Rock Ridge monster spawn

### DIFF
--- a/npc/re/mobs/fields/rockridge.txt
+++ b/npc/re/mobs/fields/rockridge.txt
@@ -19,6 +19,6 @@ rockrdg2,0,0	monster	Bowie Buffalo Bandit	3738,52
 rockrdg2,0,0	monster	Coyote	3739,8
 rockrdg2,0,0	monster	Green Plant	1080,5
 rockrdg2,0,0	monster	Yellow Plant	1081,4
-rockrdg2,0,0	monster	White Plant	1084,5
+rockrdg2,0,0	monster	White Plant	1082,5
 rockrdg2,0,0	monster	Shining Plant	1083,4
 rockrdg2,0,0	monster	Thief Bug	1051,8


### PR DESCRIPTION
* **Addressed Issue(s)**: #4474

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Corrected an incorrect monster spawn for White Plant.
Thanks to @RagnaWay!