### PR TITLE
* Fixed Dual Wielding Axes breaking when they should be unbreakable.

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2590,6 +2590,9 @@ int skill_break_equip(struct block_list *src, struct block_list *bl, unsigned sh
 				case W_2HSTAFF:
 				case W_BOOK: //Rods and Books can't be broken [Skotlex]
 				case W_HUUMA:
+				case W_DOUBLE_AA:	// Axe usage during dual wield should also prevent breaking [Neutral]
+				case W_DOUBLE_DA:
+				case W_DOUBLE_SA:
 					where &= ~EQP_WEAPON;
 			}
 		}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #4430

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Despite Axes being unbreakable they are being broken during dual wield usage which obviously shouldn't happen. Furthermore I tested a single Golem Card via 2 dagger setup to confirm if 1 unbreakable weapon meant they both were unbreakable, and I was able to confirm this as well. This means all dual wield types that use an axe should make both weapons unbreakable.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
