### PR TITLE
Fixed CSV2YAML not freeing memory

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -178,6 +178,8 @@ bool process( const std::string& type, uint32 version, const std::vector<std::st
 
 			std::ofstream out;
 
+			body.~Emitter();
+			new (&body) YAML::Emitter();
 			out.open(to);
 
 			if (!out.is_open()) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #4541

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * CSV2YAML tool will now free the memory on each database conversion.
Thanks to @Lemongrass3110!