### PR TITLE
Removes nullpo checks from CSV2YAML

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -151,7 +151,7 @@ void script_set_constant_( const char* name, int64 value, const char* constant_n
 
 const char* constant_lookup( int32 value, const char* prefix ){
 	if (prefix == nullptr)
-		retur nullptr;
+		return nullptr;
 
 	for( auto const& pair : constants ){
 		// Same prefix group and same value

--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -150,7 +150,8 @@ void script_set_constant_( const char* name, int64 value, const char* constant_n
 }
 
 const char* constant_lookup( int32 value, const char* prefix ){
-	nullpo_retr( nullptr, prefix );
+	if (prefix == nullptr)
+		retur nullptr;
 
 	for( auto const& pair : constants ){
 		// Same prefix group and same value
@@ -163,7 +164,8 @@ const char* constant_lookup( int32 value, const char* prefix ){
 }
 
 int64 constant_lookup_int(const char* constant) {
-	nullpo_retr(-100, constant);
+	if (constant == nullptr)
+		return -100;
 
 	for (auto const &pair : constants) {
 		if (strlen(pair.first) == strlen(constant) && strncasecmp(pair.first, constant, strlen(constant)) == 0) {


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4791

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Removes two nullpo checks from CSV2YAML.
  * Fixes undefined reference compile errors.
Thanks to @ecdarreola!