### PR TITLE
Fixed SG_FEEL dialog cancel

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -12320,7 +12320,9 @@ void clif_parse_skill_toid( struct map_session_data* sd, uint16 skill_id, uint16
 	if( sd->menuskill_id ) {
 		if( sd->menuskill_id == SA_TAMINGMONSTER ) {
 			clif_menuskill_clear(sd); //Cancel pet capture.
-		} else if( sd->menuskill_id != SA_AUTOSPELL )
+		}else if( sd->menuskill_id == SG_FEEL ){
+			clif_menuskill_clear( sd ); // Cancel selection
+		}else if( sd->menuskill_id != SA_AUTOSPELL )
 			return; //Can't use skills while a menu is open.
 	}
 
@@ -12428,6 +12430,8 @@ static void clif_parse_UseSkillToPosSub(int fd, struct map_session_data *sd, uin
 	if( sd->menuskill_id ) {
 		if( sd->menuskill_id == SA_TAMINGMONSTER ) {
 			clif_menuskill_clear(sd); //Cancel pet capture.
+		}else if( sd->menuskill_id == SG_FEEL ){
+			clif_menuskill_clear( sd ); // Cancel selection
 		} else if( sd->menuskill_id != SA_AUTOSPELL )
 			return; //Can't use skills while a menu is open.
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #3535

* **Server Mode**: Both

* **Description of Pull Request**: 
Since canceling the SG_FEEL dialog does not send a packet to the server, we have to clear it whenever the user uses another skill right after it and the server still thinks the user is still selecting his feel location.

Thanks to @anacondaq
