### PR TITLE
Corrected Feint Bomb infinite status

### DIFF
--- a/db/pre-re/skill_unit_db.txt
+++ b/db/pre-re/skill_unit_db.txt
@@ -134,7 +134,7 @@
 2301,0xce,    ,  2, 0,1000,all,   0xA00E //SC_CHAOSPANIC
 2302,0xcf,    ,  2, 0,  -1,all,   0xA002 //SC_MAELSTROM
 2303,0xd0,    ,  3, 0,  -1,all,   0xA058 //SC_BLOODYLUST
-2304,0xd1,    ,  0, 2, 500,enemy, 0x018  //SC_FEINTBOMB
+2304,0xd1,    ,  0, 2,  -1,enemy, 0x018  //SC_FEINTBOMB
 
 2319,0xec,    ,  0, 3,5000,all,   0x000	//LG_BANDING
 

--- a/db/re/skill_unit_db.txt
+++ b/db/re/skill_unit_db.txt
@@ -137,7 +137,7 @@
 2301,0xce,    ,  2, 0,1000,all,   0xA00E //SC_CHAOSPANIC
 2302,0xcf,    ,  2, 0,  -1,all,   0xA002 //SC_MAELSTROM
 2303,0xd0,    ,  3, 0,  -1,all,   0xA058 //SC_BLOODYLUST
-2304,0xd1,    ,  0, 2, 500,enemy, 0x018  //SC_FEINTBOMB
+2304,0xd1,    ,  0, 2,  -1,enemy, 0x018  //SC_FEINTBOMB
 
 2319,0xec,    ,  0, 3,5000,all,   0x000	//LG_BANDING
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -919,7 +919,7 @@ extern struct s_job_info job_info[CLASS_COUNT];
 
 #define pc_isfalcon(sd)       ( (sd)->sc.option&OPTION_FALCON )
 #define pc_isriding(sd)       ( (sd)->sc.option&OPTION_RIDING )
-#define pc_isinvisible(sd)    ( (sd)->sc.option&OPTION_INVISIBLE && !((sd)->sc.data && (sd)->sc.data[SC__FEINTBOMB]) )
+#define pc_isinvisible(sd)    ( (sd)->sc.option&OPTION_INVISIBLE )
 #define pc_is50overweight(sd) ( (sd)->weight * 100 >= (sd)->max_weight * battle_config.natural_heal_weight_rate )
 #define pc_is70overweight(sd) ( (sd)->weight * 100 >= (sd)->max_weight * battle_config.natural_heal_weight_rate_renewal )
 #define pc_is90overweight(sd) ( (sd)->weight * 10 >= (sd)->max_weight * 9 )

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -12313,7 +12313,6 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 				return 1;
 			}
 			map_foreachinallrange(unit_changetarget, src, AREA_SIZE, BL_MOB, src, &group->unit->bl); // Release all targets against the caster
-			pc_setinvincibletimer(sd, skill_get_time(skill_id, skill_lv));
 			skill_blown(src, src, skill_get_blewcount(skill_id, skill_lv), unit_getdir(src), BLOWN_IGNORE_NO_KNOCKBACK); // Don't stop the caster from backsliding if special_state.no_knockback is active
 			clif_skill_nodamage(src,src,skill_id,skill_lv,sc_start(src,src,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: #4508

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves an issue where Feint Bomb was giving users infinite duration from AoE statuses.
Thanks to @laziem!