### PR TITLE
Disables costumes and hat effects on GvG/PvP maps

### DIFF
--- a/npc/mapflag/pvp.txt
+++ b/npc/mapflag/pvp.txt
@@ -1,15 +1,10 @@
 //===== rAthena Script =======================================
 //= Mapflag: Player versus Player mode.
-//===== By: ==================================================
-//= rAthena Dev Team
-//===== Current Version: =====================================
-//= 1.0
-//===== Compatible With: =====================================
-//= rAthena Project
-//===== Description: ========================================= 
+//===== Description: =========================================
 //= Enables PvP on a map.
-//===== Additional Comments: ================================= 
+//===== Changelog: ===========================================
 //= 1.0 Initial script.
+//= 1.1 Disable costumes on PvP maps. [Aleos]
 //============================================================
 
 // PvP ========================
@@ -99,3 +94,89 @@ pvp_2vs2	mapflag	pvp
 turbo_e_4	mapflag	pvp
 turbo_e_8	mapflag	pvp
 turbo_e_16	mapflag	pvp
+
+// Disable Costumes =======
+pvp_y_1-1	mapflag	nocostume
+pvp_y_1-2	mapflag	nocostume
+pvp_y_1-3	mapflag	nocostume
+pvp_y_1-4	mapflag	nocostume
+pvp_y_1-5	mapflag	nocostume
+pvp_y_2-1	mapflag	nocostume
+pvp_y_2-2	mapflag	nocostume
+pvp_y_2-3	mapflag	nocostume
+pvp_y_2-4	mapflag	nocostume
+pvp_y_2-5	mapflag	nocostume
+pvp_y_3-1	mapflag	nocostume
+pvp_y_3-2	mapflag	nocostume
+pvp_y_3-3	mapflag	nocostume
+pvp_y_3-4	mapflag	nocostume
+pvp_y_3-5	mapflag	nocostume
+pvp_y_4-1	mapflag	nocostume
+pvp_y_4-2	mapflag	nocostume
+pvp_y_4-3	mapflag	nocostume
+pvp_y_4-4	mapflag	nocostume
+pvp_y_4-5	mapflag	nocostume
+pvp_y_5-1	mapflag	nocostume
+pvp_y_5-2	mapflag	nocostume
+pvp_y_5-3	mapflag	nocostume
+pvp_y_5-4	mapflag	nocostume
+pvp_y_5-5	mapflag	nocostume
+pvp_y_6-1	mapflag	nocostume
+pvp_y_6-2	mapflag	nocostume
+pvp_y_6-3	mapflag	nocostume
+pvp_y_6-4	mapflag	nocostume
+pvp_y_6-5	mapflag	nocostume
+pvp_y_7-1	mapflag	nocostume
+pvp_y_7-2	mapflag	nocostume
+pvp_y_7-3	mapflag	nocostume
+pvp_y_7-4	mapflag	nocostume
+pvp_y_7-5	mapflag	nocostume
+pvp_y_8-1	mapflag	nocostume
+pvp_y_8-2	mapflag	nocostume
+pvp_y_8-3	mapflag	nocostume
+pvp_y_8-4	mapflag	nocostume
+pvp_y_8-5	mapflag	nocostume
+pvp_n_1-1	mapflag	nocostume
+pvp_n_1-2	mapflag	nocostume
+pvp_n_1-3	mapflag	nocostume
+pvp_n_1-4	mapflag	nocostume
+pvp_n_1-5	mapflag	nocostume
+pvp_n_2-1	mapflag	nocostume
+pvp_n_2-2	mapflag	nocostume
+pvp_n_2-3	mapflag	nocostume
+pvp_n_2-4	mapflag	nocostume
+pvp_n_2-5	mapflag	nocostume
+pvp_n_3-1	mapflag	nocostume
+pvp_n_3-2	mapflag	nocostume
+pvp_n_3-3	mapflag	nocostume
+pvp_n_3-4	mapflag	nocostume
+pvp_n_3-5	mapflag	nocostume
+pvp_n_4-1	mapflag	nocostume
+pvp_n_4-2	mapflag	nocostume
+pvp_n_4-3	mapflag	nocostume
+pvp_n_4-4	mapflag	nocostume
+pvp_n_4-5	mapflag	nocostume
+pvp_n_5-1	mapflag	nocostume
+pvp_n_5-2	mapflag	nocostume
+pvp_n_5-3	mapflag	nocostume
+pvp_n_5-4	mapflag	nocostume
+pvp_n_5-5	mapflag	nocostume
+pvp_n_6-1	mapflag	nocostume
+pvp_n_6-2	mapflag	nocostume
+pvp_n_6-3	mapflag	nocostume
+pvp_n_6-4	mapflag	nocostume
+pvp_n_6-5	mapflag	nocostume
+pvp_n_7-1	mapflag	nocostume
+pvp_n_7-2	mapflag	nocostume
+pvp_n_7-3	mapflag	nocostume
+pvp_n_7-4	mapflag	nocostume
+pvp_n_7-5	mapflag	nocostume
+pvp_n_8-1	mapflag	nocostume
+pvp_n_8-2	mapflag	nocostume
+pvp_n_8-3	mapflag	nocostume
+pvp_n_8-4	mapflag	nocostume
+pvp_n_8-5	mapflag	nocostume
+pvp_2vs2	mapflag	nocostume
+turbo_e_4	mapflag	nocostume
+turbo_e_8	mapflag	nocostume
+turbo_e_16	mapflag	nocostume

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -20693,7 +20693,7 @@ void clif_hat_effects( struct map_session_data* sd, struct block_list* bl, enum 
 
 	nullpo_retv( tsd );
 
-	if( tsd->hatEffects.empty() ){
+	if( tsd->hatEffects.empty() || map_getmapdata(tbl->m)->flag[MF_NOCOSTUME] ){
 		return;
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #5212

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to 6eb896f.
  * Visual costumes are now disabled on PvP maps.
  * Hat Effects are now disabled on GvG and PvP maps.
Thanks to @Badarosk0!