### PR TITLE
Fix getnameditem command

### DIFF
--- a/sql-files/upgrades/upgrade_20210331.sql
+++ b/sql-files/upgrades/upgrade_20210331.sql
@@ -1,0 +1,4 @@
+UPDATE `inventory` SET `card2` = `card2` & 65535 WHERE `card0` = 254 OR `card0` = 255;
+UPDATE `cart_inventory` SET `card2` = `card2` & 65535 WHERE `card0` = 254 OR `card0` = 255;
+UPDATE `storage` SET `card2` = `card2` & 65535 WHERE `card0` = 254 OR `card0` = 255;
+UPDATE `guild_storage` SET `card2` = `card2` & 65535 WHERE `card0` = 254 OR `card0` = 255;

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -6028,8 +6028,8 @@ void getring (struct map_session_data* sd)
 	item_tmp.nameid = item_id;
 	item_tmp.identify = 1;
 	item_tmp.card[0] = CARD0_FORGE;
-	item_tmp.card[2] = sd->status.partner_id;
-	item_tmp.card[3] = sd->status.partner_id >> 16;
+	item_tmp.card[2] = GetWord(sd->status.partner_id,0);
+	item_tmp.card[3] = GetWord(sd->status.partner_id,1);
 
 	if((flag = pc_additem(sd,&item_tmp,1,LOG_TYPE_COMMAND))) {
 		clif_additem(sd,0,0,flag);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -7834,8 +7834,8 @@ BUILDIN_FUNC(getnameditem)
 	item_tmp.amount=1;
 	item_tmp.identify=1;
 	item_tmp.card[0]=CARD0_CREATE; //we don't use 255! because for example SIGNED WEAPON shouldn't get TOP10 BS Fame bonus [Lupus]
-	item_tmp.card[2]=tsd->status.char_id & 65535;
-	item_tmp.card[3]=tsd->status.char_id >> 16;
+	item_tmp.card[2]=GetWord(tsd->status.char_id,0);
+	item_tmp.card[3]=GetWord(tsd->status.char_id,1);
 	if(pc_additem(sd,&item_tmp,1,LOG_TYPE_SCRIPT)) {
 		script_pushint(st,0);
 		return SCRIPT_CMD_SUCCESS;	//Failed to add item, we will not drop if they don't fit

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -7834,7 +7834,7 @@ BUILDIN_FUNC(getnameditem)
 	item_tmp.amount=1;
 	item_tmp.identify=1;
 	item_tmp.card[0]=CARD0_CREATE; //we don't use 255! because for example SIGNED WEAPON shouldn't get TOP10 BS Fame bonus [Lupus]
-	item_tmp.card[2]=tsd->status.char_id;
+	item_tmp.card[2]=tsd->status.char_id & 65535;
 	item_tmp.card[3]=tsd->status.char_id >> 16;
 	if(pc_additem(sd,&item_tmp,1,LOG_TYPE_SCRIPT)) {
 		script_pushint(st,0);


### PR DESCRIPTION
* **Addressed Issue(s)**:  https://github.com/rathena/rathena/issues/5713
* **Server Mode**: -
* **Description of Pull Request**: Fix for getnameditem command.
The command must assign a character name to the item as it saw in command description.
Some quests cannot be completed without assigned item.