### PR TITLE
Small correction in bg_team_leave

### DIFF
--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -538,8 +538,8 @@ int bg_team_leave(struct map_session_data *sd, bool quit, bool deserter)
 			auto member = bgteam->members.begin();
 
 			while (member != bgteam->members.end()) {
-				if (member->sd == sd && member->entry_point.map != 0) {
-					if (!map_getmapflag(map_mapindex2mapid(member->entry_point.map), MF_NOSAVE))
+				if (member->sd == sd) {
+					if (member->entry_point.map != 0 && !map_getmapflag(map_mapindex2mapid(member->entry_point.map), MF_NOSAVE))
 						pc_setpos(sd, member->entry_point.map, member->entry_point.x, member->entry_point.y, CLR_TELEPORT);
 					else
 						pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, CLR_TELEPORT); // Warp to save point if the entry map has no save flag.


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Small correction in `bg_team_leave` to also remove the player from the bg when `entry_point` (bg enqueue) is not defined

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
