### PR TITLE
Fixed logging out on newer clients

### DIFF
--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -149,3 +149,8 @@ ping_time: 20
 // Show skill scale for clients 2015-12-23 and newer? (Note 1)
 // Official: yes
 show_skill_scale: yes
+
+// Should the connection be dropped on server side after a player disconnection request was received? (Note 1)
+// Note: Enabling this is known to cause problems on clients that make use of REST API calls.
+// Official: no
+drop_connection_on_quit: no

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9012,6 +9012,7 @@ static const struct _battle_data {
 	{ "at_logout_event",                    &battle_config.at_logout_event,                 1,      0,      1,              },
 	{ "homunculus_starving_rate",           &battle_config.homunculus_starving_rate,        10,     0,      100,            },
 	{ "homunculus_starving_delay",          &battle_config.homunculus_starving_delay,       20000,  0,      INT_MAX,        },
+	{ "drop_connection_on_quit",            &battle_config.drop_connection_on_quit,         0,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -687,6 +687,7 @@ struct Battle_Config
 	int at_logout_event;
 	int homunculus_starving_rate;
 	int homunculus_starving_delay;
+	int drop_connection_on_quit;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11165,9 +11165,12 @@ void clif_parse_QuitGame(int fd, struct map_session_data *sd)
 	if( !sd->sc.data[SC_CLOAKING] && !sd->sc.data[SC_HIDING] && !sd->sc.data[SC_CHASEWALK] && !sd->sc.data[SC_CLOAKINGEXCEED] && !sd->sc.data[SC_SUHIDE] && !sd->sc.data[SC_NEWMOON] &&
 		(!battle_config.prevent_logout || sd->canlog_tick == 0 || DIFF_TICK(gettick(), sd->canlog_tick) > battle_config.prevent_logout) )
 	{
-		set_eof(fd);
 		pc_damage_log_clear(sd,0);
 		clif_disconnect_ack(sd, 0);
+		flush_fifo( fd );
+		if( battle_config.drop_connection_on_quit ){
+			set_eof( fd );
+		}
 	} else {
 		clif_disconnect_ack(sd, 1);
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #5215

* **Server Mode**: Both

* **Description of Pull Request**: 
Connections will not be dropped on the server side anymore when a player requests to log out.

Thanks to @4144, @mazvi and @attackjom
