### PR TITLE
Fix missing pet egg checks

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6709,7 +6709,7 @@ void clif_item_repair_list(struct map_session_data *sd,struct map_session_data *
 	WFIFOW(fd,0)=0x1fc;
 	for(i=c=0;i<MAX_INVENTORY;i++){
 		unsigned short nameid;
-		if((nameid=dstsd->inventory.u.items_inventory[i].nameid) > 0 && dstsd->inventory.u.items_inventory[i].attribute!=0){// && skill_can_repair(sd,nameid)){
+		if((nameid=dstsd->inventory.u.items_inventory[i].nameid) > 0 && dstsd->inventory.u.items_inventory[i].attribute!=0 && (!itemdb_ishatched_egg(&dstsd->inventory.u.items_inventory[i]))) 	{// && skill_can_repair(sd,nameid)){
 			WFIFOW(fd,c*13+4) = i;
 			WFIFOW(fd,c*13+6) = nameid;
 			WFIFOB(fd,c*13+8) = dstsd->inventory.u.items_inventory[i].refine;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16827,6 +16827,9 @@ void skill_repairweapon(struct map_session_data *sd, int idx) {
 	if( !item->nameid || !item->attribute )
 		return; //Again invalid item....
 
+	if (itemdb_ishatched_egg(item))
+		return;
+
 	if (sd != target_sd && !battle_check_range(&sd->bl, &target_sd->bl, skill_get_range2(&sd->bl, sd->menuskill_id, sd->menuskill_val2, true))) {
 		clif_item_repaireffect(sd, idx, 1);
 		return;

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -909,6 +909,9 @@ void storage_guild_storageadd(struct map_session_data* sd, int index, int amount
 	if( amount < 1 || amount > sd->inventory.u.items_inventory[index].amount )
 		return;
 
+	if (itemdb_ishatched_egg(&sd->inventory.u.items_inventory[index]))
+		return;
+
 	if( stor->lock ) {
 		storage_guild_storageclose(sd);
 		return;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/5024

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Renewal

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Adds missing check for the items not being hatched pet eggs to repair weapon's menu and effect as well as guild storage which was also missing it.
