### PR TITLE
Fix Lord of Vermilion damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6247,7 +6247,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case WZ_VERMILION:
 						if(sd)
-							skillratio += 400 + skill_lv * 100;
+							skillratio += 300 + skill_lv * 100;
 						else
 							skillratio += 20 * skill_lv - 20; //Monsters use old formula
 						break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6247,7 +6247,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case WZ_VERMILION:
 						if(sd)
-							skillratio += 25 + skill_lv * 5;
+							skillratio += 400 + skill_lv * 100;
 						else
 							skillratio += 20 * skill_lv - 20; //Monsters use old formula
 						break;


### PR DESCRIPTION
* **Addressed Issue(s)**: #4852 
* **Server Mode**: Renewal
* **Description of Pull Request**: Corrects player WZ_VERMILION skill damage ratio to match kRO (source: divine-pride).