### PR TITLE
Fixes Flame Launcher burning duration

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1754,7 +1754,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		}
 		break;
 	case NC_FLAMELAUNCHER:
-		sc_start4(src,bl, SC_BURNING, 20 + 10 * skill_lv, skill_lv, 1000, src->id, 0, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_BURNING, 20 + 10 * skill_lv, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
 	case NC_COLDSLOWER:
 		// Status chances are applied officially through a check


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5147

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Flame Launcher should give burning status for 7 * skill level.
  * Burning no longer requires val2 or val3 values.