### PR TITLE
Corrects Ray of Genesis cooldown

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -23516,7 +23516,7 @@ Body:
         Time: 5500
     AfterCastActDelay: 2000
     Duration1: 10000
-    Cooldown: 3500
+    Cooldown: 2000
     FixedCastTime: 500
     Requires:
       SpCost:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5887

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Adjusts the Ray of Genesis cooldown to 2 seconds.
Thanks to @Badarosk0!