### PR TITLE
Fixed flags of 2 skills in prere

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -9794,9 +9794,6 @@ Body:
       NoDamage: true
       IgnoreDefense: true
       IgnoreFlee: true
-    Flags:
-      IgnoreAutoGuard: true
-      IgnoreCicada: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -13018,6 +13015,9 @@ Body:
     Flags:
       AllowOnMado: true
     Range: -2
+    Flags:
+      IgnoreAutoGuard: true
+      IgnoreCicada: true
     Hit: Single
     HitCount: 1
     Element: Weapon


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #4498

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: pre-renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes a couple inaccuracies with the pre-renewal skill_db which seems to have originated from commit [b614092](https://github.com/rathena/rathena/commit/b614092b75e9cb63892a88de7321fd0640aaee4d). Martyr's Reckoning (Sacrifice) should be blocked by Cicada Skin Shed and Auto-Guard (as it is a ATK% skill). Cart Termination should go through Cicada Skin Shed and Auto-Guard (as it is a +ATK skill).

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
