### PR TITLE
Fixed pet eggs as mail attachments

### DIFF
--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -16,6 +16,7 @@
 #include "itemdb.hpp"
 #include "log.hpp"
 #include "pc.hpp"
+#include "pet.hpp"
 
 void mail_clear(struct map_session_data *sd)
 {
@@ -289,7 +290,24 @@ void mail_getattachment(struct map_session_data* sd, struct mail_message* msg, i
 
 	for( i = 0; i < MAIL_MAX_ITEM; i++ ){
 		if( item->nameid > 0 && item->amount > 0 ){
-			pc_additem(sd, &item[i], item[i].amount, LOG_TYPE_MAIL);
+			// If no card or special card id is set
+			if( item[i].card[0] == 0 ){
+				// Check if it is a pet egg
+				std::shared_ptr<s_pet_db> pet = pet_db_search( item[i].nameid, PET_EGG );
+
+				// If it is a pet egg and the card data does not contain a pet id (see if clause above)
+				if( pet != nullptr ){
+					// Create a new pet
+					pet_create_egg( sd, item[i].nameid );
+				}else{
+					// Add the item normally
+					pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
+				}
+			}else{
+				// Add the item normally
+				pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
+			}
+
 			item_received = true;
 		}	
 	}

--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -299,15 +299,13 @@ void mail_getattachment(struct map_session_data* sd, struct mail_message* msg, i
 				if( pet != nullptr ){
 					// Create a new pet
 					pet_create_egg( sd, item[i].nameid );
-				}else{
-					// Add the item normally
-					pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
+					item_received = true;
+					continue;
 				}
-			}else{
-				// Add the item normally
-				pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
 			}
 
+			// Add the item normally
+			pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
 			item_received = true;
 		}	
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #4327

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixes the issue by adding a check when getting the attachments of a mail. This additional check ensures that pet eggs that do not have a pet id stored in their card slot get their pet data/id generated by the inter server.
Thanks to @RadianFord