### PR TITLE
Questinfo correction

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9231,7 +9231,7 @@ Examples:
 
 *questinfo <Icon>{,<Map Mark Color>{,"<condition>"}};
 
-This command should only be used in an OnInit label.
+This command should only be used in OnInit/OnInstanceInit labels.
 Show an emotion on top of a NPC, and optionally, a colored mark in the mini-map like "viewpoint".
 When a user is doing some action, each NPC is checked for questinfo that has been set on the map.
 If questinfo is present, it will check if the player fulfill the condition.

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4342,11 +4342,6 @@ void map_remove_questinfo(int m, struct npc_data *nd) {
 	nullpo_retv(nd);
 	nullpo_retv(mapdata);
 
-	for (const auto &it : nd->qi_data) {
-		if (it.condition)
-			script_free_code(it.condition);
-	}
-
 	util::vector_erase_if_exists(mapdata->qi_npc, nd->bl.id);
 	nd->qi_data.clear();
 }
@@ -4360,10 +4355,6 @@ static void map_free_questinfo(struct map_data *mapdata) {
 		if (!nd || nd->qi_data.empty())
 			continue;
 
-		for (const auto &qi : nd->qi_data) {
-			if (qi.condition)
-				script_free_code(qi.condition);
-		}
 		nd->qi_data.clear();
 	}
 
@@ -4879,8 +4870,7 @@ void do_final(void){
 	mapit_free(iter);
 
 	for (int i = 0; i < map_num; i++) {
-		struct map_data *mapdata = map_getmapdata(i);
-		map_free_questinfo(mapdata);
+		map_free_questinfo(map_getmapdata(i));
 	}
 
 	/* prepares npcs for a faster shutdown process */

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4878,6 +4878,11 @@ void do_final(void){
 		map_quit(sd);
 	mapit_free(iter);
 
+	for (int i = 0; i < map_num; i++) {
+		struct map_data *mapdata = map_getmapdata(i);
+		map_free_questinfo(mapdata);
+	}
+
 	/* prepares npcs for a faster shutdown process */
 	do_clear_npc();
 
@@ -4888,8 +4893,6 @@ void do_final(void){
 		ShowStatus("Cleaning up maps [%d/%d]: %s..." CL_CLL "\r", i++, map_num, mapdata->name);
 		map_foreachinmap(cleanup_sub, i, BL_ALL);
 		channel_delete(mapdata->channel,false);
-
-		map_free_questinfo(mapdata);
 	}
 	ShowStatus("Cleaned up %d maps." CL_CLL "\n", map_num);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4888,6 +4888,8 @@ void do_final(void){
 		ShowStatus("Cleaning up maps [%d/%d]: %s..." CL_CLL "\r", i++, map_num, mapdata->name);
 		map_foreachinmap(cleanup_sub, i, BL_ALL);
 		channel_delete(mapdata->channel,false);
+
+		map_free_questinfo(mapdata);
 	}
 	ShowStatus("Cleaned up %d maps." CL_CLL "\n", map_num);
 
@@ -4941,7 +4943,6 @@ void do_final(void){
 			for (int j=0; j<MAX_MOB_LIST_PER_MAP; j++)
 				if (mapdata->moblist[j]) aFree(mapdata->moblist[j]);
 		}
-		map_free_questinfo(mapdata);
 		mapdata->damage_adjust = {};
 	}
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4347,14 +4347,14 @@ void map_remove_questinfo(int m, struct npc_data *nd) {
 			script_free_code(it.condition);
 	}
 
-	util::vector_erase_if_exists(mapdata->qi_data, nd->bl.id);
+	util::vector_erase_if_exists(mapdata->qi_npc, nd->bl.id);
 	nd->qi_data.clear();
 }
 
 static void map_free_questinfo(struct map_data *mapdata) {
 	nullpo_retv(mapdata);
 
-	for (const auto &it : mapdata->qi_data) {
+	for (const auto &it : mapdata->qi_npc) {
 		struct npc_data *nd = map_id2nd(it);
 
 		if (!nd || nd->qi_data.empty())
@@ -4367,7 +4367,7 @@ static void map_free_questinfo(struct map_data *mapdata) {
 		nd->qi_data.clear();
 	}
 
-	mapdata->qi_data.clear();
+	mapdata->qi_npc.clear();
 }
 
 /**

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -721,13 +721,6 @@ struct iwall_data {
 	bool shootable;
 };
 
-struct s_questinfo {
-	struct npc_data *nd;
-	e_questinfo_types icon;
-	e_questinfo_markcolor color;
-	struct script_code* condition;
-};
-
 struct map_data {
 	char name[MAP_NAME_LENGTH];
 	uint16 index; // The map index used by the mapindex* functions.
@@ -765,7 +758,7 @@ struct map_data {
 	struct Channel *channel;
 
 	/* ShowEvent Data Cache */
-	std::vector<s_questinfo> qi_data;
+	std::vector<int> qi_data;
 
 	/* speeds up clif_updatestatus processing by causing hpmeter to run only when someone with the permission can view it */
 	unsigned short hpmeter_visible;

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -758,7 +758,7 @@ struct map_data {
 	struct Channel *channel;
 
 	/* ShowEvent Data Cache */
-	std::vector<int> qi_data;
+	std::vector<int> qi_npc;
 
 	/* speeds up clif_updatestatus processing by causing hpmeter to run only when someone with the permission can view it */
 	unsigned short hpmeter_visible;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -2461,6 +2461,8 @@ int npc_unload(struct npc_data* nd, bool single) {
 		}
 	}
 
+	nd->qi_data.clear();
+
 	script_stop_sleeptimers(nd->bl.id);
 	aFree(nd);
 

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -55,6 +55,12 @@ struct s_questinfo {
 	e_questinfo_types icon;
 	e_questinfo_markcolor color;
 	struct script_code* condition;
+
+	~s_questinfo(){
+		if( this->condition != nullptr ){
+			script_free_code( this->condition );
+		}
+	}
 };
 
 struct npc_data {
@@ -118,7 +124,7 @@ struct npc_data {
 	struct sc_display_entry **sc_display;
 	unsigned char sc_display_count;
 
-	std::vector<s_questinfo> qi_data;
+	std::vector<std::shared_ptr<s_questinfo>> qi_data;
 
 	struct {
 		t_tick timeout;

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -51,6 +51,12 @@ struct s_npc_buy_list {
 #pragma pack(pop)
 #endif // not NetBSD < 6 / Solaris
 
+struct s_questinfo {
+	e_questinfo_types icon;
+	e_questinfo_markcolor color;
+	struct script_code* condition;
+};
+
 struct npc_data {
 	struct block_list bl;
 	struct unit_data ud; //Because they need to be able to move....
@@ -111,6 +117,8 @@ struct npc_data {
 
 	struct sc_display_entry **sc_display;
 	unsigned char sc_display_count;
+
+	std::vector<s_questinfo> qi_data;
 
 	struct {
 		t_tick timeout;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13274,14 +13274,14 @@ void pc_show_questinfo(struct map_session_data *sd) {
 		bool show = false;
 
 		for (auto &qi : nd->qi_data) {
-			if (!qi.condition || achievement_check_condition(qi.condition, sd)) {
+			if (!qi->condition || achievement_check_condition(qi->condition, sd)) {
 				show = true;
 				// Check if need to be displayed
-				if (!sd->qi_display[i].is_active || qi.icon != sd->qi_display[i].icon || qi.color != sd->qi_display[i].color) {
+				if (!sd->qi_display[i].is_active || qi->icon != sd->qi_display[i].icon || qi->color != sd->qi_display[i].color) {
 					sd->qi_display[i].is_active = true;
-					sd->qi_display[i].icon = static_cast<e_questinfo_types>(qi.icon);
-					sd->qi_display[i].color = static_cast<e_questinfo_markcolor>(qi.color);
-					clif_quest_show_event(sd, &nd->bl, qi.icon, qi.color);
+					sd->qi_display[i].icon = static_cast<e_questinfo_types>(qi->icon);
+					sd->qi_display[i].color = static_cast<e_questinfo_markcolor>(qi->color);
+					clif_quest_show_event(sd, &nd->bl, qi->icon, qi->color);
 				}
 				break;
 			}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13290,13 +13290,13 @@ void pc_show_questinfo(struct map_session_data *sd) {
 	struct map_data *mapdata = map_getmapdata(sd->bl.m);
 	nullpo_retv(mapdata);
 
-	if (mapdata->qi_data.empty())
+	if (mapdata->qi_npc.empty())
 		return;
-	if (mapdata->qi_data.size() != sd->qi_count)
+	if (mapdata->qi_npc.size() != sd->qi_count)
 		return; // init was not called yet
 
-	for (int i = 0; i < mapdata->qi_data.size(); i++) {
-		struct npc_data *nd = map_id2nd(mapdata->qi_data[i]);
+	for (int i = 0; i < mapdata->qi_npc.size(); i++) {
+		struct npc_data *nd = map_id2nd(mapdata->qi_npc[i]);
 
 		if (!nd || nd->qi_data.empty())
 			continue;
@@ -13336,10 +13336,10 @@ void pc_show_questinfo_reinit(struct map_session_data *sd) {
 	struct map_data *mapdata = map_getmapdata(sd->bl.m);
 	nullpo_retv(mapdata);
 
-	if (mapdata->qi_data.empty())
+	if (mapdata->qi_npc.empty())
 		return;
 
-	CREATE(sd->qi_display, struct s_qi_display, (sd->qi_count = mapdata->qi_data.size()));
+	CREATE(sd->qi_display, struct s_qi_display, (sd->qi_count = mapdata->qi_npc.size()));
 #endif
 }
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -682,8 +682,7 @@ struct map_session_data {
 	std::vector<int> cloaked_npc;
 
 	/* ShowEvent Data Cache flags from map */
-	struct s_qi_display *qi_display;
-	int qi_count;
+	std::vector<s_qi_display> qi_display;
 
 	// temporary debug [flaviojs]
 	const char* debug_file;

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -265,6 +265,12 @@ struct s_combos {
 	uint32 pos;
 };
 
+struct s_qi_display {
+	bool is_active;
+	e_questinfo_types icon;
+	e_questinfo_markcolor color;
+};
+
 struct map_session_data {
 	struct block_list bl;
 	struct unit_data ud;
@@ -676,7 +682,7 @@ struct map_session_data {
 	std::vector<int> cloaked_npc;
 
 	/* ShowEvent Data Cache flags from map */
-	bool *qi_display;
+	struct s_qi_display *qi_display;
 	int qi_count;
 
 	// temporary debug [flaviojs]

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19749,11 +19749,11 @@ BUILDIN_FUNC(questinfo)
 		}
 	}
 
-	struct s_questinfo qi;
+	std::shared_ptr<s_questinfo> qi = std::make_shared<s_questinfo>();
 
-	qi.icon = static_cast<e_questinfo_types>(icon);
-	qi.color = static_cast<e_questinfo_markcolor>(color);
-	qi.condition = script;
+	qi->icon = static_cast<e_questinfo_types>(icon);
+	qi->color = static_cast<e_questinfo_markcolor>(color);
+	qi->condition = script;
 
 	nd->qi_data.push_back(qi);
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19759,8 +19759,8 @@ BUILDIN_FUNC(questinfo)
 
 	struct map_data *mapdata = map_getmapdata(nd->bl.m);
 
-	if (mapdata && !util::vector_exists(mapdata->qi_data, nd->bl.id))
-		mapdata->qi_data.push_back(nd->bl.id);
+	if (mapdata && !util::vector_exists(mapdata->qi_npc, nd->bl.id))
+		mapdata->qi_npc.push_back(nd->bl.id);
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19683,9 +19683,6 @@ BUILDIN_FUNC(questinfo)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	struct s_questinfo qi;
-	struct script_code *script = nullptr;
-	int color = QMARK_NONE;
 	int icon = script_getnum(st, 2);
 
 #if PACKETVER >= 20120410
@@ -19722,6 +19719,8 @@ BUILDIN_FUNC(questinfo)
 		icon = icon + 1;
 #endif
 
+	int color = QMARK_NONE;
+
 	if (script_hasdata(st, 3)) {
 		color = script_getnum(st, 3);
 		if (color < QMARK_NONE || color >= QMARK_MAX) {
@@ -19730,6 +19729,8 @@ BUILDIN_FUNC(questinfo)
 			color = QMARK_NONE;
 		}
 	}
+
+	struct script_code *script = nullptr;
 
 	if (script_hasdata(st, 4)) {
 		const char *str = script_getstr(st, 4);
@@ -19748,13 +19749,18 @@ BUILDIN_FUNC(questinfo)
 		}
 	}
 
-	qi.nd = nd;
+	struct s_questinfo qi;
+
 	qi.icon = static_cast<e_questinfo_types>(icon);
 	qi.color = static_cast<e_questinfo_markcolor>(color);
 	qi.condition = script;
 
+	nd->qi_data.push_back(qi);
+
 	struct map_data *mapdata = map_getmapdata(nd->bl.m);
-	mapdata->qi_data.push_back(qi);
+
+	if (mapdata && !util::vector_exists(mapdata->qi_data, nd->bl.id))
+		mapdata->qi_data.push_back(nd->bl.id);
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3397,11 +3397,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 				sd->num_quests = sd->avail_quests = 0;
 			}
 
-			if (sd->qi_display) {
-				aFree(sd->qi_display);
-				sd->qi_display = nullptr;
-			}
-			sd->qi_count = 0;
+			sd->qi_display.clear();
 
 #if PACKETVER_MAIN_NUM >= 20150507 || PACKETVER_RE_NUM >= 20150429 || defined(PACKETVER_ZERO)
 			sd->hatEffects.clear();

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3399,7 +3399,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 
 			if (sd->qi_display) {
 				aFree(sd->qi_display);
-				sd->qi_display = NULL;
+				sd->qi_display = nullptr;
 			}
 			sd->qi_count = 0;
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: -

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The bubble from `questinfo` script command wasn't always displayed when several `questinfo` were defined in a npc.

Additional note: the `questinfo` is no longer automatically duplicated from the original npc inside an instance, it now need to be defined under `OnInstanceInit`.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
