### PR TITLE
Fixed an inverted nullpointer check

### DIFF
--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -652,7 +652,7 @@ int bg_team_get_id(struct block_list *bl)
 			struct map_session_data *msd;
 			struct mob_data *md = (TBL_MOB*)bl;
 
-			if( md->special_state.ai && !(msd = map_id2sd(md->master_id)) )
+			if( md->special_state.ai && (msd = map_id2sd(md->master_id)) != nullptr )
 				return msd->bg_id;
 
 			return md->bg_id;


### PR DESCRIPTION
* **Addressed Issue(s)**: #5654

* **Server Mode**: Both

* **Description of Pull Request**: 
The check was inverted and therefore only went inside if the player was not online.

Thanks to @Singe-Horizontal
