### PR TITLE
Fixed MO_CHAINCOMBO for Knuckle Weapons

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3960,6 +3960,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 		case MO_CHAINCOMBO:
 #ifdef RENEWAL
 			skillratio += 150 + 50 * skill_lv;
+			if (sd && sd->status.weapon == W_KNUCKLE)
+				skillratio *= 2;
 #else
 			skillratio += 50 + 50 * skill_lv;
 #endif
@@ -5638,6 +5640,10 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 			case RG_BACKSTAP:
 				if (sd && sd->status.weapon == W_DAGGER)
 					wd.div_ = 2;
+				break;
+			case MO_CHAINCOMBO:
+				if (sd && sd->status.weapon == W_KNUCKLE)
+					wd.div_ = -6;
 				break;
 #endif
 			case MH_SONIC_CRAW:{


### PR DESCRIPTION
Updating MO_CHAINCOMBO as it should be for renewal.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adding its double damage and 6 Hit behavior when a Knuckle Type Weapon is equipped

Info : https://divine-pride.net/database/skill/272/raging-quadruple-blow

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
