### PR TITLE
Fixes Marionette Control versus Curse/Quagmire

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6827,14 +6827,14 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case CG_MARIONETTE:
 		{
-			struct status_change* sc = status_get_sc(src);
-
-			if( sd && dstsd && (dstsd->class_&MAPID_UPPERMASK) == MAPID_BARDDANCER && dstsd->status.sex == sd->status.sex )
-			{// Cannot cast on another bard/dancer-type class of the same gender as caster
+			if( (sd && dstsd && (dstsd->class_&MAPID_UPPERMASK) == MAPID_BARDDANCER && dstsd->status.sex == sd->status.sex) || (tsc && (tsc->data[SC_CURSE] || tsc->data[SC_QUAGMIRE])) )
+			{// Cannot cast on another bard/dancer-type class of the same gender as caster, or targets under Curse/Quagmire
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				map_freeblock_unlock();
 				return 1;
 			}
+
+			status_change* sc = status_get_sc(src);
 
 			if( sc && tsc )
 			{


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5908

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Marionette Control will no longer cast onto targets that are either Cursed or in Quagmire.
Thanks to @Tydus1!