### PR TITLE
Disables costumes on GvG maps

### DIFF
--- a/npc/mapflag/gvg.txt
+++ b/npc/mapflag/gvg.txt
@@ -1,12 +1,6 @@
 //===== rAthena Script =======================================
 //= Mapflag: Guild versus Guild mode.
-//===== By: ==================================================
-//= rAthena Dev Team
-//===== Current Version: =====================================
-//= 1.3
-//===== Compatible With: =====================================
-//= rAthena Project
-//===== Description: ========================================= 
+//===== Description: =========================================
 //= Players can attack other guilds, and will have their guild
 //= icons shown. WoE damage reductions will also take place.
 //= gvg: Turns on GvG mode.
@@ -14,10 +8,11 @@
 //= gvg_dungeon: Describes dungeon maps for WoE.
 //= gvg_te: Turns on GvG mode for WoE:TE.
 //= gvg_te_castle: Describes castle maps for WoE:TE.
-//===== Additional Comments: ================================= 
+//===== Changelogs: ==========================================
 //= 1.1 Added Novice Guild Castles.
 //= 1.2 Updated with new meanings of gvg and gvg_castle.
 //= 1.3 Renewal split. [Euphy]
+//= 1.4 Disable costumes in GvG castles. [Aleos]
 //============================================================
 
 // GvG Arenas =============
@@ -125,3 +120,40 @@ schg_dun01	mapflag	gvg_dungeon
 2012rwc_06	mapflag	gvg
 2012rwc_07	mapflag	gvg
 2012rwc_08	mapflag	gvg
+
+// Disable Costumes =======
+aldeg_cas01	mapflag	nocostume
+aldeg_cas02	mapflag	nocostume
+aldeg_cas03	mapflag	nocostume
+aldeg_cas04	mapflag	nocostume
+aldeg_cas05	mapflag	nocostume
+gefg_cas01	mapflag	nocostume
+gefg_cas02	mapflag	nocostume
+gefg_cas03	mapflag	nocostume
+gefg_cas04	mapflag	nocostume
+gefg_cas05	mapflag	nocostume
+payg_cas01	mapflag	nocostume
+payg_cas02	mapflag	nocostume
+payg_cas03	mapflag	nocostume
+payg_cas04	mapflag	nocostume
+payg_cas05	mapflag	nocostume
+prtg_cas01	mapflag	nocostume
+prtg_cas02	mapflag	nocostume
+prtg_cas03	mapflag	nocostume
+prtg_cas04	mapflag	nocostume
+prtg_cas05	mapflag	nocostume
+schg_cas01	mapflag	nocostume
+schg_cas02	mapflag	nocostume
+schg_cas03	mapflag	nocostume
+schg_cas04	mapflag	nocostume
+schg_cas05	mapflag	nocostume
+arug_cas01	mapflag	nocostume
+arug_cas02	mapflag	nocostume
+arug_cas03	mapflag	nocostume
+arug_cas04	mapflag	nocostume
+arug_cas05	mapflag	nocostume
+//n_castle	mapflag	nocostume
+nguild_alde	mapflag	nocostume
+nguild_gef	mapflag	nocostume
+nguild_pay	mapflag	nocostume
+nguild_prt	mapflag	nocostume

--- a/npc/re/mapflag/gvg.txt
+++ b/npc/re/mapflag/gvg.txt
@@ -1,12 +1,6 @@
 //===== rAthena Script =======================================
 //= Mapflag: Guild versus Guild mode.
-//===== By: ==================================================
-//= rAthena Dev Team
-//===== Current Version: =====================================
-//= 1.1
-//===== Compatible With: =====================================
-//= rAthena Project
-//===== Description: ========================================= 
+//===== Description: =========================================
 //= Players can attack other guilds, and will have their guild
 //= icons shown. WoE damage reductions will also take place.
 //= gvg: Turns on GvG mode.
@@ -14,9 +8,10 @@
 //= gvg_dungeon: Describes dungeon maps for WoE.
 //= gvg_te: Turns on GvG mode for WoE:TE.
 //= gvg_te_castle: Describes castle maps for WoE:TE.
-//===== Additional Comments: ================================= 
+//===== Changelogs: ==========================================
 //= 1.0 Renewal split. [Euphy]
 //= 1.1 Added GVG TE Castles. [Cydh]
+//= 1.2 Disable costumes in GvG castles. [Aleos]
 //============================================================
 
 // Guild Dungeons =========
@@ -38,3 +33,15 @@ te_aldecas2	mapflag	gvg_te_castle
 te_aldecas3	mapflag	gvg_te_castle
 te_aldecas4	mapflag	gvg_te_castle
 te_aldecas5	mapflag	gvg_te_castle
+
+// Disable Costumes =======
+te_prtcas01	mapflag	nocostume
+te_prtcas02	mapflag	nocostume
+te_prtcas03	mapflag	nocostume
+te_prtcas04	mapflag	nocostume
+te_prtcas05	mapflag	nocostume
+te_aldecas1	mapflag	nocostume
+te_aldecas2	mapflag	nocostume
+te_aldecas3	mapflag	nocostume
+te_aldecas4	mapflag	nocostume
+te_aldecas5	mapflag	nocostume

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13467,7 +13467,7 @@ void pc_set_costume_view(struct map_session_data *sd) {
 		sd->status.robe = id->look;
 
 	// Costumes check
-	if (!map_getmapflag(sd->bl.m, MF_NOCOSTUME) && !map_flag_gvg2(sd->bl.m)) {
+	if (!map_getmapflag(sd->bl.m, MF_NOCOSTUME)) {
 		if ((i = sd->equip_index[EQI_COSTUME_HEAD_LOW]) != -1 && (id = sd->inventory_data[i])) {
 			if (!(id->equip&(EQP_COSTUME_HEAD_MID|EQP_COSTUME_HEAD_TOP)))
 				sd->status.head_bottom = id->look;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -13467,7 +13467,7 @@ void pc_set_costume_view(struct map_session_data *sd) {
 		sd->status.robe = id->look;
 
 	// Costumes check
-	if (!map_getmapflag(sd->bl.m, MF_NOCOSTUME)) {
+	if (!map_getmapflag(sd->bl.m, MF_NOCOSTUME) && !map_flag_gvg2(sd->bl.m)) {
 		if ((i = sd->equip_index[EQI_COSTUME_HEAD_LOW]) != -1 && (id = sd->inventory_data[i])) {
 			if (!(id->equip&(EQP_COSTUME_HEAD_MID|EQP_COSTUME_HEAD_TOP)))
 				sd->status.head_bottom = id->look;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5212

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Visual costumes are now disabled on GvG maps except for hateffects.
Thanks to @ecdarreola and @Balferian!