### PR TITLE
Fixed MO_FINGEROFFENSIVE hits depending on the number of spirit spheres

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5441,8 +5441,8 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 			}
 				break;
 			case MO_FINGEROFFENSIVE:
-				if (sd && battle_config.finger_offensive_type)
-					wd.div_ = 1;
+				if (sd)
+					wd.div_ = (battle_config.finger_offensive_type)?1:sd->spiritball_old;
 				break;
 
 			case KN_PIERCE:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes Throw Spirit Sphere / Finger offensive hits depending on the number of spirit spheres.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
