### PR TITLE
Fixed an issue with fake NPCs

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4309,6 +4309,11 @@ static void script_detach_state(struct script_state* st, bool dequeue_event)
 	struct map_session_data* sd;
 
 	if(st->rid && (sd = map_id2sd(st->rid))!=NULL) {
+		if( sd->state.using_fake_npc ){
+			clif_clearunit_single( sd->npc_id, CLR_OUTSIGHT, sd->fd );
+			sd->state.using_fake_npc = 0;
+		}
+
 		sd->st = st->bk_st;
 		sd->npc_id = st->bk_npcid;
 		sd->state.disable_atcommand_on_npc = 0;


### PR DESCRIPTION
* **Addressed Issue(s)**: #5379

* **Server Mode**: Both

* **Description of Pull Request**: 
Correctly removing the state tracking of fake NPC usage in case the player was detached before the script ended.

Thanks to @blipblopblip and @Patotron
