### PR TITLE
Small fix to skill_damage_db parsing

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22703,7 +22703,7 @@ static bool skill_parse_row_skilldamage(char* split[], int columns, int current)
 	for(int offset = 3, i = SKILLDMG_PC; i < SKILLDMG_MAX && offset < columns; i++, offset++ ){
 		value = strtol(split[offset], &result, 10);
 
-		if (*result) {
+		if (*result && *result != ' ') {
 			ShowError("skill_parse_row_skilldamage: Invalid damage %s given for skill %d, defaulting to 0.\n", result, id);
 			value = 0;
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: #4690

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Ignore the space after damage rate.
Thanks to @Tutankhaten!