### PR TITLE
Fixed 'Finding the Moving Island' quest spawning the wrong monsters on pre-re

### DIFF
--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -2689,11 +2689,21 @@ OnInit:
 OnEnable:
 	enablenpc strnpcinfo(0);
 	.@c = charat(strnpcinfo(0),9);
-	switch (.@c) {
-		case 1: setarray .@m, 89,112,1551,85,110,1579; break;// G_MARSE, G_HYDRA
-		case 2: setarray .@m, 89,112,1425,80,110,1254,83,114,1254,85,110,1425; break;// G_OBEAUNE, RAGGLER
-		case 3: setarray .@m, 85,111,1451,89,112,1543,90,106,1543; break;// G_MERMAN, G_KAPHA
-		case 4: setarray .@m, 85,111,1069,89,112,1543,90,106,1543; break;// SWORD_FISH, G_KAPHA
+	if (checkre(0)) {
+		switch (.@c) {
+			case 1: setarray .@m, 89,112,1551,85,110,1579; break;// G_MARSE, G_HYDRA
+			case 2: setarray .@m, 89,112,1425,80,110,1254,83,114,1254,85,110,1425; break;// G_OBEAUNE, RAGGLER
+			case 3: setarray .@m, 85,111,1451,89,112,1543,90,106,1543; break;// G_MERMAN, G_KAPHA
+			case 4: setarray .@m, 85,111,1069,89,112,1543,90,106,1543; break;// SWORD_FISH, G_KAPHA
+		}
+	}
+	else {
+		switch (.@c) {
+			case 1: setarray .@m, 89,112,1425,85,110,1425; break;// G_OBEAUNE, G_OBEAUNE
+			case 2: setarray .@m, 89,112,1425,80,110,1426,83,114,1426,85,110,1425; break;// G_OBEAUNE, G_MARC
+			case 3:
+			case 4: setarray .@m, 85,111,1451,89,112,1543,90,106,1543; break;// G_MERMAN, G_KAPHA
+		}
 	}
 	for (.@i = 0; .@i < getarraysize(.@m); .@i += 3)
 		monster "mosk_ship",.@m[.@i],.@m[.@i+1],"Sea Monster",.@m[.@i+2],1,strnpcinfo(0)+"::OnMyMobDead";


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  Fixes 'Finding the Moving Island' quest spawning the wrong monsters on pre-renewal mode (confirmed on Aegis)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
