### PR TITLE
Fixes looter mobs getting stuck

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1723,8 +1723,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		)) {	//No valid target
 			if (mob_warpchase(md, tbl))
 				return true; //Chasing this target.
-			if(md->ud.walktimer != INVALID_TIMER && (!can_move || md->ud.walkpath.path_pos <= battle_config.mob_chase_refresh)
-				&& (tbl || md->ud.walkpath.path_pos == 0))
+			if (tbl && md->ud.walktimer != INVALID_TIMER && (!can_move || md->ud.walkpath.path_pos <= battle_config.mob_chase_refresh))
 				return true; //Walk at least "mob_chase_refresh" cells before dropping the target unless target is non-existent
 			mob_unlocktarget(md, tick); //Unlock target
 			tbl = NULL;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4941

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to b6b6b13.
  * Fixes cases of monsters getting stuck when they lose sight of their target item that is looted by another monster.
Thanks to @iraciz and @SeravySensei!