### PR TITLE
Racing Cap (Super Novice) combo

### DIFF
--- a/db/re/item_combo_db.txt
+++ b/db/re/item_combo_db.txt
@@ -844,8 +844,8 @@
 19203:29350,{ bonus bBaseAtk,15; bonus bMatk,15; if (getskilllv("OB_OBOROGENSOU") == 5) bonus bVariableCastrate,-7; autobonus3 "{ bonus bCritAtkRate,10; }",1000,60000,"KG_KAGEMUSYA"; autobonus "{ bonus bNoSizeFix; }",30,3000,BF_WEAPON;  }
 19203:29351,{ bonus bBaseAtk,20; bonus bMatk,20; if (getskilllv("OB_OBOROGENSOU") == 5) bonus bVariableCastrate,-15; autobonus3 "{ bonus bCritAtkRate,30; }",1000,60000,"KG_KAGEMUSYA"; autobonus "{ bonus bNoSizeFix; }",50,5000,BF_WEAPON;  }
 19204:29352,{ bonus bMaxHP,500; bonus bBaseAtk,10; }
-19204:29353,{ bonus bMaxHP,1000; bonus bBaseAtk,20; skill "WS_CARTBOOST",1; autobonus3 "{ bonus bBaseAtk,30; }",1000,60000,"WS_CARTBOOST"; }
-19204:29354,{ bonus bMaxHP,1500; bonus bBaseAtk,40; skill "WS_CARTBOOST",3; autobonus3 "{ bonus bBaseAtk,50; }",1000,120000,"WS_CARTBOOST"; }
+19204:29353,{ bonus bMaxHP,1000; bonus bBaseAtk,20; skill "GN_CARTBOOST",1; autobonus3 "{ bonus bBaseAtk,30; }",1000,60000,"GN_CARTBOOST"; }
+19204:29354,{ bonus bMaxHP,1500; bonus bBaseAtk,40; skill "GN_CARTBOOST",3; autobonus3 "{ bonus bBaseAtk,50; }",1000,120000,"GN_CARTBOOST"; }
 19205:29355,{ bonus2 bSkillAtk,"SU_CN_METEOR",10; bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",10; }
 19205:29356,{ bonus2 bSkillAtk,"SU_CN_METEOR",20; bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",20; bonus bFixedCast,-200; }
 19205:29357,{ bonus2 bSkillAtk,"SU_CN_METEOR",60; bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",60; bonus bFixedCast,-500; }


### PR DESCRIPTION
Racing Cap (Super Novice) & Racing (Super Novice) 2Lv (and 3Lv) should grant `GN_CARTBOOST`

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  #5227

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Edits item_combo_db to grant the correct skill

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

 * **Official Information**: In the following clips, listen to the sound effect created by the cart boost skill and the status icon added on the status bar. Also, there is no such thing as WS_CARTBOOST level 3.
1. [[1:36]](https://youtu.be/poo9tQABNeg?t=96)
2. [[0:04]](https://youtu.be/RNp3fnOdBXw?t=4)

<!-- If possible, provide information from official servers (kRO or other sources) which prove that the result is wrong. Please take into account that iRO (especially iRO Wiki) is not always the same as kRO.
