### PR TITLE
Fixed missing dummy item after reloading

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -84,7 +84,11 @@ bool YamlDatabase::verifyCompatibility( const YAML::Node& rootNode ){
 }
 
 bool YamlDatabase::load(){
-	return this->load( this->getDefaultLocation() );
+	bool ret = this->load( this->getDefaultLocation() );
+
+	this->loadingFinished();
+
+	return ret;
 }
 
 bool YamlDatabase::reload(){
@@ -127,8 +131,6 @@ bool YamlDatabase::load(const std::string& path) {
 	this->parse( rootNode );
 
 	this->parseImports( rootNode );
-
-	this->loadingFinished();
 
 	return true;
 }

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1019,6 +1019,23 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 	return 1;
 }
 
+void ItemDatabase::loadingFinished(){
+	if( !this->exists( ITEMID_DUMMY ) ){
+		// Create dummy item
+		std::shared_ptr<item_data> dummy_item = std::make_shared<item_data>();
+
+		dummy_item->nameid = ITEMID_DUMMY;
+		dummy_item->weight = 1;
+		dummy_item->value_sell = 1;
+		dummy_item->type = IT_ETC;
+		dummy_item->name = "UNKNOWN_ITEM";
+		dummy_item->ename = "Unknown Item";
+		dummy_item->view_id = UNKNOWN_ITEM_ID;
+
+		item_db.put( ITEMID_DUMMY, dummy_item );
+	}
+}
+
 ItemDatabase item_db;
 
 /**
@@ -1362,23 +1379,6 @@ static void itemdb_jobid2mapid(uint64 bclass[3], e_mapid jobmask, bool active)
 		else
 			bclass[i] &= ~temp_mask[i];
 	}
-}
-
-/**
- * Create dummy item_data
- */
-static void itemdb_create_dummy(void) {
-	std::shared_ptr<item_data> dummy_item;
-
-	dummy_item = std::make_shared<item_data>();
-	dummy_item->nameid = ITEMID_DUMMY;
-	dummy_item->weight = 1;
-	dummy_item->value_sell = 1;
-	dummy_item->type = IT_ETC;
-	dummy_item->name = "UNKNOWN_ITEM";
-	dummy_item->ename = "Unknown Item";
-	dummy_item->view_id = UNKNOWN_ITEM_ID;
-	item_db.put(ITEMID_DUMMY, dummy_item);
 }
 
 /*==========================================
@@ -2758,7 +2758,6 @@ void do_final_itemdb(void) {
 */
 void do_init_itemdb(void) {
 	itemdb_group = uidb_alloc(DB_OPT_BASE);
-	itemdb_create_dummy();
 	itemdb_read();
 
 	if (battle_config.feature_roulette)

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -989,6 +989,7 @@ public:
 
 	const std::string getDefaultLocation();
 	uint64 parseBodyNode(const YAML::Node& node);
+	void loadingFinished();
 };
 
 extern ItemDatabase item_db;

--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -763,6 +763,9 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node& node) {
 	return 1;
 }
 
+void ItemDatabase::loadingFinished(){
+}
+
 ItemDatabase item_db;
 
 static bool parse_mob_constants( char* split[], int columns, int current ){


### PR DESCRIPTION
* **Addressed Issue(s)**: #5548

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixed creation of dummy item after reloading by placing it into the loading finished hook of the database class.
Additionally fixed the hook getting called after each file.

Thanks to @reunite-ro and @Triedge
