### PR TITLE
Allow blank passwords on SQL for Local Development ENV

### DIFF
--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -81,7 +81,7 @@ AccountDB* account_db_sql(void) {
 	safestrncpy(db->db_hostname, "127.0.0.1", sizeof(db->db_hostname));
 	db->db_port = 3306;
 	safestrncpy(db->db_username, "ragnarok", sizeof(db->db_username));
-	safestrncpy(db->db_password, "ragnarok", sizeof(db->db_password));
+	safestrncpy(db->db_password, "", sizeof(db->db_password));
 	safestrncpy(db->db_database, "ragnarok", sizeof(db->db_database));
 	safestrncpy(db->codepage, "", sizeof(db->codepage));
 	// other settings

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -93,7 +93,7 @@ char guild_storage_log_table[32] = "guild_storage_log";
 char log_db_ip[64] = "127.0.0.1";
 int log_db_port = 3306;
 char log_db_id[32] = "ragnarok";
-char log_db_pw[32] = "ragnarok";
+char log_db_pw[32] = "";
 char log_db_db[32] = "log";
 Sql* logmysql_handle;
 


### PR DESCRIPTION
Just a small change to allow consistency with other fields allowing blank passwords for sql.