### PR TITLE
Cleans up checks for leaving active Battlegrounds

### DIFF
--- a/src/map/battleground.cpp
+++ b/src/map/battleground.cpp
@@ -1230,9 +1230,10 @@ void bg_queue_clear(std::shared_ptr<s_battleground_queue> queue, bool ended)
  * Sub function for leaving a Battleground queue
  * @param sd: Player leaving
  * @param members: List of players in queue data
+ * @param apply_sc: Apply the SC_ENTRY_QUEUE_APPLY_DELAY status on queue leave (default: true)
  * @return True on success or false otherwise
  */
-static bool bg_queue_leave_sub(struct map_session_data *sd, std::vector<map_session_data *> &members)
+static bool bg_queue_leave_sub(struct map_session_data *sd, std::vector<map_session_data *> &members, bool apply_sc)
 {
 	if (!sd)
 		return false;
@@ -1243,7 +1244,8 @@ static bool bg_queue_leave_sub(struct map_session_data *sd, std::vector<map_sess
 		if (*list_it == sd) {
 			members.erase(list_it);
 
-			sc_start(nullptr, &sd->bl, SC_ENTRY_QUEUE_APPLY_DELAY, 100, 1, 60000);
+			if (apply_sc)
+				sc_start(nullptr, &sd->bl, SC_ENTRY_QUEUE_APPLY_DELAY, 100, 1, 60000);
 			sd->bg_queue_id = 0;
 			pc_delete_bg_queue_timer(sd);
 			return true;
@@ -1258,9 +1260,10 @@ static bool bg_queue_leave_sub(struct map_session_data *sd, std::vector<map_sess
 /**
  * Leave a Battleground queue
  * @param sd: Player data
+ * @param apply_sc: Apply the SC_ENTRY_QUEUE_APPLY_DELAY status on queue leave (default: true)
  * @return True on success or false otherwise
  */
-bool bg_queue_leave(struct map_session_data *sd)
+bool bg_queue_leave(struct map_session_data *sd, bool apply_sc)
 {
 	if (!sd || sd->bg_queue_id == 0)
 		return false;
@@ -1269,7 +1272,7 @@ bool bg_queue_leave(struct map_session_data *sd)
 
 	for (auto &queue : bg_queues) {
 		if (sd->bg_queue_id == queue->queue_id) {
-			if (!bg_queue_leave_sub(sd, queue->teama_members) && !bg_queue_leave_sub(sd, queue->teamb_members)) {
+			if (!bg_queue_leave_sub(sd, queue->teama_members, apply_sc) && !bg_queue_leave_sub(sd, queue->teamb_members, apply_sc)) {
 				ShowError("bg_queue_leave: Couldn't find player %s in battlegrounds queue.\n", sd->status.name);
 				return false;
 			} else {

--- a/src/map/battleground.hpp
+++ b/src/map/battleground.hpp
@@ -148,7 +148,7 @@ void bg_queue_join_party(const char *name, struct map_session_data *sd);
 void bg_queue_join_guild(const char *name, struct map_session_data *sd);
 void bg_queue_join_multi(const char *name, struct map_session_data *sd, std::vector<map_session_data *> list);
 void bg_queue_clear(std::shared_ptr<s_battleground_queue> queue, bool ended);
-bool bg_queue_leave(struct map_session_data *sd);
+bool bg_queue_leave(struct map_session_data *sd, bool apply_sc = true);
 bool bg_queue_on_ready(const char *name, std::shared_ptr<s_battleground_queue> queue);
 void bg_queue_on_accept_invite(struct map_session_data *sd);
 void bg_queue_start_battleground(std::shared_ptr<s_battleground_queue> queue);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2069,7 +2069,7 @@ int map_quit(struct map_session_data *sd) {
 		bg_team_leave(sd, true, true);
 
 	if (sd->bg_queue_id > 0)
-		bg_queue_leave(sd);
+		bg_queue_leave(sd, false);
 
 	if( sd->status.clan_id )
 		clan_member_left(sd);


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * When a player deserts an active Battleground they will no longer receive the  SC_ENTRY_QUEUE_APPLY_DELAY status from leaving the queue. This makes it so that the proper Battleground desertion message is shown when trying to join another Battleground.