### PR TITLE
Add Removespecialeffect script

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5816,6 +5816,7 @@ character.
 ---------------------------------------
 
 *specialeffect <effect number>{,<send_target>{,"<NPC Name>"}};
+*removespecialeffect <effect number>{,<send_target>{,"<NPC Name>"}};
 
 This command will display special effect with the given number, centered on the
 specified NPCs coordinates, if any. For a full list of special effect numbers
@@ -5839,6 +5840,7 @@ will retain the default behavior of the command.
 ---------------------------------------
 
 *specialeffect2 <effect number>{,<send_target>{,"<Player Name>"}};
+*removespecialeffect2 <effect number>{,<send_target>{,"<Player Name>"}};
 
 This command behaves identically to 'specialeffect', but the effect will be
 centered on the invoking character's sprite.

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -9546,6 +9546,43 @@ void clif_specialeffect_value(struct block_list* bl, int effect_id, int num, sen
 	}
 }
 
+void clif_specialeffect_remove(struct block_list* bl, int type, enum send_target target)
+{
+#if PACKETVER >= 20181002
+	nullpo_retv( bl );
+
+	struct PACKET_ZC_REMOVE_EFFECT p;
+
+	p.packetType = HEADER_ZC_REMOVE_EFFECT;
+	p.AID = bl->id;
+	p.effectId = type;
+
+	clif_send( &p, sizeof( struct PACKET_ZC_REMOVE_EFFECT ), bl, target );
+
+	if( disguised(bl) )
+	{
+		p.AID = disguised_bl_id( bl->id );
+		clif_send( &p, sizeof( struct PACKET_ZC_REMOVE_EFFECT ), bl, SELF );
+	}
+#endif
+}
+
+void clif_specialeffect_remove_single(struct block_list* bl, int type, struct block_list* target)
+{
+#if PACKETVER >= 20181002
+	nullpo_retv( bl );
+	nullpo_retv( target );
+
+	struct PACKET_ZC_REMOVE_EFFECT p;
+
+	p.packetType = HEADER_ZC_REMOVE_EFFECT;
+	p.AID = bl->id;
+	p.effectId = type;
+
+	clif_send( &p, sizeof( struct PACKET_ZC_REMOVE_EFFECT ), target, SELF );
+#endif
+}
+
 /// Monster/NPC color chat [SnakeDrak] (ZC_NPC_CHAT).
 /// 02c1 <packet len>.W <id>.L <color>.L <message>.?B
 void clif_messagecolor_target(struct block_list *bl, unsigned long color, const char *msg, bool rgb2bgr, enum send_target type, struct map_session_data *sd) {

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -885,6 +885,8 @@ void clif_friendslist_reqack(struct map_session_data *sd, struct map_session_dat
 void clif_weather(int16 m); // [Valaris]
 void clif_specialeffect(struct block_list* bl, int type, enum send_target target); // special effects [Valaris]
 void clif_specialeffect_single(struct block_list* bl, int type, int fd);
+void clif_specialeffect_remove(struct block_list* bl, int type, enum send_target target);
+void clif_specialeffect_remove_single(struct block_list* bl, int type, struct block_list* target);
 void clif_messagecolor_target(struct block_list *bl, unsigned long color, const char *msg, bool rgb2bgr, enum send_target type, struct map_session_data *sd);
 #define clif_messagecolor(bl, color, msg, rgb2bgr, type) clif_messagecolor_target(bl, color, msg, rgb2bgr, type, NULL) // Mob/Npc color talk [SnakeDrak]
 void clif_specialeffect_value(struct block_list* bl, int effect_id, int num, send_target target);

--- a/src/map/packets_struct.hpp
+++ b/src/map/packets_struct.hpp
@@ -2977,9 +2977,10 @@ struct PACKET_CZ_MEMORIALDUNGEON_COMMAND {
 
 struct PACKET_ZC_REMOVE_EFFECT {
 	int16 packetType;
-	uint32 aid;
+	uint32 AID;
 	uint32 effectId;
 } __attribute__((packed));
+DEFINE_PACKET_HEADER(ZC_REMOVE_EFFECT, 0x0b0d);
 
 #if PACKETVER >= 20160525
 struct PACKET_ZC_CAMERA_INFO {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -14649,6 +14649,57 @@ BUILDIN_FUNC(specialeffect2)
 	return SCRIPT_CMD_SUCCESS;
 }
 
+BUILDIN_FUNC(removespecialeffect)
+{
+	struct block_list *bl=map_id2bl(st->oid);
+	int type = script_getnum(st,2);
+	enum send_target target = script_hasdata(st,3) ? (send_target)script_getnum(st,3) : AREA;
+
+	if(bl==NULL)
+		return SCRIPT_CMD_SUCCESS;
+
+	if( type <= EF_NONE || type >= EF_MAX ){
+		ShowError( "buildin_removespecialeffect: unsupported effect id %d\n", type );
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	if( script_hasdata(st,4) )
+	{
+		TBL_NPC *nd = npc_name2id(script_getstr(st,4));
+		if(nd)
+			clif_specialeffect_remove(&nd->bl, type, target);
+	}
+	else
+	{
+		if (target == SELF) {
+			TBL_PC *sd;
+			if (script_rid2sd(sd))
+				clif_specialeffect_remove_single(bl,type,&sd->bl);
+		} else {
+			clif_specialeffect_remove(bl, type, target);
+		}
+	}
+	return SCRIPT_CMD_SUCCESS;
+}
+
+BUILDIN_FUNC(removespecialeffect2)
+{
+	TBL_PC *sd;
+
+	if( script_nick2sd(4,sd) ){
+		int type = script_getnum(st,2);
+		enum send_target target = script_hasdata(st,3) ? (send_target)script_getnum(st,3) : AREA;
+
+		if( type <= EF_NONE || type >= EF_MAX ){
+			ShowError( "buildin_removespecialeffect2: unsupported effect id %d\n", type );
+			return SCRIPT_CMD_FAILURE;
+		}
+
+		clif_specialeffect_remove(&sd->bl, type, target);
+	}
+	return SCRIPT_CMD_SUCCESS;
+}
+
 /**
  * nude({<char_id>});
  * @author [Valaris]
@@ -25069,6 +25120,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(npcskilleffect,"viii"), // npc skill effect [Valaris]
 	BUILDIN_DEF(specialeffect,"i??"), // npc skill effect [Valaris]
 	BUILDIN_DEF(specialeffect2,"i??"), // skill effect on players[Valaris]
+	BUILDIN_DEF(removespecialeffect,"i??"),
+	BUILDIN_DEF(removespecialeffect2,"i??"),
 	BUILDIN_DEF(nude,"?"), // nude command [Valaris]
 	BUILDIN_DEF(mapwarp,"ssii??"),		// Added by RoVeRT
 	BUILDIN_DEF(atcommand,"s"), // [MouseJstr]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  - 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Add new script to remove speicialeffect that attach to NPC / Player.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
- removespecialeffect
- removespecialeffect2

In official server it was used too many situation ex. Specialeffect cursor above NPC like arrow that disappear when clicked to NPC in some instances.
