### PR TITLE
[Suggestion] Custom Config for NPC EMOTION Behavior

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -370,6 +370,13 @@ can_damage_skill: 1
 // Legacy Athena: 1
 land_protector_behavior: 0
 
+// NPC EMOTION behavior (Note 1)
+// On official servers, certain mobs cast NPC EMOTION skill which displays an emoticon and change their mode from
+// Aggressive to Passive for a certain time. The Athena behavior does not change their mode to Passive.
+// Official: 0
+// Legacy Athena: 1
+npc_emotion_behavior: 1
+
 // Should Tarot Card of Fate have the same chance for each card to occur? (Note 1)
 // Official chances: 15%: LOVERS | 10%: FOOL, MAGICIAN, HIGH PRIESTESS, STRENGTH, SUN | 8%: TEMPERANCE
 // 7%: CHARIOT | 6%: THE HANGED MAN | 5%: DEATH, STAR | 2%: TOWER | 1%: WHEEL OF FORTUNE, DEVIL

--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -375,7 +375,7 @@ land_protector_behavior: 0
 // Aggressive to Passive for a certain time. The Athena behavior does not change their mode to Passive.
 // Official: 0
 // Legacy Athena: 1
-npc_emotion_behavior: 1
+npc_emotion_behavior: 0
 
 // Should Tarot Card of Fate have the same chance for each card to occur? (Note 1)
 // Official chances: 15%: LOVERS | 10%: FOOL, MAGICIAN, HIGH PRIESTESS, STRENGTH, SUN | 8%: TEMPERANCE

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8747,6 +8747,7 @@ static const struct _battle_data {
 	{ "mail_show_status",                   &battle_config.mail_show_status,                0,      0,      2,              },
 	{ "client_limit_unit_lv",               &battle_config.client_limit_unit_lv,            0,      0,      BL_ALL,         },
 	{ "land_protector_behavior",            &battle_config.land_protector_behavior,         0,      0,      1,              },
+	{ "npc_emotion_behavior",               &battle_config.npc_emotion_behavior,            0,      0,      1,              },
 // BattleGround Settings
 	{ "bg_update_interval",                 &battle_config.bg_update_interval,              1000,   100,    INT_MAX,        },
 	{ "bg_short_attack_damage_rate",        &battle_config.bg_short_damage_rate,            80,     0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -349,6 +349,7 @@ struct Battle_Config
 	int prevent_logout;	// Added by RoVeRT
 	int prevent_logout_trigger;
 	int land_protector_behavior;
+	int npc_emotion_behavior;
 
 	int alchemist_summon_reward;	// [Valaris]
 	int drops_by_luk;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8838,11 +8838,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if(md->db->skill[md->skill_idx].val[4] && tsce)
 				status_change_end(bl, type, INVALID_TIMER);
 
-			if (battle_config.npc_emotion_behavior && skill_id == NPC_EMOTION && md->db->skill[md->skill_idx].val[1] && md->db->skill[md->skill_idx].val[1] == 0x81)
-				break;
-
 			//If mode gets set by NPC_EMOTION then the target should be reset [Playtester]
-			if(skill_id == NPC_EMOTION && md->db->skill[md->skill_idx].val[1])
+			if(!battle_config.npc_emotion_behavior && skill_id == NPC_EMOTION && md->db->skill[md->skill_idx].val[1])
 				mob_unlocktarget(md,tick);
 
 			if(md->db->skill[md->skill_idx].val[1] || md->db->skill[md->skill_idx].val[2])
@@ -8853,7 +8850,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 					skill_get_time(skill_id, skill_lv));
 
 			//Reset aggressive state depending on resulting mode
-			md->state.aggressive = status_has_mode(&md->status,MD_ANGRY)?1:0;
+			if (!battle_config.npc_emotion_behavior)
+				md->state.aggressive = status_has_mode(&md->status,MD_ANGRY)?1:0;
 		}
 		break;
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8838,6 +8838,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if(md->db->skill[md->skill_idx].val[4] && tsce)
 				status_change_end(bl, type, INVALID_TIMER);
 
+			if (battle_config.npc_emotion_behavior && skill_id == NPC_EMOTION && md->db->skill[md->skill_idx].val[1] && md->db->skill[md->skill_idx].val[1] == 0x81)
+				break;
+
 			//If mode gets set by NPC_EMOTION then the target should be reset [Playtester]
 			if(skill_id == NPC_EMOTION && md->db->skill[md->skill_idx].val[1])
 				mob_unlocktarget(md,tick);


### PR DESCRIPTION
* Adds config for NPC EMOTION behavior.
* This battle config option adds the ability to modify NPC EMOTION skill to the Athena behavior.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #4727

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
On official servers, certain mobs cast NPC EMOTION skill which displays an emoticon and change their mode from Aggressive to Passive for a certain time. The Athena behavior does not change their mode to Passive.

The default config to `npc_emotion_behavior` is `0`. Changing to `1` will modify it to the Athena behavior.