### PR TITLE
Fixes Soul Unity being removed on map change

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2914,7 +2914,6 @@ int unit_remove_map_(struct block_list *bl, clr_type clrtype, const char* file, 
 		status_change_end(bl, SC_TINDER_BREAKER, INVALID_TIMER);
 		status_change_end(bl, SC_TINDER_BREAKER2, INVALID_TIMER);
 		status_change_end(bl, SC_FLASHKICK, INVALID_TIMER);
-		status_change_end(bl, SC_SOULUNITY, INVALID_TIMER);
 		status_change_end(bl, SC_HIDING, INVALID_TIMER);
 		// Ensure the bl is a PC; if so, we'll handle the removal of cloaking and cloaking exceed later
 		if ( bl->type != BL_PC ) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #4733

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Soul Unity should not be removed on map change.
Thanks to @Balferian!