### PR TITLE
Cancel skill usage keeping on death

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8323,6 +8323,11 @@ int pc_dead(struct map_session_data *sd,struct block_list *src)
 			duel_reject(sd->duel_invite, sd);
 	}
 
+	if( sd->skill_keep_using.tid != INVALID_TIMER ){
+		delete_timer( sd->skill_keep_using.tid, skill_keep_using );
+		sd->skill_keep_using.tid = INVALID_TIMER;
+	}
+
 	pc_close_npc(sd,2); //close npc if we were using one
 
 	/* e.g. not killed thru pc_damage */

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -23141,6 +23141,7 @@ void do_init_skill(void)
 	add_timer_func_list(skill_castend_pos,"skill_castend_pos");
 	add_timer_func_list(skill_timerskill,"skill_timerskill");
 	add_timer_func_list(skill_blockpc_end, "skill_blockpc_end");
+	add_timer_func_list(skill_keep_using, "skill_keep_using");
 
 	add_timer_interval(gettick()+SKILLUNITTIMER_INTERVAL,skill_unit_timer,0,0,SKILLUNITTIMER_INTERVAL);
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: #5058

* **Server Mode**: Both

* **Description of Pull Request**: 
Skill usage keeping will be cancelled properly on death now.
Additionally added the function to the known timer functions, so that the correct name will be displayed in future errors.

Thanks to @admkakaroto and @qwerty7vp
