### PR TITLE
Fixed Giant Fly Wing behavior

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -4201,6 +4201,7 @@ SavePoint:    All party members are warped to the save point of the currently
               attached player (will fail if there's no player attached).
 Leader:       All party members are warped to the leader's position. The leader must
               be online and in the current map-server for this to work.
+RandomAll:    All party members are warped to the same random position in their current map
 
 If you specify a from_mapname, 'warpparty' will only affect those on that map.
 

--- a/npc/other/CashShop_Functions.txt
+++ b/npc/other/CashShop_Functions.txt
@@ -51,10 +51,10 @@ function	script	F_CashStore	{
 // - Summon Party members on party leader map to a 3x3 location around the leader.
 // - No arguments.
 function	script	F_CashPartyCall	{
-	itemskill "AL_TELEPORT",1;
-	sleep2 1;	// a slight delay seems necessary after itemskill
-	if (is_party_leader() == true)
-		warpparty "Leader", 0, 0, getcharid(1), strcharinfo(3), 3, 3;
+	if (is_party_leader())
+		warpparty "RandomAll", 0, 0, getcharid(1), strcharinfo(3), 3, 3;
+	else
+		itemskill "AL_TELEPORT",1;
 	return;
 }
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5826,19 +5826,20 @@ BUILDIN_FUNC(warpparty)
 				continue;
 		case 4: // RandomAll
 		case 5: // m,x,y
-			if (rx || ry) {
-				int x1 = x + rx, y1 = y + ry,
-					x0 = x - rx, y0 = y - ry;
-				uint8 attempts = 10;
+			if(!map_getmapflag(pl_sd->bl.m, MF_NORETURN) && !map_getmapflag(pl_sd->bl.m, MF_NOWARP) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
+				if (rx || ry) {
+					int x1 = x + rx, y1 = y + ry,
+						x0 = x - rx, y0 = y - ry;
+					uint8 attempts = 10;
 
-				do {
-					x = x0 + rnd()%(x1 - x0 + 1);
-					y = y0 + rnd()%(y1 - y0 + 1);
-				} while ((--attempts) > 0 && !map_getcell(m, x, y, CELL_CHKPASS));
+					do {
+						x = x0 + rnd()%(x1 - x0 + 1);
+						y = y0 + rnd()%(y1 - y0 + 1);
+					} while ((--attempts) > 0 && !map_getcell(m, x, y, CELL_CHKPASS));
+				}
+
+				ret = pc_setpos(pl_sd, mapindex, x, y, CLR_TELEPORT);
 			}
-
-			if(!map_getmapflag(pl_sd->bl.m, MF_NORETURN) && !map_getmapflag(pl_sd->bl.m, MF_NOWARP) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level))
-				ret = pc_setpos(pl_sd,mapindex,x,y,CLR_TELEPORT);
 		break;
 		}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5722,7 +5722,7 @@ BUILDIN_FUNC(warpparty)
 	TBL_PC *sd = NULL;
 	TBL_PC *pl_sd;
 	struct party_data* p;
-	int type, ret, mapindex = 0, m = -1, i, rx = 0, ry = 0;
+	int type, mapindex = 0, m = -1, i, rx = 0, ry = 0;
 
 	const char* str = script_getstr(st,2);
 	int x = script_getnum(st,3);
@@ -5796,6 +5796,9 @@ BUILDIN_FUNC(warpparty)
 			break;
 	}
 
+	int ret;
+	map_data *mapdata = map_getmapdata(pl_sd->bl.m);
+
 	for (i = 0; i < MAX_PARTY; i++)
 	{
 		if( !(pl_sd = p->data[i].sd) || pl_sd->status.party_id != p_id )
@@ -5810,15 +5813,15 @@ BUILDIN_FUNC(warpparty)
 		switch( type )
 		{
 		case 0: // Random
-			if(!map_getmapflag(pl_sd->bl.m, MF_NOWARP))
+			if (!mapdata->flag[MF_NOWARP])
 				ret = pc_randomwarp(pl_sd,CLR_TELEPORT);
 		break;
 		case 1: // SavePointAll
-			if(!map_getmapflag(pl_sd->bl.m, MF_NORETURN))
+			if (!mapdata->[MF_NORETURN])
 				ret = pc_setpos(pl_sd,pl_sd->status.save_point.map,pl_sd->status.save_point.x,pl_sd->status.save_point.y,CLR_TELEPORT);
 		break;
 		case 2: // SavePoint
-			if(!map_getmapflag(pl_sd->bl.m, MF_NORETURN))
+			if (!mapdata->flag[MF_NORETURN])
 				ret = pc_setpos(pl_sd,sd->status.save_point.map,sd->status.save_point.x,sd->status.save_point.y,CLR_TELEPORT);
 		break;
 		case 3: // Leader
@@ -5830,7 +5833,7 @@ BUILDIN_FUNC(warpparty)
 				break;
 			}
 		case 5: // m,x,y
-			if(!map_getmapflag(pl_sd->bl.m, MF_NORETURN) && !map_getmapflag(pl_sd->bl.m, MF_NOWARP) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
+			if (!mapdata->flag[MF_NORETURN]) && !mapdata->flag[MF_NOWARP]) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
 				if (rx || ry) {
 					int x1 = x + rx, y1 = y + ry,
 						x0 = x - rx, y0 = y - ry,

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5796,26 +5796,21 @@ BUILDIN_FUNC(warpparty)
 				return SCRIPT_CMD_FAILURE;
 			}
 			} break;
-		case WARPPARTY_RANDOMALLAREA: {
+		case WARPPARTY_RANDOMALLAREA:
 			mapindex = mapindex_name2id(str);
 			if (!mapindex) {// Invalid map
 				return SCRIPT_CMD_FAILURE;
 			}
 			m = map_mapindex2mapid(mapindex);
-
-			struct map_data *mapdata = map_getmapdata(m);
-
-			if ( mapdata == nullptr || mapdata->flag[MF_NOWARP] || mapdata->flag[MF_NOTELEPORT] )
-				return SCRIPT_CMD_FAILURE;
-			} break;
+			break;
 	}
-
-	map_data *mapdata = map_getmapdata(pl_sd->bl.m);
 
 	for (i = 0; i < MAX_PARTY; i++)
 	{
 		if( !(pl_sd = p->data[i].sd) || pl_sd->status.party_id != p_id )
 			continue;
+
+		map_data* mapdata = map_getmapdata(pl_sd->bl.m);
 
 		if( str2 && strcmp(str2, mapdata->name) != 0 )
 			continue;
@@ -5823,13 +5818,13 @@ BUILDIN_FUNC(warpparty)
 		if( pc_isdead(pl_sd) )
 			continue;
 
-		enum e_setpos ret = SETPOS_OK;
+		e_setpos ret = SETPOS_OK;
 
 		switch( type )
 		{
 		case WARPPARTY_RANDOM:
 			if (!mapdata->flag[MF_NOWARP])
-				ret = pc_randomwarp(pl_sd,CLR_TELEPORT);
+				ret = (e_setpos)pc_randomwarp(pl_sd,CLR_TELEPORT);
 		break;
 		case WARPPARTY_SAVEPOINTALL:
 			if (!mapdata->flag[MF_NORETURN])
@@ -5842,6 +5837,7 @@ BUILDIN_FUNC(warpparty)
 		case WARPPARTY_LEADER:
 			if (p->party.member[i].leader)
 				continue;
+			// Fall through
 		case WARPPARTY_RANDOMALL:
 			if (pl_sd == sd) {
 				ret = pc_setpos(pl_sd, mapindex, x, y, CLR_TELEPORT);
@@ -5849,7 +5845,7 @@ BUILDIN_FUNC(warpparty)
 			}
 			// Fall through
 		case WARPPARTY_RANDOMALLAREA:
-			if (pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
+			if(!mapdata->flag[MF_NORETURN] && !mapdata->flag[MF_NOWARP] && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)){
 				if (rx || ry) {
 					int x1 = x + rx, y1 = y + ry,
 						x0 = x - rx, y0 = y - ry,

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5752,7 +5752,7 @@ BUILDIN_FUNC(warpparty)
 		case 2:
 			//"SavePoint" uses save point of the currently attached player
 			if ( !script_rid2sd(sd) )
-				return SCRIPT_CMD_SUCCESS;
+				return SCRIPT_CMD_FAILURE;
 			break;
 		case 3:
 			for(i = 0; i < MAX_PARTY && !p->party.member[i].leader; i++);
@@ -5766,7 +5766,7 @@ BUILDIN_FUNC(warpparty)
 			break;
 		case 4: {
 			if ( !script_rid2sd(sd) )
-				return SCRIPT_CMD_SUCCESS;
+				return SCRIPT_CMD_FAILURE;
 
 			mapindex = sd->mapindex;
 			m = map_mapindex2mapid(mapindex);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5804,7 +5804,7 @@ BUILDIN_FUNC(warpparty)
 		if( !(pl_sd = p->data[i].sd) || pl_sd->status.party_id != p_id )
 			continue;
 
-		if( str2 && strcmp(str2, map_getmapdata(pl_sd->bl.m)->name) != 0 )
+		if( str2 && strcmp(str2, mapdata->name) != 0 )
 			continue;
 
 		if( pc_isdead(pl_sd) )
@@ -5817,7 +5817,7 @@ BUILDIN_FUNC(warpparty)
 				ret = pc_randomwarp(pl_sd,CLR_TELEPORT);
 		break;
 		case 1: // SavePointAll
-			if (!mapdata->[MF_NORETURN])
+			if (!mapdata->flag[MF_NORETURN])
 				ret = pc_setpos(pl_sd,pl_sd->status.save_point.map,pl_sd->status.save_point.x,pl_sd->status.save_point.y,CLR_TELEPORT);
 		break;
 		case 2: // SavePoint
@@ -5833,7 +5833,7 @@ BUILDIN_FUNC(warpparty)
 				break;
 			}
 		case 5: // m,x,y
-			if (!mapdata->flag[MF_NORETURN]) && !mapdata->flag[MF_NOWARP]) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
+			if (!mapdata->flag[MF_NORETURN] && !mapdata->flag[MF_NOWARP] && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pl_sd->group_level)) {
 				if (rx || ry) {
 					int x1 = x + rx, y1 = y + ry,
 						x0 = x - rx, y0 = y - ry,


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6160 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  Adds new RandomAll warpparty mode that first finds a random cell first and then teleports all party members in the map to that position at once, fixing Giant Fly Wing behavior.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
