### PR TITLE
Fixes sphere requirement for Knuckle Arrow

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -24351,6 +24351,16 @@ Body:
           Amount: 1
         - Level: 5
           Amount: 1
+        - Level: 6
+          Amount: 0
+        - Level: 7
+          Amount: 0
+        - Level: 8
+          Amount: 0
+        - Level: 9
+          Amount: 0
+        - Level: 10
+          Amount: 0
   - Id: 2337
     Name: SR_WINDMILL
     Description: Windmill


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5245

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Corrects the sphere requirement of Knuckle Arrow to 0 for levels 6-10.
Thanks to @Badarosk0!