### PR TITLE
Fixes script command getgroupitem

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1270,6 +1270,8 @@ static void itemdb_pc_get_itemgroup_sub(struct map_session_data *sd, bool identi
 	else
 		get_amt = data->amount;
 
+	tmp.amount = get_amt;
+
 	// Do loop for non-stackable item
 	for (i = 0; i < data->amount; i += get_amt) {
 		char flag = 0;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5727

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes items that get dropped on the floor from script command getgroupitem being 0.
Thanks to @eppc0330!