### PR TITLE
Fixed Estun not damaging all monsters

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6320,8 +6320,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case SL_STIN: //Target size must be small (0) for full damage
 						skillratio += (tstatus->size != SZ_SMALL ? -99 : 10 * skill_lv);
 						break;
-					case SL_STUN: //Full damage is dealt on small/medium targets
-						skillratio += (tstatus->size != SZ_BIG ? 5 * skill_lv : -99);
+					case SL_STUN:
+						skillratio += 5 * skill_lv;
 						break;
 					case SL_SMA: //Base damage is 40% + lv%
 						skillratio += -60 + status_get_lv(src);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Acording to kRO's description and tests on official servers, Estun should damage all monsters, but only stun medium sized ones.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
