### PR TITLE
Moves AUTOLOOT_DISTANCE macro define location

### DIFF
--- a/src/map/atcommand.hpp
+++ b/src/map/atcommand.hpp
@@ -9,12 +9,6 @@
 
 struct map_session_data;
 
-//This is the distance at which @autoloot works,
-//if the item drops farther from the player than this,
-//it will not be autolooted. [Skotlex]
-//Note: The range is unlimited unless this define is set.
-//#define AUTOLOOT_DISTANCE AREA_SIZE
-
 //global var
 extern char atcommand_symbol;
 extern char charcommand_symbol;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -15,6 +15,12 @@
 
 struct guardian_data;
 
+//This is the distance at which @autoloot works,
+//if the item drops farther from the player than this,
+//it will not be autolooted. [Skotlex]
+//Note: The range is unlimited unless this define is set.
+//#define AUTOLOOT_DISTANCE AREA_SIZE
+
 //The number of drops all mobs have and the max drop-slot that the steal skill will attempt to steal from.
 #define MAX_MOB_DROP 10
 #define MAX_MVP_DROP 3


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5375

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Moves the macro define for AUTOLOOT_DISTANCE to mob.hpp as mob.cpp requires this, not atcommand.cpp.
Thanks to @vstumpf!