### PR TITLE
fix an initialization bug of combo_idx in pc_checkcombo

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10251,8 +10251,8 @@ static int pc_checkcombo(struct map_session_data *sd, item_data *data) {
 		combo_idx.reserve(nb_itemCombo);
 
 		// Zero out temporary combo array
-		for (auto &tmp_combo : combo_idx) {
-			tmp_combo = {};
+		for (j = 0; j < nb_itemCombo; j++) {
+			combo_idx[j] = {};
 		}
 
 		for (j = 0; j < nb_itemCombo; j++) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: the original code won't initial correctly in debian environment, and will make combo bonus doesn't work

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
