### PR TITLE
Fixes Shadow Leap and Shadow Slash cast ranges

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -14365,15 +14365,15 @@ Body:
       AllowWhenHidden: true
     Range:
       - Level: 1
-        Size: 7
+        Size: 5
       - Level: 2
-        Size: 9
+        Size: 6
       - Level: 3
-        Size: 11
+        Size: 7
       - Level: 4
-        Size: 13
+        Size: 8
       - Level: 5
-        Size: 15
+        Size: 9
     Hit: Single
     HitCount: 1
     CopyFlags:
@@ -14398,15 +14398,15 @@ Body:
       AlterRangeShadowJump: true
     Range:
       - Level: 1
-        Size: 7
+        Size: 5
       - Level: 2
-        Size: 9
+        Size: 6
       - Level: 3
-        Size: 11
+        Size: 7
       - Level: 4
-        Size: 13
+        Size: 8
       - Level: 5
-        Size: 15
+        Size: 9
     Hit: Single
     HitCount: 1
     Element: Weapon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -14662,15 +14662,15 @@ Body:
       AllowWhenHidden: true
     Range:
       - Level: 1
-        Size: 7
+        Size: 6
       - Level: 2
-        Size: 9
+        Size: 7
       - Level: 3
-        Size: 11
+        Size: 8
       - Level: 4
-        Size: 13
+        Size: 9
       - Level: 5
-        Size: 15
+        Size: 10
     Hit: Single
     HitCount: 1
     CopyFlags:
@@ -14695,15 +14695,15 @@ Body:
       AlterRangeShadowJump: true
     Range:
       - Level: 1
-        Size: 7
+        Size: 6
       - Level: 2
-        Size: 9
+        Size: 7
       - Level: 3
-        Size: 11
+        Size: 8
       - Level: 4
-        Size: 13
+        Size: 9
       - Level: 5
-        Size: 15
+        Size: 10
     Hit: Single
     HitCount: -3
     Element: Weapon

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2381,6 +2381,8 @@ static int battle_range_type(struct block_list *src, struct block_list *target, 
 			// Renewal changes to ranged physical damage
 			return BF_LONG;
 #endif
+		case NJ_KIRIKAGE:
+			// Cast range mimics NJ_SHADOWJUMP but damage is considered melee
 		case GC_CROSSIMPACT:
 			// Cast range is 7 cells and player jumps to target but skill is considered melee
 			return BF_SHORT;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4265

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Shadow Leap's cast range is now 5-9 in pre-renewal and 6-10 in renewal.
  * Shadow Slash is now considered a melee attack.