### PR TITLE
Fixed warning for YAML database header

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -73,7 +73,8 @@ bool YamlDatabase::verifyCompatibility( const YAML::Node& rootNode ){
 			ShowError( "Database version %hu is not supported. Maximum version is: %hu\n", tmpVersion, this->version );
 			return false;
 		}else if( tmpVersion >= this->minimumVersion ){
-			ShowWarning( "Database version %hu is outdated and should be updated. Current version is: %hu\n", tmpVersion, this->minimumVersion );
+			ShowWarning( "Database version %hu is outdated and should be updated. Current version is: %hu\n", tmpVersion, this->version );
+			ShowWarning( "Reduced compatibility with %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), this->currentFile.c_str() );
 		}else{
 			ShowError( "Database version %hu is not supported anymore. Minimum version is: %hu\n", tmpVersion, this->minimumVersion );
 			return false;


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
The wrong version was given when the database was not the latest version but was still compatible with the parser's minimum version.
Additionally only in cases of full incompatibility the file name was displayed. Added this as well so the file that needs an upgrade is known to the user. This has especially been a problem with empty import databases with outdated header versions.
