### PR TITLE
Fixed a potential dead end in the merchant quest

### DIFF
--- a/npc/pre-re/jobs/1-1/merchant.txt
+++ b/npc/pre-re/jobs/1-1/merchant.txt
@@ -180,7 +180,7 @@ alberta_in,53,43,6	script	Merchant#mer	86,{
 		mes "But we all know that~";
 		close;
 	}
-	else if (job_merchant_q <= 6 && job_merchant_q != 0) {
+	else if (job_merchant_q2 && job_merchant_q > 0 && job_merchant_q < 7) {
 		mes "[Chief Mahnsoo]";
 		if (job_merchant_q2 == 1 || job_merchant_q2 == 2) {
 			mes "First, get the delivery package from the storehouse, and then take it to the former Swordman's Association in Prontera.";
@@ -266,7 +266,7 @@ alberta_in,53,43,6	script	Merchant#mer	86,{
 		mes "Take care!";
 		close;
 	}
-	else if (job_merchant_q == 0) {
+	else {
 		mes "[Chief Mahnsoo]";
 		mes "So, what brings you to";
 		mes "the Merchant Association?";


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes a dead end in the merchant quest in the event of the dialog window closing after paying the fee (**job_merchant_q**) but before receiving the package code (**job_merchant_q2**)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
