### PR TITLE
Added/improved SG's maps and monsters reset script and GM commands

### DIFF
--- a/conf/msg_conf/map_msg.conf
+++ b/conf/msg_conf/map_msg.conf
@@ -1723,5 +1723,8 @@
 1513: Currently in WoE hours, unable to delegate Guild leader
 1514: You have to wait for a while before delegating a new Guild leader
 
+// @hatereset
+1515: Reset 'Hatred' monsters.
+
 //Custom translations
 import: conf/msg_conf/import/map_msg_eng_conf.txt

--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -920,6 +920,14 @@ Resets stats (@streset), skills (@skreset), or both (@reset).
 @feelreset
 
 Resets a Star Gladiator's marked maps.
+Only works on Star Gladiator and Star Emperor classes.
+
+---------------------------------------
+
+@hatereset
+
+Resets a Star Gladiator's marked monsters.
+Only works on Star Gladiator and Star Emperor classes.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -5676,6 +5676,20 @@ Used in reset NPC's (duh!)
 
 ---------------------------------------
 
+*resetfeel({<char_id>});
+
+This command will reset the Star Gladiator's designated maps on the invoking character.
+Only works on Star Gladiator and Star Emperor classes.
+
+---------------------------------------
+
+*resethate({<char_id>});
+
+This command will reset the Star Gladiator's designated monsters on the invoking character.
+Only works on Star Gladiator and Star Emperor classes.
+
+---------------------------------------
+
 *sc_start <effect type>,<ticks>,<value 1>{,<rate>,<flag>{,<GID>}};
 *sc_start2 <effect type>,<ticks>,<value 1>,<value 2>{,<rate>,<flag>{,<GID>}};
 *sc_start4 <effect type>,<ticks>,<value 1>,<value 2>,<value 3>,<value 4>{,<rate>,<flag>{,<GID>}};

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8753,12 +8753,33 @@ ACMD_FUNC(request)
 }
 
 /*==========================================
- * Feel (SG save map) Reset [HiddenDragon]
+ * Feel (SG designated maps) Reset [HiddenDragon]
  *------------------------------------------*/
 ACMD_FUNC(feelreset)
 {
+	if ((sd->class_&MAPID_UPPERMASK) != MAPID_STAR_GLADIATOR) {
+		clif_displaymessage(sd->fd,msg_txt(sd,35));	// You can't use this command with this class.
+		return -1;
+	}
+
 	pc_resetfeel(sd);
 	clif_displaymessage(fd, msg_txt(sd,1324)); // Reset 'Feeling' maps.
+
+	return 0;
+}
+
+/*==========================================
+ * Hate (SG designated monsters) Reset
+ *------------------------------------------*/
+ACMD_FUNC(hatereset)
+{
+	if ((sd->class_&MAPID_UPPERMASK) != MAPID_STAR_GLADIATOR) {
+		clif_displaymessage(sd->fd,msg_txt(sd,35));	// You can't use this command with this class.
+		return -1;
+	}
+
+	pc_resethate(sd);
+	clif_displaymessage(fd, msg_txt(sd,1515)); // Reset 'Hatred' monsters.
 
 	return 0;
 }
@@ -10523,6 +10544,7 @@ void atcommand_basecommands(void) {
 		ACMD_DEF(homshuffle),
 		ACMD_DEF(showmobs),
 		ACMD_DEF(feelreset),
+		ACMD_DEF(hatereset),
 		ACMD_DEF(auction),
 		ACMD_DEF(mail),
 		ACMD_DEF2("noks", ksprotection),

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -9293,8 +9293,9 @@ bool pc_jobchange(struct map_session_data *sd,int job, char upper)
 	}
 
 	if( (sd->class_&MAPID_UPPERMASK) == MAPID_STAR_GLADIATOR && (b_class&MAPID_UPPERMASK) != MAPID_STAR_GLADIATOR) {
-		/* going off star glad lineage, reset feel to not store no-longer-used vars in the database */
+		/* going off star glad lineage, reset feel and hate to not store no-longer-used vars in the database */
 		pc_resetfeel(sd);
+		pc_resethate(sd);
 	}
 
 	// Reset body style to 0 before changing job to avoid

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12156,6 +12156,32 @@ BUILDIN_FUNC(resetskill)
 }
 
 /**
+ * Reset SG designated maps
+ * resetfeel({<char_id>});
+ **/
+BUILDIN_FUNC(resetfeel)
+{
+	TBL_PC *sd;
+	if (!script_charid2sd(2,sd) || (sd->class_&MAPID_UPPERMASK) != MAPID_STAR_GLADIATOR)
+		return SCRIPT_CMD_FAILURE;
+	pc_resetfeel(sd);
+	return SCRIPT_CMD_SUCCESS;
+}
+
+/**
+ * Reset SG designated monsters
+ * resethate({<char_id>});
+ **/
+BUILDIN_FUNC(resethate)
+{
+	TBL_PC *sd;
+	if (!script_charid2sd(2,sd) || (sd->class_&MAPID_UPPERMASK) != MAPID_STAR_GLADIATOR)
+		return SCRIPT_CMD_FAILURE;
+	pc_resethate(sd);
+	return SCRIPT_CMD_SUCCESS;
+}
+
+/**
  * Counts total amount of skill points.
  * skillpointcount({<char_id>})
  **/
@@ -25062,6 +25088,8 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(resetlvl,"i?"),
 	BUILDIN_DEF(resetstatus,"?"),
 	BUILDIN_DEF(resetskill,"?"),
+	BUILDIN_DEF(resetfeel,"?"),
+	BUILDIN_DEF(resethate,"?"),
 	BUILDIN_DEF(skillpointcount,"?"),
 	BUILDIN_DEF(changebase,"i?"),
 	BUILDIN_DEF(changesex,"?"),


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adds and improves Star Gladiator's designated maps and monsters reset script and at commands.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
