### PR TITLE
Fixes Spore Explosion item consumption

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5214,7 +5214,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 
 			if (skill_id == RA_ARROWSTORM)
 				status_change_end(src, SC_CAMOUFLAGE, INVALID_TIMER);
-			if( skill_id == AS_SPLASHER || skill_id == GN_SPORE_EXPLOSION ) {
+			if( skill_id == AS_SPLASHER ) {
 				map_freeblock_unlock(); // Don't consume a second gemstone.
 				return 0;
 			}


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Spore Explosion will now properly consume the Bomb Mushroom Spore on skill use.
Thanks to @limitro!