### PR TITLE
Fixing round, ceil and floor not using precision

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -25291,9 +25291,9 @@ struct script_function buildin_func[] = {
 
 
 	BUILDIN_DEF(getequiprefinecost,"iii?"),
-	BUILDIN_DEF2(round, "round", "i"),
-	BUILDIN_DEF2(round, "ceil", "i"),
-	BUILDIN_DEF2(round, "floor", "i"),
+	BUILDIN_DEF2(round, "round", "ii"),
+	BUILDIN_DEF2(round, "ceil", "ii"),
+	BUILDIN_DEF2(round, "floor", "ii"),
 	BUILDIN_DEF(getequiptradability, "i?"),
 	BUILDIN_DEF(mail, "isss*"),
 	BUILDIN_DEF(open_roulette,"?"),


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/4898
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Only missing one integer in parameter in BUILDIN_DEF2, already ready to read in the definition of the function.

mes round(2500,1000);
mes ceil(2500,1000);
mes floor(2500,1000);
mes "---";
mes round(2499,1000);
mes ceil(2499,1000);
mes floor(2499,1000);

![issue4898](https://user-images.githubusercontent.com/14162419/81146308-5994e880-8f78-11ea-8d8c-2782614e3bba.JPG)

The documentation :
*round(<number>,<precision>);
*ceil(<number>,<precision>);
*floor(<number>,<precision>);

Returns <number> rounded to multiple of <precision>.

`round` function will round the <number> up if its division with <precision> yield a remainder
with a value equals to or more than half of <precision>. Otherwise, it rounds the <number> down.
`ceil` always round the <number> up.
`floor` always round the <number> down.
