### PR TITLE
Adds a config for slave teleporting to master

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -280,3 +280,7 @@ boss_nopc_move_rate: 100
 // When killing a monster, do AG_BATTLE type achievements trigger for everyone in the same party within the area?
 // Area is limited to area_size battle config.
 achievement_mob_share: no
+
+// Should slaves teleport back to their master if they get too far during chase? (Note 1)
+// Default (Official): no
+slave_stick_with_master: no

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -284,8 +284,3 @@ achievement_mob_share: no
 // Should slaves teleport back to their master if they get too far during chase? (Note 1)
 // Default (Official): no
 slave_stick_with_master: no
-
-// Should slaves teleport back to their master if they are more than client.conf::max_walk_path cells away from their master and lose sight of their target?
-// This will keep slaves from becoming "stuck" and not move or attack when drug away from their master.
-// Default (Official): no
-recall_stuck_slave: no

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -284,3 +284,8 @@ achievement_mob_share: no
 // Should slaves teleport back to their master if they get too far during chase? (Note 1)
 // Default (Official): no
 slave_stick_with_master: no
+
+// Should slaves teleport back to their master if they are more than client.conf::max_walk_path cells away from their master and lose sight of their target?
+// This will keep slaves from becoming "stuck" and not move or attack when drug away from their master.
+// Default (Official): no
+recall_stuck_slave: no

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8952,6 +8952,7 @@ static const struct _battle_data {
 	{ "ping_time",                          &battle_config.ping_time,                       20,     0,      99999999,       },
 	{ "show_skill_scale",                   &battle_config.show_skill_scale,                1,      0,      1,              },
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
+	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8953,7 +8953,6 @@ static const struct _battle_data {
 	{ "show_skill_scale",                   &battle_config.show_skill_scale,                1,      0,      1,              },
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
 	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
-	{ "recall_stuck_slave",                 &battle_config.recall_stuck_slave,              0,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8953,6 +8953,7 @@ static const struct _battle_data {
 	{ "show_skill_scale",                   &battle_config.show_skill_scale,                1,      0,      1,              },
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
 	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
+	{ "recall_stuck_slave",                 &battle_config.recall_stuck_slave,              0,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -682,6 +682,7 @@ struct Battle_Config
 	int ping_time;
 	int show_skill_scale;
 	int achievement_mob_share;
+	int slave_stick_with_master;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -683,6 +683,7 @@ struct Battle_Config
 	int show_skill_scale;
 	int achievement_mob_share;
 	int slave_stick_with_master;
+	int recall_stuck_slave;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -683,7 +683,6 @@ struct Battle_Config
 	int show_skill_scale;
 	int achievement_mob_share;
 	int slave_stick_with_master;
-	int recall_stuck_slave;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1437,20 +1437,18 @@ static int mob_ai_sub_hard_slavemob(struct mob_data *md,t_tick tick)
 
 	if(status_has_mode(&md->status,MD_CANMOVE))
 	{	//If the mob can move, follow around. [Check by Skotlex]
-		int old_dist;
+		int old_dist = md->master_dist;
 
 		// Distance with between slave and master is measured.
-		old_dist=md->master_dist;
-		md->master_dist=distance_bl(&md->bl, bl);
+		md->master_dist = distance_bl(&md->bl, bl);
 
-		// Since the master was in near immediately before, teleport is carried out and it pursues.
-		if(bl->m != md->bl.m ||
-			(old_dist<10 && md->master_dist>18) ||
-			md->master_dist > MAX_MINCHASE
-		){
-			md->master_dist = 0;
-			unit_warp(&md->bl,bl->m,bl->x,bl->y,CLR_TELEPORT);
-			return 1;
+		if (battle_config.slave_stick_with_master) {
+			// Since the master was in near immediately before, teleport is carried out and it pursues.
+			if (bl->m != md->bl.m || (old_dist < 10 && md->master_dist > 18) || md->master_dist > MAX_MINCHASE) {
+				md->master_dist = 0;
+				unit_warp(&md->bl, bl->m, bl->x, bl->y, CLR_TELEPORT);
+				return 1;
+			}
 		}
 
 		if(md->target_id) //Slave is busy with a target.


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5003

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds a battle config to toggle the ability for slaves to teleport back to their master when they are too far away.
  * Officially, players can drag slaves away from the master without them teleporting back.