### PR TITLE
Addtionnal check in npc_touch_areanpc for npc_click

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -1142,8 +1142,8 @@ int npc_touch_areanpc(struct map_session_data* sd, int16 m, int16 x, int16 y, st
 		if (npc_ontouch_event(sd, nd) > 0 && npc_ontouch2_event(sd, nd) > 0) { // failed to run OnTouch event, so just click the npc
 			if (!util::vector_exists(sd->areanpc, nd->bl.id))
 				sd->areanpc.push_back(nd->bl.id);
-
-			npc_click(sd, nd);
+			if (sd->npc_id == 0)
+				npc_click(sd, nd);
 		}
 		break;
 	}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
As noticed in https://github.com/rathena/rathena/issues/5383, this PR adds a check for `npc_click` in `npc_touch_areanpc` - only one 'click npc' can be triggered at a time.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
