### PR TITLE
Fix Meteor Assault not affected by item bonus ATK-modifier

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -11274,7 +11274,6 @@ Body:
     TargetType: Self
     DamageFlags:
       Splash: true
-      IgnoreAtkCard: true
     Flags:
       TargetTrap: true
       IgnoreAutoGuard: true


### PR DESCRIPTION
Meteor assault should increase damage with ATK item bonus.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/4912

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Fix damage flag of Meteor Assault that should increase damage with ATK-modifier itembonus
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
