### PR TITLE
Adjusts server configuration string storage

### DIFF
--- a/src/char/int_party.cpp
+++ b/src/char/int_party.cpp
@@ -342,7 +342,7 @@ int party_check_family_share(struct party_data *p) {
 // Returns whether this party can keep having exp share or not.
 int party_check_exp_share(struct party_data *p)
 {
-	return (p->party.count < 2 || p->max_lv - p->min_lv <= party_share_level || party_check_family_share(p));
+	return (p->party.count < 2 || p->max_lv - p->min_lv <= inter_config.party_share_level || party_check_family_share(p));
 }
 
 // Is there any member in the party?
@@ -790,7 +790,7 @@ int mapif_parse_PartyShareLevel(int fd,unsigned int share_lvl)
 	struct party_data *p;
 	DBIterator* iter = db_iterator(party_db_);
 
-	party_share_level = share_lvl;
+	inter_config.party_share_level = share_lvl;
 
 	for(p = (struct party_data *)dbi_first(iter); dbi_exists(iter); p = (struct party_data *)dbi_next(iter)) { //Update online parties
 		if(p->party.count > 1)

--- a/src/char/inter.hpp
+++ b/src/char/inter.hpp
@@ -14,6 +14,19 @@
 
 struct s_storage_table;
 
+struct s_inter_serv_config {
+	uint16 char_server_port; ///< Char server port
+	std::string char_server_ip; ///< Char server IP
+	std::string char_server_id; ///< Char server username
+	std::string char_server_pw; ///< Char server password
+	std::string char_server_db; ///< Char server database
+	std::string default_codepage; ///< Codepage [irmin]
+
+	uint32 party_share_level; ///< Party share level
+};
+
+extern s_inter_serv_config inter_config;
+
 class InterServerDatabase : public TypesafeYamlDatabase<uint32, s_storage_table>{
 public:
 	InterServerDatabase() : TypesafeYamlDatabase( "INTER_SERVER_DB", 1 ){
@@ -36,8 +49,6 @@ void mapif_accinfo_ack(bool success, int map_fd, int u_fd, int u_aid, int accoun
 	const char *birthdate, const char *userid);
 
 int inter_log(const char *fmt,...);
-
-extern unsigned int party_share_level;
 
 extern Sql* sql_handle;
 extern Sql* lsql_handle;

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -4,9 +4,7 @@
 #include "ipban.hpp"
 
 #include <stdlib.h>
-#include <string.h>
 
-#include "../common/cbasetypes.hpp"
 #include "../common/showmsg.hpp"
 #include "../common/sql.hpp"
 #include "../common/strlib.hpp"
@@ -15,14 +13,7 @@
 #include "login.hpp"
 #include "loginlog.hpp"
 
-// login sql settings
-static char   ipban_db_hostname[64] = "127.0.0.1";
-static uint16 ipban_db_port = 3306;
-static char   ipban_db_username[32] = "ragnarok";
-static char   ipban_db_password[32] = "";
-static char   ipban_db_database[32] = "ragnarok";
-static char   ipban_codepage[32] = "";
-static char   ipban_table[32] = "ipbanlist";
+s_ipban_config ipban_config;
 
 // globals
 static Sql* sql_handle = NULL;
@@ -46,7 +37,7 @@ bool ipban_check(uint32 ip) {
 		return false;// ipban disabled
 
 	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT count(*) FROM `%s` WHERE `rtime` > NOW() AND (`list` = '%u.*.*.*' OR `list` = '%u.%u.*.*' OR `list` = '%u.%u.%u.*' OR `list` = '%u.%u.%u.%u')",
-		ipban_table, p[3], p[3], p[2], p[3], p[2], p[1], p[3], p[2], p[1], p[0]) )
+		ipban_config.ipban_table.c_str(), p[3], p[3], p[2], p[3], p[2], p[1], p[3], p[2], p[1], p[0]) )
 	{
 		Sql_ShowDebug(sql_handle);
 		// close connection because we can't verify their connectivity.
@@ -81,7 +72,7 @@ void ipban_log(uint32 ip) {
 	{
 		uint8* p = (uint8*)&ip;
 		if( SQL_ERROR == Sql_Query(sql_handle, "INSERT INTO `%s`(`list`,`btime`,`rtime`,`reason`) VALUES ('%u.%u.%u.*', NOW() , NOW() +  INTERVAL %d MINUTE ,'Password error ban')",
-			ipban_table, p[3], p[2], p[1], login_config.dynamic_pass_failure_ban_duration) )
+			ipban_config.ipban_table.c_str(), p[3], p[2], p[1], login_config.dynamic_pass_failure_ban_duration) )
 			Sql_ShowDebug(sql_handle);
 	}
 }
@@ -100,7 +91,7 @@ TIMER_FUNC(ipban_cleanup){
 	if( !login_config.ipban )
 		return 0;// ipban disabled
 
-	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `rtime` <= NOW()", ipban_table) )
+	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `rtime` <= NOW()", ipban_config.ipban_table.c_str()) )
 		Sql_ShowDebug(sql_handle);
 
 	return 0;
@@ -123,19 +114,19 @@ bool ipban_config_read(const char* key, const char* value) {
 	{
 		key += strlen(signature);
 		if( strcmpi(key, "ip") == 0 )
-			safestrncpy(ipban_db_hostname, value, sizeof(ipban_db_hostname));
+			ipban_config.ipban_db_hostname = value;
 		else
 		if( strcmpi(key, "port") == 0 )
-			ipban_db_port = (uint16)strtoul(value, NULL, 10);
+			ipban_config.ipban_db_port = (uint16)strtoul(value, nullptr, 10);
 		else
 		if( strcmpi(key, "id") == 0 )
-			safestrncpy(ipban_db_username, value, sizeof(ipban_db_username));
+			ipban_config.ipban_db_username = value;
 		else
 		if( strcmpi(key, "pw") == 0 )
-			safestrncpy(ipban_db_password, value, sizeof(ipban_db_password));
+			ipban_config.ipban_db_password = value;
 		else
 		if( strcmpi(key, "db") == 0 )
-			safestrncpy(ipban_db_database, value, sizeof(ipban_db_database));
+			ipban_config.ipban_db_database = value;
 		else
 			return false;// not found
 		return true;
@@ -146,10 +137,10 @@ bool ipban_config_read(const char* key, const char* value) {
 	{
 		key += strlen(signature);
 		if( strcmpi(key, "codepage") == 0 )
-			safestrncpy(ipban_codepage, value, sizeof(ipban_codepage));
+			ipban_config.ipban_codepage = value;
 		else
 		if( strcmpi(key, "ipban_table") == 0 )
-			safestrncpy(ipban_table, value, sizeof(ipban_table));
+			ipban_config.ipban_table = value;
 		else
 		if( strcmpi(key, "enable") == 0 )
 			login_config.ipban = (config_switch(value) != 0);
@@ -158,13 +149,13 @@ bool ipban_config_read(const char* key, const char* value) {
 			login_config.dynamic_pass_failure_ban = (config_switch(value) != 0);
 		else
 		if( strcmpi(key, "dynamic_pass_failure_ban_interval") == 0 )
-			login_config.dynamic_pass_failure_ban_interval = atoi(value);
+			login_config.dynamic_pass_failure_ban_interval = (uint32)strtoul(value, nullptr, 10);
 		else
 		if( strcmpi(key, "dynamic_pass_failure_ban_limit") == 0 )
-			login_config.dynamic_pass_failure_ban_limit = atoi(value);
+			login_config.dynamic_pass_failure_ban_limit = (uint32)strtoul(value, nullptr, 10);
 		else
 		if( strcmpi(key, "dynamic_pass_failure_ban_duration") == 0 )
-			login_config.dynamic_pass_failure_ban_duration = atoi(value);
+			login_config.dynamic_pass_failure_ban_duration = (uint32)strtoul(value, nullptr, 10);
 		else
 			return false;// not found
 		return true;
@@ -177,45 +168,43 @@ bool ipban_config_read(const char* key, const char* value) {
 /// Constructor destructor
 
 /**
+ * Assign default values for IP Ban configurations
+ */
+static void ipban_config_init() {
+	ipban_config.ipban_db_port = 3306;
+	ipban_config.ipban_db_hostname = "127.0.0.1";
+	ipban_config.ipban_db_username = "ragnarok";
+	ipban_config.ipban_db_password = "";
+	ipban_config.ipban_db_database = "ragnarok";
+	ipban_config.ipban_codepage = "";
+	ipban_config.ipban_table = "ipbanlist";
+}
+
+/**
  * Initialize the module.
  * Launched at login-serv start, create db or other long scope variable here.
  */
 void ipban_init(void) {
-	const char* username = ipban_db_username;
-	const char* password = ipban_db_password;
-	const char* hostname = ipban_db_hostname;
-	uint16      port     = ipban_db_port;
-	const char* database = ipban_db_database;
-	const char* codepage = ipban_codepage;
+	ipban_config_init();
 
 	ipban_inited = true;
 
 	if( !login_config.ipban )
 		return;// ipban disabled
 
-	if( ipban_db_hostname[0] != '\0' )
-	{// local settings
-		username = ipban_db_username;
-		password = ipban_db_password;
-		hostname = ipban_db_hostname;
-		port     = ipban_db_port;
-		database = ipban_db_database;
-		codepage = ipban_codepage;
-	}
-
 	// establish connections
 	sql_handle = Sql_Malloc();
-	if( SQL_ERROR == Sql_Connect(sql_handle, username, password, hostname, port, database) )
+	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_config.ipban_db_username.c_str(), ipban_config.ipban_db_password.c_str(), ipban_config.ipban_db_hostname.c_str(), ipban_config.ipban_db_port, ipban_config.ipban_db_database.c_str()) )
 	{
                 ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-                        username, password, hostname, port, database);
+					ipban_config.ipban_db_username.c_str(), ipban_config.ipban_db_password.c_str(), ipban_config.ipban_db_hostname.c_str(), ipban_config.ipban_db_port, ipban_config.ipban_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);
 	}
         ShowInfo("Ipban connection made.\n");
         
-	if( codepage[0] != '\0' && SQL_ERROR == Sql_SetEncoding(sql_handle, codepage) )
+	if( !ipban_config.ipban_codepage.empty() && SQL_ERROR == Sql_SetEncoding(sql_handle, ipban_config.ipban_codepage.c_str()) )
 		Sql_ShowDebug(sql_handle);
 
 	if( login_config.ipban_cleanup_interval > 0 )

--- a/src/login/ipban.hpp
+++ b/src/login/ipban.hpp
@@ -4,7 +4,21 @@
 #ifndef IPBAN_HPP
 #define IPBAN_HPP
 
+#include <string>
+
 #include "../common/cbasetypes.hpp"
+
+struct s_ipban_config {
+	uint16 ipban_db_port; ///< IP Ban port
+	std::string ipban_db_hostname; ///< IP Ban IP
+	std::string ipban_db_username; ///< IP Ban username
+	std::string ipban_db_password; ///< IP Ban password
+	std::string ipban_db_database; ///< IP Ban database
+	std::string ipban_codepage; ///< Codepage [irmin]
+	std::string ipban_table; ///< IP Ban SQL Table
+};
+
+extern s_ipban_config ipban_config;
 
 /**
  * Check if ip is in the active bans list.

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -24,6 +24,25 @@ struct npc_data;
 struct item_data;
 struct Channel;
 
+struct s_map_serv_config {
+	// Map database
+	uint16 map_server_port; ///< Map server port
+	std::string map_server_ip; ///< Map server IP
+	std::string map_server_id; ///< Map server username
+	std::string map_server_pw; ///< Map server password
+	std::string map_server_db; ///< Map server database
+	// Log database
+	uint16 log_db_port = 3306;
+	std::string log_db_ip;
+	std::string log_db_id;
+	std::string log_db_pw;
+	std::string log_db_db;
+
+	std::string default_codepage; ///< Codepage [irmin]
+};
+
+extern s_map_serv_config map_config;
+
 enum E_MAPSERVER_ST {
 	MAPSERVER_ST_RUNNING = CORE_ST_LAST,
 	MAPSERVER_ST_STARTING,


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5324

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Partial merge from #252.
  * Adjusts all inter_athena.conf SQL setting string storage types from static char arrays to std::string.
  * This removes the character limit for IP, username, password, database name, and code page name.
  * Moves the settings into their own config structure.
  * Changes usage of atoi to strtoul.
Thanks to @reunite-ro and @cydh!