### PR TITLE
Deprecates support for old compilers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2013
+image: Visual Studio 2015
 # This is the default location, but we put it here for safety reasons, since we use it in our test script
 clone_folder: c:\projects\rathena
 # We do not need the git history for our integration tests
@@ -8,10 +8,8 @@ pull_requests:
   do_not_increment_build_number: true
 environment:
   matrix:
-  - VisualStudioVersion: 14.0
-    Defines: "\"BUILDBOT\""
-  - VisualStudioVersion: 14.0
-    Defines: "\"BUILDBOT;PRERE\""
+  - Defines: "\"BUILDBOT\""
+  - Defines: "\"BUILDBOT;PRERE\""
 platform:
   - Win32
   - x64

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -31,7 +31,7 @@
 		#error "Visual Studio versions older than Visual Studio 2015 are not officially supported anymore"
 	#elif defined( __clang__ ) && __clang_major__ < 4 && !( __clang_major__ == 3 && __clang_minor__ >= 7 )
 		#error "clang versions older than clang 3.7 are not officially supported anymore"
-	#elif defined( __GNUC__ ) && __GNUC__ < 5
+	#elif !defined( __clang__ ) && defined( __GNUC__ ) && __GNUC__ < 5
 		#error "GCC versions older than GCC 5 are not officially supported anymore"
 	#endif
 #endif

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -3,6 +3,8 @@
 
 #include "core.hpp"
 
+#include "../config/core.hpp"
+
 #ifndef MINICORE
 #include "ers.hpp"
 #include "socket.hpp"
@@ -23,6 +25,16 @@
 #include "mmo.hpp"
 #include "showmsg.hpp"
 #include "strlib.hpp"
+
+#ifndef DEPRECATED_COMPILER_SUPPORT
+	#if defined( _MSC_VER ) && _MSC_VER < 1900
+		#error "Visual Studio versions older than Visual Studio 2015 are not officially supported anymore"
+	#elif defined( __clang__ ) && __clang_major__ < 4 && !( __clang_major__ == 3 && __clang_minor__ >= 7 )
+		#error "clang versions older than clang 3.7 are not officially supported anymore"
+	#elif defined( __GNUC__ ) && __GNUC__ < 5
+		#error "GCC versions older than GCC 5 are not officially supported anymore"
+	#endif
+#endif
 
 /// Called when a terminate signal is received.
 void (*shutdown_callback)(void) = NULL;

--- a/src/config/core.hpp
+++ b/src/config/core.hpp
@@ -74,6 +74,13 @@
 // overflows, which is approximately every ~49 days.
 //#define DEPRECATED_WINDOWS_SUPPORT
 
+// Uncomment to enable compilation for unsupported compilers
+// Note:
+// Compilation might work on these compilers, but they might not fully follow newer C++ rules and
+// cause unexpected behavior.
+// Do NOT create any issues or ask for help with these compilers.
+//#define DEPRECATED_COMPILER_SUPPORT
+
 /**
  * No settings past this point
  **/

--- a/tools/serv.bat
+++ b/tools/serv.bat
@@ -36,10 +36,10 @@ PING -n 15 127.0.0.1 > NUL
 :START_RA
 %1
 ECHO.
-REM Return value > 1 is exception&~0xC0000000
-IF ERRORLEVEL 2 GOTO CRASHED
 REM Return value 1 is EXIT_FAILURE
 IF ERRORLEVEL 1 GOTO EXIT1
+REM Return value is not 0 the process has crashed
+IF NOT ERRORLEVEL 0 GOTO CRASHED
 REM Return value 0 is EXIT_SUCCESS
 ECHO %2 has shutdown successfully.
 GOTO RESTART_NT


### PR DESCRIPTION
* **Addressed Issue(s)**: #4646

* **Server Mode**: Both

* **Description of Pull Request**: 
Deprecates support for Visual Studio older than 2015, GCC older than version 5 and clang older than version 3.7.
Switches AppVeyor build worker image to Visual Studio 2015.

Thanks to @aleos89