### PR TITLE
Fixes MF_PVP_NIGHTMAREDROP not clearing on reload

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3649,6 +3649,7 @@ void map_flags_init(void){
 
 		mapdata->flag.clear();
 		mapdata->flag.reserve(MF_MAX); // Reserve the bucket size
+		mapdata->drop_list.clear();
 		args.flag_val = 100;
 
 		// additional mapflag data


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes MF_PVP_NIGHTMAREDROP not being cleared during a script reload and resulting in the drop list reaching the max size.