### PR TITLE
Update size of storage/cart/inv max doc

### DIFF
--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -377,7 +377,7 @@ struct s_storage {
 		unsigned get : 1;
 		unsigned put : 1;
 	} state;
-	union { // Max for inventory, storage, cart, and guild storage are 818 each without changing this struct and struct item [2020]
+	union { // Max for inventory, storage, cart, and guild storage are 818 each without changing this struct and struct item [2016/08/14]
 		struct item items_inventory[MAX_INVENTORY];
 		struct item items_storage[MAX_STORAGE];
 		struct item items_cart[MAX_CART];

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -377,7 +377,7 @@ struct s_storage {
 		unsigned get : 1;
 		unsigned put : 1;
 	} state;
-	union { // Max for inventory, storage, cart, and guild storage are 1637 each without changing this struct and struct item [2014/10/27]
+	union { // Max for inventory, storage, cart, and guild storage are 818 each without changing this struct and struct item [2020]
 		struct item items_inventory[MAX_INVENTORY];
 		struct item items_storage[MAX_STORAGE];
 		struct item items_cart[MAX_CART];


### PR DESCRIPTION
i didn't know what to call this  PR
* **Server Mode**: Both

* **Description of Pull Request**: 
after the random option update the struct size increased , so the max now is 818 without changing struct.
I think and not sure about the exact number back then but it started from f296409ada211a0aa89863db4d9603054845cf65 (the random options update), so I will just put the date of it

818 = 65477
819 = 65557