### PR TITLE
Fixes temp skills not clearing from skill tree

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5447,7 +5447,7 @@ void clif_addskill(struct map_session_data *sd, int skill_id)
 
 /// Deletes a skill from the skill tree (ZC_SKILLINFO_DELETE).
 /// 0441 <skill id>.W
-void clif_deleteskill(struct map_session_data *sd, int skill_id)
+void clif_deleteskill(struct map_session_data *sd, int skill_id, bool flag)
 {
 #if PACKETVER >= 20081217
 	nullpo_retv(sd);
@@ -5463,7 +5463,10 @@ void clif_deleteskill(struct map_session_data *sd, int skill_id)
 	WFIFOW(fd,2) = skill_id;
 	WFIFOSET(fd,packet_len(0x441));
 #endif
-	clif_skillinfoblock(sd);
+#if PACKETVER_MAIN_NUM >= 20190807 || PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+	if (!flag)
+#endif
+		clif_skillinfoblock(sd);
 }
 
 /// Updates a skill in the skill tree (ZC_SKILLINFO_UPDATE).

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -696,7 +696,7 @@ void clif_skillinfoblock(struct map_session_data *sd);
 void clif_skillup(struct map_session_data *sd, uint16 skill_id, int lv, int range, int upgradable);
 void clif_skillinfo(struct map_session_data *sd,int skill_id, int inf);
 void clif_addskill(struct map_session_data *sd, int skill_id);
-void clif_deleteskill(struct map_session_data *sd, int skill_id);
+void clif_deleteskill(struct map_session_data *sd, int skill_id, bool flag = false);
 
 void clif_skillcasting(struct block_list* bl, int src_id, int dst_id, int dst_x, int dst_y, uint16 skill_id, uint16 skill_lv, int property, int casttime);
 void clif_skillcastcancel(struct block_list* bl);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2089,8 +2089,13 @@ void pc_calc_skilltree(struct map_session_data *sd)
 		uint16 skill_id = skill.second->nameid;
 		uint16 idx = skill_get_index(skill_id);
 
-		if( sd->status.skill[idx].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[idx].flag != SKILL_FLAG_PERM_GRANTED ) //Don't touch these
+		if (sd->status.skill[idx].flag != SKILL_FLAG_PLAGIARIZED && sd->status.skill[idx].flag != SKILL_FLAG_PERM_GRANTED) { //Don't touch these
+#if PACKETVER_MAIN_NUM >= 20190807 || PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
+			if (sd->status.skill[idx].flag == SKILL_FLAG_TEMPORARY || sd->status.skill[idx].flag == SKILL_FLAG_PERMANENT)
+				clif_deleteskill(sd, skill_id, true);
+#endif
 			sd->status.skill[idx].id = 0; //First clear skills.
+		}
 		/* permanent skills that must be re-checked */
 		if( sd->status.skill[idx].flag == SKILL_FLAG_PERM_GRANTED ) {
 			if (skill_id == 0) {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -4705,6 +4705,10 @@ bool pc_skill(struct map_session_data* sd, uint16 skill_id, int level, enum e_ad
 				sd->status.skill[idx].flag = SKILL_FLAG_TEMPORARY;
 			}
 			sd->status.skill[idx].lv = level;
+			if (level == 0)
+				clif_deleteskill(sd,skill_id);
+			else
+				clif_addskill(sd,skill_id);
 			break;
 
 		case ADDSKILL_TEMP_ADDLEVEL: //Add skill bonus on top of what you had.


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5382

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes temporary skills not removing themselves from the skill tree when switching equipment.
Thanks to @attackjom!