### PR TITLE
Added CL_CLL to all message categories

### DIFF
--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -728,28 +728,28 @@ int _vShowMessage(enum msg_type flag, const char *string, va_list ap)
 		case MSG_NONE: // direct printf replacement
 			break;
 		case MSG_STATUS: //Bright Green (To inform about good things)
-			strcat(prefix,CL_GREEN "[Status]" CL_RESET ":");
+			strcat(prefix,CL_GREEN "[Status]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_SQL: //Bright Violet (For dumping out anything related with SQL) <- Actually, this is mostly used for SQL errors with the database, as successes can as well just be anything else... [Skotlex]
-			strcat(prefix,CL_MAGENTA "[SQL]" CL_RESET ":");
+			strcat(prefix,CL_MAGENTA "[SQL]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_INFORMATION: //Bright White (Variable information)
-			strcat(prefix,CL_WHITE "[Info]" CL_RESET ":");
+			strcat(prefix,CL_WHITE "[Info]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_NOTICE: //Bright White (Less than a warning)
-			strcat(prefix,CL_WHITE "[Notice]" CL_RESET ":");
+			strcat(prefix,CL_WHITE "[Notice]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_WARNING: //Bright Yellow
-			strcat(prefix,CL_YELLOW "[Warning]" CL_RESET ":");
+			strcat(prefix,CL_YELLOW "[Warning]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_DEBUG: //Bright Cyan, important stuff!
-			strcat(prefix,CL_CYAN "[Debug]" CL_RESET ":");
+			strcat(prefix,CL_CYAN "[Debug]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_ERROR: //Bright Red  (Regular errors)
-			strcat(prefix,CL_RED "[Error]" CL_RESET ":");
+			strcat(prefix,CL_RED "[Error]" CL_RESET ":" CL_CLL);
 			break;
 		case MSG_FATALERROR: //Bright Red (Fatal errors, abort(); if possible)
-			strcat(prefix,CL_RED "[Fatal Error]" CL_RESET ":");
+			strcat(prefix,CL_RED "[Fatal Error]" CL_RESET ":" CL_CLL);
 			break;
 		default:
 			ShowError("In function _vShowMessage() -> Invalid flag passed.\n");


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
This makes sure that every possible leftover of any console messages that contained \r are correctly removed when using a category based show message call.
