### PR TITLE
Fixed an issue with status reset

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7984,15 +7984,11 @@ int pc_resetstate(struct map_session_data* sd)
 	}
 	else
 	{
-		int add=0;
-		add += pc_need_status_point(sd, SP_STR, 1-pc_getstat(sd, SP_STR));
-		add += pc_need_status_point(sd, SP_AGI, 1-pc_getstat(sd, SP_AGI));
-		add += pc_need_status_point(sd, SP_VIT, 1-pc_getstat(sd, SP_VIT));
-		add += pc_need_status_point(sd, SP_INT, 1-pc_getstat(sd, SP_INT));
-		add += pc_need_status_point(sd, SP_DEX, 1-pc_getstat(sd, SP_DEX));
-		add += pc_need_status_point(sd, SP_LUK, 1-pc_getstat(sd, SP_LUK));
+		sd->status.status_point = 48;
 
-		sd->status.status_point+=add;
+		for( int i = 1; i < sd->status.base_level; i++ ){
+			sd->status.status_point += pc_gets_status_point( i );
+		}
 	}
 
 	if( ( sd->class_&JOBL_UPPER ) != 0 ){


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
If use_statpoint_table was disabled and the player got additional stats or status points from somewhere (bugs in scripts, gm commands, etc.) they were not reset correctly, because the additional points were taken into account when reseting the stats.

Thanks to @Everade
