### PR TITLE
Fixes Head Crush vs Boss class

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4788,7 +4788,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case LK_AURABLADE:
 	case LK_SPIRALPIERCE:
 	case ML_SPIRALPIERCE:
-	case LK_HEADCRUSH:
 	case CG_ARROWVULCAN:
 	case HW_MAGICCRASHER:
 	case ITM_TOMAHAWK:
@@ -4855,6 +4854,15 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 
 	case MO_TRIPLEATTACK:
 		skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag|SD_ANIMATION);
+		break;
+
+	case LK_HEADCRUSH:
+		if (status_get_class_(bl) == CLASS_BOSS) {
+			if (sd)
+				clif_skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
+			break;
+		}
+		skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag);
 		break;
 
 	case LK_JOINTBEAT:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5765

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Head Crush is no longer usable against Boss class monsters.
Thanks to @mrjnumber1!