### PR TITLE
Removed skilleffect/npcskilleffect cap

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -14622,14 +14622,6 @@ BUILDIN_FUNC(skilleffect)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	uint16 skill_lv_cap = cap_value(skill_lv, 1, skill_get_max(skill_id));
-
-	if (skill_lv != skill_lv_cap) {
-		ShowWarning("buildin_skilleffect: Invalid skill level %d, capping to %d.\n", skill_lv, skill_lv_cap);
-		skill_lv = skill_lv_cap;
-		script_reportsrc(st);
-	}
-
 	/* Ensure we're standing because the following packet causes the client to virtually set the char to stand,
 	 * which leaves the server thinking it still is sitting. */
 	if( pc_issit(sd) && pc_setstand(sd, false) ) {
@@ -14667,14 +14659,6 @@ BUILDIN_FUNC(npcskilleffect)
 	if (skill_db.find(skill_id) == nullptr) {
 		ShowError("buildin_npcskilleffect: Invalid skill defined (%s)!\n", script_getstr(st, 2));
 		return SCRIPT_CMD_FAILURE;
-	}
-
-	uint16 skill_lv_cap = cap_value(skill_lv, 1, skill_get_max(skill_id));
-
-	if (skill_lv != skill_lv_cap) {
-		ShowWarning("buildin_npcskilleffect: Invalid skill level %d, capping to %d.\n", skill_lv, skill_lv_cap);
-		skill_lv = skill_lv_cap;
-		script_reportsrc(st);
 	}
 
 	script_skill_effect(bl, skill_id, skill_lv, bl->x, bl->y);


### PR DESCRIPTION
*Partially revert of eccf5ab20c3ae02cf46c9827f485b8d88a62b531

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes skilleffect/npcskilleffect skilllv value being used for healed hp / damage, or 0 if the level isn't needed.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
