### PR TITLE
Resolves Tetra Vortex AoE

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -17987,11 +17987,32 @@ Body:
     Range: 11
     Hit: Single
     HitCount: 1
+    SplashArea:
+      - Level: 1
+        Area: 0
+      - Level: 2
+        Area: 0
+      - Level: 3
+        Area: 0
+      - Level: 4
+        Area: 0
+      - Level: 5
+        Area: 0
+      - Level: 6
+        Area: 1
+      - Level: 7
+        Area: 1
+      - Level: 8
+        Area: 2
+      - Level: 9
+        Area: 2
+      - Level: 10
+        Area: 3
     CopyFlags:
       Skill:
         Reproduce: true
     CastCancel: true
-    CastTime:
+    CastTime: # !TODO: Confirm cast time
       - Level: 1
         Time: 5000
       - Level: 2
@@ -18001,6 +18022,16 @@ Body:
       - Level: 4
         Time: 8000
       - Level: 5
+        Time: 9000
+      - Level: 6
+        Time: 9000
+      - Level: 7
+        Time: 9000
+      - Level: 8
+        Time: 9000
+      - Level: 9
+        Time: 9000
+      - Level: 10
         Time: 9000
     AfterCastActDelay: 2000
     Cooldown: 15000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -18952,11 +18952,32 @@ Body:
     Range: 11
     Hit: Single
     HitCount: 1
+    SplashArea:
+      - Level: 1
+        Area: 0
+      - Level: 2
+        Area: 0
+      - Level: 3
+        Area: 0
+      - Level: 4
+        Area: 0
+      - Level: 5
+        Area: 0
+      - Level: 6
+        Area: 1
+      - Level: 7
+        Area: 1
+      - Level: 8
+        Area: 2
+      - Level: 9
+        Area: 2
+      - Level: 10
+        Area: 3
     CopyFlags:
       Skill:
         Reproduce: true
     CastCancel: true
-    CastTime:
+    CastTime: # !TODO: Confirm cast time
       - Level: 1
         Time: 5000
       - Level: 2
@@ -18966,6 +18987,16 @@ Body:
       - Level: 4
         Time: 8000
       - Level: 5
+        Time: 9000
+      - Level: 6
+        Time: 9000
+      - Level: 7
+        Time: 9000
+      - Level: 8
+        Time: 9000
+      - Level: 9
+        Time: 9000
+      - Level: 10
         Time: 9000
     AfterCastActDelay: 2000
     Cooldown: 15000


### PR DESCRIPTION
* **Addressed Issue(s)**: #4623

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Resolves Tetra Vortex levels 6-10 not doing an AoE.
  * Adds placeholder for missing cast time for levels 6-10.
Thanks to @Miraakol!