### PR TITLE
Added a missing cap for default value for AttackDelay and AttackMotion in mob_db.yml

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4712,7 +4712,7 @@ uint64 MobDatabase::parseBodyNode(const YAML::Node &node) {
 		mob->status.adelay = cap_value(speed, battle_config.monster_max_aspd * 2, 4000);
 	} else {
 		if (!exists)
-			mob->status.adelay = 0;
+			mob->status.adelay = cap_value(0, battle_config.monster_max_aspd * 2, 4000);
 	}
 	
 	if (this->nodeExists(node, "AttackMotion")) {
@@ -4724,7 +4724,7 @@ uint64 MobDatabase::parseBodyNode(const YAML::Node &node) {
 		mob->status.amotion = cap_value(speed, battle_config.monster_max_aspd, 2000);
 	} else {
 		if (!exists)
-			mob->status.amotion = 0;
+			mob->status.amotion = cap_value(0, battle_config.monster_max_aspd, 2000);
 	}
 
 	if (this->nodeExists(node, "DamageMotion")) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/6082

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Although the default value is 0 for AttackDelay and AttackMotion in the YAML file, the value should always be capped by the battleconfig source side.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
