### PR TITLE
Cleanup for the new_account feature

### DIFF
--- a/conf/login_athena.conf
+++ b/conf/login_athena.conf
@@ -52,7 +52,8 @@ console_silent: 0
 console: off
 
 // Can you use _M/_F to make new accounts on the server?
-new_account: yes
+// Note: This only works if client side password encryption is not enabled.
+new_account: no
 
 //If new_account is enabled, minimum length to userid and passwords should be 4?
 //Must be 'Yes' unless your client uses both 'Disable 4 LetterUserID/Password' Diffs

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -316,9 +316,14 @@ int login_mmo_auth(struct login_session_data* sd, bool isServer) {
 	// Account creation with _M/_F
 	if( login_config.new_account_flag ) {
 		if( len > 2 && strnlen(sd->passwd, NAME_LENGTH) > 0 && // valid user and password lengths
-			sd->passwdenc == 0 && // unencoded password
 			sd->userid[len-2] == '_' && memchr("FfMm", sd->userid[len-1], 4) ) // _M/_F suffix
 		{
+			// Encoded password
+			if( sd->passwdenc != 0 ){
+				ShowError( "Account '%s' could not be created, because client side password encryption is enabled.\n", sd->userid );
+				return 0; // unregistered id
+			}
+
 			int result;
 			// remove the _M/_F suffix
 			len -= 2;

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -320,7 +320,7 @@ int login_mmo_auth(struct login_session_data* sd, bool isServer) {
 		{
 			// Encoded password
 			if( sd->passwdenc != 0 ){
-				ShowError( "Account '%s' could not be created, because client side password encryption is enabled.\n", sd->userid );
+				ShowError( "Account '%s' could not be created because client side password encryption is enabled.\n", sd->userid );
 				return 0; // unregistered id
 			}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Disabled by default - as on official servers.
Gives a better warning if it is turned on and client side password encryption is enabled and the account cannot be created because of this.
