### PR TITLE
mapduplicate script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3116,15 +3116,22 @@ map ID doesn't exist.
 
 *mapduplicate("<map name>")
 
-This command allows you to duplicate a map using npc,
-Without adding the map files to the client , it work the same as
-The map duplication in the instance system,
+This command allows you to duplicate a map using script,
+Without adding a copy of the map files to the client ,
+It work the same as map duplication in the instance system,
 The duplicate map will be have no map data (aka npcs and mapflags),
-Duplicate Maps are removed on the server restart.
-'$map_duplicate_list$' Global Variable will have a list of all the
-map duplicate names.
+Duplicated Maps are removed on the server restart.
 
 Returns the new map name if successed , and Empty string if failed.
+
+Example:
+	//warp to the duplicated map.
+	warp $mymap$,150,180;
+	end;
+
+	OnInterIfInitOnce:
+		//duplicate prontera once on the server start.
+		$mymap$ = mapduplicate("prontera");
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3114,6 +3114,12 @@ map ID doesn't exist.
 
 ---------------------------------------
 
+*mapduplicate("<map name>")
+
+Returns the new map name if successed , and Empty string if failed.
+
+---------------------------------------
+
 *getgmlevel({<char_id>})
 
 This function will return the (GM) level associated with the player group to which

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3116,6 +3116,14 @@ map ID doesn't exist.
 
 *mapduplicate("<map name>")
 
+This command allows you to duplicate a map using npc,
+Without adding the map files to the client , it work the same as
+The map duplication in the instance system,
+The duplicate map will be have no map data (aka npcs and mapflags),
+Duplicate Maps are removed on the server restart.
+'$map_duplicate_list$' Global Variable will have a list of all the
+map duplicate names.
+
 Returns the new map name if successed , and Empty string if failed.
 
 ---------------------------------------

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2716,6 +2716,7 @@ int map_duplicate(int src_m)
 		return -1;
 	}
 
+	//#TODO clear the $map_duplicate_list$ on server restart.
 	mapreg_setregstr(reference_uid(add_str("$map_duplicate_list$"), mapduplicate), dst_map->name);
 	mapduplicate++;
 	map_num++;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2710,8 +2710,8 @@ int map_duplicate(int src_m)
 	struct map_data* src_map = map_getmapdata(src_m);
 	struct map_data* dst_map = map_getmapdata(dst_m);
 
-	//duplicate maps use alphabet instead of numbers.
-	//this help distinguish between instances maps and duplicated maps.
+	//duplicated maps use alphabet instead of numbers.
+	//this help distinguish duplicated maps from instances maps.
 	//also helps maps name size.
 	const char* alphabet = "abcdefghijklmnopqrstuvwxyz";
 	size_t abc_size = strlen(alphabet);
@@ -2724,14 +2724,11 @@ int map_duplicate(int src_m)
 	}
 
 	snprintf(dst_map->name, sizeof(dst_map->name), "%s#%s", addiotion.c_str(), name);
-
 	if (strlen(dst_map->name) > MAP_NAME_LENGTH) {
 		ShowError("map_duplicate: can't add long map name \"%s\" source map \"%s\"\n", dst_map->name, name);
 		return -1;
 	}
 
-	//#TODO clear the $map_duplicate_list$ on server restart.
-	//mapreg_setregstr(reference_uid(add_str("$map_duplicate_list$"), mapduplicate), dst_map->name);
 	mapduplicate++;
 	map_num++;
 	dst_map->m = dst_m;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2692,7 +2692,7 @@ bool map_addnpc(int16 m,struct npc_data *nd)
 }
 
 /*==========================================
- * duplicate a map , return the new map id.
+ * duplicate a map , return the new map id , and -1 if failed.
  *------------------------------------------*/
 int mapduplicate = 0;
 int map_duplicate(int src_m)
@@ -2711,7 +2711,7 @@ int map_duplicate(int src_m)
 	struct map_data* dst_map = map_getmapdata(dst_m);
 	snprintf(dst_map->name, sizeof(dst_map->name), "%d#%s", mapduplicate + 1, name);
 
-	if (strlen(dst_map->name) < MAP_NAME_LENGTH) {
+	if (strlen(dst_map->name) > MAP_NAME_LENGTH) {
 		ShowError("map_duplicate: can't add long map name \"%s\" source map \"%s\"\n", dst_map->name, name);
 		return -1;
 	}

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2717,19 +2717,12 @@ int map_duplicate(int src_m)
 	size_t abc_size = strlen(alphabet);
 	std::string addiotion = "";
 	int count = mapduplicate;
-
-	//still need adjustment.
-	if (count >= (abc_size* (abc_size+1) )) {	//handles aaa to zzz
-		int b = abc_size * abc_size;
-		addiotion += alphabet[static_cast<int>(count / b) - 1];
-		count -= b * static_cast<int>(count / b);
-	}
-	if (count >= abc_size) {	//handles aa to zz
-		addiotion += alphabet[static_cast<int>(count / abc_size) - 1];
-		count -= abc_size * static_cast<int>(count / abc_size);
+	while (count >= 0) {
+		int r = count % abc_size;
+		addiotion += alphabet[r];
+		count = static_cast<int>(count /abc_size )-1;
 	}
 
-	addiotion += alphabet[count];
 	snprintf(dst_map->name, sizeof(dst_map->name), "%s#%s", addiotion.c_str(), name);
 
 	if (strlen(dst_map->name) > MAP_NAME_LENGTH) {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1027,6 +1027,7 @@ bool map_closest_freecell(int16 m, int16 *x, int16 *y, int type, int flag);
 int map_quit(struct map_session_data *);
 // npc
 bool map_addnpc(int16 m,struct npc_data *);
+int map_duplicate(int src_m);
 
 // map item
 TIMER_FUNC(map_clearflooritem_timer);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -15392,6 +15392,19 @@ BUILDIN_FUNC(mapid2name)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+BUILDIN_FUNC(mapduplicate)
+{
+	const char* map_name = script_getstr(st, 2);
+	int m;
+	if ((m = map_duplicate(map_mapname2mapid(map_name))) == -1) {
+		script_pushconststr(st, "");
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	script_pushconststr(st, map_mapid2mapname(m));
+	return SCRIPT_CMD_SUCCESS;
+}
+
 /*==========================================
  * Allows player to write NPC logs (i.e. Bank NPC, etc) [Lupus]
  *------------------------------------------*/

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -24973,6 +24973,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(npcstop,""), // [Valaris]
 	BUILDIN_DEF(getmapxy,"rrr??"),	//by Lorky [Lupus]
 	BUILDIN_DEF(mapid2name,"i"),
+	BUILDIN_DEF(mapduplicate,"s"),
 	BUILDIN_DEF(checkoption1,"i?"),
 	BUILDIN_DEF(checkoption2,"i?"),
 	BUILDIN_DEF(guildgetexp,"i"),


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 
mapduplicate script command allows to duplicate maps in the server without the need to duplicate it in the client
this command will make things much easier for custom systems and event scripts
the idea is when you want to create a new event or a new pvp map or system, for example instead of uploading the script with the related map files or the "how to duplicate a map in your client"
this will allow scripters/server owners to skip this steps.

**Old idea to store the map names:**
> the reason I use `$map_duplicate_list$` global variable to save the maps name is that `$@` variable get cleared on `@reloadscript` command, the user can save the map names on his own or can check the list of duplicated maps from the  global variable
> 
> still to do is clearing the `$map_duplicate_list$`  on server restart, if there is an alternative to the global variable idea, it would be better!
> for example , we could create an empty vector to save the map names to it , and create a command script that give us the output of that vector , i think this would be better, will check it out, however i am up for suggestions.



and hopefully soon a duplicate command for npcs would be the best compo with this command.

test script:
```cs
prontera,153,180,0	script	mapduplicate_test	444,{
	if(select("create new duplicate to prontera:names list") == 2){
		if(!getarraysize($mapduplicate$)){
			mes "no maps on the list yet";
			end;
		}
		mes "select a map to warp to it!";
		.@s = select(implode($mapduplicate$, ":")) -1;
		warp $mapduplicate$[.@s],155,183;
		end;
	}
	$mapduplicate$[getarraysize($mapduplicate$)] = mapduplicate("prontera");
	debugmes $mapduplicate$[getarraysize($mapduplicate$)];
end;

OnInterIfInitOnce:
	deletearray $mapduplicate$[0],getarraysize($mapduplicate$);
end;
}
```

talk to the npc , create a new copy of prontera, check the map lists , click on the map and it will teleport you to it.


IRL Example:
```cs
//npc that have all the maps duplicate and load once at the server start.
-	script	eventmaps_duplicates	-1,{
OnInterIfInitOnce:
	//you can put all the map duplicates here.
	$some_event_map$ = mapduplicate("prontera");
end;
}

//some random event that uses the duplicated map
prontera,150,180,0	script	some_event	444,{
	mes "whatto the even map ?";
	if(select("yes:no") == 2)
		end;
	warp $some_event_map$,150,180; //this will warp you to the map event.
end;
}
```

https://github.com/rathena/rathena/pull/4914/commits/95a5872b07208b8f2cf9c5745dcc55325cafd372
With this update , the duplicated maps uses alphabet instead of numbers at the start
with that now instance maps not the same as the duplicated maps
also for maps with long name `a~z` have more than `1~9`
for example if i use prontera i can do from `1#prontera` to `99#prontera` means 99
but with alphabet i can do `a#prontera` to `zz#prontera` means ‭676‬
![image](https://user-images.githubusercontent.com/5981261/81488873-42ebdb80-926f-11ea-945d-cb77e028bc9f.png)
