### PR TITLE
Fixes a crash in the csv2yaml tool

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -2957,7 +2957,7 @@ static bool itemdb_read_randomopt_group(char* str[], int columns, int current) {
 		if (group != nullptr)
 			entries = group->slots[j];
 
-		std::shared_ptr<s_random_opt_group_entry> entry;
+		std::shared_ptr<s_random_opt_group_entry> entry = std::make_shared<s_random_opt_group_entry>();
 
 		entry->id = static_cast<uint16>(randid_tmp);
 		entry->min_value = (int16)strtoul(str[k + 1], nullptr, 10);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

* **Description of Pull Request**: 

As discussed with nitrous on discord, next line is bound to throw an exception given that the pointer was left uninitialized
