### PR TITLE
Fixes pet taming item consumption

### DIFF
--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1193,10 +1193,9 @@ int pet_catch_process2(struct map_session_data* sd, int target_id)
 
 	int i = sd->itemindex;
 
-	if (i >= 0 && sd->inventory.u.items_inventory[i].nameid == sd->itemid && sd->inventory.u.items_inventory[i].amount > 0 && sd->inventory_data[i] != nullptr && sd->inventory_data[i]->flag.delay_consume > 0) {
+	if (i >= 0 && sd->inventory.u.items_inventory[i].nameid == sd->itemid && sd->inventory_data[i] != nullptr && sd->inventory_data[i]->flag.delay_consume > 0 && !pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_CONSUME)) {
 		sd->itemid = 0;
 		sd->itemindex = -1;
-		pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_CONSUME);
 	} else { // Invalid taming item, abort capture.
 		clif_pet_roulette(sd, 0);
 		sd->catch_target_class = PET_CATCH_FAIL;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1191,7 +1191,16 @@ int pet_catch_process2(struct map_session_data* sd, int target_id)
 		return 1;
 	}
 
-	//FIXME: delete taming item here, if this was an item-invoked capture and the item was flagged as delay-consume [ultramage]
+	int i = sd->itemindex;
+	if (!(i == -1 ||
+		sd->inventory.u.items_inventory[i].nameid != sd->itemid ||
+		sd->inventory_data[i] == NULL ||
+		!sd->inventory_data[i]->flag.delay_consume ||
+		sd->inventory.u.items_inventory[i].amount < 1
+		)) {
+		sd->itemid = sd->itemindex = -1;
+		pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_CONSUME);
+	}
 
 	std::shared_ptr<s_pet_db> pet = pet_db.find(md->mob_id);
 

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1192,14 +1192,17 @@ int pet_catch_process2(struct map_session_data* sd, int target_id)
 	}
 
 	int i = sd->itemindex;
-	if (!(i == -1 ||
-		sd->inventory.u.items_inventory[i].nameid != sd->itemid ||
-		sd->inventory_data[i] == NULL ||
-		!sd->inventory_data[i]->flag.delay_consume ||
-		sd->inventory.u.items_inventory[i].amount < 1
-		)) {
-		sd->itemid = sd->itemindex = -1;
+
+	if (i >= 0 && sd->inventory.u.items_inventory[i].nameid == sd->itemid && sd->inventory.u.items_inventory[i].amount > 0 && sd->inventory_data[i] != nullptr && sd->inventory_data[i]->flag.delay_consume > 0) {
+		sd->itemid = 0;
+		sd->itemindex = -1;
 		pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_CONSUME);
+	} else { // Invalid taming item, abort capture.
+		clif_pet_roulette(sd, 0);
+		sd->catch_target_class = PET_CATCH_FAIL;
+		sd->itemid = 0;
+		sd->itemindex = -1;
+		return 1;
 	}
 
 	std::shared_ptr<s_pet_db> pet = pet_db.find(md->mob_id);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

Line 1209 on pet.cpp :
//FIXME: delete taming item here, if this was an item-invoked capture and the item was flagged as delay-consume [ultramage]

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Both I guess?

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Implements consuming the item.