### PR TITLE
Fixed a small typo in the item parsing

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -420,7 +420,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 	} else {
 		if (!exists) {
 			if (itemdb_isequip2(item.get())) {
-				this->invalidWarning(node["Locations"], "Invalid item equip location as it has no equip location, defaulting to IT_ETC.\n");
+				this->invalidWarning(node, "Invalid item equip location as it has no equip location, defaulting to IT_ETC.\n");
 				item->type = IT_ETC;
 			} else
 				item->equip = 0;


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The 'Locations' node doesn't exist in the block resulting to a crash when the warning show up.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
