### PR TITLE
Corrected mob availability database sprite lookup

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4363,14 +4363,12 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 	if (!this->asString(node, "Mob", mob_name))
 		return 0;
 
-	uint32 mob_id = mobdb_search_aegisname(mob_name.c_str());
+	mob_db *mob = mobdb_search_aegisname(mob_name.c_str());
 
-	if (mob_id == 0) {
+	if (mob == nullptr) {
 		this->invalidWarning(node["Mob"], "Unknown mob %s.\n", mob_name.c_str());
 		return 0;
 	}
-
-	struct mob_db *mob = mob_db(mob_id);
 
 	if (this->nodeExists(node, "Sprite")) {
 		std::string sprite;
@@ -4386,12 +4384,14 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 				return 0;
 			}
 		} else {
-			constant = mobdb_search_aegisname(sprite.c_str());
+			mob_db *sprite_mob = mobdb_search_aegisname(sprite.c_str());
 
-			if (constant == 0) {
+			if (sprite_mob == nullptr) {
 				this->invalidWarning(node["Sprite"], "Unknown mob sprite constant %s.\n", sprite.c_str());
 				return 0;
 			}
+
+			constant = sprite_mob->vd.class_;
 		}
 
 		mob->vd.class_ = constant;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4363,7 +4363,7 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 	if (!this->asString(node, "Mob", mob_name))
 		return 0;
 
-	mob_db *mob = mobdb_search_aegisname(mob_name.c_str());
+	struct mob_db *mob = mobdb_search_aegisname(mob_name.c_str());
 
 	if (mob == nullptr) {
 		this->invalidWarning(node["Mob"], "Unknown mob %s.\n", mob_name.c_str());
@@ -4384,7 +4384,7 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 				return 0;
 			}
 		} else {
-			mob_db *sprite_mob = mobdb_search_aegisname(sprite.c_str());
+			struct mob_db *sprite_mob = mobdb_search_aegisname(sprite.c_str());
 
 			if (sprite_mob == nullptr) {
 				this->invalidWarning(node["Sprite"], "Unknown mob sprite constant %s.\n", sprite.c_str());

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4363,7 +4363,7 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 	if (!this->asString(node, "Mob", mob_name))
 		return 0;
 
-	uint32 mob_id = mobdb_searchname(mob_name.c_str());
+	uint32 mob_id = mobdb_search_aegisname(mob_name.c_str());
 
 	if (mob_id == 0) {
 		this->invalidWarning(node["Mob"], "Unknown mob %s.\n", mob_name.c_str());
@@ -4386,7 +4386,7 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 				return 0;
 			}
 		} else {
-			constant = mobdb_searchname(sprite.c_str());
+			constant = mobdb_search_aegisname(sprite.c_str());
 
 			if (constant == 0) {
 				this->invalidWarning(node["Sprite"], "Unknown mob sprite constant %s.\n", sprite.c_str());


### PR DESCRIPTION
* **Addressed Issue(s)**: #4495

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adjusted the monster sprite lookup to ignore any restrictions based on monster data.
Thanks to @sader1992!