### PR TITLE
Fixed RODEX in newer 2020 clients

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -15883,6 +15883,9 @@ void clif_Mail_read( struct map_session_data *sd, int mail_id ){
 				mailitem->bindOnEquip = item->bound ? 2 : data->flag.bindOnEquip ? 1 : 0;
 				clif_addcards( &mailitem->slot, item );
 				clif_add_random_options( mailitem->optionData, item );
+#if PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200724
+				mailitem->enchantgrade = 0;
+#endif
 
 				offset += sizeof( struct mail_item );
 				count++;

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -2257,7 +2257,7 @@
 	parseable_packet(0x09E8,11,clif_parse_Mail_refreshinbox,2,3); // CZ_OPEN_MAILBOX
 	parseable_packet(0x09E9,2,clif_parse_dull,0); // CZ_CLOSE_MAILBOX
 	parseable_packet(0x09EA,11,clif_parse_Mail_read,2,3); // CZ_REQ_READ_MAIL
-	packet(0x09EB,-1); // ZC_ACK_READ_MAIL
+	packet(rodexread,-1); // ZC_ACK_READ_MAIL
 	parseable_packet(0x09EC,-1,clif_parse_Mail_send,2,4,28,52,60,62,64); // CZ_REQ_WRITE_MAIL
 	packet(0x09ED,3); // ZC_ACK_WRITE_MAIL
 	parseable_packet(0x09EE,11,clif_parse_Mail_refreshinbox,2,3); // CZ_REQ_NEXT_MAIL_LIST

--- a/src/map/packets_struct.hpp
+++ b/src/map/packets_struct.hpp
@@ -303,7 +303,11 @@ enum packet_headers {
 #endif // PACKETVER >= 20141022
 	/* Rodex */
 	rodexicon = 0x09E7,
+#if PACKETVER_MAIN_NUM >= 20191030 || PACKETVER_RE_NUM >= 20191030 || PACKETVER_ZERO_NUM >= 20191106
+	rodexread = 0x0B63,
+#else
 	rodexread = 0x09EB,
+#endif
 	rodexwriteresult = 0x09ED,
 	rodexnextpage = 0x09F0,
 	rodexgetzeny = 0x09F2,
@@ -1586,6 +1590,9 @@ struct mail_item {
 	uint16 viewSprite;
 	uint16 bindOnEquip;
 	struct ItemOptions optionData[MAX_ITEM_OPTIONS];
+#if PACKETVER_MAIN_NUM >= 20200916 || PACKETVER_RE_NUM >= 20200724
+	uint8 enchantgrade;
+#endif
 } __attribute__((packed));
 
 struct PACKET_CZ_REQ_OPEN_WRITE_MAIL {


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Added the new changes from the 4th class update to the RODEX packet mail reading packet.

Thanks to @LunarSHINING
