### PR TITLE
Fix the problem that changing source map's name when instancing new o…

### DIFF
--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -632,6 +632,28 @@ int instance_create(int owner_id, const char *name, e_instance_mode mode) {
 }
 
 /**
+ * Generating map name for instances
+ * @param instance_id: Instance ID to add map to
+ * @param dst_name: pointer to put the new name to
+ * @param src_name: source map's name
+ */
+void instance_mapname(int instance_id, char* dst_name, const char* src_name) {
+	char tmp_name[MAP_NAME_LENGTH];
+
+	strcpy(tmp_name, src_name);
+
+	// Alter the name
+	// Due to this being custom we only worry about preserving as many characters as necessary for accurate map distinguishing
+	// This also allows us to maintain complete independence with main map functions
+	if ((strchr(tmp_name, '@') == nullptr) && strlen(tmp_name) > 8) {
+		memmove(tmp_name, tmp_name + (strlen(tmp_name) - 9), strlen(tmp_name));
+		snprintf(dst_name, MAP_NAME_LENGTH, "%d#%s", (instance_id % 1000), tmp_name);
+	}
+	else
+		snprintf(dst_name, MAP_NAME_LENGTH, "%.3d%s", (instance_id % 1000), tmp_name);
+}
+
+/**
  * Adds maps to the instance
  * @param instance_id: Instance ID to add map to
  * @return 0 on failure or map count on success
@@ -733,15 +755,8 @@ int16 instance_mapid(int16 m, int instance_id)
 
 	for (const auto &it : idata->map) {
 		if (it.src_m == m) {
-			char iname[MAP_NAME_LENGTH], alt_name[MAP_NAME_LENGTH];
-
-			strcpy(iname, name);
-
-			if (!(strchr(iname, '@')) && strlen(iname) > 8) {
-				memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
-				snprintf(alt_name, sizeof(alt_name), "%d#%s", (instance_id % 1000), iname);
-			} else
-				snprintf(alt_name, sizeof(alt_name), "%.3d%s", (instance_id % 1000), iname);
+			char alt_name[MAP_NAME_LENGTH];
+			instance_mapname(instance_id, alt_name, name);
 			return map_mapname2mapid(alt_name);
 		}
 	}

--- a/src/map/instance.hpp
+++ b/src/map/instance.hpp
@@ -120,6 +120,7 @@ bool instance_addusers(int instance_id);
 bool instance_delusers(int instance_id);
 int16 instance_mapid(int16 m, int instance_id);
 int instance_addmap(int instance_id);
+void instance_mapname(int instance_id, char* dst_name, const char* src_name);
 
 void instance_addnpc(std::shared_ptr<s_instance_data> idata);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2723,18 +2723,7 @@ int map_addinstancemap(int src_m, int instance_id)
 
 	struct map_data *src_map = map_getmapdata(src_m);
 	struct map_data *dst_map = map_getmapdata(dst_m);
-	char iname[MAP_NAME_LENGTH];
-
-	strcpy(iname, name);
-
-	// Alter the name
-	// Due to this being custom we only worry about preserving as many characters as necessary for accurate map distinguishing
-	// This also allows us to maintain complete independence with main map functions
-	if ((strchr(iname, '@') == nullptr) && strlen(iname) > 8) {
-		memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
-		snprintf(dst_map->name, sizeof(dst_map->name), "%d#%s", (instance_id % 1000), iname);
-	} else
-		snprintf(dst_map->name, sizeof(dst_map->name), "%.3d%s", (instance_id % 1000), iname);
+	instance_mapname(instance_id, dst_map->name, src_map->name);
 	dst_map->name[MAP_NAME_LENGTH - 1] = '\0';
 
 	dst_map->m = dst_m;


### PR DESCRIPTION
…ne which map name's length is longer than 8

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5216

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
[Issue]
Source maps which aren't in the Instance System(ones without '@' in the map name), its name will be changed mistakenly and forever until server ends when creating new Instance Map for them.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
