### PR TITLE
Missing NC_ARMSCANNON Cooldown

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -21276,17 +21276,18 @@ Body:
         Time: 2000
       - Level: 5
         Time: 2200
-    AfterCastActDelay:
+    AfterCastActDelay: 1000
+    Cooldown:
       - Level: 1
-        Time: 1000
+        Time: 150
       - Level: 2
-        Time: 1000
+        Time: 200
       - Level: 3
-        Time: 1000
+        Time: 300
       - Level: 4
-        Time: 1000
+        Time: 450
       - Level: 5
-        Time: 1000
+        Time: 650 
     FixedCastTime:
       - Level: 1
         Time: 600


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: NC_ARMSCANNON was missing Cooldown from third classes skill adjustment on 185/65 patch

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Cooldown info : https://www.divine-pride.net/forum/index.php?/topic/4202-kro-third-classes-skill-adjustment-on-18565-patch/
![image](https://user-images.githubusercontent.com/62680611/81227471-de0c5900-8fc2-11ea-8c67-70f66876996a.png)
