### PR TITLE
Fixes Ur's and Peuz's Greave refine bonus

### DIFF
--- a/db/re/item_db.txt
+++ b/db/re/item_db.txt
@@ -1697,8 +1697,8 @@
 2472,Shoes_Of_Judgement,Shoes Of Judgement,4,20,,300,,12,,0,0x00000100,63,2,64,,100,1,0,{ bonus2 bSkillAtk,"AB_JUDEX",30; bonus2 bSkillUseSP,"AB_JUDEX",-40; bonus bMaxSP,150; },{},{}
 2473,Para_Team_Boots4,Eden Team Boots IV,4,0,,0,,20,,0,0xFFFFFFFF,63,2,64,,60,0,0,{ bonus bAgi,1; bonus bVit,1; bonus bHPrecovRate,28; bonus bSPrecovRate,12; },{},{}
 2474,Lehmannza_Shoes,Lehmannza Shoes,4,20,,500,,3,,1,0xFFFFFFFF,63,2,64,,60,1,0,{ bonus bMdef,3; },{},{}
-2475,Ur_Greave,Ur's Greaves,4,20,,900,,32,,1,0x00000080,56,2,64,,100,1,0,{ bonus bMaxSP,40; .@r = getrefine(); bonus bMaxHPrate,(.@r<=7?.@r-7:1); },{},{}
-2476,Peuz_Greave,Peuz's Greaves,4,20,,900,,32,,1,0x00000080,56,2,64,,100,1,0,{ bonus bMaxSP,40; .@r = getrefine(); bonus bAgi,(.@r<=7?.@r-7:1); },{},{}
+2475,Ur_Greave,Ur's Greaves,4,20,,900,,32,,1,0x00000080,56,2,64,,100,1,0,{ bonus bMaxSP,40; .@r = getrefine(); if(.@r>7) bonus bMaxHPrate,.@r-7; },{},{}
+2476,Peuz_Greave,Peuz's Greaves,4,20,,900,,32,,1,0x00000080,56,2,64,,100,1,0,{ bonus bMaxSP,40; .@r = getrefine(); if(.@r>7) bonus bAgi,.@r-7; },{},{}
 2477,Sabah_Shoes,Sapha Shoes,4,20,,400,,18,,1,0x00001000,63,2,64,,100,1,0,{ bonus bMaxSP,30; bonus bLuk,3; },{},{}
 2478,Nab_Shoes,Nab Shoes,4,20,,400,,18,,1,0x00001000,63,2,64,,100,1,0,{ bonus bFlee,3; bonus bInt,2; },{},{}
 2479,White_Wing_Boots,White Wing Boots,4,20,,400,,18,,1,0x00000800,63,2,64,,100,1,0,{ bonus bAgi,2; bonus2 bSkillUseSP,"RA_AIMEDBOLT",10; },{},{}


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4889 

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes Ur's and Peuz's Greave giving negative stats if the refine is less than 8.
Thanks to @Questune09!