### PR TITLE
Fixes a potential crash when adding new maps

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3559,7 +3559,7 @@ int map_readfromcache(struct map_data *m, char *buffer, char *decode_buffer)
 		info = (struct map_cache_map_info *)p;
 
 		// name exists in maps_athena.conf but not in map_cache.dat
-		if (info->name != nullptr && info->name[0] == '\0')
+		if (info->name == nullptr || info->name[0] == '\0')
 			continue;
 		if( strcmp(m->name, info->name) == 0 )
 			break; // Map found

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3558,6 +3558,9 @@ int map_readfromcache(struct map_data *m, char *buffer, char *decode_buffer)
 	for(i = 0; i < header->map_count; i++) {
 		info = (struct map_cache_map_info *)p;
 
+		// name exists in maps_athena.conf but not in map_cache.dat
+		if (info->name != nullptr && info->name[0] == '\0')
+			continue;
 		if( strcmp(m->name, info->name) == 0 )
 			break; // Map found
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5396

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes a potential crash on start up when adding a map to maps_athena.conf and the map has not yet been added to map_cache.dat.
Thanks to @nubspixel!