### PR TITLE
Added a config for triggering OnPCLogout events on autotrade

### DIFF
--- a/conf/battle/misc.conf
+++ b/conf/battle/misc.conf
@@ -114,6 +114,9 @@ at_timeout: 0
 // Makes player cannot be attacked when autotrade? (turns player's state.monster_ignore) (Note 1)
 at_monsterignore: no
 
+// Should autotrade trigger OnPCLogout script events? (Note 1)
+at_logout_event: yes
+
 // Auction system, fee per hour. Default is 12000
 auction_feeperhour: 12000
 

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -6100,6 +6100,9 @@ ACMD_FUNC(autotrade) {
 		status_change_start(NULL,&sd->bl, SC_AUTOTRADE, 10000, 0, 0, 0, 0, ((timeout > 0) ? min(timeout,battle_config.at_timeout) : battle_config.at_timeout) * 60000, SCSTART_NONE);
 	}
 
+	if (battle_config.at_logout_event)
+		npc_script_event(sd, NPCE_LOGOUT); //Logout Event
+
 	channel_pcquit(sd,0xF); //leave all chan
 	clif_authfail_fd(sd->fd, 15);
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8953,6 +8953,7 @@ static const struct _battle_data {
 	{ "show_skill_scale",                   &battle_config.show_skill_scale,                1,      0,      1,              },
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
 	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
+	{ "at_logout_event",                    &battle_config.at_logout_event,                 1,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -684,6 +684,7 @@ struct Battle_Config
 	int show_skill_scale;
 	int achievement_mob_share;
 	int slave_stick_with_master;
+	int at_logout_event;
 
 #include "../custom/battle_config_struct.inc"
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adds a config for triggering OnPCLogout script events when using the @autotrade command. It could prevent exploits on custom scripts.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
