### PR TITLE
Add another entry in view_data for original mob id.

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -5193,7 +5193,7 @@ uint64 MobAvailDatabase::parseBodyNode(const YAML::Node &node) {
 
 			constant = sprite_mob->vd.class_;
 		}
-
+		mob->vd.class_o = mob->vd.class_;
 		mob->vd.class_ = (unsigned short)constant;
 	} else {
 		this->invalidWarning(node["Sprite"], "Sprite is missing.\n");

--- a/src/map/quest.cpp
+++ b/src/map/quest.cpp
@@ -128,7 +128,10 @@ uint64 QuestDatabase::parseBodyNode(const YAML::Node &node) {
 					return 0;
 				}
 
-				mob_id = mob->vd.class_;
+				if (mob->vd.class_o)
+					mob_id = mob->vd.class_o;
+				else
+					mob_id = mob->vd.class_;
 
 				it = std::find_if(quest->objectives.begin(), quest->objectives.end(), [&](std::shared_ptr<s_quest_objective> const &v) {
 					return (*v).mob_id == mob_id;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -66,6 +66,7 @@ struct unit_data {
 struct view_data {
 #ifdef __64BIT__
 	unsigned int class_; //why arch dependant ??? make no sense imo [lighta]
+	unsigned short class_o;
 #else
 	unsigned short class_;
 	unsigned short class_o;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -68,6 +68,7 @@ struct view_data {
 	unsigned int class_; //why arch dependant ??? make no sense imo [lighta]
 #else
 	unsigned short class_;
+	unsigned short class_o;
 #endif
 	t_itemid
 		weapon,


### PR DESCRIPTION
Fixes the bug where the original id is not being loaded on quest db if its in mob_avail db.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6055

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-re

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Follow up to the issue mentioned above.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Now it will check if it has an original mob id instead of a fake(sprite) id and load it to quest db instead.
