### PR TITLE
Fixes Rolling Cutter counter not resetting

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8552,7 +8552,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 #ifdef RENEWAL
 		clif_blown(src); // Always blow, otherwise it shows a casting animation. [Lemongrass]
 #endif
-		status_change_end(src, SC_ROLLINGCUTTER, INVALID_TIMER);
 		break;
 
 	case TK_HIGHJUMP:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2881,6 +2881,8 @@ short skill_blown(struct block_list* src, struct block_list* target, char count,
 	if (tsc) {
 		if (tsc->data[SC_SU_STOOP]) // Any knockback will cancel it.
 			status_change_end(target, SC_SU_STOOP, INVALID_TIMER);
+		if (tsc->data[SC_ROLLINGCUTTER])
+			status_change_end(target, SC_ROLLINGCUTTER, INVALID_TIMER);
 		if (tsc->data[SC_SV_ROOTTWIST]) // Shouldn't move.
 			return 0;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5052

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes Rolling Cutter counter not resetting with blown-type attacks/movements.
Thanks to @LordWhiplash!