### PR TITLE
Fixed Sealed Shrine timer not being disabled

### DIFF
--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -766,6 +766,7 @@ OnInstanceInit: // Temporary fix for @reloadscript.
 		set 'ins_baphomet,5;
 		specialeffect EF_TELEPORTATION;
 		enablenpc instance_npcname("ins_bapho_to_2f");
+		donpcevent instance_npcname("ins_baphomet_1f_timer")+"::OnDisable";
 		mes "[Ancient Hero's Soul]";
 		mes "Now you can go to the main altar. It is located in the bottom right corner of this floor.";
 		next;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes Sealed Shrine timer not being disabled, causing all players in the instance to be teleported out after 1h.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
