### PR TITLE
Fixes skill units not clearing from unit_data

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18979,6 +18979,8 @@ int skill_delunitgroup_(std::shared_ptr<s_skill_unit_group> group, const char* f
 	if (skillunit_group_db.erase(group->group_id) != 1)
 		ShowError("skill_delunitgroup: Group not found! (src_id: %d skill_id: %d)\n", group->src_id, group->skill_id);
 
+	util::vector_erase_if_exists(ud->skillunits, group);
+
 	if(link_group_id) {
 		std::shared_ptr<s_skill_unit_group> group_cur = skill_id2group(link_group_id);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6217

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to a84e731.
  * Adds a missing erase for skill unit data from the unit_data of an object.
Thanks to @AsurielRO!