### PR TITLE
fix crash on deleting soul balls when increasing max skill level

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -641,8 +641,8 @@ int pc_delsoulball(struct map_session_data *sd, int count, int type)
 	if (count > sd->soulball)
 		count = sd->soulball;
 	sd->soulball -= count;
-	if (count > MAX_SKILL_LEVEL)
-		count = MAX_SKILL_LEVEL;
+	if (count > MAX_SOUL_BALL)
+		count = MAX_SOUL_BALL;
 
 	for (int i = 0; i < count; i++) {
 		if (sd->soul_timer[i] != INVALID_TIMER) {
@@ -651,7 +651,7 @@ int pc_delsoulball(struct map_session_data *sd, int count, int type)
 		}
 	}
 
-	for (int i = count; i < MAX_SKILL_LEVEL; i++) {
+	for (int i = count; i < MAX_SOUL_BALL; i++) {
 		sd->soul_timer[i - count] = sd->soul_timer[i];
 		sd->soul_timer[i] = INVALID_TIMER;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/5076

* **Server Mode**: renewal

* **Description of Pull Request**: 
change pc_delsoulball loop to check MAX_SOUL_BALL instead of MAX_SKILL_LEVEL
