### PR TITLE
Fixes an issue with players joining active BG

### DIFF
--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -1348,6 +1348,8 @@ void bg_join_active(map_session_data *sd, std::shared_ptr<s_battleground_queue> 
 		return;
 	}
 
+	pc_delete_bg_queue_timer(sd); // Cancel timer so player doesn't leave the queue.
+
 	int bg_id_team_1 = static_cast<int>(mapreg_readreg(add_str(queue->map->team1.bg_id_var.c_str())));
 	std::shared_ptr<s_battleground_data> bgteam_1 = util::umap_find(bg_team_db, bg_id_team_1);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Fixes a timer not getting removed from players when they join an active battleground. The timer would continue after accepting the invite and would eventually remove the player from the queue resulting in the player getting the "Left queue time penalty".