### PR TITLE
Corrects status icon timer after relog

### DIFF
--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -910,6 +910,7 @@ CREATE TABLE IF NOT EXISTS `sc_data` (
   `account_id` int(11) unsigned NOT NULL,
   `char_id` int(11) unsigned NOT NULL,
   `type` smallint(11) unsigned NOT NULL,
+  `tick_total` bigint(20) NOT NULL,
   `tick` bigint(20) NOT NULL,
   `val1` int(11) NOT NULL default '0',
   `val2` int(11) NOT NULL default '0',

--- a/sql-files/upgrades/upgrade_20200803.sql
+++ b/sql-files/upgrades/upgrade_20200803.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `sc_data` ADD COLUMN `tick_total` BIGINT(20) NOT NULL AFTER `tick`;
+UPDATE `sc_data` SET `tick_total` = `tick`;

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -2338,7 +2338,7 @@ bool char_checkdb(void){
 		return false;
 	}
 	//checking scdata_db
-	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT  `account_id`,`char_id`,`type`,`tick`,`val1`,`val2`,`val3`,`val4`"
+	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT  `account_id`,`char_id`,`type`,`tick`,`tick_total`,`val1`,`val2`,`val3`,`val4`"
 		" FROM `%s` LIMIT 1;", schema_config.scdata_db) ){
 		Sql_ShowDebug(sql_handle);
 		return false;

--- a/src/char/char_mapif.cpp
+++ b/src/char/char_mapif.cpp
@@ -279,7 +279,7 @@ int chmapif_parse_askscdata(int fd){
 		int aid, cid;
 		aid = RFIFOL(fd,2);
 		cid = RFIFOL(fd,6);
-		if( SQL_ERROR == Sql_Query(sql_handle, "SELECT type, tick, val1, val2, val3, val4 from `%s` WHERE `account_id` = '%d' AND `char_id`='%d'",
+		if( SQL_ERROR == Sql_Query(sql_handle, "SELECT type, tick, tick_total, val1, val2, val3, val4 from `%s` WHERE `account_id` = '%d' AND `char_id`='%d'",
 			schema_config.scdata_db, aid, cid) )
 		{
 			Sql_ShowDebug(sql_handle);
@@ -299,10 +299,11 @@ int chmapif_parse_askscdata(int fd){
 			{
 				Sql_GetData(sql_handle, 0, &data, NULL); scdata.type = atoi(data);
 				Sql_GetData(sql_handle, 1, &data, NULL); scdata.tick = strtoll( data, nullptr, 10 );
-				Sql_GetData(sql_handle, 2, &data, NULL); scdata.val1 = atoi(data);
-				Sql_GetData(sql_handle, 3, &data, NULL); scdata.val2 = atoi(data);
-				Sql_GetData(sql_handle, 4, &data, NULL); scdata.val3 = atoi(data);
-				Sql_GetData(sql_handle, 5, &data, NULL); scdata.val4 = atoi(data);
+				Sql_GetData(sql_handle, 2, &data, NULL); scdata.tick_total = strtoll(data, nullptr, 10);
+				Sql_GetData(sql_handle, 3, &data, NULL); scdata.val1 = atoi(data);
+				Sql_GetData(sql_handle, 4, &data, NULL); scdata.val2 = atoi(data);
+				Sql_GetData(sql_handle, 5, &data, NULL); scdata.val3 = atoi(data);
+				Sql_GetData(sql_handle, 6, &data, NULL); scdata.val4 = atoi(data);
 				memcpy(WFIFOP(fd, 14+count*sizeof(struct status_change_data)), &scdata, sizeof(struct status_change_data));
 			}
 			if (count >= 50)
@@ -942,14 +943,14 @@ int chmapif_parse_save_scdata(int fd){
 			int i;
 
 			StringBuf_Init(&buf);
-			StringBuf_Printf(&buf, "INSERT INTO `%s` (`account_id`, `char_id`, `type`, `tick`, `val1`, `val2`, `val3`, `val4`) VALUES ", schema_config.scdata_db);
+			StringBuf_Printf(&buf, "INSERT INTO `%s` (`account_id`, `char_id`, `type`, `tick`, `tick_total`, `val1`, `val2`, `val3`, `val4`) VALUES ", schema_config.scdata_db);
 			for( i = 0; i < count; ++i )
 			{
 				memcpy (&data, RFIFOP(fd, 14+i*sizeof(struct status_change_data)), sizeof(struct status_change_data));
 				if( i > 0 )
 					StringBuf_AppendStr(&buf, ", ");
-				StringBuf_Printf(&buf, "('%d','%d','%hu','%" PRtf "','%ld','%ld','%ld','%ld')", aid, cid,
-					data.type, data.tick, data.val1, data.val2, data.val3, data.val4);
+				StringBuf_Printf(&buf, "('%d','%d','%hu','%" PRtf "','%" PRtf "','%ld','%ld','%ld','%ld')", aid, cid,
+					data.type, data.tick, data.tick_total, data.val1, data.val2, data.val3, data.val4);
 			}
 			if( SQL_ERROR == Sql_QueryStr(sql_handle, StringBuf_Value(&buf)) )
 				Sql_ShowDebug(sql_handle);

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -340,6 +340,7 @@ struct status_change_data {
 	unsigned short type; //SC_type
 	long val1, val2, val3, val4;
 	t_tick tick; //Remaining duration.
+	t_tick tick_total; // Total duration
 };
 
 #define MAX_BONUS_SCRIPT_LENGTH 512

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1330,6 +1330,7 @@ int chrif_save_scdata(struct map_session_data *sd) { //parses the sc_data of the
 				data.tick = 0; //Negative tick does not necessarily mean that sc has expired
 		} else
 			data.tick = INFINITE_TICK; //Infinite duration
+		data.tick_total = sc->data[i]->tick_total;
 		data.type = i;
 		data.val1 = sc->data[i]->val1;
 		data.val2 = sc->data[i]->val2;
@@ -1413,7 +1414,7 @@ int chrif_load_scdata(int fd) {
 	for (i = 0; i < count; i++) {
 		struct status_change_data *data = (struct status_change_data*)RFIFOP(fd,14 + i*sizeof(struct status_change_data));
 
-		status_change_start(NULL,&sd->bl, (sc_type)data->type, 10000, data->val1, data->val2, data->val3, data->val4, data->tick, SCSTART_NOAVOID|SCSTART_NOTICKDEF|SCSTART_LOADED|SCSTART_NORATEDEF);
+		status_change_start_sub(NULL,&sd->bl, (sc_type)data->type, 10000, data->val1, data->val2, data->val3, data->val4, data->tick, data->tick_total, SCSTART_NOAVOID|SCSTART_NOTICKDEF|SCSTART_LOADED|SCSTART_NORATEDEF);
 	}
 
 	pc_scdata_received(sd);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6126,17 +6126,17 @@ void clif_cooking_list( struct map_session_data *sd, int trigger, uint16 skill_i
 /// 0196 <index>.W <id>.L <state>.B (ZC_MSG_STATE_CHANGE) [used for ending status changes and starting them on non-pc units (when needed)]
 /// 043f <index>.W <id>.L <state>.B <remain msec>.L { <val>.L }*3 (ZC_MSG_STATE_CHANGE2) [used exclusively for starting statuses on pcs]
 /// 0983 <index>.W <id>.L <state>.B <total msec>.L <remain msec>.L { <val>.L }*3 (ZC_MSG_STATE_CHANGE3) (PACKETVER >= 20120618)
-/// @param bl Sends packet to clients around this object
-/// @param id ID of object that has this effect
-/// @param type Status icon see enum efst_types
-/// @param flag 1:Active, 0:Deactive
-/// @param tick Duration in ms
-/// @param val1
-/// @param val2
-/// @param val3
-void clif_status_change_sub(struct block_list *bl, int id, int type, int flag, t_tick tick, int val1, int val2, int val3, enum send_target target_type)
+/// @param bl: Sends packet to clients around this object
+/// @param type: Status icon (see efst_types)
+/// @param flag: 1:Active, 0:Inactive
+/// @param tick_total: Total duration in ms
+/// @param tick: Remaining duration in ms
+/// @param val1: Value 1
+/// @param val2: Value 2
+/// @param val3: Value 3
+void clif_status_change_sub(struct block_list *bl, int type, int flag, t_tick tick_total, t_tick tick, int val1, int val2, int val3)
 {
-	unsigned char buf[32];
+	nullpo_retv(bl);
 
 	if (type == EFST_BLANK)  //It shows nothing on the client...
 		return;
@@ -6144,79 +6144,61 @@ void clif_status_change_sub(struct block_list *bl, int id, int type, int flag, t
 	if (type == EFST_POSTDELAY && tick == 0)
 		return;
 
-	nullpo_retv(bl);
+	if (!(status_type2relevant_bl_types(type) & bl->type)) // only send status changes that actually matter to the client
+		return;
 
-	// Statuses with an infinite duration, but still needs a duration sent to display properly.
-	if (type == EFST_LUNARSTANCE || type == EFST_UNIVERSESTANCE || type == EFST_SUNSTANCE || type == EFST_STARSTANCE)
-		tick = 200;
+	packet_status_change p = { 0 };
+	map_session_data *sd = BL_CAST(BL_PC, bl);
+
+	if (battle_config.display_status_timers > 0) {
+		// Statuses with an infinite duration, but still needs a duration sent to display properly.
+		switch (type) {
+			case EFST_LUNARSTANCE:
+			case EFST_UNIVERSESTANCE:
+			case EFST_SUNSTANCE:
+			case EFST_STARSTANCE:
+				tick = 200;
+				break;
+			default:
+				if (tick < 0)
+					tick = 9999; // this is indeed what official servers do
+				break;
+		}
+
+		p.PacketType = status_changeType;
+	} else
+		p.PacketType = sc_notickType;
+	p.index = type;
+	p.AID = bl->id;
+	p.state = (uint8)flag;
 
 #if PACKETVER >= 20120618
-	if (flag && battle_config.display_status_timers)
-		WBUFW(buf,0) = 0x983;
-	else
-#elif PACKETVER >= 20090121
-	if (flag && battle_config.display_status_timers)
-		WBUFW(buf,0) = 0x43f;
-	else
+	if (battle_config.display_status_timers > 0)
+		p.Total = client_tick(tick_total);
 #endif
-		WBUFW(buf,0) = 0x196;
-	WBUFW(buf,2) = type;
-	WBUFL(buf,4) = id;
-	WBUFB(buf,8) = flag;
-#if PACKETVER >= 20120618
-	if (flag && battle_config.display_status_timers) {
-		if (tick <= 0)
-			tick = 9999; // this is indeed what official servers do
-
-		WBUFL(buf,9) = client_tick(tick);/* at this stage remain and total are the same value I believe */
-		WBUFL(buf,13) = client_tick(tick);
-		WBUFL(buf,17) = val1;
-		WBUFL(buf,21) = val2;
-		WBUFL(buf,25) = val3;
-	}
-#elif PACKETVER >= 20090121
-	if (flag && battle_config.display_status_timers) {
-		if (tick <= 0)
-			tick = 9999; // this is indeed what official servers do
-
-		WBUFL(buf,9) = client_tick(tick);
-		WBUFL(buf,13) = val1;
-		WBUFL(buf,17) = val2;
-		WBUFL(buf,21) = val3;
+#if PACKETVER >= 20090121
+	if (battle_config.display_status_timers > 0) {
+		p.Left = client_tick(tick);
+		p.val1 = val1;
+		p.val2 = val2;
+		p.val3 = val3;
 	}
 #endif
-	clif_send(buf, packet_len(WBUFW(buf,0)), bl, target_type);
+
+	clif_send(&p, sizeof(p), bl, (sd && sd->status.option & OPTION_INVISIBLE) ? SELF : AREA);
 }
 
 /* Sends status effect to clients around the bl
- * @param bl Object that has the effect
- * @param type Status icon see enum efst_types
- * @param flag 1:Active, 0:Deactive
- * @param tick Duration in ms
- * @param val1
- * @param val2
- * @param val3
+ * @param bl: Object that has the effect
+ * @param type: Status icon (see efst_types)
+ * @param flag: 1:Active, 0:Inactive
+ * @param tick_total: Total duration in ms
+ * @param val1: Value 1
+ * @param val2: Value 2
+ * @param val3: Value 3
  */
-void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick, int val1, int val2, int val3) {
-	struct map_session_data *sd = NULL;
-
-	if (type == EFST_BLANK)  //It shows nothing on the client...
-		return;
-
-	if (type == EFST_POSTDELAY && tick == 0)
-		return;
-
-	if (type == EFST_ILLUSION && !battle_config.display_hallucination) // Disable Hallucination.
-		return;
-
-	nullpo_retv(bl);
-
-	sd = BL_CAST(BL_PC, bl);
-
-	if (!(status_type2relevant_bl_types(type)&bl->type)) // only send status changes that actually matter to the client
-		return;
-
-	clif_status_change_sub(bl, bl->id, type, flag, tick, val1, val2, val3, ((sd ? (pc_isinvisible(sd) ? SELF : AREA) : AREA_WOS)));
+void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick_total, int val1, int val2, int val3) {
+	clif_status_change_sub(bl, type, flag, tick_total, tick_total, val1, val2, val3);
 }
 
 /**
@@ -6267,13 +6249,13 @@ void clif_efst_status_change_sub(struct block_list *tbl, struct block_list *bl, 
 #if PACKETVER > 20120418
 			clif_efst_status_change(tbl, bl->id, AREA_WOS, StatusIconChangeTable[type], tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3);
 #else
-			clif_status_change_sub(tbl, bl->id, StatusIconChangeTable[type], 1, tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3, AREA_WOS);
+			clif_status_change_sub(tbl, StatusIconChangeTable[type], 1, tick, tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3, AREA_WOS);
 #endif
 		}else{
 #if PACKETVER > 20120418
 			clif_efst_status_change(tbl, bl->id, target, StatusIconChangeTable[type], tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3);
 #else
-			clif_status_change_sub(tbl, bl->id, StatusIconChangeTable[type], 1, tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3, target);
+			clif_status_change_sub(tbl, StatusIconChangeTable[type], 1, tick, tick, sc_display[i]->val1, sc_display[i]->val2, sc_display[i]->val3, target);
 #endif
 		}
 	}

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -728,7 +728,8 @@ void clif_bladestop(struct block_list *src, int dst_id, int active);
 void clif_changemapcell(int fd, int16 m, int x, int y, int type, enum send_target target);
 
 #define clif_status_load(bl, type, flag) clif_status_change((bl), (type), (flag), 0, 0, 0, 0)
-void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick, int val1, int val2, int val3);
+void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick_total, int val1, int val2, int val3);
+void clif_status_change_sub(struct block_list *bl, int type, int flag, t_tick tick_total, t_tick tick, int val1, int val2, int val3);
 void clif_efst_status_change(struct block_list *bl, int tid, enum send_target target, int type, t_tick tick, int val1, int val2, int val3);
 void clif_efst_status_change_sub(struct block_list *tbl, struct block_list *bl, enum send_target target);
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -2571,6 +2571,7 @@ struct sc_display_entry {
 struct status_change_entry {
 	int timer;
 	int val1,val2,val3,val4;
+	t_tick tick_total;
 };
 
 ///Status change
@@ -2706,6 +2707,7 @@ t_tick status_get_sc_def(struct block_list *src,struct block_list *bl, enum sc_t
 #define sc_start4(src, bl, type, rate, val1, val2, val3, val4, tick) status_change_start(src,bl,type,100*(rate),val1,val2,val3,val4,tick,SCSTART_NONE)
 
 int status_change_start(struct block_list* src, struct block_list* bl,enum sc_type type,int rate,int val1,int val2,int val3,int val4,t_tick duration,unsigned char flag);
+int status_change_start_sub(struct block_list *src, struct block_list *bl, enum sc_type type, int rate, int val1, int val2, int val3, int val4, t_tick duration, t_tick duration_total, unsigned char flag);
 int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const char* file, int line);
 #define status_change_end(bl,type,tid) status_change_end_(bl,type,tid,__FILE__,__LINE__)
 TIMER_FUNC(status_change_timer);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4984

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves status icon timers not properly showing the difference of remaining/total time when a player relogs.
  * Fixes status icon timers going into negative values.
Thanks to @attackjom!