### PR TITLE
Fix issue with mob not spawning at selected option

### DIFF
--- a/npc/re/instances/NightmarishJitterbug.txt
+++ b/npc/re/instances/NightmarishJitterbug.txt
@@ -1419,6 +1419,7 @@ OnTouch_:
 		break;
 	case 3:
 		jitterbug_options |= 1;
+		areamonster 'map_jtb$,380,121,361,126, "--ja--", 3109,1;	// no label
 		unittalk getcharid(3), "" + strcharinfo(0) + " : I like your Red Potion (feat. Muka).";
 		mes "[Newoz]";
 		mes "Hah hah, this is embarassing, but thank you.";

--- a/npc/re/instances/NightmarishJitterbug.txt
+++ b/npc/re/instances/NightmarishJitterbug.txt
@@ -1419,7 +1419,7 @@ OnTouch_:
 		break;
 	case 3:
 		jitterbug_options |= 1;
-		areamonster 'map_jtb$,380,121,361,126, "--ja--", 3109,1;	// no label
+		areamonster 'map_jtb$,351,131,389,96, "--ja--", 3108,1;	// no label
 		unittalk getcharid(3), "" + strcharinfo(0) + " : I like your Red Potion (feat. Muka).";
 		mes "[Newoz]";
 		mes "Hah hah, this is embarassing, but thank you.";


### PR DESCRIPTION
In Jitterbug Nightmare when the player selects from dialog menu 
"Newoz's Red Potion (feat. Muka)",
An extra Jitterbug should be spawned,

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
