### PR TITLE
Fixes skill cooldown adjustment from items

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6354,20 +6354,17 @@ int pc_get_skillcooldown(struct map_session_data *sd, uint16 skill_id, uint16 sk
 
 	int cooldown = skill_get_cooldown(skill_id, skill_lv);
 
-	if (cooldown == 0)
-		return 0;
-
-	if (skill_id == SU_TUNABELLY && pc_checkskill(sd, SU_SPIRITOFSEA))
+	if (skill_id == SU_TUNABELLY && pc_checkskill(sd, SU_SPIRITOFSEA) > 0)
 		cooldown -= skill_get_time(SU_TUNABELLY, skill_lv);
 
 	for (auto &it : sd->skillcooldown) {
 		if (it.id == skill_id) {
 			cooldown += it.val;
-			cooldown = max(0, cooldown);
 			break;
 		}
 	}
-	return cooldown;
+
+	return max(0, cooldown);
 }
 
 /*==========================================


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5934

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Items that adjust cooldown will now not return 0 if no cooldown is defined for a skill.
Thanks to @Felleonel!