### PR TITLE
Fixed slave monsters not teleporting with their master

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8148,6 +8148,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_warppoint(sd,skill_id,skill_lv, (unsigned short)-1,sd->status.save_point.map,0,0);
 		} else
 			unit_warp(bl,-1,-1,-1,CLR_TELEPORT);
+			if (md && mob_countslave(bl) > 0)
+				mob_warpslave(src,MOB_SLAVEDISTANCE);
 		break;
 
 	case NPC_EXPULSION:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8148,8 +8148,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_warppoint(sd,skill_id,skill_lv, (unsigned short)-1,sd->status.save_point.map,0,0);
 		} else
 			unit_warp(bl,-1,-1,-1,CLR_TELEPORT);
-			if (!battle_config.slave_stick_with_master && md && mob_countslave(bl) > 0)
-				mob_warpslave(src,MOB_SLAVEDISTANCE);
 		break;
 
 	case NPC_EXPULSION:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8148,7 +8148,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				clif_skill_warppoint(sd,skill_id,skill_lv, (unsigned short)-1,sd->status.save_point.map,0,0);
 		} else
 			unit_warp(bl,-1,-1,-1,CLR_TELEPORT);
-			if (md && mob_countslave(bl) > 0)
+			if (!battle_config.slave_stick_with_master && md && mob_countslave(bl) > 0)
 				mob_warpslave(src,MOB_SLAVEDISTANCE);
 		break;
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1272,6 +1272,9 @@ int unit_warp(struct block_list *bl,short m,short x,short y,clr_type type)
 	clif_spawn(bl);
 	skill_unit_move(bl,gettick(),1);
 
+	if (!battle_config.slave_stick_with_master && bl->type == BL_MOB && mob_countslave(bl) > 0)
+		mob_warpslave(bl,MOB_SLAVEDISTANCE);
+
 	return 0;
 }
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes slave monsters not teleporting with their master when slave_stick_with_master is disabled.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
