### PR TITLE
Adjusts homunculi hunger delay rate when starving

### DIFF
--- a/conf/battle/homunc.conf
+++ b/conf/battle/homunc.conf
@@ -95,3 +95,7 @@ idletime_hom_option: 0x1F
 // Only applies to renewal mode.
 // Official: 10%
 homunculus_exp_gain: 10
+
+// Homunculi normally lose hunger every 60 seconds but when one is starving (hunger between 0-10) the hunger delay drops to 20 seconds (config in milliseconds).
+// Official: 20 seconds
+homunculus_starving_delay: 20000

--- a/conf/battle/homunc.conf
+++ b/conf/battle/homunc.conf
@@ -96,6 +96,12 @@ idletime_hom_option: 0x1F
 // Official: 10%
 homunculus_exp_gain: 10
 
-// Homunculi normally lose hunger every 60 seconds but when one is starving (hunger between 0-10) the hunger delay drops to 20 seconds (config in milliseconds).
+// The hunger rate, less than or equal to, at which a homunculus' hunger delay changes. (Note 2)
+// See 'homunculus_starving_delay' for the delay value.
+// Set to 0 to disable.
+// Official: 10
+homunculus_starving_rate: 10
+
+// Homunculi normally lose hunger every 60 seconds but when the 'homunculus_starving_rate' is met the hunger delay drops to 20 seconds (in milliseconds).
 // Official: 20 seconds
 homunculus_starving_delay: 20000

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8998,6 +8998,7 @@ static const struct _battle_data {
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
 	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
 	{ "at_logout_event",                    &battle_config.at_logout_event,                 1,      0,      1,              },
+	{ "homunculus_starving_rate",           &battle_config.homunculus_starving_rate,        10,     0,      100,            },
 	{ "homunculus_starving_delay",          &battle_config.homunculus_starving_delay,       20000,  0,      INT_MAX,        },
 
 #include "../custom/battle_config_init.inc"

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8998,6 +8998,7 @@ static const struct _battle_data {
 	{ "achievement_mob_share",              &battle_config.achievement_mob_share,           0,      0,      1,              },
 	{ "slave_stick_with_master",            &battle_config.slave_stick_with_master,         0,      0,      1,              },
 	{ "at_logout_event",                    &battle_config.at_logout_event,                 1,      0,      1,              },
+	{ "homunculus_starving_delay",          &battle_config.homunculus_starving_delay,       20000,  0,      INT_MAX,        },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -685,6 +685,7 @@ struct Battle_Config
 	int achievement_mob_share;
 	int slave_stick_with_master;
 	int at_logout_event;
+	int homunculus_starving_delay;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -685,6 +685,7 @@ struct Battle_Config
 	int achievement_mob_share;
 	int slave_stick_with_master;
 	int at_logout_event;
+	int homunculus_starving_rate;
 	int homunculus_starving_delay;
 
 #include "../custom/battle_config_struct.inc"

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -906,7 +906,10 @@ static TIMER_FUNC(hom_hungry){
 	}
 
 	clif_send_homdata(sd,SP_HUNGRY,hd->homunculus.hunger);
-	hd->hungry_timer = add_timer(tick+hd->homunculusDB->hungryDelay,hom_hungry,sd->bl.id,0); //simple Fix albator
+
+	int hunger_delay = hd->homunculus.hunger <= 10 ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
+
+	hd->hungry_timer = add_timer(tick+hunger_delay,hom_hungry,sd->bl.id,0); //simple Fix albator
 	return 0;
 }
 
@@ -1057,8 +1060,11 @@ void hom_alloc(struct map_session_data *sd, struct s_homunculus *hom)
 */
 void hom_init_timers(struct homun_data * hd)
 {
-	if (hd->hungry_timer == INVALID_TIMER)
-		hd->hungry_timer = add_timer(gettick()+hd->homunculusDB->hungryDelay,hom_hungry,hd->master->bl.id,0);
+	if (hd->hungry_timer == INVALID_TIMER) {
+		int hunger_delay = hd->homunculus.hunger <= 10 ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
+
+		hd->hungry_timer = add_timer(gettick()+hunger_delay,hom_hungry,hd->master->bl.id,0);
+	}
 	hd->regen.state.block = 0; //Restore HP/SP block.
 	hd->masterteleport_timer = INVALID_TIMER;
 }

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -907,7 +907,7 @@ static TIMER_FUNC(hom_hungry){
 
 	clif_send_homdata(sd,SP_HUNGRY,hd->homunculus.hunger);
 
-	int hunger_delay = hd->homunculus.hunger <= 10 ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
+	int hunger_delay = (battle_config.homunculus_starving_rate > 0 && hd->homunculus.hunger <= battle_config.homunculus_starving_rate) ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
 
 	hd->hungry_timer = add_timer(tick+hunger_delay,hom_hungry,sd->bl.id,0); //simple Fix albator
 	return 0;
@@ -1061,7 +1061,7 @@ void hom_alloc(struct map_session_data *sd, struct s_homunculus *hom)
 void hom_init_timers(struct homun_data * hd)
 {
 	if (hd->hungry_timer == INVALID_TIMER) {
-		int hunger_delay = hd->homunculus.hunger <= 10 ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
+		int hunger_delay = (battle_config.homunculus_starving_rate > 0 && hd->homunculus.hunger <= battle_config.homunculus_starving_rate) ? battle_config.homunculus_starving_delay : hd->homunculusDB->hungryDelay; // Every 20 seconds if hunger <= 10
 
 		hd->hungry_timer = add_timer(gettick()+hunger_delay,hom_hungry,hd->master->bl.id,0);
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #2242

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * When a homunculus is starving (hunger between 0-10) their hunger delay drops from 60 seconds to 20 seconds.
  * Added a battle config to allow easy adjustment.
Thanks to @mmalka and @mrjnumber1!