### PR TITLE
Fix hasnext page in search stores

### DIFF
--- a/src/map/searchstore.cpp
+++ b/src/map/searchstore.cpp
@@ -249,7 +249,7 @@ void searchstore_query(struct map_session_data* sd, unsigned char type, unsigned
  */
 bool searchstore_querynext(struct map_session_data* sd)
 {
-	if( sd->searchstore.count && ( sd->searchstore.count-1 )/SEARCHSTORE_RESULTS_PER_PAGE < sd->searchstore.pages )
+	if( sd->searchstore.count && ( sd->searchstore.count-1 )/SEARCHSTORE_RESULTS_PER_PAGE > sd->searchstore.pages )
 		return true;
 
 	return false;


### PR DESCRIPTION
Thanks to Insomnia#4862 on discord!

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

* **Description of Pull Request**: 
There's an issue with search stores, with results greater than the number shown on the page.
`searchstore_querynext` checks if there are more pages after the current page. It checks `(results - 1) / RES_PER_PAGE < current_page`. This should be flipped, as if the results outnumber the current page, there must be another page.

With fix:
![AAAARagexeRE_patched_2021-06-16_21-29-14](https://user-images.githubusercontent.com/6844975/122331597-f2bb6000-cee9-11eb-8477-9958a533b5b9.png)
