### PR TITLE
Fixes Weapon Crush and Weapon Blocking combo

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -18583,6 +18583,8 @@ Body:
     Duration1: 60000
     Requires:
       SpCost: 20
+      Status:
+        Weaponblock_On: true
   - Id: 2031
     Name: GC_VENOMPRESSURE
     Description: Venom Pressure

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -19325,6 +19325,8 @@ Body:
     FixedCastTime: -1
     Requires:
       SpCost: 20
+      Status:
+        Weaponblock_On: true
   - Id: 2031
     Name: GC_VENOMPRESSURE
     Description: Venom Pressure

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1171,7 +1171,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 
 		if( sc->data[SC_WEAPONBLOCKING] && flag&(BF_SHORT|BF_WEAPON) && rnd()%100 < sc->data[SC_WEAPONBLOCKING]->val2 ) {
 			clif_skill_nodamage(bl,src,GC_WEAPONBLOCKING,sc->data[SC_WEAPONBLOCKING]->val1,1);
-			sc_start(src, bl, SC_WEAPONBLOCK_ON, 100, 0, skill_get_time2(GC_WEAPONBLOCKING, 1));
+			sc_start(src, bl, SC_WEAPONBLOCK_ON, 100, src->id, skill_get_time2(GC_WEAPONBLOCKING, 1));
 			d->dmg_lv = ATK_BLOCK;
 			return 0;
 		}

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3483,7 +3483,11 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 		{
 			wd->div_ = skill_get_num(GS_CHAINACTION,skill_lv);
 			wd->type = DMG_MULTI_HIT;
-			sc_start(src,src,SC_QD_SHOT_READY,100,target->id,skill_get_time(RL_QD_SHOT,1));
+
+			status_data *status = status_get_status_data(src);
+
+			if (status && status->amotion > 70) // Only triggers if ASPD < 193
+				sc_start(src,src,SC_QD_SHOT_READY,100,target->id,skill_get_time(RL_QD_SHOT,1));
 		}
 		else if(sc && sc->data[SC_FEARBREEZE] && sd->weapontype1==W_BOW
 			&& (i = sd->equip_index[EQI_AMMO]) >= 0 && sd->inventory_data[i] && sd->inventory.u.items_inventory[i].amount > 1)

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -15478,8 +15478,10 @@ static bool skill_check_condition_sc_required(struct map_session_data *sd, unsig
 				break;
 		}
 
-		clif_skill_fail(sd, skill_id, cause, 0);
-		return false;
+		if (!sc->data[reqStatus]) {
+			clif_skill_fail(sd, skill_id, cause, 0);
+			return false;
+		}
 	}
 
 	return true;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11408,11 +11408,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			// Main target always receives damage
 			clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
 			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_LEVEL);
-		}
-		else {
+		} else {
 			clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
 			map_foreachinrange(skill_area_sub, src, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
 		}
+		status_change_end(src, SC_QD_SHOT_READY, INVALID_TIMER); // End here to prevent spamming of the skill onto the target.
 		skill_area_temp[0] = 0;
 		skill_area_temp[1] = 0;
 		break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2948,7 +2948,6 @@ int skill_is_combo(uint16 skill_id) {
 		case TK_COUNTER:
 		case TK_JUMPKICK:
 		case HT_POWER:
-		case GC_WEAPONCRUSH:
 		case SR_DRAGONCOMBO:
 			return 1;
 		case SR_FALLENEMPIRE:
@@ -4845,6 +4844,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case NC_POWERSWING:
 	case NC_MAGMA_ERUPTION:
 	case GC_CROSSIMPACT:
+	case GC_WEAPONCRUSH:
 	case GC_VENOMPRESSURE:
 	case SC_TRIANGLESHOT:
 	case SC_FEINTBOMB:
@@ -5687,13 +5687,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			}
 
 		}
-		break;
-
-	case GC_WEAPONCRUSH:
-		if( sc && sc->data[SC_COMBO] && sc->data[SC_COMBO]->val1 == GC_WEAPONBLOCKING )
-			skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag);
-		else if( sd )
-			clif_skill_fail(sd,skill_id,USESKILL_FAIL_GC_WEAPONBLOCKING,0);
 		break;
 
 	case GC_CROSSRIPPERSLASHER:
@@ -15485,6 +15478,7 @@ static bool skill_check_condition_sc_required(struct map_session_data *sd, unsig
 				}
 				break;
 			case GC_COUNTERSLASH:
+			case GC_WEAPONCRUSH:
 				if (!sc->data[SC_WEAPONBLOCK_ON]) {
 					clif_skill_fail(sd, skill_id, USESKILL_FAIL_GC_WEAPONBLOCKING, 0);
 					return false;
@@ -16046,12 +16040,6 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 		case GC_HALLUCINATIONWALK:
 			if( sc && (sc->data[SC_HALLUCINATIONWALK] || sc->data[SC_HALLUCINATIONWALK_POSTDELAY]) ) {
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
-				return false;
-			}
-			break;
-		case GC_WEAPONCRUSH:
-			if( !(sc && sc->data[SC_COMBO] && sc->data[SC_COMBO]->val1 == GC_WEAPONBLOCKING) ) {
-				clif_skill_fail(sd, skill_id, USESKILL_FAIL_GC_WEAPONBLOCKING, 0);
 				return false;
 			}
 			break;

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1595,12 +1595,14 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 				if (sc && sc->data[SC_WEAPONBLOCK_ON]) {
 					if ((target = map_id2bl(sc->data[SC_WEAPONBLOCK_ON]->val1)) == nullptr)
 						return 0;
+					combo = 1;
 				}
 				break;
 			case RL_QD_SHOT:
 				if (sc && sc->data[SC_QD_SHOT_READY]) {
 					if ((target = map_id2bl(sc->data[SC_QD_SHOT_READY]->val1)) == nullptr)
 						return 0;
+					combo = 1;
 				}
 				break;
 			case WE_MALE:

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1577,8 +1577,19 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 	} else if ( target_id == src->id &&
 		inf&INF_SELF_SKILL &&
 		(skill->inf2[INF2_NOTARGETSELF] ||
+		(skill_id == GC_WEAPONCRUSH && sc && sc->data[SC_WEAPONBLOCK_ON]) ||
 		(skill_id == RL_QD_SHOT && sc && sc->data[SC_QD_SHOT_READY])) ) {
-		target_id = ud->target; // Auto-select target. [Skotlex]
+		switch (skill_id) {
+			case GC_WEAPONCRUSH:
+				target_id = sc->data[SC_WEAPONBLOCK_ON]->val1;
+				break;
+			case RL_QD_SHOT:
+				target_id = sc->data[SC_QD_SHOT_READY]->val1;
+				break;
+			default:
+				target_id = ud->target; // Auto-select target. [Skotlex]
+				break;
+		}
 		combo = 1;
 	}
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1574,17 +1574,15 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 			target_id = src->id;
 
 		combo = 1;
-	} else if ( target_id == src->id &&
-		inf&INF_SELF_SKILL &&
-		(skill->inf2[INF2_NOTARGETSELF] ||
-		(skill_id == GC_WEAPONCRUSH && sc && sc->data[SC_WEAPONBLOCK_ON]) ||
-		(skill_id == RL_QD_SHOT && sc && sc->data[SC_QD_SHOT_READY])) ) {
+	} else if (target_id == src->id && inf&INF_SELF_SKILL && skill->inf2[INF2_NOTARGETSELF]) {
 		switch (skill_id) {
 			case GC_WEAPONCRUSH:
-				target_id = sc->data[SC_WEAPONBLOCK_ON]->val1;
+				if (sc && sc->data[SC_WEAPONBLOCK_ON])
+					target_id = sc->data[SC_WEAPONBLOCK_ON]->val1;
 				break;
 			case RL_QD_SHOT:
-				target_id = sc->data[SC_QD_SHOT_READY]->val1;
+				if (sc && sc->data[SC_QD_SHOT_READY])
+					target_id = sc->data[SC_QD_SHOT_READY]->val1;
 				break;
 			default:
 				target_id = ud->target; // Auto-select target. [Skotlex]

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1575,19 +1575,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 
 		combo = 1;
 	} else if (target_id == src->id && inf&INF_SELF_SKILL && skill->inf2[INF2_NOTARGETSELF]) {
-		switch (skill_id) {
-			case GC_WEAPONCRUSH:
-				if (sc && sc->data[SC_WEAPONBLOCK_ON])
-					target_id = sc->data[SC_WEAPONBLOCK_ON]->val1;
-				break;
-			case RL_QD_SHOT:
-				if (sc && sc->data[SC_QD_SHOT_READY])
-					target_id = sc->data[SC_QD_SHOT_READY]->val1;
-				break;
-			default:
-				target_id = ud->target; // Auto-select target. [Skotlex]
-				break;
-		}
+		target_id = ud->target; // Auto-select target. [Skotlex]
 		combo = 1;
 	}
 
@@ -1600,6 +1588,18 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 			case MO_CHAINCOMBO:
 				if (sc && sc->data[SC_BLADESTOP]) {
 					if ((target=map_id2bl(sc->data[SC_BLADESTOP]->val4)) == NULL)
+						return 0;
+				}
+				break;
+			case GC_WEAPONCRUSH:
+				if (sc && sc->data[SC_WEAPONBLOCK_ON]) {
+					if ((target = map_id2bl(sc->data[SC_WEAPONBLOCK_ON]->val1)) == nullptr)
+						return 0;
+				}
+				break;
+			case RL_QD_SHOT:
+				if (sc && sc->data[SC_QD_SHOT_READY]) {
+					if ((target = map_id2bl(sc->data[SC_QD_SHOT_READY]->val1)) == nullptr)
 						return 0;
 				}
 				break;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4808

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Weapon Crush now uses SC_WEAPONBLOCK_ON to track the target instead of SC_COMBO.
  * Also fixes Quick Draw Shot target selection.
Thanks to @wdivet!