### PR TITLE
Resolve Aco/Priest self-AoE skill ranges and animation behaviour for partymates

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -2345,17 +2345,7 @@ Body:
       NoDamage: true
     Hit: Single
     HitCount: 1
-    SplashArea:
-      - Level: 1
-        Area: 3
-      - Level: 2
-        Area: 3
-      - Level: 3
-        Area: 7
-      - Level: 4
-        Area: 7
-      - Level: 5
-        Area: 15
+    SplashArea: 18
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 1000
@@ -2365,15 +2355,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 13
+          Amount: 59
         - Level: 2
-          Amount: 16
+          Amount: 62
         - Level: 3
-          Amount: 19
+          Amount: 65
         - Level: 4
-          Amount: 22
+          Amount: 68
         - Level: 5
-          Amount: 25
+          Amount: 71
   - Id: 67
     Name: PR_SUFFRAGIUM
     Description: Suffragium
@@ -2647,7 +2637,7 @@ Body:
       Splash: true
     Hit: Single
     HitCount: 1
-    SplashArea: -1
+    SplashArea: 18
     CastCancel: true
     CastTime: 3200
     AfterCastActDelay: 2000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -1591,7 +1591,7 @@ Body:
       Splash: true
     Hit: Single
     HitCount: 1
-    SplashArea: -1
+    SplashArea: 18
     CastCancel: true
     CastTime: 350
     AfterCastActDelay: 3500
@@ -2666,7 +2666,7 @@ Body:
       Splash: true
     Hit: Single
     HitCount: 1
-    SplashArea: -1
+    SplashArea: 18
     CastCancel: true
     AfterCastActDelay: 2000
     Duration1:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7657,14 +7657,25 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		}
 		status_damage(src, src, sstatus->max_hp,0,0,1, skill_id);
 		break;
-
 	case AL_ANGELUS:
 #ifdef RENEWAL
-	case MC_LOUD:
 	case PR_SUFFRAGIUM:
+	case PR_IMPOSITIO:
 #endif
 	case PR_MAGNIFICAT:
 	case PR_GLORIA:
+		if (sd == NULL || sd->status.party_id == 0 || (flag & 1))
+			if (check_distance_bl(src, bl, AREA_SIZE))
+				clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start(src, bl, type, 100, skill_lv, skill_get_time(skill_id, skill_lv)));
+			else
+				// Animations don't play when outside visible range
+				sc_start(src, bl, type, 100, skill_lv, skill_get_time(skill_id, skill_lv));
+		else if (sd)
+			party_foreachsamemap(skill_area_sub, sd, skill_get_splash(skill_id, skill_lv), src, skill_id, skill_lv, tick, flag | BCT_PARTY | 1, skill_castend_nodamage_id);
+		break;
+#ifdef RENEWAL
+	case MC_LOUD:
+#endif
 	case SN_WINDWALK:
 	case CASH_BLESSING:
 	case CASH_INCAGI:
@@ -9800,9 +9811,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case AB_PRAEFATIO:
 	case AB_RENOVATIO:
-#ifdef RENEWAL
-	case PR_IMPOSITIO:
-#endif
 		if( !sd || sd->status.party_id == 0 || flag&1 ) {
 			if (skill_id == AB_PRAEFATIO)
 				clif_skill_nodamage(bl, bl, skill_id, skill_lv, sc_start4(src, bl, type, 100, skill_lv, 0, 0, (sd && sd->status.party_id ? party_foreachsamemap(party_sub_count, sd, 0) : 1 ), skill_get_time(skill_id, skill_lv)));


### PR DESCRIPTION
* **Addressed Issue(s)**: #4975
* **Server Mode**: Renewal
* **Description of Pull Request**: 

Sets AoE size for Angelus, Gloria, Magnificat, Impositio Manus to 18 to match kRO Sakray tests.
Fixes Impositio Manus SP consumption per level to match kRO Sakray.

Check if party member is within visible range before sending `clif_skill_nodamage`, otherwise, just do an `sc_start` instead for Angelus, Gloria, Magnificat, Impositio Manus and Suffragium.