### PR TITLE
Fix potential crash in pc_setpos

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6059,7 +6059,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 				instance_addusers(new_map_instance_id);
 		}
 
-		if (sd->bg_id && !mapdata->flag[MF_BATTLEGROUND]) // Moving to a map that isn't a Battlegrounds
+		if (sd->bg_id && mapdata && !mapdata->flag[MF_BATTLEGROUND]) // Moving to a map that isn't a Battlegrounds
 			bg_team_leave(sd, false, true);
 
 		sd->state.pmap = sd->bl.m;
@@ -6130,6 +6130,9 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 		}else{
 			st = nullptr;
 		}
+
+		if (sd->bg_id) // Switching map servers, remove from bg
+			bg_team_leave(sd, false, true);
 
 		npc_script_event(sd, NPCE_LOGOUT);
 		//remove from map, THEN change x/y coordinates

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6134,6 +6134,9 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 		if (sd->bg_id) // Switching map servers, remove from bg
 			bg_team_leave(sd, false, true);
 
+		if (sd->state.vending) // Stop vending
+			vending_closevending(sd);
+
 		npc_script_event(sd, NPCE_LOGOUT);
 		//remove from map, THEN change x/y coordinates
 		unit_remove_map_pc(sd,clrtype);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6096,7 +6096,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 		if (sd->regen.state.gc)
 			sd->regen.state.gc = 0;
 		// make sure vending is allowed here
-		if (sd->state.vending && mapdata->flag[MF_NOVENDING]) {
+		if (sd->state.vending && mapdata && mapdata->flag[MF_NOVENDING]) {
 			clif_displaymessage (sd->fd, msg_txt(sd,276)); // "You can't open a shop on this map"
 			vending_closevending(sd);
 		}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

* **Server Mode**:  N/A

* **Description of Pull Request**: 

If a player is in battlegrounds and tries to warp to a map not on that map-server, the server will crash.

This can happen if the target map is on a separate map server, or in my case, was removed from the list because it did not exist in the mapcache.