### PR TITLE
add cutins for Friendship Quest

### DIFF
--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -2026,6 +2026,7 @@ OnTouch_:
 //============================================================
 lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 	if (BaseLevel < 50) {
+		cutin "lhz_diguts02",2;
 		mes "[Digotz]";
 		mes "Oh, an adventurer?";
 		mes "Welcome to Uptown";
@@ -2041,26 +2042,30 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "you to explore. I mean, you";
 		mes "just seem to be kind of new";
 		mes "at this adventurer thing...";
-		close;
+		close3;
 	}
 	if (friendship > 14) {
+		cutin "lhz_diguts05",2;
 		mes "^3355FFDigotz has passed";
 		mes "away, but the look on";
 		mes "his face seems very";
 		mes "peaceful and content.^000000";
-		close;
+		close3;
 	}
 	if (friendship == 14) {
+		cutin "lhz_diguts06",2;
 		mes "^3355FFDigotz is seriously";
 		mes "injured from a wound";
 		mes "by a knife that is still";
 		mes "embedded in his belly.^000000";
 		next;
+		cutin "",255;
 		mes "["+ strcharinfo(0) +"]";
 		mes "Digotz...?";
 		mes "Oh no, let me";
 		mes "get you some help!";
 		next;
+		cutin "lhz_diguts06",2;
 		mes "[Digotz]";
 		mes "H-hey... It's the";
 		mes "adventurer... Man,";
@@ -2069,6 +2074,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "It's too late for me and";
 		mes "I don't have much time...";
 		next;
+		cutin "lhz_diguts04",2;
 		mes "[Digotz]";
 		mes "Those guards I told you";
 		mes "about... The ones who don't";
@@ -2093,6 +2099,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "I was wrong. Life's too short";
 		mes "to be angry with your frie--";
 		next;
+		cutin "lhz_diguts05",2;
 		mes "[Digotz]";
 		mes "..............";
 		next;
@@ -2105,6 +2112,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes ".......................";
 		mes "...............................";
 		next;
+		cutin "",255;
 		mes "^3355FFDigotz stopped breathing.";
 		mes "You remove the Knife from";
 		mes "his lifeless body as a final";
@@ -2117,6 +2125,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close;
 	}
 	if (friendship == 13) {
+		cutin "lhz_diguts02",2;
 		mes "[Digotz]";
 		mes "Wh-whoa, I need to";
 		mes "get ready! That Maku's";
@@ -2124,9 +2133,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "I look too rich and pampered.";
 		mes "Damn! Where did I put all of";
 		mes "my fashionable street clothes?";
-		close;
+		close3;
 	}
 	if ((friendship == 12 && countitem(7351) > 0)) {
+		cutin "lhz_diguts07",2;
 		mes "[Digotz]";
 		mes "Even if Benkaistein";
 		mes "did come back, I don't";
@@ -2134,7 +2144,9 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "In fact, you know what?";
 		mes "I think I'd even be madder!";
 		next;
+		cutin "",255;
 		if (select("Show Benkaistein's Journal.:Don't show Benkaistein's Journal.") == 1) {
+			cutin "lhz_diguts08",2;
 			mes "[Digotz]";
 			mes "Why am I so ticked off?";
 			mes "^3355FF*Sigh*^000000 You have something";
@@ -2143,6 +2155,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "of his? Sure, why not? I do";
 			mes "owe him a lot over the years...";
 			next;
+			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Today, me, Digotz and";
 			mes "Maku played this crazy flying";
@@ -2159,6 +2172,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "I think about it. Boy, I hope";
 			mes "we don't do that again.^000000";
 			next;
+			cutin "lhz_diguts02",2;
 			mes "[Digotz]";
 			mes "Oh yeah, I remember that!";
 			mes "Maku wore the wings most";
@@ -2167,6 +2181,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "air the longest! Yeah, I was";
 			mes "a regular Kid Pegasus~";
 			next;
+			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Maku, Digotz and me went";
 			mes "outside of town. Of course,";
@@ -2183,6 +2198,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "bad and the monster got away.";
 			mes "Boy, mom was not happy...^000000";
 			next;
+			cutin "lhz_diguts03",2;
 			mes "[Digotz]";
 			mes "Huh. I don't remember";
 			mes "that so well. But I know that";
@@ -2191,6 +2207,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "then. We must have been totally";
 			mes "nuts to fight a monster, though.";
 			next;
+			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Digotz's been sick for three";
 			mes "days now. It's just a normal";
@@ -2198,6 +2215,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "it's Digotz's fault he got sick.^FFFFFF ^856363 But he's always asking me to";
 			mes "go visit him and see if he's okay.^000000";
 			next;
+			cutin "lhz_diguts01",2;
 			mes "[Digotz]";
 			mes "I think I remember being";
 			mes "pretty sick. Maku was worried?";
@@ -2206,6 +2224,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "um, Gonorrhitis. You know.";
 			mes "That might have been it.";
 			next;
+			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Mom and dad keep telling";
 			mes "me not to hang out with Maku";
@@ -2221,12 +2240,14 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "But Digotz doesn't care.";
 			mes "I know he likes Maku a lot.^000000";
 			next;
+			cutin "lhz_diguts07",2;
 			mes "[Digotz]";
 			mes "Well, we were a lot";
 			mes "younger and closer back";
 			mes "then, so... ^333333*Ahem!*^000000 Why did";
 			mes "Benkaistein even write that?!";
 			next;
+			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Today, the three of us";
 			mes "made an oath of brotherhood,";
@@ -2235,6 +2256,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "be friends no matter what.";
 			mes "For always and for always.^000000";
 			next;
+			cutin "lhz_diguts07",2;
 			mes "[Digotz]";
 			mes "I... I was forced to make";
 			mes "that oath! And people do";
@@ -2243,6 +2265,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "it's not like that oath really";
 			mes "means anything now, does it?";
 			next;
+			cutin "",255;
 			set friendship,13;
 			mes "[Digotz]";
 			mes "That does it. I'm gonna";
@@ -2253,6 +2276,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "beat up him a little bit.";
 			close;
 		}
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "I don't understand";
 		mes "why I'm so angry!";
@@ -2263,6 +2287,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close;
 	}
 	if (friendship == 7) {
+		cutin "lhz_diguts07",2;
 		mes "[Digotz]";
 		mes "Even if Benkaistein came";
 		mes "back from wherever he was";
@@ -2270,9 +2295,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "able to get Maku to apologize";
 		mes "to me. That guy is just way";
 		mes "too stubborn for his own good!";
-		close;
+		close3;
 	}
 	if (friendship == 6) {
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "Oh, it's been a while.";
 		mes "What are you doing back";
@@ -2281,6 +2307,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "to Maku? Now when I think";
 		mes "about it, I was kind of--";
 		next;
+		cutin "",255;
 		mes "["+ strcharinfo(0) +"]";
 		mes "I delivered your message";
 		mes "word for word, and Maku";
@@ -2288,6 +2315,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "and has been threatening to";
 		mes "beat you up pretty badly.";
 		next;
+		cutin "lhz_diguts08",2;
 		mes "[Digotz]";
 		mes "That no-good, dirty";
 		mes "lying rotten scoundrel!";
@@ -2296,6 +2324,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "the ghetto and beat Maku";
 		mes "up myself! That stupid guy!";
 		next;
+		cutin "lhz_diguts03",2;
 		mes "[Digotz]";
 		mes "During times like this,";
 		mes "I really miss ^FF0000Benkaistein^000000.";
@@ -2322,6 +2351,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		set friendship,7;
 		changequest 12002,12003;
 		next;
+		cutin "",255;
 		mes "[Digotz]";
 		mes "I don't know why,";
 		mes "but I'm so angry!";
@@ -2348,6 +2378,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close;
 	}
 	if (friendship == 3) {
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "I know that the";
 		mes "opulence of Uptown";
@@ -2362,6 +2393,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "And I met someone";
 		mes "named Maku there.";
 		next;
+		cutin "lhz_diguts08",2;
 		mes "[Digotz]";
 		mes "Maku?! Oh, he must have";
 		mes "mentioned something about";
@@ -2386,6 +2418,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "on the worst blind dates a";
 		mes "man can possibly experience!";
 		next;
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "Maku doesn't know a damn";
 		mes "about friendship! Even if I did";
@@ -2401,6 +2434,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "and check up on him! I only";
 		mes "have one regret though...";
 		next;
+		cutin "lhz_diguts07",2;
 		mes "[Digotz]";
 		mes "I only wish I had one";
 		mes "last chance to see Maku...";
@@ -2432,9 +2466,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "^FF0000But who cares what you think?!";
 		mes "I'm so goddamn happy without you!^000000";
 		set friendship,4;
-		close;
+		close3;
 	}
 	if (friendship == 2) {
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "What are you still";
 		mes "doing hanging around";
@@ -2447,9 +2482,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "Just hearing about";
 		mes "Maku makes me so feel";
 		mes "so upset for some reason!";
-		close;
+		close3;
 	}
 	if (friendship == 1) {
+		cutin "lhz_diguts02",2;
 		mes "[Digotz]";
 		mes "Oh, an adventurer?";
 		mes "Welcome to Uptown";
@@ -2466,6 +2502,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "your stay in my hometown.";
 		next;
 		select("Do you know someone named Maku?");
+		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "Maku? Maku. Yes, he's my";
 		mes "childhood friend. Or he was,";
@@ -2483,9 +2520,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "Just forget everything I said.";
 		set friendship,2;
 		changequest 12000,12001;
-		close;
+		close3;
 	}
 	mes "[Digotz]";
+	cutin "lhz_diguts02",2;
 	mes "Oh, an adventurer?";
 	mes "Welcome to Uptown";
 	mes "Lighthalzen. However,";
@@ -3021,6 +3059,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		close;
 	}
 	if (friendship == 15) {
+		cutin "lhz_benkaistin01",2;
 		mes "[Benkaistein]";
 		mes "Were you able to bring";
 		mes "my journal to Digotz and";
@@ -3062,9 +3101,10 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "adventurer. When the three";
 		mes "of us get together, I'll be";
 		mes "sure to let you know~";
-		close;
+		close3;
 	}
 	if ((friendship == 11 && countitem(7351) > 0)) {
+		cutin "lhz_benkaistin01",2;
 		mes "[Benkaistein]";
 		mes "Aw nuts, this is";
 		mes "taking much longer";
@@ -3104,9 +3144,10 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "acting. Thanks in advance,";
 		mes "and please take care of";
 		mes "Maku and Digotz for me.";
-		close;
+		close3;
 	}
 	if ((friendship == 10 || friendship == 11)) {
+		cutin "lhz_benkaistin01",2;
 		mes "[Benkaistein]";
 		mes "Aw nuts, this is";
 		mes "taking much longer";
@@ -3118,9 +3159,10 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "be best if you help";
 		mes "Benkaistein look for";
 		mes "he is searching for.^000000";
-		close;
+		close3;
 	}
 	if (friendship == 9) {
+		cutin "lhz_benkaistin01",2;
 		mes "[Passionate Student]";
 		mes "Oh, you startled me!";
 		mes "Still, I'm aware that it's";
@@ -3154,9 +3196,10 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "so important? Wait! Would you";
 		mes "please wait a second while";
 		mes "I look for something?";
-		close;
+		close3;
 	}
 	if (friendship == 8) {
+		cutin "lhz_benkaistin01",2;
 		mes "[Passionate Student]";
 		mes "Let's see, now.";
 		mes "Wind Magic, Black Magic,";
@@ -3212,8 +3255,9 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "No, wait. Have you been";
 		mes "calling me all this time?";
 		set friendship,9;
-		close;
+		close3;
 	}
+	cutin "lhz_benkaistin01",2;
 	mes "[Passionate Student]";
 	mes "Let's see, now.";
 	mes "Wind Magic, Black Magic,";
@@ -3228,7 +3272,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 	mes "academic subject. For now,";
 	mes "it would be best to leave him";
 	mes "alone so that he can study.^000000";
-	close;
+	close3;
 }
 
 yuno_in04,168,117,3	script	Book#lhz	HIDDEN_NPC,{

--- a/npc/quests/quests_lighthalzen.txt
+++ b/npc/quests/quests_lighthalzen.txt
@@ -2026,7 +2026,6 @@ OnTouch_:
 //============================================================
 lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 	if (BaseLevel < 50) {
-		cutin "lhz_diguts02",2;
 		mes "[Digotz]";
 		mes "Oh, an adventurer?";
 		mes "Welcome to Uptown";
@@ -2042,10 +2041,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "you to explore. I mean, you";
 		mes "just seem to be kind of new";
 		mes "at this adventurer thing...";
-		close3;
+		close;
 	}
 	if (friendship > 14) {
-		cutin "lhz_diguts05",2;
+		cutin "lhz_diguts05.bmp",2;
 		mes "^3355FFDigotz has passed";
 		mes "away, but the look on";
 		mes "his face seems very";
@@ -2053,19 +2052,17 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close3;
 	}
 	if (friendship == 14) {
-		cutin "lhz_diguts06",2;
 		mes "^3355FFDigotz is seriously";
 		mes "injured from a wound";
 		mes "by a knife that is still";
 		mes "embedded in his belly.^000000";
 		next;
-		cutin "",255;
 		mes "["+ strcharinfo(0) +"]";
 		mes "Digotz...?";
 		mes "Oh no, let me";
 		mes "get you some help!";
 		next;
-		cutin "lhz_diguts06",2;
+		cutin "lhz_diguts04.bmp",2;
 		mes "[Digotz]";
 		mes "H-hey... It's the";
 		mes "adventurer... Man,";
@@ -2074,7 +2071,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "It's too late for me and";
 		mes "I don't have much time...";
 		next;
-		cutin "lhz_diguts04",2;
 		mes "[Digotz]";
 		mes "Those guards I told you";
 		mes "about... The ones who don't";
@@ -2091,6 +2087,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "to him. We'll hang out and have";
 		mes "fun, just like the good old days.";
 		next;
+		cutin "lhz_diguts05.bmp",2;
 		mes "[Digotz]";
 		mes "I missed my buddies, but now...";
 		mes "Now I can hear them calling me.";
@@ -2099,7 +2096,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "I was wrong. Life's too short";
 		mes "to be angry with your frie--";
 		next;
-		cutin "lhz_diguts05",2;
 		mes "[Digotz]";
 		mes "..............";
 		next;
@@ -2112,7 +2108,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes ".......................";
 		mes "...............................";
 		next;
-		cutin "",255;
 		mes "^3355FFDigotz stopped breathing.";
 		mes "You remove the Knife from";
 		mes "his lifeless body as a final";
@@ -2122,10 +2117,11 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		set friendship,15;
 		changequest 12005,12006;
 		getitem 1201,1; //Knife
+		cutin "",255;
 		close;
 	}
 	if (friendship == 13) {
-		cutin "lhz_diguts02",2;
+		cutin "lhz_diguts08.bmp",2;
 		mes "[Digotz]";
 		mes "Wh-whoa, I need to";
 		mes "get ready! That Maku's";
@@ -2135,8 +2131,8 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "my fashionable street clothes?";
 		close3;
 	}
-	if ((friendship == 12 && countitem(7351) > 0)) {
-		cutin "lhz_diguts07",2;
+	if (friendship == 12 && countitem(7351) > 0) {
+		cutin "lhz_diguts08.bmp",2;
 		mes "[Digotz]";
 		mes "Even if Benkaistein";
 		mes "did come back, I don't";
@@ -2144,9 +2140,8 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "In fact, you know what?";
 		mes "I think I'd even be madder!";
 		next;
-		cutin "",255;
 		if (select("Show Benkaistein's Journal.:Don't show Benkaistein's Journal.") == 1) {
-			cutin "lhz_diguts08",2;
+			cutin "",255;
 			mes "[Digotz]";
 			mes "Why am I so ticked off?";
 			mes "^3355FF*Sigh*^000000 You have something";
@@ -2155,7 +2150,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "of his? Sure, why not? I do";
 			mes "owe him a lot over the years...";
 			next;
-			cutin "",255;
 			mes "[Benkaistein's Journal]";
 			mes "^856363Today, me, Digotz and";
 			mes "Maku played this crazy flying";
@@ -2172,7 +2166,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "I think about it. Boy, I hope";
 			mes "we don't do that again.^000000";
 			next;
-			cutin "lhz_diguts02",2;
+			cutin "lhz_diguts02.bmp",2;
 			mes "[Digotz]";
 			mes "Oh yeah, I remember that!";
 			mes "Maku wore the wings most";
@@ -2198,7 +2192,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "bad and the monster got away.";
 			mes "Boy, mom was not happy...^000000";
 			next;
-			cutin "lhz_diguts03",2;
+			cutin "lhz_diguts03.bmp",2;
 			mes "[Digotz]";
 			mes "Huh. I don't remember";
 			mes "that so well. But I know that";
@@ -2215,7 +2209,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "it's Digotz's fault he got sick.^FFFFFF ^856363 But he's always asking me to";
 			mes "go visit him and see if he's okay.^000000";
 			next;
-			cutin "lhz_diguts01",2;
+			cutin "lhz_diguts01.bmp",2;
 			mes "[Digotz]";
 			mes "I think I remember being";
 			mes "pretty sick. Maku was worried?";
@@ -2240,7 +2234,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "But Digotz doesn't care.";
 			mes "I know he likes Maku a lot.^000000";
 			next;
-			cutin "lhz_diguts07",2;
+			cutin "lhz_diguts07.bmp",2;
 			mes "[Digotz]";
 			mes "Well, we were a lot";
 			mes "younger and closer back";
@@ -2256,7 +2250,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "be friends no matter what.";
 			mes "For always and for always.^000000";
 			next;
-			cutin "lhz_diguts07",2;
+			cutin "lhz_diguts07.bmp",2;
 			mes "[Digotz]";
 			mes "I... I was forced to make";
 			mes "that oath! And people do";
@@ -2276,7 +2270,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 			mes "beat up him a little bit.";
 			close;
 		}
-		cutin "lhz_diguts01",2;
 		mes "[Digotz]";
 		mes "I don't understand";
 		mes "why I'm so angry!";
@@ -2284,10 +2277,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "more like Maku, though,";
 		mes "don't get me wrong, it's";
 		mes "not like I care about the guy.";
-		close;
+		close3;
 	}
 	if (friendship == 7) {
-		cutin "lhz_diguts07",2;
+		cutin "lhz_diguts03.bmp",2;
 		mes "[Digotz]";
 		mes "Even if Benkaistein came";
 		mes "back from wherever he was";
@@ -2298,7 +2291,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close3;
 	}
 	if (friendship == 6) {
-		cutin "lhz_diguts01",2;
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "Oh, it's been a while.";
 		mes "What are you doing back";
@@ -2307,7 +2300,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "to Maku? Now when I think";
 		mes "about it, I was kind of--";
 		next;
-		cutin "",255;
 		mes "["+ strcharinfo(0) +"]";
 		mes "I delivered your message";
 		mes "word for word, and Maku";
@@ -2315,7 +2307,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "and has been threatening to";
 		mes "beat you up pretty badly.";
 		next;
-		cutin "lhz_diguts08",2;
+		cutin "lhz_diguts08.bmp",2;
 		mes "[Digotz]";
 		mes "That no-good, dirty";
 		mes "lying rotten scoundrel!";
@@ -2324,7 +2316,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "the ghetto and beat Maku";
 		mes "up myself! That stupid guy!";
 		next;
-		cutin "lhz_diguts03",2;
+		cutin "lhz_diguts03.bmp",2;
 		mes "[Digotz]";
 		mes "During times like this,";
 		mes "I really miss ^FF0000Benkaistein^000000.";
@@ -2359,7 +2351,8 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "out so much over this?!";
 		close;
 	}
-	if ((friendship == 4 || friendship == 5)) {
+	if (friendship == 4 || friendship == 5) {
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "Still checking out";
 		mes "Uptown Lighthalzen?";
@@ -2375,10 +2368,10 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "^FF0000Not to mention an apology!";
 		mes "^FF0000But who cares what you think?!";
 		mes "I'm so goddamn happy without you!^000000";
-		close;
+		close3;
 	}
 	if (friendship == 3) {
-		cutin "lhz_diguts01",2;
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "I know that the";
 		mes "opulence of Uptown";
@@ -2393,7 +2386,6 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "And I met someone";
 		mes "named Maku there.";
 		next;
-		cutin "lhz_diguts08",2;
 		mes "[Digotz]";
 		mes "Maku?! Oh, he must have";
 		mes "mentioned something about";
@@ -2401,7 +2393,9 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "says, unless it's an apology";
 		mes "for being a fully blown jerk.";
 		mes "Ever since we were kids...";
+		cutin "",255;
 		next;
+		cutin "lhz_diguts08.bmp",2;
 		mes "[Digotz]";
 		mes "Anyway, we used to be close,";
 		mes "but that guy was never a true";
@@ -2418,7 +2412,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "on the worst blind dates a";
 		mes "man can possibly experience!";
 		next;
-		cutin "lhz_diguts01",2;
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "Maku doesn't know a damn";
 		mes "about friendship! Even if I did";
@@ -2434,7 +2428,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "and check up on him! I only";
 		mes "have one regret though...";
 		next;
-		cutin "lhz_diguts07",2;
+		cutin "lhz_diguts07.bmp",2;
 		mes "[Digotz]";
 		mes "I only wish I had one";
 		mes "last chance to see Maku...";
@@ -2469,7 +2463,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close3;
 	}
 	if (friendship == 2) {
-		cutin "lhz_diguts01",2;
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "What are you still";
 		mes "doing hanging around";
@@ -2485,7 +2479,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		close3;
 	}
 	if (friendship == 1) {
-		cutin "lhz_diguts02",2;
+		cutin "lhz_diguts02.bmp",2;
 		mes "[Digotz]";
 		mes "Oh, an adventurer?";
 		mes "Welcome to Uptown";
@@ -2502,7 +2496,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		mes "your stay in my hometown.";
 		next;
 		select("Do you know someone named Maku?");
-		cutin "lhz_diguts01",2;
+		cutin "lhz_diguts01.bmp",2;
 		mes "[Digotz]";
 		mes "Maku? Maku. Yes, he's my";
 		mes "childhood friend. Or he was,";
@@ -2522,8 +2516,8 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 		changequest 12000,12001;
 		close3;
 	}
+	cutin "lhz_diguts02.bmp",2;
 	mes "[Digotz]";
-	cutin "lhz_diguts02",2;
 	mes "Oh, an adventurer?";
 	mes "Welcome to Uptown";
 	mes "Lighthalzen. However,";
@@ -2538,7 +2532,7 @@ lhz_in02,201,210,5	script	Digotz	4_M_LGTMAN,{
 	mes "glad to see somebody";
 	mes "aside from the stuck up";
 	mes "rich people who live here.";
-	close;
+	close3;
 }
 
 lighthalzen,337,232,3	script	Maku	4_M_LGTPOOR,{
@@ -3059,7 +3053,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		close;
 	}
 	if (friendship == 15) {
-		cutin "lhz_benkaistin01",2;
+		cutin "lhz_benkaistin01.bmp",2;
 		mes "[Benkaistein]";
 		mes "Were you able to bring";
 		mes "my journal to Digotz and";
@@ -3103,8 +3097,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "sure to let you know~";
 		close3;
 	}
-	if ((friendship == 11 && countitem(7351) > 0)) {
-		cutin "lhz_benkaistin01",2;
+	if (friendship == 11 && countitem(7351) > 0) {
 		mes "[Benkaistein]";
 		mes "Aw nuts, this is";
 		mes "taking much longer";
@@ -3112,6 +3105,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "Now where did I put";
 		mes "that thing? Hmmmm...";
 		next;
+		cutin "lhz_benkaistin02.bmp",2;
 		mes "[Benkaistein]";
 		mes "Oh, is that it?";
 		mes "Did you find my";
@@ -3120,6 +3114,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "This is it! Thank you";
 		mes "for finding this for me!";
 		next;
+		cutin "",255;
 		mes "[Benkaistein]";
 		mes "Would you mind doing";
 		mes "a favor for me? It'd be";
@@ -3137,6 +3132,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		next;
 		set friendship,12;
 		changequest 12004,12005;
+		cutin "lhz_benkaistin04.bmp",2;
 		mes "[Benkaistein]";
 		mes "Anyway, this should at";
 		mes "least help them realize";
@@ -3146,8 +3142,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "Maku and Digotz for me.";
 		close3;
 	}
-	if ((friendship == 10 || friendship == 11)) {
-		cutin "lhz_benkaistin01",2;
+	if (friendship == 10 || friendship == 11) {
 		mes "[Benkaistein]";
 		mes "Aw nuts, this is";
 		mes "taking much longer";
@@ -3159,10 +3154,10 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "be best if you help";
 		mes "Benkaistein look for";
 		mes "he is searching for.^000000";
-		close3;
+		close;
 	}
 	if (friendship == 9) {
-		cutin "lhz_benkaistin01",2;
+		cutin "lhz_benkaistin03.bmp",2;
 		mes "[Passionate Student]";
 		mes "Oh, you startled me!";
 		mes "Still, I'm aware that it's";
@@ -3172,6 +3167,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "I help you, adventurer?";
 		next;
 		select("Tell him about Maku and Digotz.");
+		cutin "lhz_benkaistin02.bmp",2;
 		mes "[Benkaistein]";
 		mes "Oh, how are my friends";
 		mes "doing? Oh, what? They're";
@@ -3199,7 +3195,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		close3;
 	}
 	if (friendship == 8) {
-		cutin "lhz_benkaistin01",2;
+		cutin "lhz_benkaistin04.bmp",2;
 		mes "[Passionate Student]";
 		mes "Let's see, now.";
 		mes "Wind Magic, Black Magic,";
@@ -3246,7 +3242,9 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		mes "["+ strcharinfo(0) +"]";
 		mes "HEY YOU...!";
 		mes "BENKAISTEIN~!";
+		cutin "",255;
 		next;
+		cutin "lhz_benkaistin02.bmp",2;
 		mes "[Passionate Student]";
 		mes "Oh, good heavens!";
 		mes "C-can't you keep";
@@ -3257,7 +3255,6 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 		set friendship,9;
 		close3;
 	}
-	cutin "lhz_benkaistin01",2;
 	mes "[Passionate Student]";
 	mes "Let's see, now.";
 	mes "Wind Magic, Black Magic,";
@@ -3272,7 +3269,7 @@ yuno_in04,96,106,5	script	Passionate Student	4_M_SAGE_A,{
 	mes "academic subject. For now,";
 	mes "it would be best to leave him";
 	mes "alone so that he can study.^000000";
-	close3;
+	close;
 }
 
 yuno_in04,168,117,3	script	Book#lhz	HIDDEN_NPC,{


### PR DESCRIPTION
I made this quest in Iro Chaos server 2 years ago, and all the cutins are enabled, 
Lhz friendship quest related cutins, exist since forever in data.grf and was never applied here. 15 years or more without noticing this.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
