### PR TITLE
Fixes #4693: Removed Bowling Bash Chain Damage

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5333,8 +5333,10 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 					break;
 				}
 			}
+#ifndef  RENEWAL
 			// Original hit or chain hit depending on flag
 			skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,(flag&0xFFF)>0?SD_ANIMATION:0);
+#endif
 		}
 		break;
 


### PR DESCRIPTION
- Removed Bowling Bash chained damage for class rework

* **Addressed Issue(s)**:  #4693 Class Re-balancing Update for Bowling Bash Knight