### PR TITLE
Added a config for respawn time variance

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -137,10 +137,11 @@ plant_spawn_delay: 100
 boss_spawn_delay: 100
 
 // Should the mobs respawn time have variance applied to it? (Note 3)
-// On official servers only boss monsters have variance, legacy Athena behavior is that variance is applied for all mobs.
+// On official servers monsters spawned by the boss_monster command (mostly MVPs) have variance, legacy Athena behavior is that variance is applied for all mobs.
 // 0: None
 // 1: Boss monsters (official)
 // 2: Normal monsters
+// 3: All monsters (legacy Athena)
 mob_spawn_variance: 1
 
 // Should mobs not spawn within the viewing range of players?

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -136,6 +136,13 @@ mob_spawn_delay: 100
 plant_spawn_delay: 100
 boss_spawn_delay: 100
 
+// Should the mobs respawn time have variance applied to it? (Note 3)
+// On official servers only boss monsters have variance, legacy Athena behavior is that variance is applied for all mobs.
+// 0: None
+// 1: Boss monsters (official)
+// 2: Normal monsters
+mob_spawn_variance: 1
+
 // Should mobs not spawn within the viewing range of players?
 // 0 is disabled, otherwise it is the number of retries before giving up 
 // and spawning the mob within player-view anyway, unless the max (100) is used,

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9020,6 +9020,7 @@ static const struct _battle_data {
 	{ "homunculus_starving_rate",           &battle_config.homunculus_starving_rate,        10,     0,      100,            },
 	{ "homunculus_starving_delay",          &battle_config.homunculus_starving_delay,       20000,  0,      INT_MAX,        },
 	{ "drop_connection_on_quit",            &battle_config.drop_connection_on_quit,         0,      0,      1,              },
+	{ "mob_spawn_variance",                 &battle_config.mob_spawn_variance,              1,      0,      3,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -688,6 +688,7 @@ struct Battle_Config
 	int homunculus_starving_rate;
 	int homunculus_starving_delay;
 	int drop_connection_on_quit;
+	int mob_spawn_variance;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4151,7 +4151,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	}
 
 	// Check if monsters should have variance applied to their respawn time
-	if(	( ( battle_config.mob_spawn_variance & 1 ) == 0 && mob.state.boss ) || ( ( battle_config.mob_spawn_variance & 2 ) == 0 && !mob.state.boss ) ){
+	if( ( ( battle_config.mob_spawn_variance & 1 ) == 0 && mob.state.boss ) || ( ( battle_config.mob_spawn_variance & 2 ) == 0 && !mob.state.boss ) ){
 		// Remove the variance
 		mob.delay2 = 0;
 	}

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -4150,6 +4150,12 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 		mob.xs = mob.ys = -1;
 	}
 
+	// Check if monsters should have variance applied to their respawn time
+	if(	( ( battle_config.mob_spawn_variance & 1 ) == 0 && mob.state.boss ) || ( ( battle_config.mob_spawn_variance & 2 ) == 0 && !mob.state.boss ) ){
+		// Remove the variance
+		mob.delay2 = 0;
+	}
+
 	if(mob.delay1>0xfffffff || mob.delay2>0xfffffff) {
 		ShowError("npc_parse_mob: Invalid spawn delays %u %u (file '%s', line '%d').\n", mob.delay1, mob.delay2, filepath, strline(buffer,start-buffer));
 		return strchr(start,'\n');// skip and continue


### PR DESCRIPTION
* **Addressed Issue(s)**: #5714

* **Server Mode**: Both

* **Description of Pull Request**: 
By default the respawn time variance only applies to boss monsters on official servers.

Thanks to @Playtester
