### PR TITLE
Resolves players warping to freed maps

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -336,6 +336,9 @@ int map_addblock(struct block_list* bl)
 
 	struct map_data *mapdata = map_getmapdata(m);
 
+	if (mapdata->cell == nullptr) // Player warped to a freed map. Stop them!
+		return 1;
+
 	if( x < 0 || x >= mapdata->xs || y < 0 || y >= mapdata->ys )
 	{
 		ShowError("map_addblock: out-of-bounds coordinates (\"%s\",%d,%d), map is %dx%d\n", mapdata->name, x, y, mapdata->xs, mapdata->ys);
@@ -2850,6 +2853,7 @@ int map_delinstancemap(int m)
 	mapdata->damage_adjust = {};
 	mapdata->flag.clear();
 	mapdata->skill_damage.clear();
+	mapdata->instance_id = 0;
 
 	mapindex_removemap(mapdata->index);
 	map_removemapdb(mapdata);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2841,13 +2841,13 @@ int map_delinstancemap(int m)
 	// Free memory
 	if (mapdata->cell)
 		aFree(mapdata->cell);
-	mapdata->cell = NULL;
+	mapdata->cell = nullptr;
 	if (mapdata->block)
 		aFree(mapdata->block);
-	mapdata->block = NULL;
+	mapdata->block = nullptr;
 	if (mapdata->block_mob)
 		aFree(mapdata->block_mob);
-	mapdata->block_mob = NULL;
+	mapdata->block_mob = nullptr;
 
 	map_free_questinfo(mapdata);
 	mapdata->damage_adjust = {};
@@ -2858,6 +2858,7 @@ int map_delinstancemap(int m)
 	mapindex_removemap(mapdata->index);
 	map_removemapdb(mapdata);
 
+	mapdata->index = 0;
 	memset(&mapdata->name, '\0', sizeof(map[0].name)); // just remove the name
 	return 1;
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4363

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves players warping to freed maps resulting in a crash.
  * Clear out the instance_id from mapdata when clearing.
Thanks to everyone who reported and helped get to the bottom of the issue!