### PR TITLE
Fixes refine attack bonus

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3984,7 +3984,7 @@ int status_calc_pc_sub(struct map_session_data* sd, enum e_status_calc_opt opt)
 			}
 			wa->atk += sd->inventory_data[index]->atk;
 			if(r)
-				wa->atk2 = refine_info[wlv].bonus[r-1] / 100;
+				wa->atk2 += refine_info[wlv].bonus[r-1] / 100;
 #ifdef RENEWAL
 			wa->matk += sd->inventory_data[index]->matk;
 			wa->wlv = wlv;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4007

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes an issue where the refine bonus of a weapon was overwriting ATK2 bonuses given by other equipment.
Thanks to @cahya1992!