### PR TITLE
Fixes Bowling Bash behavior

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -303,7 +303,7 @@ dancing_weaponswitch_fix: yes
 // 3: 1+2
 skill_trap_type: 0
 
-// Area of Bowling Bash chain reaction
+// Area of Bowling Bash chain reaction (pre-renewal only)
 // 0: Use official gutter line system
 // 1: Gutter line system without demi gutter bug
 // 2-20: Area around caster (2 = 5x5, 3 = 7x7, 4 = 9x9, ..., 20 = 41x41)

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -2279,8 +2279,6 @@ Body:
     MaxLevel: 10
     Type: Weapon
     TargetType: Attack
-    DamageFlags:
-      Splash: true
     Flags:
       TargetTrap: true
     Range: -2
@@ -2288,7 +2286,7 @@ Body:
     HitCount: 2
     Element: Weapon
     SplashArea: 2
-    Knockback: 1
+    Knockback: 5
     CopyFlags:
       Skill:
         Plagiarism: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -2286,7 +2286,27 @@ Body:
     HitCount: 2
     Element: Weapon
     SplashArea: 2
-    Knockback: 5
+    Knockback:
+      - Level: 1
+        Amount: 1
+      - Level: 2
+        Amount: 1
+      - Level: 3
+        Amount: 2
+      - Level: 4
+        Amount: 2
+      - Level: 5
+        Amount: 3
+      - Level: 6
+        Amount: 3
+      - Level: 7
+        Amount: 4
+      - Level: 8
+        Amount: 4
+      - Level: 9
+        Amount: 5
+      - Level: 10
+        Amount: 5
     CopyFlags:
       Skill:
         Plagiarism: true

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5656,8 +5656,12 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 				break;
 #ifdef RENEWAL
 			case KN_BOWLINGBASH:
-				if (skill_id == KN_BOWLINGBASH && sd && sd->status.weapon == W_2HSWORD)
-					wd.div_ = cap_value(wd.miscflag, 2, 4);
+				if (sd && sd->status.weapon == W_2HSWORD) {
+					if (wd.miscflag >= 2 && wd.miscflag <= 3)
+						wd.div_ = 3;
+					else if (wd.miscflag >= 4)
+						wd.div_ = 4;
+				}
 				break;
 #endif
 			case KN_AUTOCOUNTER:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5646,17 +5646,20 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 				wd.amotion = sstatus->amotion;
 				//Fall through
 			case KN_SPEARSTAB:
+#ifndef RENEWAL
 			case KN_BOWLINGBASH:
-#ifdef RENEWAL
-				if (skill_id == KN_BOWLINGBASH && sd && sd->status.weapon == W_2HSWORD)
-					wd.div_ = cap_value(wd.miscflag, 2, 4);
 #endif
 			case MS_BOWLINGBASH:
 			case MO_BALKYOUNG:
 			case TK_TURNKICK:
 				wd.blewcount = 0;
 				break;
-
+#ifdef RENEWAL
+			case KN_BOWLINGBASH:
+				if (skill_id == KN_BOWLINGBASH && sd && sd->status.weapon == W_2HSWORD)
+					wd.div_ = cap_value(wd.miscflag, 2, 4);
+				break;
+#endif
 			case KN_AUTOCOUNTER:
 				wd.flag = (wd.flag&~BF_SKILLMASK)|BF_NORMAL;
 				break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5078,6 +5078,9 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case MC_CARTREVOLUTION:
 	case NPC_SPLASHATTACK:
 		flag |= SD_PREAMBLE; // a fake packet will be sent for the first target to be hit
+#ifdef RENEWAL
+	case KN_BOWLINGBASH:
+#endif
 	case AS_SPLASHER:
 	case HT_BLITZBEAT:
 	case AC_SHOWER:
@@ -5272,7 +5275,9 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag);
 		break;
 
+#ifndef RENEWAL
 	case KN_BOWLINGBASH:
+#endif
 	case MS_BOWLINGBASH:
 		{
 			int min_x,max_x,min_y,max_y,i,c,dir,tx,ty;
@@ -5344,10 +5349,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 					break;
 				}
 			}
-#ifndef  RENEWAL
 			// Original hit or chain hit depending on flag
 			skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,(flag&0xFFF)>0?SD_ANIMATION:0);
-#endif
 		}
 		break;
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5169,6 +5169,11 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			if ((skill_id == SP_SHA || skill_id == SP_SWHOO) && !battle_config.allow_es_magic_pc && bl->type != BL_MOB)
 				break;
 
+#ifdef RENEWAL
+			if (skill_id == KN_BOWLINGBASH)
+				sflag &= ~4; // Always trigger knockback
+#endif
+
 			heal = (int)skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, sflag);
 			if( skill_id == NPC_VAMPIRE_GIFT && heal > 0 ) {
 				clif_skill_nodamage(NULL, src, AL_HEAL, heal, 1);
@@ -5196,7 +5201,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 			switch ( skill_id ) {
 #ifdef RENEWAL
 				case KN_BOWLINGBASH:
-					flag |= SD_LEVEL;
+					flag |= SD_LEVEL; // Get area count
 					break;
 #endif
 				case LG_EARTHDRIVE:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5277,7 +5277,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		if (flag & 1) {
 			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, (skill_area_temp[0]) > 0 ? SD_ANIMATION | skill_area_temp[0] : skill_area_temp[0]);
 			skill_blown(src, bl, skill_get_blewcount(skill_id, skill_lv), -1, BLOWN_NONE);
-			skill_area_temp[0] = 0;
 		} else {
 			skill_area_temp[0] = map_foreachinallrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
 			map_foreachinrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR|BL_SKILL, src, skill_id, skill_lv, tick, flag | BCT_ENEMY | SD_SPLASH | 1, skill_castend_damage_id);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5194,6 +5194,11 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				status_change_end(src, SC_USE_SKILL_SP_SPA, INVALID_TIMER);
 
 			switch ( skill_id ) {
+#ifdef RENEWAL
+				case KN_BOWLINGBASH:
+					flag |= SD_LEVEL;
+					break;
+#endif
 				case LG_EARTHDRIVE:
 				case GN_CARTCANNON:
 				case SU_SCRATCH:


### PR DESCRIPTION
* **Addressed Issue(s)**: #5489

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Removes the gutterline feature from Bowling Bash in renewal mode.
  * Skill will now behave as a normal 5x5 AoE.
  * Fixes knockback getting removed during battle calculation.
Thanks to @humanwizzard!