### PR TITLE
Fixed RODEX's retrieve all feature

### DIFF
--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -290,23 +290,44 @@ void mail_getattachment(struct map_session_data* sd, struct mail_message* msg, i
 
 	for( i = 0; i < MAIL_MAX_ITEM; i++ ){
 		if( item->nameid > 0 && item->amount > 0 ){
-			// If no card or special card id is set
-			if( item[i].card[0] == 0 ){
-				// Check if it is a pet egg
-				std::shared_ptr<s_pet_db> pet = pet_db_search( item[i].nameid, PET_EGG );
+			struct item_data* id = itemdb_search( item->nameid );
 
-				// If it is a pet egg and the card data does not contain a pet id (see if clause above)
-				if( pet != nullptr ){
-					// Create a new pet
-					pet_create_egg( sd, item[i].nameid );
+			// Item does not exist (anymore?)
+			if( id == nullptr ){
+				continue;
+			}
+
+			// Reduce the pending weight
+			sd->mail.pending_weight -= ( id->weight * item[i].amount );
+
+			// Check if it is a pet egg
+			std::shared_ptr<s_pet_db> pet = pet_db_search( item[i].nameid, PET_EGG );
+
+			// If it is a pet egg and the card data does not contain a pet id or other special ids are set
+			if( pet != nullptr && item[i].card[0] == 0 ){
+				// Create a new pet
+				if( pet_create_egg( sd, item[i].nameid ) ){
 					item_received = true;
-					continue;
+				}else{
+					// Do not send receive packet so that the mail is still displayed with item attachment
+					item_received = false;
+					// Additionally stop the processing
+					break;
+				}
+			}else{
+				// Add the item normally
+				if( pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL ) == ADDITEM_SUCCESS ){
+					item_received = true;
+				}else{
+					// Do not send receive packet so that the mail is still displayed with item attachment
+					item_received = false;
+					// Additionally stop the processing
+					break;
 				}
 			}
 
-			// Add the item normally
-			pc_additem( sd, &item[i], item[i].amount, LOG_TYPE_MAIL );
-			item_received = true;
+			// Make sure no requests are possible anymore
+			item->amount = 0;
 		}	
 	}
 
@@ -316,6 +337,10 @@ void mail_getattachment(struct map_session_data* sd, struct mail_message* msg, i
 
 	// Zeny receive
 	if( zeny > 0 ){
+		// Reduce the pending zeny
+		sd->mail.pending_zeny -= zeny;
+
+		// Add the zeny
 		pc_getzeny(sd, zeny,LOG_TYPE_MAIL, NULL);
 		clif_mail_getattachment( sd, msg, 0, MAIL_ATT_ZENY );
 	}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1683,6 +1683,8 @@ bool pc_authok(struct map_session_data *sd, uint32 login_id2, time_t expiration_
 	sd->avail_quests = 0;
 	sd->save_quest = false;
 	sd->count_rewarp = 0;
+	sd->mail.pending_weight = 0;
+	sd->mail.pending_zeny = 0;
 
 	sd->regs.vars = i64db_alloc(DB_OPT_BASE);
 	sd->regs.arrays = NULL;

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -661,6 +661,8 @@ struct map_session_data {
 		int zeny;
 		struct mail_data inbox;
 		bool changed; // if true, should sync with charserver on next mailbox request
+		uint32 pending_weight;
+		uint32 pending_zeny;
 	} mail;
 
 	//Quest log system


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixed an issue when players tried to retrieve too many items or zeny at once.

Thanks to @limitro
