### PR TITLE
Adds a pre-parse check for file format

### DIFF
--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -1054,7 +1054,7 @@
 
 // @reloadatcommand
 1036: Error reading groups.conf, reload failed.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Please enter at least one valid list number (usage: @mapinfo <0-3> <map>).

--- a/conf/msg_conf/map_msg_chn.conf
+++ b/conf/msg_conf/map_msg_chn.conf
@@ -867,7 +867,7 @@
 
 // @reloadatcommand
 1036: Error reading groups.conf, reload failed.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: 請至少輸入一個有效的列表數字 (使用方法: @mapinfo <0-3> [地圖名稱])

--- a/conf/msg_conf/map_msg_frn.conf
+++ b/conf/msg_conf/map_msg_frn.conf
@@ -879,7 +879,7 @@
 
 // @reloadatcommand
 1036: Erreur à la lecture de groups.conf, reload échoué.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Entrez un numéro de la liste (usage: @mapinfo <0-3> <map>).

--- a/conf/msg_conf/map_msg_grm.conf
+++ b/conf/msg_conf/map_msg_grm.conf
@@ -601,6 +601,8 @@
 758: Baby Gunslinger
 759: Baby Rebellion
 
+1037: A database has failed to load and was haulted, please check the map-server console.
+
 // @guild
 1498: You cannot create a guild because you are in a clan.
 

--- a/conf/msg_conf/map_msg_idn.conf
+++ b/conf/msg_conf/map_msg_idn.conf
@@ -969,7 +969,7 @@
 
 // @reloadatcommand
 1036: Terjadi kesalahan saat membaca groups.conf, tidak berhasil dimuat ulang.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Harap masukkan setidaknya 1 pilihan. (Penggunaan: @mapinfo <0-3> <map>).

--- a/conf/msg_conf/map_msg_por.conf
+++ b/conf/msg_conf/map_msg_por.conf
@@ -1048,7 +1048,7 @@
 
 // @reloadatcommand
 1036: Erro na leitura do grups.conf, recarregamento falhou.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Digite pelo menos um número válido da lista (uso: @mapinfo <0-3> <mapa>).

--- a/conf/msg_conf/map_msg_rus.conf
+++ b/conf/msg_conf/map_msg_rus.conf
@@ -880,7 +880,7 @@
 
 // @reloadatcommand
 1036: Ошибка чтения файла groups.conf, перезагрузка не удалась.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Введите хотя бы один номер (Использование: @mapinfo <0-3> <локация>).

--- a/conf/msg_conf/map_msg_spn.conf
+++ b/conf/msg_conf/map_msg_spn.conf
@@ -1017,7 +1017,7 @@
 
 // @reloadatcommand
 1036: Ha ocurrido un error al cargar el archivo groups.conf.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: Introduce un número de la lista (instrucciones: @mapinfo <0-3> <mapa>).

--- a/conf/msg_conf/map_msg_tha.conf
+++ b/conf/msg_conf/map_msg_tha.conf
@@ -873,7 +873,7 @@
 
 // @reloadatcommand
 1036: เกิดข้อผิดพลาดในการผ่านไฟล์ groups.conf, การโหลดใหม่ล้มเหลว.
-//1037 free
+1037: A database has failed to load and was haulted, please check the map-server console.
 
 // @mapinfo
 1038: โปรดระบุเลขอย่างหน่อยหนึ่งค่าจากรายการ (วิธีใช้: @mapinfo <0-3> <map>).

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -3923,14 +3923,20 @@ ACMD_FUNC(reload) {
 		clif_displaymessage(fd, msg_txt(sd,97)); // Item database has been reloaded.
 	} else if (strstr(command, "mobdb") || strncmp(message, "mobdb", 3) == 0) {
 		mob_reload();
-		pet_db.reload();
+		if (pet_db.load())
+			pet_db.reload();
+		else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 		hom_reload();
 		mercenary_readdb();
 		mercenary_read_skilldb();
 		reload_elementaldb();
 		clif_displaymessage(fd, msg_txt(sd,98)); // Monster database has been reloaded.
 	} else if (strstr(command, "skilldb") || strncmp(message, "skilldb", 4) == 0) {
-		skill_reload();
+		if (skill_db.load() && abra_db.load() && improvised_song_db.load() && magic_mushroom_db.load() && reading_spellbook_db.load())
+			skill_reload();
+		else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 		hom_reload_skill();
 		reload_elemental_skilldb();
 		mercenary_read_skilldb();
@@ -3945,7 +3951,10 @@ ACMD_FUNC(reload) {
 
 		config_destroy(&run_test);
 
-		atcommand_doload();
+		if (atcommand_alias_db.load())
+			atcommand_doload();
+		else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 		pc_groups_reload();
 		clif_displaymessage(fd, msg_txt(sd,254)); // GM command configuration has been reloaded.
 	} else if (strstr(command, "battleconf") || strncmp(message, "battleconf", 3) == 0) {
@@ -4027,17 +4036,28 @@ ACMD_FUNC(reload) {
 		map_msg_reload();
 		clif_displaymessage(fd, msg_txt(sd,463)); // Message configuration has been reloaded.
 	} else if (strstr(command, "questdb") || strncmp(message, "questdb", 3) == 0) {
-		if (quest_db.reload())
-			clif_displaymessage(fd, msg_txt(sd,1377)); // Quest database has been reloaded.
+		if (quest_db.load()) {
+			quest_db.reload();
+			clif_displaymessage(fd, msg_txt(sd, 1377)); // Quest database has been reloaded.
+		} else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 	} else if (strstr(command, "instancedb") || strncmp(message, "instancedb", 4) == 0) {
-		if (instance_db.reload())
-			clif_displaymessage(fd, msg_txt(sd,516)); // Instance database has been reloaded.
+		if (instance_db.load()) {
+			clif_displaymessage(fd, msg_txt(sd, 516)); // Instance database has been reloaded.
+		} else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 	} else if (strstr(command, "achievementdb") || strncmp(message, "achievementdb", 4) == 0) {
-		achievement_db_reload();
-		clif_displaymessage(fd, msg_txt(sd,771)); // Achievement database has been reloaded.
+		if (achievement_db.load()) {
+			achievement_db_reload();
+			clif_displaymessage(fd, msg_txt(sd, 771)); // Achievement database has been reloaded.
+		} else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 	} else if (strstr(command, "attendancedb") || strncmp(message, "attendancedb", 4) == 0) {
-		attendance_db.reload();
-		clif_displaymessage(fd, msg_txt(sd, 795)); // Attendance database has been reloaded.
+		if (attendance_db.load()) {
+			attendance_db.reload();
+			clif_displaymessage(fd, msg_txt(sd, 795)); // Attendance database has been reloaded.
+		} else
+			clif_displaymessage(fd, msg_txt(sd, 1037)); // A database has failed to load and was haulted, please check the map-server console.
 	}
 
 	return 0;

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -450,6 +450,8 @@ public:
 	uint64 parseBodyNode(const YAML::Node& node);
 };
 
+extern AbraDatabase abra_db;
+
 struct s_skill_improvise_db {
 	uint16 skill_id, per;
 };
@@ -463,6 +465,8 @@ public:
 	const std::string getDefaultLocation();
 	uint64 parseBodyNode(const YAML::Node& node);
 };
+
+extern ImprovisedSongDatabase improvised_song_db;
 
 void do_init_skill(void);
 void do_final_skill(void);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4849

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds an extra check during `@reload` commands to attempt to parse the YAML database for validity.
  * This prevents file structures that may be incorrectly formatted from preemptively clearing the database from memory and causing a cascading effect in-game.
Thanks to @Latiosu!