### PR TITLE
[Suggestion] setquest, erasequest, completequest, checkquest atcommand

### DIFF
--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -1706,5 +1706,17 @@
 1503: You've entered a PK Zone.
 1504: You've entered a PK Zone (safe until level %d).
 
+// @setquest, @erasequest, @completequest
+1505: Usage: %s <quest ID>
+1506: Quest %d not found in DB.
+1507: Character already has quest %d.
+1508: Character doesn't have quest %d.
+
+// @checkquest
+1509: Checkquest value for quest %d
+1510: >    HAVEQUEST : %d
+1511: >    HUNTING   : %d
+1512: >    PLAYTIME  : %d
+
 //Custom translations
 import: conf/msg_conf/import/map_msg_eng_conf.txt

--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -1766,3 +1766,12 @@ Bans or unbans a player from the specified channel.
 Binds or unbinds your global chat with the specified channel, which sends all global messages to the specified channel.
 
 ---------------------------------------
+
+@setquest <quest ID>
+@erasequest <quest ID>
+@completequest <quest ID>
+@checkquest <quest ID>
+
+Changes/checks the status of the specified quest ID.
+
+---------------------------------------


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Content
--------------------------------
Suggestion to add some quests debug commands for admin.
- `@setquest` : _self explaining_
- `@erasequest` : _self explaining_
- `@completequest` : give and complete the quest
- `@checkquest` : display the quest status HAVEQUEST, HUNTING, PLAYTIME

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
