### PR TITLE
Fix GC_POISONREACT missing skill bonus

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3755,6 +3755,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 			if( tsc && tsc->data[SC_JYUMONJIKIRI] )
 				wd->div_ = wd->div_ * -1;// needs more info
 			break;
+#ifdef RENEWAL
 		case AS_POISONREACT:
 			skill_lv = pc_checkskill(sd, TF_DOUBLE);
 			if (skill_lv > 0) {
@@ -3763,6 +3764,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 				}
 			}
 		break;
+#endif
 	}
 }
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10293,7 +10293,11 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			}
 			break;
 		case SC_POISONREACT:
-			val2=(val1 - ((val1-1) % 1 - 1)) / 2; // Number of counters [Skotlex]
+#ifdef RENEWAL
+			val2=(val1 - ((val1-1) % 1 - 1)) / 2;
+#else
+			val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]
+#endif
 			val3=50; // + 5*val1; // Chance to counter. [Skotlex]
 			break;
 		case SC_MAGICROD:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10293,7 +10293,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			}
 			break;
 		case SC_POISONREACT:
-			val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]
+			val2=(val1 - ((val1-1) % 1 - 1)) / 2; // Number of counters [Skotlex]
 			val3=50; // + 5*val1; // Chance to counter. [Skotlex]
 			break;
 		case SC_MAGICROD:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5804 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Poison React now have chance to attack twice, with same rate of Double Attack, when character is learning Double Attack.

Number of counters is changed to 1/1/2/2/3/3/4/4/5/5.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
