### PR TITLE
Corrects some details about new Alchemist Potions

### DIFF
--- a/db/re/produce_db.txt
+++ b/db/re/produce_db.txt
@@ -661,12 +661,12 @@
 265,100232,29,2497,1,1092,10,507,45,608,5
 //-- Blue Herb Activator <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 15 Blue Herb, 5 Yggdrasil Seed
 266,100233,29,2497,1,1092,10,510,15,608,5
-//-- Concentrated Red Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 10 Empty Potion Bottle, 15 Red Syrup
-267,1100003,29,2497,1,1092,10,1093,10,11621,15
-//-- Concentrated Blue Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 10 Empty Potion Bottle, 15 Blue Syrup
-268,1100004,29,2497,1,1092,10,1093,10,11624,15
-//-- Concentrated Golden Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 10 Empty Potion Bottle, 15 White Syrup, 10 Yellow Syrup
-269,1100005,29,2497,1,1092,10,1093,10,11623,15,11622,10
+//-- Concentrated Red Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 5 Empty Potion Bottle, 15 Red Syrup
+267,1100003,29,2497,1,1092,10,1093,5,11621,15
+//-- Concentrated Blue Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 5 Empty Potion Bottle, 15 Blue Syrup
+268,1100004,29,2497,1,1092,10,1093,5,11624,15
+//-- Concentrated Golden Syrup Potion <-- GN_S_PHARMACY Lvl, 10 Empty Testtube, 5 Empty Potion Bottle, 10 White Syrup, 10 Yellow Syrup
+269,1100005,29,2497,1,1092,10,1093,5,11623,10,11622,10
 //===============================================
 
 //--------------------LEVEL 30-----------

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7304,8 +7304,12 @@ int64 battle_calc_return_damage(struct block_list* bl, struct block_list *src, i
 				return 0;
 	}
 
-	if (ssc && (ssc->data[SC_REF_T_POTION] || ssc->data[SC_HELLS_PLANT]))
-		return 0;
+	if (ssc) {
+		if (ssc->data[SC_HELLS_PLANT])
+			return 0;
+		if (ssc->data[SC_REF_T_POTION])
+			return 1; // Returns 1 damage
+	}
 
 	if (flag & BF_SHORT) {//Bounces back part of the damage.
 		if ( (skill_get_inf2(skill_id, INF2_ISTRAP) || !status_reflect) && sd && sd->bonus.short_weapon_damage_return ) {


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes the Concentrated Red, Blue, and Golden Syrup Potions to only require 5 Empty Potion Bottles instead of 10.
  * Fixes Golden X to return 1 damage instead of 0 on reflect.
Thanks to @Badarosk0 and Sigma!