### PR TITLE
Fixes a compile error for older clients

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -17134,7 +17134,7 @@ void clif_quest_update_objective(struct map_session_data *sd, struct quest *qd, 
 			WFIFOL(fd, offset) = qd->quest_id * 1000 + i;
 			offset += 4;
 #else
-			WFIFOL(fd, offset) = qi->objectives[i].mob_id;
+			WFIFOL(fd, offset) = qi->objectives[i]->mob_id;
 			offset += 4;
 #endif
 			WFIFOW(fd, offset) = qi->objectives[i]->count;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4773

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves a compile error for clients older than 20150513 quest objectives.
Thanks to @Cainho!