### PR TITLE
Minor cleanups to AutoSpell item bonuses

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2527,7 +2527,7 @@ int pc_disguise(struct map_session_data *sd, int class_)
  * @param flag: Battle flag
  * @param card_id: Used to prevent card stacking
  */
-static void pc_bonus_autospell(std::vector<s_autospell> &spell, short id, short lv, short rate, short flag, unsigned short card_id)
+static void pc_bonus_autospell(std::vector<s_autospell> &spell, int id, int lv, short rate, short flag, t_itemid card_id)
 {
 	if (spell.size() == MAX_PC_BONUS) {
 		ShowWarning("pc_bonus_autospell: Reached max (%d) number of autospells per character!\n", MAX_PC_BONUS);
@@ -2580,7 +2580,7 @@ static void pc_bonus_autospell(std::vector<s_autospell> &spell, short id, short 
  * @param rate: Success chance
  * @param card_id: Used to prevent card stacking
  */
-static void pc_bonus_autospell_onskill(std::vector<s_autospell> &spell, short src_skill, short id, short lv, short rate, unsigned short card_id)
+static void pc_bonus_autospell_onskill(std::vector<s_autospell> &spell, int src_skill, int id, int lv, short rate, t_itemid card_id)
 {
 	if (spell.size() == MAX_PC_BONUS) {
 		ShowWarning("pc_bonus_autospell_onskill: Reached max (%d) number of autospells per character!\n", MAX_PC_BONUS);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -194,8 +194,9 @@ struct weapon_data {
 
 /// AutoSpell bonus struct
 struct s_autospell {
-	short id, lv, rate, flag;
-	unsigned short card_id;
+	int id, lv;
+	short rate, flag;
+	t_itemid card_id;
 	bool lock;  // bAutoSpellOnSkill: blocks autospell from triggering again, while being executed
 };
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2274,15 +2274,14 @@ int skill_onskillusage(struct map_session_data *sd, struct block_list *bl, uint1
 		return 0;
 
 	for (auto &it : sd->autospell3) {
-		int skill, skill_lv, type;
-
 		if (it.flag != skill_id)
 			continue;
 
 		if (it.lock)
 			continue;  // autospell already being executed
 
-		skill = it.id;
+		int skill = it.id;
+
 		sd->state.autocast = 1; //set this to bypass sd->canskill_tick check
 
 		if( skill_isNotOk((skill > 0) ? skill : skill*-1, sd) ) {
@@ -2297,14 +2296,19 @@ int skill_onskillusage(struct map_session_data *sd, struct block_list *bl, uint1
 		if( rnd()%1000 >= it.rate )
 			continue;
 
-		skill_lv = it.lv ? it.lv : 1;
-		if( skill < 0 ) {
+		if( skill < 0 ) { // Negative value used for selecting target as self
 			tbl = &sd->bl;
 			skill *= -1;
-			skill_lv = 1 + rnd()%(-skill_lv); //random skill_lv
 		}
 		else
 			tbl = bl;
+
+		int skill_lv = it.lv ? it.lv : 1;
+
+		if (skill_lv < 0) // Negative value used as random level casted
+			skill_lv = 1 + rnd() % (-skill_lv); //random skill_lv
+
+		int type;
 
 		if ((type = skill_get_casttype(skill)) == CAST_GROUND) {
 			if (!skill_pos_maxcount_check(&sd->bl, tbl->x, tbl->y, skill_id, skill_lv, BL_PC, false))


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6153

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes variable types to avoid any loss of data.
  * Fixes AutoSpellOnSkill random level cast being mixed with the target selection flag.
Thanks @Badarosk0!