### PR TITLE
Fixes Dark Claw boss damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1495,11 +1495,14 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 
 		if (sc->data[SC_SOUNDOFDESTRUCTION])
 			damage <<= 1;
-        if (sc->data[SC_DARKCROW] && (flag&(BF_SHORT|BF_MAGIC)) == BF_SHORT) {
-            damage += damage * sc->data[SC_DARKCROW]->val2 / 100;
-            if (status_get_class_(bl) == CLASS_BOSS)
-                damage /= 2;
-        }
+		if (sc->data[SC_DARKCROW] && (flag&(BF_SHORT|BF_MAGIC)) == BF_SHORT) {
+			int bonus = sc->data[SC_DARKCROW]->val2;
+
+			if (status_get_class_(bl) == CLASS_BOSS)
+				bonus /= 2;
+
+			damage += damage * bonus / 100;
+		}
 
 		// Damage reductions
 		// Assumptio increases DEF on RE mode, otherwise gives a reduction on the final damage. [Igniz]


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Dark Claw damage increase is only by half versus boss monsters.
  * Flipped the check around from halving the final damage.
Thanks to @limitro!