### PR TITLE
Removed HP require from Magnum break

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -287,27 +287,6 @@ Body:
     Duration2: 10000
     Cooldown: 2000
     Requires:
-      HpCost:
-        - Level: 1
-          Amount: 20
-        - Level: 2
-          Amount: 20
-        - Level: 3
-          Amount: 19
-        - Level: 4
-          Amount: 19
-        - Level: 5
-          Amount: 18
-        - Level: 6
-          Amount: 18
-        - Level: 7
-          Amount: 17
-        - Level: 8
-          Amount: 17
-        - Level: 9
-          Amount: 16
-        - Level: 10
-          Amount: 16
       SpCost: 30
   - Id: 8
     Name: SM_ENDURE


### PR DESCRIPTION
* **Addressed Issue(s)**: -
* **Server Mode**: Renewal

* **Description of Pull Request**: 
kRo remove HP require from Magnum break skill from [31 october 2018](https://www.divine-pride.net/forum/index.php?/topic/3505-kro-changelog-october-31-2018/).
But this is not mentioned in the Job Rebalance patch note.
![image](https://user-images.githubusercontent.com/16213511/128637850-078f6e3e-4609-4067-ae14-9f5361de2b61.png)
