### PR TITLE
Removed refine UI state during warp

### DIFF
--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -1421,7 +1421,7 @@ Affected files:
 -- questdb: quest_db.yml
 -- script: /npc/*.txt, /npc/*.conf
 -- skilldb: skill_db.yml, const.txt, skill_nocast_db.txt, skill_changematerial_db.txt, skill_damage_db.txt, abra_db.yml, create_arrow_db.txt, produce_db.txt, spellbook_db.yml, magicmushroom_db.yml
--- statusdb: attr_fix.txt, size_fix.yml, refine_db.txt
+-- statusdb: attr_fix.txt, size_fix.yml, refine.yml
 -- achievementdb: achievement_db.yml
 -- attendancedb: attendance.yml
 

--- a/npc/merchants/refine.txt
+++ b/npc/merchants/refine.txt
@@ -627,7 +627,7 @@ lhz_in02,282,20,7	script	Fulerr	4_M_LGTMAN,{
 //= To allow auto safe refining/multiple refining set the
 //= second argument to '1' in the function call.
 //= If you enable this function, be sure to edit the value of
-//= .@safe to the max safe refine in refine_db.txt as well.
+//= .@safe to the max safe refine in refine_db.yml as well.
 //============================================================
 function	script	refinemain	{
 	disable_items;

--- a/npc/re/merchants/refine.txt
+++ b/npc/re/merchants/refine.txt
@@ -43,7 +43,7 @@ payon_in01,18,132,3	duplicate(Vestri#prt)	Vestri#pay	4_M_DWARF
 //= To allow auto safe refining/multiple refining set the
 //= second argument to '1' in the function call.
 //= If you enable this function, be sure to edit the value of
-//= .@safe to the max safe refine in refine_db.txt as well.
+//= .@safe to the max safe refine in refine_db.yml as well.
 //=
 //= On official servers, if an item is unsuccessfully refined
 //= it will break at a 20% rate and downgrade at an 80% rate.

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6048,6 +6048,7 @@ enum e_setpos pc_setpos(struct map_session_data* sd, unsigned short mapindex, in
 	sd->state.warping = 1;
 	sd->state.workinprogress = WIP_DISABLE_NONE;
 	sd->state.mail_writing = false;
+	sd->state.refineui_open = false;
 
 	if( sd->state.changemap ) { // Misc map-changing settings
 		int curr_map_instance_id = map_getmapdata(sd->bl.m)->instance_id, new_map_instance_id = (mapdata ? mapdata->instance_id : 0);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -15980,7 +15980,7 @@ static bool status_readdb_attrfix(const char *basedir,bool silent)
  * DBs being read:
  *	attr_fix.txt: Attribute adjustment table for attacks
  *	size_fix.yml: Size adjustment table for weapons
- *	refine_db.txt: Refining data table
+ *	refine_db.yml: Refining data table
  * @return 0
  */
 int status_readdb(void)

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -22,7 +22,6 @@ struct status_change;
 
 /**
  * Max Refine available to your server
- * Changing this limit requires edits to refine_db.txt
  **/
 #ifdef RENEWAL
 #	define MAX_REFINE 20


### PR DESCRIPTION
* **Addressed Issue(s)**: #5869 

* **Server Mode**: Both

* **Description of Pull Request**: 
Removed refine UI state during warp
Fixed some leftover refine_db.txt references

Thanks to @reunite-ro and @RadianFord