### PR TITLE
Fixes achievements and multi level up events

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1559,9 +1559,9 @@ ACMD_FUNC(baselevelup)
 		status_calc_pc(sd, SCO_FORCE);
 		status_percent_heal(&sd->bl, 100, 100);
 		clif_misceffect(&sd->bl, 0);
-		for (uint16 i = sd->status.base_level - level; i <= sd->status.base_level; i++) {
-			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, i);
-			achievement_update_objective(sd, AG_GOAL_STATUS, 2, i, sd->status.class_);
+		for (uint32 j = sd->status.base_level - level; j <= sd->status.base_level; j++) {
+			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, j);
+			achievement_update_objective(sd, AG_GOAL_STATUS, 2, j, sd->status.class_);
 		}
 		clif_displaymessage(fd, msg_txt(sd,21)); // Base level raised.
 	} else {
@@ -1624,7 +1624,7 @@ ACMD_FUNC(joblevelup)
 		sd->status.job_level += (unsigned int)level;
 		sd->status.skill_point += level;
 		clif_misceffect(&sd->bl, 1);
-		for (uint16 i = sd->status.job_level - level; i <= sd->status.job_level; i++)
+		for (uint32 i = sd->status.job_level - level; i <= sd->status.job_level; i++)
 			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, i);
 		clif_displaymessage(fd, msg_txt(sd,24)); // Job level raised.
 	} else {

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1559,9 +1559,9 @@ ACMD_FUNC(baselevelup)
 		status_calc_pc(sd, SCO_FORCE);
 		status_percent_heal(&sd->bl, 100, 100);
 		clif_misceffect(&sd->bl, 0);
-		for (uint16 i = 1; i <= (sd->status.base_level - level); i++) {
-			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, level + i);
-			achievement_update_objective(sd, AG_GOAL_STATUS, 2, level + i, sd->status.class_);
+		for (uint16 i = sd->status.base_level - level; i <= sd->status.base_level; i++) {
+			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, i);
+			achievement_update_objective(sd, AG_GOAL_STATUS, 2, i, sd->status.class_);
 		}
 		clif_displaymessage(fd, msg_txt(sd,21)); // Base level raised.
 	} else {
@@ -1624,8 +1624,8 @@ ACMD_FUNC(joblevelup)
 		sd->status.job_level += (unsigned int)level;
 		sd->status.skill_point += level;
 		clif_misceffect(&sd->bl, 1);
-		for (uint16 i = 1; i <= (sd->status.job_level - level); i++)
-			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, level + i);
+		for (uint16 i = sd->status.job_level - level; i <= sd->status.job_level; i++)
+			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, i);
 		clif_displaymessage(fd, msg_txt(sd,24)); // Job level raised.
 	} else {
 		if (sd->status.job_level == 1) {

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1559,8 +1559,10 @@ ACMD_FUNC(baselevelup)
 		status_calc_pc(sd, SCO_FORCE);
 		status_percent_heal(&sd->bl, 100, 100);
 		clif_misceffect(&sd->bl, 0);
-		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, sd->status.base_level);
-		achievement_update_objective(sd, AG_GOAL_STATUS, 2, sd->status.base_level, sd->status.class_);
+		for (uint16 i = 1; i <= (sd->status.base_level - level); i++) {
+			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, level + i);
+			achievement_update_objective(sd, AG_GOAL_STATUS, 2, level + i, sd->status.class_);
+		}
 		clif_displaymessage(fd, msg_txt(sd,21)); // Base level raised.
 	} else {
 		if (sd->status.base_level == 1) {
@@ -1622,7 +1624,8 @@ ACMD_FUNC(joblevelup)
 		sd->status.job_level += (unsigned int)level;
 		sd->status.skill_point += level;
 		clif_misceffect(&sd->bl, 1);
-		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, sd->status.job_level);
+		for (uint16 i = 1; i <= (sd->status.job_level - level); i++)
+			achievement_update_objective(sd, AG_GOAL_LEVEL, 1, level + i);
 		clif_displaymessage(fd, msg_txt(sd,24)); // Job level raised.
 	} else {
 		if (sd->status.job_level == 1) {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7050,6 +7050,8 @@ int pc_checkbaselevelup(struct map_session_data *sd) {
 	if (!next || sd->status.base_exp < next || pc_is_maxbaselv(sd))
 		return 0;
 
+	uint32 base_level = sd->status.base_level;
+
 	do {
 		sd->status.base_exp -= next;
 		//Kyoki pointed out that the max overcarry exp is the exp needed for the previous level -1. [Skotlex]
@@ -7093,8 +7095,10 @@ int pc_checkbaselevelup(struct map_session_data *sd) {
 		party_send_levelup(sd);
 
 	pc_baselevelchanged(sd);
-	achievement_update_objective(sd, AG_GOAL_LEVEL, 1, sd->status.base_level);
-	achievement_update_objective(sd, AG_GOAL_STATUS, 2, sd->status.base_level, sd->status.class_);
+	for (uint16 i = 1; i <= (sd->status.base_level - base_level); i++) {
+		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, base_level + i);
+		achievement_update_objective(sd, AG_GOAL_STATUS, 2, base_level + i, sd->status.class_);
+	}
 	return 1;
 }
 
@@ -7116,6 +7120,8 @@ int pc_checkjoblevelup(struct map_session_data *sd)
 	nullpo_ret(sd);
 	if(!next || sd->status.job_exp < next || pc_is_maxjoblv(sd))
 		return 0;
+
+	uint32 job_level = sd->status.job_level;
 
 	do {
 		sd->status.job_exp -= next;
@@ -7142,7 +7148,8 @@ int pc_checkjoblevelup(struct map_session_data *sd)
 		clif_status_change(&sd->bl, EFST_DEVIL1, 1, 0, 0, 0, 1); //Permanent blind effect from SG_DEVIL.
 
 	npc_script_event(sd, NPCE_JOBLVUP);
-	achievement_update_objective(sd, AG_GOAL_LEVEL, 1, sd->status.job_level);
+	for (uint16 i = 1; i <= (sd->status.job_level); i++)
+		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, job_level + 1);
 
 	pc_show_questinfo(sd);
 	return 1;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7095,9 +7095,9 @@ int pc_checkbaselevelup(struct map_session_data *sd) {
 		party_send_levelup(sd);
 
 	pc_baselevelchanged(sd);
-	for (uint16 i = 1; i <= (sd->status.base_level - base_level); i++) {
-		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, base_level + i);
-		achievement_update_objective(sd, AG_GOAL_STATUS, 2, base_level + i, sd->status.class_);
+	for (; base_level <= sd->status.base_level; base_level++) {
+		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, base_level);
+		achievement_update_objective(sd, AG_GOAL_STATUS, 2, base_level, sd->status.class_);
 	}
 	return 1;
 }
@@ -7148,8 +7148,8 @@ int pc_checkjoblevelup(struct map_session_data *sd)
 		clif_status_change(&sd->bl, EFST_DEVIL1, 1, 0, 0, 0, 1); //Permanent blind effect from SG_DEVIL.
 
 	npc_script_event(sd, NPCE_JOBLVUP);
-	for (uint16 i = 1; i <= (sd->status.job_level); i++)
-		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, job_level + 1);
+	for (; job_level <= sd->status.job_level; job_level++)
+		achievement_update_objective(sd, AG_GOAL_LEVEL, 1, job_level);
 
 	pc_show_questinfo(sd);
 	return 1;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5413

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes an issue where achievements that check for specific base/job level events don't get triggered if battle_config.multi_level_up is enabled.
Thanks to @saya9200!