### PR TITLE
Battlegrounds Novice Check Correction

### DIFF
--- a/npc/battleground/flavius/flavius_enter.txt
+++ b/npc/battleground/flavius/flavius_enter.txt
@@ -26,7 +26,7 @@ bat_room,133,178,5	script	Flavius Officer#01a	418,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Guillaume Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -95,7 +95,7 @@ bat_room,133,121,1	script	Flavius Officer#01b	414,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Croix Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -228,7 +228,7 @@ bat_room,148,178,5	script	Flavius Officer#02a	418,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Guillaume Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -297,7 +297,7 @@ bat_room,148,121,1	script	Flavius Officer#02b	414,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Croix Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}

--- a/npc/battleground/tierra/tierra_enter.txt
+++ b/npc/battleground/tierra/tierra_enter.txt
@@ -27,7 +27,7 @@ bat_room,124,178,5	script	Tierra Gorge Officer#01a	418,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Guillaume Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -96,7 +96,7 @@ bat_room,140,178,5	script	Tierra Gorge Officer#02a	418,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Guillaume Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Croix Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -233,7 +233,7 @@ bat_room,125,121,1	script	Tierra Gorge Officer#01b	414,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Croix Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}
@@ -302,7 +302,7 @@ bat_room,140,121,1	script	Tierra Gorge Officer#02b	414,{
 	next;
 	switch(select("I want to join your army!:End Conversation")) {
 	case 1:
-		if ((Class == Job_Novice) || (BaseClass == Job_Super_Novice)) {
+		if ((BaseJob == Job_Novice) || (BaseJob == Job_Super_Novice)) {
 			mes "[Croix Army Officer]";
 			mes "I'm very pleased that you want to join us and fight the Guillaume Army, but I'm sorry: I can't send a rookie like you to die on the cruel battlefield.";
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/5965

* **Server Mode**: 
Both

* **Description of Pull Request**: 
Corrects wrong Super Novice check when trying to enter the Battlegrounds waiting queues.
Job_Super_Novice isn't considered a BaseClass, as such it's never true.