### PR TITLE
Atcommand Killmonster2 bypassed the "no drops"-flag. Do check without…

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2283,7 +2283,7 @@ ACMD_FUNC(killmonster)
 
 	parent_cmd = atcommand_alias_db.checkAlias(command+1);
 
-	drop_flag = strcmp(parent_cmd, "killmonster2");
+	drop_flag = strcmpi(parent_cmd, "killmonster2");
 
 	map_foreachinmap(atkillmonster_sub, map_id, BL_MOB, -drop_flag);
 


### PR DESCRIPTION
… case sensitivity

Using '@Killmonster2' (notice the capital K) was treated like '@killmonster'. It killed monsters with items dropping
