### PR TITLE
fix stuck on warp while writing mail

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -5927,6 +5927,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 	sd->state.changemap = (sd->mapindex != mapindex);
 	sd->state.warping = 1;
 	sd->state.workinprogress = WIP_DISABLE_NONE;
+	sd->state.mail_writing = false;
 
 	if( sd->state.changemap ) { // Misc map-changing settings
 		int curr_map_instance_id = map_getmapdata(sd->bl.m)->instance_id, new_map_instance_id = (mapdata ? mapdata->instance_id : 0);


### PR DESCRIPTION
* **Addressed Issue(s)**: none

* **Server Mode**: both

* **Description of Pull Request**: 
when the player get teleported while writing a mail , he will get stuck
for test you can (open the writing mail after you clicked to move to a warp)
a real example , player stand on the warp place in the endless tower , they write a mail , they will stuck after the warp is enabled
