### PR TITLE
Fixed Forced Sonic Blow Animation

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2270,9 +2270,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 				!battle_check_range(bl, tbl, skill_get_range2(src, skill, autospl_skill_lv, true)))
 				continue;
 
-			if (skill == AS_SONICBLOW)
-				pc_stop_attack(sd); //Special case, Sonic Blow autospell should stop the player attacking.
-			else if (skill == PF_SPIDERWEB) //Special case, due to its nature of coding.
+			if (skill == PF_SPIDERWEB) //Special case, due to its nature of coding.
 				type = CAST_GROUND;
 
 			sd->state.autocast = 1;


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/4925

* **Server Mode**:  Renewal

* **Description of Pull Request**: 
- Removed forced stop attacking when using Sonic Blow
- Users now does not need to wait for Sonic Blow animation to end before attacking
