### PR TITLE
Fixes Maya Purple Card and Box of Sunlight usage

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3829,7 +3829,7 @@ int status_calc_pc_sub(struct map_session_data* sd, enum e_status_calc_opt opt)
 	memset (&sd->right_weapon.overrefine, 0, sizeof(sd->right_weapon) - sizeof(sd->right_weapon.atkmods));
 	memset (&sd->left_weapon.overrefine, 0, sizeof(sd->left_weapon) - sizeof(sd->left_weapon.atkmods));
 
-	if (sd->special_state.intravision && !sd->sc.data[SC_INTRAVISION]) // Clear intravision as long as nothing else is using it
+	if (sd->special_state.intravision)
 		clif_status_load(&sd->bl, EFST_CLAIRVOYANCE, 0);
 
 	if (sd->special_state.no_walk_delay)


### PR DESCRIPTION
* **Addressed Issue(s)**: Partial fix for #5766

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves the interaction between Maya Purple Card and Box of Sunlight.
  * Intravision status will now end if a hat with Maya Purple Card is taken off while Box of Sunlight is active.
Thanks to @mrjnumber1!