### PR TITLE
Fixed Mental Change cooldown

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -33556,7 +33556,7 @@ Body:
         Time: 180000
       - Level: 3
         Time: 300000
-    Duration2:
+    Cooldown:
       - Level: 1
         Time: 600000
       - Level: 2

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9589,7 +9589,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case HAMI_BLOODLUST:
 	case HFLI_FLEET:
 	case HFLI_SPEED:
+#ifndef RENEWAL
 	case HLIF_CHANGE:
+#endif
 	case MH_ANGRIFFS_MODUS:
 	case MH_GOLDENE_FERSE:
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,
@@ -9597,6 +9599,15 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		if (hd)
 			skill_blockhomun_start(hd, skill_id, skill_get_time2(skill_id,skill_lv));
 		break;
+
+#ifdef RENEWAL
+	case HLIF_CHANGE:
+		clif_skill_nodamage(src,bl,skill_id,skill_lv,
+			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
+		if (hd)
+			skill_blockhomun_start(hd, skill_id, skill_get_cooldown(skill_id,skill_lv));
+		break;
+#endif
 
 	case NPC_DRAGONFEAR:
 		if (flag&1) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Currently on rAthena the effect goes away on teleport, and the cooldown goes away on relog.
How it should work:
On pre-re: Both the effect and the cast delay should go away on teleport
On renewal: The effect should go only on changing maps, and the cooldown shouldn't go away no matter what

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
