### PR TITLE
Fix erroneous freeing of global combo script

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -263,11 +263,6 @@ struct s_combos {
 	script_code *bonus;
 	uint32 id;
 	uint32 pos;
-
-	~s_combos() {
-		if (this->bonus)
-			script_free_code(this->bonus);
-	}
 };
 
 struct map_session_data {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5476 

* **Server Mode**: Both

* **Description of Pull Request**:
We free the combo's bonus script when a combo is deleted!
The fix is simple, don't free the global script!
Thanks @saya9200

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
