### PR TITLE
Add default for CMake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,17 @@ set(CMAKE_CXX_CREATE_SHARED_LIBRARY)
 set(CMAKE_DEBUG_POSTFIX "d")
 set(CMAKE_RELEASE_POSTFIX "r")
 
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 #
 # Prevent building in the source directory by default
 #

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.11
 WORKDIR /rathena
-RUN apk add --no-cache git cmake make gcc g++ gdb zlib-dev mariadb-dev ca-certificates linux-headers bash
+RUN apk add --no-cache git cmake make gcc g++ gdb zlib-dev mariadb-dev ca-certificates linux-headers bash valgrind
 ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->
Issue #5585 

* **Server Mode**: 
Both

* **Description of Pull Request**: 
Simply define a default build_type for cmake to have optimisation on for compiler.
