### PR TITLE
bg_join - battleground doc update

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9437,6 +9437,7 @@ Returns battle group ID on success. Returns 0 on failure.
 
 Adds an attached player or <char id> if specified to an existing battleground group. The player will also be warped
 to the default spawn point of the battle group or to the specified coordinates <x> and <y> on the given <map>.
+Note: The map need the mapflag MF_BATTLEGROUND otherwise the player is removed from the Battleground team.
 
 Returns true on success. Returns false on failure.
 
@@ -9484,6 +9485,7 @@ to their save point if the map had MF_NOSAVE.
 
 Similar to the 'warp' command.
 Places all members of <Battle Group> at the specified map and coordinates.
+Note: The map need the mapflag MF_BATTLEGROUND otherwise the players are removed from the Battleground team.
 
 Example:
 	//place the battle group one for Tierra Gorge at starting position.
@@ -9566,8 +9568,8 @@ Example:
 Retrieves data related to given Battle Group. Type can be one of the following:
 
 	0 - Amount of players currently belonging to the group.
-	1 - Store GID of players in <Battle Group> in a temporary global array $@arenamembers
-		and returns amount of players currently belonging to the group.
+	1 - Store GID of players in <Battle Group> in a temporary global array $@arenamembers,
+		stores and also returns the amount of players currently belonging to the group in $@arenamemberscount.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9392,6 +9392,7 @@ QMARK_PURPLE - Purple Marker
 Adds the first waiting player from the chat room of the given NPC to an existing battleground group.
 The player will also be warped to the default spawn point of the battle group or to the specified coordinates
 <x> and <y> on the given <map>.
+Note: The map need the mapflag MF_BATTLEGROUND otherwise the player is removed from the Battleground team.
 
 ---------------------------------------
 
@@ -9485,7 +9486,6 @@ to their save point if the map had MF_NOSAVE.
 
 Similar to the 'warp' command.
 Places all members of <Battle Group> at the specified map and coordinates.
-Note: The map need the mapflag MF_BATTLEGROUND otherwise the players are removed from the Battleground team.
 
 Example:
 	//place the battle group one for Tierra Gorge at starting position.

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19970,6 +19970,11 @@ BUILDIN_FUNC(waitingroom2bg_single)
 		x = bg->cemetery.x;
 		y = bg->cemetery.y;
 	}
+	if (!map_getmapflag(map_mapindex2mapid(mapindex), MF_BATTLEGROUND)) {
+		ShowWarning("buildin_waitingroom2bg_single: Map %s requires the mapflag MF_BATTLEGROUND.\n", mapindex_id2name(mapindex));
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
+	}
 
 	nd = npc_name2id(script_getstr(st,6));
 
@@ -20052,6 +20057,11 @@ BUILDIN_FUNC(bg_join) {
 	}
 
 	if (!script_charid2sd(6, sd)) {
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
+	}
+	if (!map_getmapflag(map_mapindex2mapid(mapindex), MF_BATTLEGROUND)) {
+		ShowWarning("buildin_bg_join: Map %s requires the mapflag MF_BATTLEGROUND.\n", mapindex_id2name(mapindex));
 		script_pushint(st, false);
 		return SCRIPT_CMD_FAILURE;
 	}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Added a note and a check in `bg_join` to prevent the player to join a bg when the battle map is not a battleground map - before that change the player was warped on the map but `pc_setpos` removed him from the bg team without notice.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
