### PR TITLE
Fixes MO_EXTREMITYFIST

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3791,7 +3791,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 		case MO_EXTREMITYFIST:
 #ifdef RENEWAL
 			if (wd->miscflag&1)
-				skillratio += 100; // More than 5 spirit balls active
+				skillratio += 100 + 100 * (7 + sstatus->sp / 10); // More than 5 spirit balls active
 #endif
 			skillratio += 100 * (7 + sstatus->sp / 10);
 			skillratio = min(500000,skillratio); //We stop at roughly 50k SP for overflow protection

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3789,11 +3789,11 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 #endif
 			break;
 		case MO_EXTREMITYFIST:
+			skillratio += 100 * (7 + sstatus->sp / 10);			
 #ifdef RENEWAL
 			if (wd->miscflag&1)
-				skillratio += 100 + 100 * (7 + sstatus->sp / 10); // More than 5 spirit balls active
+				skillratio *= 2; // More than 5 spirit balls active
 #endif
-			skillratio += 100 * (7 + sstatus->sp / 10);
 			skillratio = min(500000,skillratio); //We stop at roughly 50k SP for overflow protection
 			break;
 		case MO_TRIPLEATTACK:


### PR DESCRIPTION
Fixes MO_EXTREMITYFIST double damage with more than 5 spheres

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #4880

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: MO_EXTREMITYFIST is suposed to do double damage when user has 6 or more spirit spheres

Thanks to @ecdarreola
