### PR TITLE
Fixes Blood Sucker not being able to be recast

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11079,12 +11079,12 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 			if( sc && sc->bs_counter < skill_get_maxcount( skill_id , skill_lv) ) {
 				if( tsc && tsc->data[type] ){
-					(sc->bs_counter)--;
+					sc->bs_counter--;
 					status_change_end(src, type, INVALID_TIMER); // the first one cancels and the last one will take effect resetting the timer
 				}
 				clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
 				sc_start2(src,bl, type, 100, skill_lv, src->id, skill_get_time(skill_id,skill_lv));
-				(sc->bs_counter)++;
+				sc->bs_counter++;
 			} else if( sd ) {
 				clif_skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
 				break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13337,9 +13337,12 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 		case SC_BLOODSUCKER:
 			if( sce->val2 ) {
 				struct block_list *src = map_id2bl(sce->val2);
-				if(src) {
+
+				if (src && !status_isdead(src)) {
 					struct status_change *sc2 = status_get_sc(src);
-					sc2->bs_counter--;
+
+					if (sc2)
+						sc2->bs_counter--;
 				}
 			}
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4964

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes Blood Sucker not being able to be recast on another map if caster dies while active.
  * Minor cleanups and added safety checks.
Thanks to @Everade!