### PR TITLE
Fix Nodamage skill can't use on Ghost level 3-4 monster

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6251,7 +6251,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	tsce = (tsc && type != -1)?tsc->data[type]:NULL;
 
 	if (src!=bl && type > -1 &&
-		CHK_ELEMENT((i = skill_get_ele(skill_id, skill_lv))) &&
+		CHK_ELEMENT((i = skill_get_ele(skill_id, skill_lv))) && i > ELE_NEUTRAL &&
 		skill_get_inf(skill_id) != INF_SUPPORT_SKILL &&
 		battle_attr_fix(NULL, NULL, 100, i, tstatus->def_ele, tstatus->ele_lv) <= 0)
 		return 1; //Skills that cause an status should be blocked if the target element blocks its element.


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:   https://github.com/rathena/rathena/issues/4661

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Fix missing condition that check Non-Neutral element in skill_castend_nodamage_id

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

- nodamage skill can use on Ghost level 3-4 monster.