### PR TITLE
Fixed a compiler warning in pc.cpp

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9753,9 +9753,9 @@ bool pc_setreg2(struct map_session_data *sd, const char *reg, int64 val) {
 		case '@':
 			return pc_setreg(sd, add_str(reg), val);
 		case '#':
-			return (reg[1] == '#') ? pc_setaccountreg2(sd, add_str(reg), val) > 0 : pc_setaccountreg(sd, add_str(reg), val) > 0;
+			return (reg[1] == '#') ? pc_setaccountreg2(sd, add_str(reg), val) : pc_setaccountreg(sd, add_str(reg), val);
 		default:
-			return pc_setglobalreg(sd, add_str(reg), val) > 0;
+			return pc_setglobalreg(sd, add_str(reg), val);
 	}
 
 	return false;


### PR DESCRIPTION
* **rAthena Hash:** 6c8840ca5419b49715df56b780c38ae7f5c420c3

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  20180620

* **Server Mode**: All

* **Description of Pull Request**: 

fix warning C4804: '>': unsafe use of type 'bool' in operation
