### PR TITLE
Bug fix for npc_earthquake skill: MATK calculation should be based on …

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6067,7 +6067,13 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 				ad.damage = sstatus->rhw.atk * 20 * skill_lv;
 				break;
 			default: {
-				if (sstatus->matk_max > sstatus->matk_min) {
+                if (skill_id == NPC_EARTHQUAKE) { // should be 'is magic atk based on user physical atk?'
+                    if (sstatus->rhw.atk2 > sstatus->rhw.atk) {
+                        MATK_ADD(sstatus->rhw.atk + rnd() % (sstatus->rhw.atk2 - sstatus->rhw.atk))
+                    } else {
+                        MATK_ADD(sstatus->rhw.atk)
+                    }
+                } else if (sstatus->matk_max > sstatus->matk_min) {
 					MATK_ADD(sstatus->matk_min+rnd()%(sstatus->matk_max-sstatus->matk_min));
 				} else {
 					MATK_ADD(sstatus->matk_min);


### PR DESCRIPTION
…user's physical attack.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/3176

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
This bug fix should fix the NPC_EARTHQUAKE matk dmg calculation, which should be based on user's physical atk instead of matk. This patch could be improved by adding a specific block for any skill based on physical attack instead of magic, but this is the only one I know which should be like this... Hope it helps!