### PR TITLE
Fixed item restrictions for "All"

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -286,7 +286,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 			if (!this->asBool(jobNode, "All", active))
 				return 0;
 
-			itemdb_jobid2mapid(item->class_base, static_cast<e_mapid>(MAPID_ALL), active);
+			itemdb_jobid2mapid(item->class_base, MAPID_ALL, active);
 		}
 
 		for (const auto &jobit : jobNode) {
@@ -301,7 +301,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 
 			if (!script_get_constant(jobName_constant.c_str(), &constant)) {
 				this->invalidWarning(jobNode[jobName], "Invalid item job %s, defaulting to All.\n", jobName.c_str());
-				itemdb_jobid2mapid(item->class_base, static_cast<e_mapid>(MAPID_ALL), true);
+				itemdb_jobid2mapid(item->class_base, MAPID_ALL, true);
 				break;
 			}
 
@@ -316,7 +316,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 		if (!exists) {
 			item->class_base[0] = item->class_base[1] = item->class_base[2] = 0;
 
-			itemdb_jobid2mapid(item->class_base, static_cast<e_mapid>(MAPID_ALL), true);
+			itemdb_jobid2mapid(item->class_base, MAPID_ALL, true);
 		}
 	}
 

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -73,12 +73,11 @@ void map_msg_reload(void);
 #define MAPID_BASEMASK 0x00ff
 #define MAPID_UPPERMASK 0x0fff
 #define MAPID_THIRDMASK (JOBL_THIRD|MAPID_UPPERMASK)
-#define MAPID_ALL 0xffff
 
 //First Jobs
 //Note the oddity of the novice:
 //Super Novices are considered the 2-1 version of the novice! Novices are considered a first class type, too...
-enum e_mapid {
+enum e_mapid : uint64{
 //Novice And 1-1 Jobs
 	MAPID_NOVICE = 0x0,
 	MAPID_SWORDMAN,
@@ -220,6 +219,8 @@ enum e_mapid {
 	MAPID_BABY_GENETIC,
 	MAPID_BABY_SHADOW_CHASER,
 	MAPID_BABY_SOUL_REAPER,
+// Additional constants
+	MAPID_ALL = UINT64_MAX
 };
 
 //Max size for inputs to Graffiti, Talkie Box and Vending text prompts


### PR DESCRIPTION
* **Addressed Issue(s)**:  #5516

* **Server Mode**: Renewal

* **Description of Pull Request**: 
Since Doram's are 16 and MAPID_ALL was defined with only the first 16 bits were covered by 0xFFFF, the job restriction failed if Summoner was not explicitly allowed.

Thanks to @kaninhot004
