### PR TITLE
Fixed secure timeout triggering npc_scriptcont debug messages

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -12858,7 +12858,7 @@ void clif_parse_NpcSelectMenu(int fd,struct map_session_data *sd){
 	uint8 select = RFIFOB(fd,info->pos[1]);
 
 #ifdef SECURE_NPCTIMEOUT
-	if( sd->npc_idle_timer == INVALID_TIMER )
+	if( sd->npc_idle_timer == INVALID_TIMER && !sd->state.ignoretimeout  )
 		return;
 #endif
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -12858,7 +12858,7 @@ void clif_parse_NpcSelectMenu(int fd,struct map_session_data *sd){
 	uint8 select = RFIFOB(fd,info->pos[1]);
 
 #ifdef SECURE_NPCTIMEOUT
-	if( sd->npc_idle_timer == INVALID_TIMER && !sd->state.ignoretimeout  )
+	if( sd->npc_idle_timer == INVALID_TIMER && !sd->state.ignoretimeout )
 		return;
 #endif
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -12857,16 +12857,15 @@ void clif_parse_NpcSelectMenu(int fd,struct map_session_data *sd){
 	int npc_id = RFIFOL(fd,info->pos[0]);
 	uint8 select = RFIFOB(fd,info->pos[1]);
 
-	if( (select > sd->npc_menu && select != 0xff) || select == 0 ) {
 #ifdef SECURE_NPCTIMEOUT
-		if( sd->npc_idle_timer != INVALID_TIMER ) {
+	if( sd->npc_idle_timer == INVALID_TIMER )
+		return;
 #endif
+
+	if( (select > sd->npc_menu && select != 0xff) || select == 0 ) {
 			TBL_NPC* nd = map_id2nd(npc_id);
 			ShowWarning("Invalid menu selection on npc %d:'%s' - got %d, valid range is [%d..%d] (player AID:%d, CID:%d, name:'%s')!\n", npc_id, (nd)?nd->name:"invalid npc id", select, 1, sd->npc_menu, sd->bl.id, sd->status.char_id, sd->status.name);
 			clif_GM_kick(NULL,sd);
-#ifdef SECURE_NPCTIMEOUT
-		}
-#endif
 		return;
 	}
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1462,6 +1462,9 @@ bool npc_scriptcont(struct map_session_data* sd, int id, bool closing){
 
 	nullpo_retr(true, sd);
 
+	if( sd->npc_idle_timer == INVALID_TIMER )
+		return true;
+
 	if( id != sd->npc_id ){
 		TBL_NPC* nd_sd = (TBL_NPC*)map_id2bl(sd->npc_id);
 		TBL_NPC* nd = BL_CAST(BL_NPC, target);

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1463,7 +1463,7 @@ bool npc_scriptcont(struct map_session_data* sd, int id, bool closing){
 	nullpo_retr(true, sd);
 
 #ifdef SECURE_NPCTIMEOUT
-	if( sd->npc_idle_timer == INVALID_TIMER )
+	if( sd->npc_idle_timer == INVALID_TIMER && !sd->state.ignoretimeout )
 		return true;
 #endif
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1462,8 +1462,10 @@ bool npc_scriptcont(struct map_session_data* sd, int id, bool closing){
 
 	nullpo_retr(true, sd);
 
+#ifdef SECURE_NPCTIMEOUT
 	if( sd->npc_idle_timer == INVALID_TIMER )
 		return true;
+#endif
 
 	if( id != sd->npc_id ){
 		TBL_NPC* nd_sd = (TBL_NPC*)map_id2bl(sd->npc_id);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4369,7 +4369,7 @@ void script_attach_state(struct script_state* st){
 		sd->npc_item_flag = st->npc_item_flag; // load default.
 		sd->state.disable_atcommand_on_npc = battle_config.atcommand_disable_npc && (!pc_has_permission(sd, PC_PERM_ENABLE_COMMAND));
 #ifdef SECURE_NPCTIMEOUT
-		if( sd->npc_idle_timer == INVALID_TIMER &&  && !sd->state.ignoretimeout )
+		if( sd->npc_idle_timer == INVALID_TIMER && !sd->state.ignoretimeout )
 			sd->npc_idle_timer = add_timer(gettick() + (SECURE_NPCTIMEOUT_INTERVAL*1000),npc_secure_timeout_timer,sd->bl.id,0);
 		sd->npc_idle_tick = gettick();
 #endif

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4369,7 +4369,7 @@ void script_attach_state(struct script_state* st){
 		sd->npc_item_flag = st->npc_item_flag; // load default.
 		sd->state.disable_atcommand_on_npc = battle_config.atcommand_disable_npc && (!pc_has_permission(sd, PC_PERM_ENABLE_COMMAND));
 #ifdef SECURE_NPCTIMEOUT
-		if( sd->npc_idle_timer == INVALID_TIMER )
+		if( sd->npc_idle_timer == INVALID_TIMER &&  && !sd->state.ignoretimeout )
 			sd->npc_idle_timer = add_timer(gettick() + (SECURE_NPCTIMEOUT_INTERVAL*1000),npc_secure_timeout_timer,sd->bl.id,0);
 		sd->npc_idle_tick = gettick();
 #endif


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5235

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes secure timeout triggering npc_scriptcont debug messages

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
