### PR TITLE
Adjusts map_foreachindir to include caster's cell

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -355,6 +355,10 @@ default_fixed_castrate: 20
 // Note: Brandish Spear will always use this algorithm due to its special damage behavior.
 skill_eightpath_algorithm: yes
 
+// Should skills that use skill_eightpath_algorithm include targets in the caster's cell?
+// Official: yes
+skill_eightpath_same_cell: yes
+
 // Can damage skill units like icewall and traps (Note 3)
 // On official servers, players can damage icewalls and some traps with skills. When monsters use skills, damage
 // will show on the icewalls and traps, but it is not actually substracted from the durability.

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8935,6 +8935,7 @@ static const struct _battle_data {
 	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
 	{ "monster_stuck_warning",              &battle_config.mob_stuck_warning,               0,      0,      1,              },
 	{ "skill_eightpath_algorithm",          &battle_config.skill_eightpath_algorithm,       1,      0,      1,              },
+	{ "skill_eightpath_same_cell",          &battle_config.skill_eightpath_same_cell,       1,      0,      1,              },
 	{ "death_penalty_maxlv",                &battle_config.death_penalty_maxlv,             0,      0,      3,              },
 	{ "exp_cost_redemptio",                 &battle_config.exp_cost_redemptio,              1,      0,      100,            },
 	{ "exp_cost_redemptio_limit",           &battle_config.exp_cost_redemptio_limit,        5,      0,      MAX_PARTY,      },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -622,6 +622,7 @@ struct Battle_Config
 	int mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
 	int mob_stuck_warning; //Show warning if a monster is stuck too long
 	int skill_eightpath_algorithm; //Official path algorithm
+	int skill_eightpath_same_cell;
 	int death_penalty_maxlv;
 	int exp_cost_redemptio;
 	int exp_cost_redemptio_limit;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1420,8 +1420,8 @@ int map_foreachindir(int(*func)(struct block_list*, va_list), int16 m, int16 x0,
 						rx = (bl->x - x0);
 						ry = (bl->y - y0);
 						//Do not hit source cell
-						if (rx == 0 && ry == 0)
-							continue;
+						//if (rx == 0 && ry == 0)
+						//	continue;
 						//This turns it so that the area that is hit is always with positive rx and ry
 						rx *= dx;
 						ry *= dy;
@@ -1456,8 +1456,8 @@ int map_foreachindir(int(*func)(struct block_list*, va_list), int16 m, int16 x0,
 						rx = (bl->x - x0);
 						ry = (bl->y - y0);
 						//Do not hit source cell
-						if (rx == 0 && ry == 0)
-							continue;
+						//if (rx == 0 && ry == 0)
+						//	continue;
 						//This turns it so that the area that is hit is always with positive rx and ry
 						rx *= dx;
 						ry *= dy;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1420,8 +1420,8 @@ int map_foreachindir(int(*func)(struct block_list*, va_list), int16 m, int16 x0,
 						rx = (bl->x - x0);
 						ry = (bl->y - y0);
 						//Do not hit source cell
-						//if (rx == 0 && ry == 0)
-						//	continue;
+						if (battle_config.skill_eightpath_same_cell == 0 && rx == 0 && ry == 0)
+							continue;
 						//This turns it so that the area that is hit is always with positive rx and ry
 						rx *= dx;
 						ry *= dy;
@@ -1456,8 +1456,8 @@ int map_foreachindir(int(*func)(struct block_list*, va_list), int16 m, int16 x0,
 						rx = (bl->x - x0);
 						ry = (bl->y - y0);
 						//Do not hit source cell
-						//if (rx == 0 && ry == 0)
-						//	continue;
+						if (battle_config.skill_eightpath_same_cell == 0 && rx == 0 && ry == 0)
+							continue;
 						//This turns it so that the area that is hit is always with positive rx and ry
 						rx *= dx;
 						ry *= dy;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #3502

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adjusts map_foreachindir to include the caster's cell when calculating area of effect.
Thanks to @mrjnumber1!