### PR TITLE
Add dockerised local development environment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -177,6 +177,16 @@ Developers can get up and running quickly with a Dockerized development environm
 #### Tips & tricks for local development :beginner:
 
 - Ensure you don't have a database running locally and listening on port `3306` this will cause the database container to fail starting up.
+- To connect a client on the same machine to the server, add these values to their respective configuration files:
+```
+// Add below two lines into conf/import/char_conf.txt
+login_ip: 127.0.0.1
+char_ip: 127.0.0.1
+
+// Add below two lines into conf/import/map_conf.txt
+char_ip: 127.0.0.1
+map_ip: 127.0.0.1
+```
 - All file edits within the repository are reflected inside the container, so you can develop in your preferred text editor or IDE.
 - Connect to the local database with following credentials:
   - Host: `localhost`

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Table of Contents
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Issue Labels](#issue-labels)
+  * [Local Development Environment](#local-development-environment)
   * [Become a Team Member](#become-a-team-member)
 
 Reporting Bugs
@@ -160,6 +161,32 @@ For the most part you as a user will have no reason to worry about the **Milesto
 [search-rathena-label-typeenhancement]: https://github.com/rathena/rathena/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Aenhancement
 [search-rathena-label-typemaintenance]: https://github.com/rathena/rathena/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Amaintenance
 [search-rathena-label-typequestion]: https://github.com/rathena/rathena/issues?q=is%3Aissue+is%3Aopen+label%3Atype%3Aquestion
+
+Local Development Environment
+-----------------------------
+
+Developers can get up and running quickly with a Dockerized development environment that installs all dependencies needed to run and develop on rAthena. Note that this Dockerized environment **is not suitable** for production deployments, see [Installations](https://github.com/rathena/rathena/wiki/installations) instead.
+
+### How to setup a local development environment :computer:
+
+1. `docker-compose up -d` to spin up dev container and database (ensure port `3306` is free)
+2. `docker exec -it rathena bash` to connect to dev container
+3. All rAthena development commands can be executed inside the dev container, such as compiling (`./configure`, `make clean server`) and starting the server (`./athena-start`, `gdb map-server`, etc ...)
+4. `docker-compose down` outside the dev container when done to close database and free resources
+
+#### Tips & tricks for local development :beginner:
+
+- Ensure you don't have a database running locally and listening on port `3306` this will cause the database container to fail starting up.
+- All file edits within the repository are reflected inside the container, so you can develop in your preferred text editor or IDE.
+- Connect to the local database with following credentials:
+  - Host: `localhost`
+  - Port: `3306`
+  - User: `ragnarok`
+  - Password: `ragnarok`
+- On first start up all `/sql-files/*.sql` files are imported into the database. This does not happen on future start ups unless the volume has been deleted.
+- Database is saved to local disk so state is persisted between shutdowns and start ups. To fully erase your database and start fresh, delete the volume with `docker-compose down --volumes`
+- Check the status of containers with `docker-compose ps`
+- If you have modified the `Dockerfile`, be sure to rebuild the docker image with `docker-compose build`
 
 Become a Team Member
 --------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.11
+WORKDIR /rathena
+RUN apk add --no-cache git make gcc g++ gdb zlib-dev mariadb-dev ca-certificates linux-headers bash
+ENTRYPOINT [ "bash" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.7"
+
+services:
+    db:
+        image: "mariadb:bionic"
+        container_name: "rathena_db"
+        ports:
+            - "3306:3306" # allow DB connections from host
+        volumes:
+            - "rathenadb:/var/lib/mysql" # save database to local disk
+            - "./sql-files/:/docker-entrypoint-initdb.d" # initialize db with ./sql-files
+        environment:
+            MYSQL_ROOT_PASSWORD: ragnarok
+            MYSQL_DATABASE: ragnarok
+            MYSQL_USER: ragnarok
+            MYSQL_PASSWORD: ragnarok
+    server:
+        image: "rathena:local"
+        container_name: "rathena"
+        ports:
+            - "5121:5121" # map server
+            - "6121:6121" # char server
+            - "6900:6900" # login server
+        volumes:
+            - ".:/rathena" # mount directory inside container
+            - "./tools/docker_db.conf:/rathena/conf/import/inter_conf.txt" # load db connection
+        tty: true
+        stdin_open: true
+        build:
+            context: .
+            dockerfile: Dockerfile
+        depends_on:
+            - db
+
+volumes:
+    rathenadb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
         volumes:
             - ".:/rathena" # mount directory inside container
             - "./tools/docker_db.conf:/rathena/conf/import/inter_conf.txt" # load db connection
+        init: true # helps with signal forwarding and process reaping
         tty: true
         stdin_open: true
         build:

--- a/tools/docker_db.conf
+++ b/tools/docker_db.conf
@@ -1,0 +1,5 @@
+login_server_ip: db
+ipban_db_ip: db
+char_server_ip: db
+map_server_ip: db
+log_db_ip: db


### PR DESCRIPTION
* **Addressed Issue(s)**: None
* **Server Mode**: Both
* **Description of Pull Request**:
Adds an easy way for developers new to rAthena to get a local development environment up and running with only a single pre-requisite (Docker Desktop).

**Instructions for use:**
1. `docker-compose up -d` to spin up database (automatically imports `/sql-files/*.sql` on first load)
2. `docker exec -it rathena bash` to connect to lightweight linux container with all rathena dependencies (plus gdb)
3. Devs can now run usual commands (`./configure`, `make`, etc ...) or start server (`./athena-start`, `gdb map-server`, etc ...)
4. `docker-compose down` to free resources when done

**Demonstration:** https://terminalizer.com/view/c05443023904

**Additional Information:**
- Database is persisted to local disk so no need to recreate database every time.
- First time the database volume is created, all `*.sql` files are imported into the database. This does not happen on future start ups unless the volume has been deleted (devs can delete volume with `docker-compose down --volumes`)
- Devs can inspect state of containers with `docker-compose ps` and modify the setup as they see fit (Official Docs: https://docs.docker.com/compose/compose-file/)
- It would be ideal to have a page of documentation to accompany this feature (if it is approved), which I'm happy write but not sure where it would best live; perhaps in `CONTRIBUTING.md`?