### PR TITLE
Clean up instance map name generation

### DIFF
--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -822,7 +822,7 @@ int chclif_parse_charselect(int fd, struct char_session_data* sd,uint32 ipl){
 			WFIFOHEAD(fd, 24);
 			WFIFOW(fd, 0) = 0x840;
 			WFIFOW(fd, 2) = 24;
-			memcpy(WFIFOP(fd, 4), "0", 20); // we can't send it empty (otherwise the list will pop up)
+			strncpy(WFIFOCP(fd, 4), "0", 20); // we can't send it empty (otherwise the list will pop up)
 			WFIFOSET(fd, 24);
 			return 1;
 		}

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -710,24 +710,21 @@ int instance_addmap(int instance_id) {
 
 /**
  * Fills outname with the name of the instance map name
- * @param inname: Name of map to use
- * @param instance_id: Instance id to prepend
- * @param outname: Pointer to allocated memory that will be filled in. Should be size MAP_NAME_LENGTH
+ * @param map_id: Mapid to use
+ * @param instance_id: Instance id
+ * @param outname: Pointer to allocated memory that will be filled in
  */
-void instance_gen_mapname(const char * inname, int instance_id, char * outname) {
-	char iname[MAP_NAME_LENGTH];
-	if (outname == nullptr)
-		return;
+void instance_generate_mapname(int map_id, int instance_id, char outname[MAP_NAME_LENGTH]) {
 
-	strncpy(iname, inname, MAP_NAME_LENGTH - 1);
-
-	if ((strchr(iname, '@') == nullptr) && strlen(iname) > 8) {
-		memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
-		snprintf(outname, MAP_NAME_LENGTH, "%d#", (instance_id % 1000));
-	} else
-		snprintf(outname, MAP_NAME_LENGTH, "%.3d", (instance_id % 1000));
-
-	strncat(outname, iname, MAP_NAME_LENGTH - strlen(outname) - 1);
+#if MAX_MAP_PER_SERVER > 9999
+	#error This algorithm is only safe for up to 9999 maps, change at your own risk.
+#endif
+	// Since we can't truncate integers like we can strings, allocate enough of a buffer
+	// to hold two integers, a symbol, and \0, then copy it to outname
+	char name[30];
+	snprintf(name, 30, "%d#%d", map_id, (instance_id % 1000000));
+	memcpy(outname, name, MAP_NAME_LENGTH - 1);
+	outname[MAP_NAME_LENGTH - 1] = 0;
 }
 
 /**
@@ -753,7 +750,7 @@ int16 instance_mapid(int16 m, int instance_id)
 	for (const auto &it : idata->map) {
 		if (it.src_m == m) {
 			char alt_name[MAP_NAME_LENGTH];
-			instance_gen_mapname(name, instance_id, alt_name);
+			instance_generate_mapname(m, instance_id, alt_name);
 			return map_mapname2mapid(alt_name);
 		}
 	}

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -4,6 +4,7 @@
 #include "instance.hpp"
 
 #include <stdlib.h>
+#include <math.h>
 #include <yaml-cpp/yaml.h>
 
 #include "../common/cbasetypes.hpp"
@@ -719,12 +720,13 @@ void instance_generate_mapname(int map_id, int instance_id, char outname[MAP_NAM
 #if MAX_MAP_PER_SERVER > 9999
 	#error This algorithm is only safe for up to 9999 maps, change at your own risk.
 #endif
-	// Since we can't truncate integers like we can strings, allocate enough of a buffer
-	// to hold two integers, a symbol, and \0, then copy it to outname
-	char name[30];
-	snprintf(name, 30, "%d#%d", map_id, (instance_id % 1000000));
-	memcpy(outname, name, MAP_NAME_LENGTH - 1);
-	outname[MAP_NAME_LENGTH - 1] = 0;
+	// Safe up to 9999 maps per map-server
+	static const int prefix_length = 4;
+	// Full map name length - prefix length - seperator character - zero termination
+	static const int suffix_length = MAP_NAME_LENGTH - prefix_length - 1 - 1;
+	static const int prefix_limit = pow(10, prefix_length);
+	static const int suffix_limit = pow(10, suffix_length);
+	safesnprintf(outname, MAP_NAME_LENGTH, "%0*u#%0*u", prefix_length, map_id % prefix_limit, suffix_length, instance_id % suffix_limit);
 }
 
 /**

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -709,6 +709,28 @@ int instance_addmap(int instance_id) {
 }
 
 /**
+ * Fills outname with the name of the instance map name
+ * @param inname: Name of map to use
+ * @param instance_id: Instance id to prepend
+ * @param outname: Pointer to allocated memory that will be filled in. Should be size MAP_NAME_LENGTH
+ */
+void instance_gen_mapname(const char * inname, int instance_id, char * outname) {
+	char iname[MAP_NAME_LENGTH];
+	if (outname == nullptr)
+		return;
+
+	strncpy(iname, inname, MAP_NAME_LENGTH - 1);
+
+	if ((strchr(iname, '@') == nullptr) && strlen(iname) > 8) {
+		memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
+		snprintf(outname, MAP_NAME_LENGTH, "%d#", (instance_id % 1000));
+	} else
+		snprintf(outname, MAP_NAME_LENGTH, "%.3d", (instance_id % 1000));
+
+	strncat(outname, iname, MAP_NAME_LENGTH - strlen(outname) - 1);
+}
+
+/**
  * Returns an instance map ID
  * @param m: Source map ID
  * @param instance_id: Instance to search
@@ -730,15 +752,8 @@ int16 instance_mapid(int16 m, int instance_id)
 
 	for (const auto &it : idata->map) {
 		if (it.src_m == m) {
-			char iname[MAP_NAME_LENGTH], alt_name[MAP_NAME_LENGTH];
-
-			strcpy(iname, name);
-
-			if (!(strchr(iname, '@')) && strlen(iname) > 8) {
-				memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
-				snprintf(alt_name, sizeof(alt_name), "%d#%s", (instance_id % 1000), iname);
-			} else
-				snprintf(alt_name, sizeof(alt_name), "%.3d%s", (instance_id % 1000), iname);
+			char alt_name[MAP_NAME_LENGTH];
+			instance_gen_mapname(name, instance_id, alt_name);
 			return map_mapname2mapid(alt_name);
 		}
 	}

--- a/src/map/instance.hpp
+++ b/src/map/instance.hpp
@@ -118,6 +118,7 @@ e_instance_enter instance_enter(struct map_session_data *sd, int instance_id, co
 bool instance_reqinfo(struct map_session_data *sd, int instance_id);
 bool instance_addusers(int instance_id);
 bool instance_delusers(int instance_id);
+void instance_gen_mapname(const char * inname, int instance_id, char * outname);
 int16 instance_mapid(int16 m, int instance_id);
 int instance_addmap(int instance_id);
 

--- a/src/map/instance.hpp
+++ b/src/map/instance.hpp
@@ -118,7 +118,7 @@ e_instance_enter instance_enter(struct map_session_data *sd, int instance_id, co
 bool instance_reqinfo(struct map_session_data *sd, int instance_id);
 bool instance_addusers(int instance_id);
 bool instance_delusers(int instance_id);
-void instance_gen_mapname(const char * inname, int instance_id, char * outname);
+void instance_generate_mapname(int map_id, int instance_id, char outname[MAP_NAME_LENGTH]);
 int16 instance_mapid(int16 m, int instance_id);
 int instance_addmap(int instance_id);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2724,18 +2724,12 @@ int map_addinstancemap(int src_m, int instance_id)
 
 	struct map_data *src_map = map_getmapdata(src_m);
 	struct map_data *dst_map = map_getmapdata(dst_m);
-	char iname[MAP_NAME_LENGTH];
-
-	strcpy(iname, name);
 
 	// Alter the name
 	// Due to this being custom we only worry about preserving as many characters as necessary for accurate map distinguishing
 	// This also allows us to maintain complete independence with main map functions
-	if ((strchr(iname, '@') == nullptr) && strlen(iname) > 8) {
-		memmove(iname, iname + (strlen(iname) - 9), strlen(iname));
-		snprintf(dst_map->name, sizeof(dst_map->name), "%d#%s", (instance_id % 1000), iname);
-	} else
-		snprintf(dst_map->name, sizeof(dst_map->name), "%.3d%s", (instance_id % 1000), iname);
+	instance_gen_mapname(name, instance_id, dst_map->name);
+	
 	dst_map->name[MAP_NAME_LENGTH - 1] = '\0';
 
 	dst_map->m = dst_m;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2726,11 +2726,8 @@ int map_addinstancemap(int src_m, int instance_id)
 	struct map_data *dst_map = map_getmapdata(dst_m);
 
 	// Alter the name
-	// Due to this being custom we only worry about preserving as many characters as necessary for accurate map distinguishing
 	// This also allows us to maintain complete independence with main map functions
-	instance_gen_mapname(name, instance_id, dst_map->name);
-	
-	dst_map->name[MAP_NAME_LENGTH - 1] = '\0';
+	instance_generate_mapname(src_m, instance_id, dst_map->name);
 
 	dst_map->m = dst_m;
 	dst_map->instance_id = instance_id;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5691 and #5185

* **Server Mode**: Both

* **Description of Pull Request**: 

Put the instance map name generation in a seperate function
Fix some compiler warnings
Fixes #5691
Thanks @RadianFord


Some tests I ran:
```
[Info]: [Instance] Created map '9#aldebaran' (1075) from 'aldebaran' (9).
[Info]: [Instance] Created: CustomInstance (9)
[Info]: [Instance] Destroyed: CustomInstance (9)
[Info]: [Instance] Created map '10#aldebara' (1075) from 'aldebaran' (9).
[Info]: [Instance] Created: CustomInstance (10)
[Info]: [Instance] Destroyed: CustomInstance (10)
...
[Info]: [Instance] Created map '0111@swat' (1075) from '1@swat' (933).
[Info]: [Instance] Created: CustomInstance2 (11)
[Info]: [Instance] Destroyed: CustomInstance2 (11)
```