### PR TITLE
Remove delayed consumption when switching types

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -103,8 +103,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 			constant = IT_USABLE;
 			item->flag.delay_consume |= DELAYCONSUME_TEMP;
 		} else {
-			if (exists && item->flag.delay_consume & DELAYCONSUME_TEMP) // Remove delayed consumption flag if switching types
-				item->flag.delay_consume &= ~DELAYCONSUME_TEMP;
+			item->flag.delay_consume &= ~DELAYCONSUME_TEMP; // Remove delayed consumption flag if switching types
 		}
 
 		item->type = static_cast<item_types>(constant);

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -102,6 +102,9 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 		if (constant == IT_DELAYCONSUME) { // Items that are consumed only after target confirmation
 			constant = IT_USABLE;
 			item->flag.delay_consume |= DELAYCONSUME_TEMP;
+		} else {
+			if (exists && item->flag.delay_consume & DELAYCONSUME_TEMP) // Remove delayed consumption flag if switching types
+				item->flag.delay_consume &= ~DELAYCONSUME_TEMP;
 		}
 
 		item->type = static_cast<item_types>(constant);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5937

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Removed the delayed consumption flag when switching item types.
Thanks to @mazvi!