### PR TITLE
fix skill cast delay flag

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22211,9 +22211,9 @@ uint64 SkillDatabase::parseBodyNode(const YAML::Node &node) {
 				return 0;
 
 			if (active)
-				skill->castnodex |= constant;
+				skill->delaynodex |= constant;
 			else
-				skill->castnodex &= ~constant;
+				skill->delaynodex &= ~constant;
 		}
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both (my test was on pre-re)

* **Description of Pull Request**: 
`CastDelayFlags` not working
to test , get bragi and cast sonic in pre-re , not sure if the skill the same in renewal
but the fix is for both renewal and pre-renewal
