### PR TITLE
Fixes Frost Nova versus targets on Land Protector

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -17828,6 +17828,8 @@ int skill_attack_area(struct block_list *bl, va_list ap)
 		case WZ_FROSTNOVA: //Skills that don't require the animation to be removed
 			if (src->x == bl->x && src->y == bl->y)
 				return 0; //Does not hit current cell
+			if (map_getcell(bl->m, bl->x, bl->y, CELL_CHKLANDPROTECTOR)) // Attack should not happen if the target is on Land Protector
+				return 0;
 			//Fall through
 		case NPC_ACIDBREATH:
 		case NPC_DARKNESSBREATH:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5926

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Frost Nova will no longer damage targets who are standing on Land Protector.
Thanks to @Miraakol and @Playtester!