### PR TITLE
Hotfix for issue 5764

### DIFF
--- a/npc/other/CashShop_Functions.txt
+++ b/npc/other/CashShop_Functions.txt
@@ -51,7 +51,7 @@ function	script	F_CashStore	{
 // - Summon Party members on party leader map to a 3x3 location around the leader.
 // - No arguments.
 function	script	F_CashPartyCall	{
-	warp "Random",0,0;
+	itemskill "AL_TELEPORT",1;
 	if (is_party_leader() == true)
 		warpparty "Leader", 0, 0, getcharid(1), strcharinfo(3), 3, 3;
 	return;

--- a/npc/re/merchants/nightmare_biolab.txt
+++ b/npc/re/merchants/nightmare_biolab.txt
@@ -104,11 +104,11 @@ function	script	F_Cursed_Fragment	{	// 23016
 	}
 	else if (.@r == 5) {
 		showscript "Please... Stay with me...";
-		warp "Random",0,0;
+		itemskill "AL_TELEPORT",1;
 	}
 	else if (.@r == 6) {
 		showscript "Stay... here with me...";
-		warp "Random",0,0;
+		itemskill "AL_TELEPORT",1;
 	}
 	else if (.@r == 7) {
 		showscript "You shouldn't have come here...";

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6246,7 +6246,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
  *	0 = Success
  *	1,2,3 = Fail
  *------------------------------------------*/
-char pc_randomwarp(struct map_session_data *sd, clr_type type)
+char pc_randomwarp(struct map_session_data *sd, clr_type type, bool ignore_mapflag)
 {
 	int x,y,i=0;
 
@@ -6254,7 +6254,7 @@ char pc_randomwarp(struct map_session_data *sd, clr_type type)
 
 	struct map_data *mapdata = map_getmapdata(sd->bl.m);
 
-	if (mapdata->flag[MF_NOTELEPORT]) //Teleport forbidden
+	if (mapdata->flag[MF_NOTELEPORT] && !ignore_mapflag) //Teleport forbidden
 		return 3;
 
 	do {

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1179,7 +1179,7 @@ enum e_setpos{
 
 enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, int x, int y, clr_type clrtype);
 void pc_setsavepoint(struct map_session_data *sd, short mapindex,int x,int y);
-char pc_randomwarp(struct map_session_data *sd,clr_type type);
+char pc_randomwarp(struct map_session_data *sd,clr_type type,bool ignore_mapflag = false);
 bool pc_memo(struct map_session_data* sd, int pos);
 
 char pc_checkadditem(struct map_session_data *sd, t_itemid nameid, int amount);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5583,7 +5583,7 @@ BUILDIN_FUNC(warp)
 	y = script_getnum(st,4);
 
 	if(strcmp(str,"Random")==0)
-		ret = pc_randomwarp(sd,CLR_TELEPORT);
+		ret = pc_randomwarp(sd,CLR_TELEPORT,true);
 	else if(strcmp(str,"SavePoint")==0 || strcmp(str,"Save")==0)
 		ret = pc_setpos(sd,sd->status.save_point.map,sd->status.save_point.x,sd->status.save_point.y,CLR_TELEPORT);
 	else
@@ -5611,7 +5611,7 @@ static int buildin_areawarp_sub(struct block_list *bl,va_list ap)
 	y3 = va_arg(ap,int);
 
 	if(index == 0)
-		pc_randomwarp((TBL_PC *)bl,CLR_TELEPORT);
+		pc_randomwarp((TBL_PC *)bl,CLR_TELEPORT,true);
 	else if(x3 && y3) {
 		int max, tx, ty, j = 0;
 		int16 m;
@@ -12563,7 +12563,7 @@ BUILDIN_FUNC(warpwaitingpc)
 		mapreg_setreg(reference_uid(add_str("$@warpwaitingpc"), i), sd->bl.id);
 
 		if( strcmp(map_name,"Random") == 0 )
-			pc_randomwarp(sd,CLR_TELEPORT);
+			pc_randomwarp(sd,CLR_TELEPORT,true);
 		else if( strcmp(map_name,"SavePoint") == 0 )
 			pc_setpos(sd, sd->status.save_point.map, sd->status.save_point.x, sd->status.save_point.y, CLR_TELEPORT);
 		else


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5764 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Replaced `warp "Random",0,0;` by `itemskill "AL_TELEPORT",1;` in the items script functions
- Suggestion to add an exception to bypass the mapflag MF_NOTELEPORT in `pc_randomwarp` for some script commands (`warp`, `areawarp` and `warpwaitingpc`, it doesn't seem necessary for the others warp commands since they have a mapflag check)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
