### PR TITLE
Quest data should be cleared on char deletion

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1708,6 +1708,10 @@ enum e_char_del_response char_delete(struct char_session_data* sd, uint32 char_i
 	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `char_id` = '%d'", schema_config.bonus_script_db, char_id) )
 		Sql_ShowDebug(sql_handle);
 
+	/* Quest Data */
+	if (SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `char_id` = '%d'", schema_config.quest_db, char_id))
+		Sql_ShowDebug(sql_handle);
+
 	/* Achievement Data */
 	if (SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `char_id` = '%d'", schema_config.achievement_table, char_id))
 		Sql_ShowDebug(sql_handle);


### PR DESCRIPTION
* **Addressed Issue(s)**: #4628

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Player quest data should be deleted when the character is deleted.
Thanks to @Tokeiburu!