### PR TITLE
Fix Skilltree's windows refresh in new clients.

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5418,7 +5418,7 @@ void clif_addskill(struct map_session_data *sd, int skill_id)
 
 /// Deletes a skill from the skill tree (ZC_SKILLINFO_DELETE).
 /// 0441 <skill id>.W
-void clif_deleteskill(struct map_session_data *sd, int skill_id)
+void clif_deleteskill(struct map_session_data *sd, int skill_id, int flag)
 {
 #if PACKETVER >= 20081217
 	int fd;
@@ -5435,7 +5435,11 @@ void clif_deleteskill(struct map_session_data *sd, int skill_id)
 	WFIFOW(fd,2) = skill_id;
 	WFIFOSET(fd,packet_len(0x441));
 #endif
-	clif_skillinfoblock(sd);
+#if PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+	if (!flag)
+#endif
+		clif_skillinfoblock(sd);
+
 }
 
 /// Updates a skill in the skill tree (ZC_SKILLINFO_UPDATE).

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -696,7 +696,7 @@ void clif_skillinfoblock(struct map_session_data *sd);
 void clif_skillup(struct map_session_data *sd, uint16 skill_id, int lv, int range, int upgradable);
 void clif_skillinfo(struct map_session_data *sd,int skill_id, int inf);
 void clif_addskill(struct map_session_data *sd, int skill_id);
-void clif_deleteskill(struct map_session_data *sd, int skill_id);
+void clif_deleteskill(struct map_session_data *sd, int skill_id, int flag = 0);
 
 void clif_skillcasting(struct block_list* bl, int src_id, int dst_id, int dst_x, int dst_y, uint16 skill_id, uint16 skill_lv, int property, int casttime);
 void clif_skillcastcancel(struct block_list* bl);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1973,8 +1973,13 @@ void pc_calc_skilltree(struct map_session_data *sd)
 		uint16 skill_id = skill.second->nameid;
 		uint16 idx = skill_get_index(skill_id);
 
-		if( sd->status.skill[idx].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[idx].flag != SKILL_FLAG_PERM_GRANTED ) //Don't touch these
+		if( sd->status.skill[idx].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[idx].flag != SKILL_FLAG_PERM_GRANTED ) { //Don't touch these
+#if PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+			if (sd->status.skill[idx].flag == SKILL_FLAG_TEMPORARY || sd->status.skill[idx].flag == SKILL_FLAG_PERMANENT)
+				clif_deleteskill(sd, skill_id,1);
+#endif
 			sd->status.skill[idx].id = 0; //First clear skills.
+		}
 		/* permanent skills that must be re-checked */
 		if( sd->status.skill[idx].flag == SKILL_FLAG_PERM_GRANTED ) {
 			if (skill_id == 0) {


### PR DESCRIPTION
Solve the problem that skilltree won't refresh in new clients (Late 2019+).
It will refresh skill tree windows and skill in shortcut.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  https://github.com/rathena/rathena/issues/5169

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
- According to KRO sakray.  When unequip item that contain skill  like Observer (Sense Level1) it will send 0x441 packet (clif_deleteskill).  So, I just add it.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
New client will refresh skilltree windows after sending 0x441 packet.

Please feel free to reviews and guides me.