### PR TITLE
Corrects NPC_DARKBREATH behavior

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -5836,11 +5836,8 @@ Body:
     Name: NPC_DARKBREATH
     Description: Dark Breath
     MaxLevel: 5
-    Type: Misc
+    Type: Magic
     TargetType: Attack
-    DamageFlags:
-      IgnoreFlee: true
-      IgnoreDefCard: true
     Flags:
       IsNpc: true
     Range: 9

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -6121,11 +6121,8 @@ Body:
     Name: NPC_DARKBREATH
     Description: Dark Breath
     MaxLevel: 5
-    Type: Misc
+    Type: Magic
     TargetType: Attack
-    DamageFlags:
-      IgnoreFlee: true
-      IgnoreDefCard: true
     Flags:
       IsNpc: true
     Range: 9

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6164,6 +6164,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 #endif
 				}
 				break;
+			case NPC_DARKBREATH:
+				ad.damage = tstatus->hp * (skill_lv <= 5 ? 100 / (2 * 6 - skill_lv) : 50) / 100;
+				break;
 			case PF_SOULBURN:
 				ad.damage = tstatus->sp * 2;
 				break;
@@ -6906,9 +6909,6 @@ struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *
 			break;
 		case NPC_SMOKING:
 			md.damage = 3;
-			break;
-		case NPC_DARKBREATH:
-			md.damage = tstatus->max_hp * skill_lv * 10 / 100;
 			break;
 		case NPC_EVILLAND:
 			md.damage = skill_calc_heal(src,target,skill_id,skill_lv,false);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5514,6 +5514,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 
 	case NPC_DARKBREATH:
 		clif_emotion(src,ET_ANGER);
+		if (rnd() % 2 == 0)
+			break; // 50% chance
 	case SN_FALCONASSAULT:
 #ifndef RENEWAL
 	case PA_PRESSURE:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4864

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adjusts damage formula to official.
  * Adjusts damage type from Misc to Magic.
  * Skill now has a 50% success chance to damage the target.
  * Removes Flee and Defense Card ignore flags.
Thanks to @Masao87 and @mrjnumber1!