### PR TITLE
Fixes Strip Weapon/Shield skills

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -2079,6 +2079,7 @@ Body:
     ActiveInstance: 5
     Knockback: 2
     CastTime: 700
+    Duration1: 1000
     Requires:
       SpCost: 12
       Weapon:
@@ -6810,8 +6811,8 @@ Body:
     CastDefenseReduction: 33
     CastTime: 3000
     AfterCastActDelay: 1500
-    AfterCastWalkDelay: 800
-    Duration1: 800
+    AfterCastWalkDelay: 1000
+    Duration1: 950
     Duration2: 30000
     Requires:
       SpCost:
@@ -9043,9 +9044,8 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Dark
-    AfterCastWalkDelay: 900
-    Duration1: 900
-    Duration2: 30000
+    AfterCastWalkDelay: 1000
+    Duration1: 30000
     Unit:
       Id: Dummyskill
       Layout: -1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -7196,8 +7196,8 @@ Body:
     CastDefenseReduction: 33
     CastTime: 1000
     AfterCastActDelay: 500
-    AfterCastWalkDelay: 800
-    Duration1: 800
+    AfterCastWalkDelay: 1000
+    Duration1: 950
     Duration2: 20000
     Cooldown: 1000
     FixedCastTime: 500
@@ -9379,9 +9379,8 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Dark
-    AfterCastWalkDelay: 900
-    Duration1: 900
-    Duration2: 20000
+    AfterCastWalkDelay: 1000
+    Duration1: 20000
     Unit:
       Id: Dummyskill
       Layout: -1

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1464,7 +1464,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		break;
 
 	case NPC_GRANDDARKNESS:
-		sc_start(src, bl, SC_BLIND, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_BLIND, 100, skill_lv, skill_get_time(skill_id, skill_lv));
 		attack_type |= BF_WEAPON;
 		break;
 
@@ -12004,12 +12004,10 @@ TIMER_FUNC(skill_castend_id){
 				sd->canequip_tick = tick + skill_get_time(ud->skill_id, ud->skill_lv);
 				break;
 			case KN_BRANDISHSPEAR:
-			case KN_BOWLINGBASH:
-			case CR_GRANDCROSS:
-			case NPC_GRANDDARKNESS: {
+			case CR_GRANDCROSS: {
 				sc_type type;
 
-				if (ud->skill_id == KN_BRANDISHSPEAR || ud->skill_id == KN_BOWLINGBASH)
+				if (ud->skill_id == KN_BRANDISHSPEAR)
 					type = SC_STRIPWEAPON;
 				else
 					type = SC_STRIPSHIELD;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5768

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Bowling Bash will no longer cause Strip Weapon.
  * Fixes Brandish Spear not causing Strip Weapon for pre-renewal.
  * Brandish Spear will now cause Strip Weapon for 1 second.
  * Players who cast Grand Cross will have Strip Shield for 950ms and a walk delay of 1 second.
  * Monsters who cast Grand Cross or Grand Darkness will not have any strip effects and a walk delay of 1 second.
Thanks to @mrjnumber1!