### PR TITLE
Adjusts Assassin Cross of Sunset ASPD bonus

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7508,6 +7508,9 @@ static short status_calc_aspd(struct block_list *bl, struct status_change *sc, b
 		}
 
 		if (sc->data[SC_ASSNCROS] && bonus < sc->data[SC_ASSNCROS]->val2) {
+#ifdef RENEWAL
+			bonus += sc->data[SC_ASSNCROS]->val2;
+#else
 			if (bl->type != BL_PC)
 				bonus += sc->data[SC_ASSNCROS]->val2;
 			else {
@@ -7524,6 +7527,7 @@ static short status_calc_aspd(struct block_list *bl, struct status_change *sc, b
 						break;
 				}
 			}
+#endif
 		}
 
 		if (bonus < 20 && sc->data[SC_MADNESSCANCEL])


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5738

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * The ASPD increase of Assassin Cross of Sunset should apply to all weapon types in renewal.
Thanks to @Balferian!