### PR TITLE
Remove Summoner Hide when changing maps

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -5861,6 +5861,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 			status_change_end(&sd->bl, SC_PROPERTYWALK, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_CLOAKING, INVALID_TIMER);
 			status_change_end(&sd->bl, SC_CLOAKINGEXCEED, INVALID_TIMER);
+			status_change_end(&sd->bl, SC_SUHIDE, INVALID_TIMER);
 		}
 		for(int i = 0; i < EQI_MAX; i++ ) {
 			if( sd->equip_index[i] >= 0 )


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4953

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Remove Summoner Hide when changing maps to avoid equipment from being stripped due to the inability to change equipment while the status is active.
Thanks to @Everade!