### PR TITLE
Fixes a crash non-player objects and timed skills

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4221,6 +4221,8 @@ static TIMER_FUNC(skill_timerskill){
 					case SR_FALLENEMPIRE:
 					case SR_TIGERCANNON:
 					case SR_SKYNETBLOW:
+						if (src->type != BL_PC)
+							continue;
 						break; // Exceptions
 					default:
 						continue; // Caster is Dead
@@ -4497,6 +4499,8 @@ int skill_cleartimerskill (struct block_list *src)
 				case SR_FALLENEMPIRE:
 				case SR_TIGERCANNON:
 				case SR_SKYNETBLOW:
+					if (src->type != BL_PC)
+						break;
 					continue;
 			}
 			delete_timer(ud->skilltimerskill[i]->timer, skill_timerskill);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5110

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes a potential map server crash when non-player objects attempt to use Chain Lightning, Tetra Vortex, or Flash Combo and are kill during duration.
Thanks to @Hope8888!