### PR TITLE
Refactor BG Team Balancing

### DIFF
--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -1106,6 +1106,8 @@ void bg_queue_join_guild(const char *name, struct map_session_data *sd)
 void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vector <map_session_data *> list)
 {
 	std::vector<map_session_data*> *team = NULL;
+	std::shared_ptr<s_battleground_data> bg_active_team1 = util::umap_find(bg_team_db, 1);
+	std::shared_ptr<s_battleground_data> bg_active_team2 = util::umap_find(bg_team_db, 2);
 	
 	if (!sd) {
 		ShowError("bg_queue_join_multi: Tried to join non-existent player\n.");
@@ -1132,11 +1134,19 @@ void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vec
 			break;
 		}
 
-		// Balance teams based on team sizes.
-		if (queue->teama_members.size() <= queue->teamb_members.size()) {
-			team = &queue->teama_members;
+		// Balance active BG based on team sizes.
+		if (queue->state == QUEUE_STATE_ACTIVE) {
+			if (bgteam1->members.size() <= bgteam2->members.size()) {
+				team = &queue->teama_members;
+			} else {
+				team = &queue->teamb_members;
+			}
 		} else {
-			team = &queue->teamb_members;
+			if ((queue->teama_members.size()) <= queue->teamb_members.size()) {
+				team = &queue->teama_members;
+			} else {
+				team = &queue->teamb_members;
+			}
 		}
 
 		while (!list.empty() && team->size() < bg->max_players) {

--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -1136,7 +1136,7 @@ void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vec
 
 		// Balance active BG based on team sizes.
 		if (queue->state == QUEUE_STATE_ACTIVE) {
-			if (bgteam1->members.size() <= bgteam2->members.size()) {
+			if (bg_active_team1->members.size() <= bg_active_team2->members.size()) {
 				team = &queue->teama_members;
 			} else {
 				team = &queue->teamb_members;

--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -1105,6 +1105,8 @@ void bg_queue_join_guild(const char *name, struct map_session_data *sd)
  */
 void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vector <map_session_data *> list)
 {
+	std::vector<map_session_data*> *team = NULL;
+	
 	if (!sd) {
 		ShowError("bg_queue_join_multi: Tried to join non-existent player\n.");
 		return;
@@ -1130,19 +1132,11 @@ void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vec
 			break;
 		}
 
-		bool r = rnd() % 2 != 0;
-		std::vector<map_session_data *> *team = r ? &queue->teamb_members : &queue->teama_members;
-
-		if (queue->state == QUEUE_STATE_ACTIVE) {
-			// If one team has lesser members try to balance (on an active BG)
-			if (r && queue->teama_members.size() < queue->teamb_members.size())
-				team = &queue->teama_members;
-			else if (!r && queue->teamb_members.size() < queue->teama_members.size())
-				team = &queue->teamb_members;
+		// Balance teams based on team sizes.
+		if (queue->teama_members.size() <= queue->teamb_members.size()) {
+			team = &queue->teama_members;
 		} else {
-			// If the designated team is full, put the player into the other team
-			if (team->size() + list.size() > bg->required_players)
-				team = r ? &queue->teama_members : &queue->teamb_members;
+			team = &queue->teamb_members;
 		}
 
 		while (!list.empty() && team->size() < bg->max_players) {


### PR DESCRIPTION
**Description of Pull Request**: 
The change removes the random team placement leading to unbalanced teams instead favoring a balanced team approach.

- [x] Refactors the code readability for future maintenance.
- [x] Removed logic check for team assignment on line 1144. (seems redundant)
- [x] Check for active BG team size before placing member on a team
- [x] Balance queue team assignment without random