### PR TITLE
Cleans up some cast time and delay behaviors

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -9660,7 +9660,6 @@ Body:
     Duration1: 30000
     CastTimeFlags:
       IgnoreDex: true
-      IgnoreStatus: true
       IgnoreItemBonus: true
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -9953,7 +9953,6 @@ Body:
     FixedCastTime: 700
     CastTimeFlags:
       IgnoreDex: true
-      IgnoreStatus: true
     Requires:
       SpCost:
         - Level: 1

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -17328,6 +17328,8 @@ int skill_delayfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 	if (time < 0)
 		time = -time + status_get_amotion(bl);	// If set to <0, add to attack motion.
 
+	status_change* sc = status_get_sc(bl);
+
 	// Delay reductions
 	switch (skill_id) {	//Monk combo skills have their delay reduced by agi/dex.
 		case MO_TRIPLEATTACK:
@@ -17368,8 +17370,6 @@ int skill_delayfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 			}
 	}
 
-	status_change *sc = status_get_sc(bl);
-
 	if (sc && sc->count) {
 		if (sc->data[SC_SPIRIT]) {
 			switch (skill_id) {
@@ -17397,7 +17397,7 @@ int skill_delayfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 	}
 
 	if (!(delaynodex&4) && bl->type == BL_PC) {
-		map_session_data *sd = BL_CAST(BL_PC, bl);
+		map_session_data* sd = (map_session_data*)bl;
 
 		if (sd->delayrate != 100) // bonus bDelayRate
 			time += time * sd->delayrate / 100;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -17048,9 +17048,9 @@ struct s_skill_condition skill_get_requirement(struct map_session_data* sd, uint
  * Does cast-time reductions based on dex, item bonuses and config setting
  *------------------------------------------*/
 int skill_castfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv) {
-	double time = skill_get_cast(skill_id, skill_lv);
-
 	nullpo_ret(bl);
+
+	double time = skill_get_cast(skill_id, skill_lv);
 
 #ifndef RENEWAL_CAST
 	{
@@ -17099,11 +17099,13 @@ int skill_castfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv) {
 				reduce_cast_rate += sc->data[SC_POEMBRAGI]->val2;
 			// Foresight halves the cast time, it does not stack additively
 			if (sc->data[SC_MEMORIZE]) {
-				if(!(flag&2))
-					time -= time * 50 / 100;
-				// Foresight counter gets reduced even if the skill is not affected by it
-				if ((--sc->data[SC_MEMORIZE]->val2) <= 0)
-					status_change_end(bl, SC_MEMORIZE, INVALID_TIMER);
+				if ((sd && pc_checkskill(sd, skill_id) > 0) || !sd) { // Foresight only decreases cast times from learned skills, not skills granted by items
+					if(!(flag&2))
+						time -= time * 50 / 100;
+					// Foresight counter gets reduced even if the skill is not affected by it
+					if ((--sc->data[SC_MEMORIZE]->val2) <= 0)
+						status_change_end(bl, SC_MEMORIZE, INVALID_TIMER);
+				}
 			}
 		}
 
@@ -17130,13 +17132,13 @@ int skill_castfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv) {
  */
 int skill_castfix_sc(struct block_list *bl, double time, uint8 flag)
 {
-	struct status_change *sc = status_get_sc(bl);
-
 	if (time < 0)
 		return 0;
 
 	if (bl->type == BL_MOB || bl->type == BL_NPC)
 		return (int)time;
+
+	status_change *sc = status_get_sc(bl);
 
 	if (sc && sc->count) {
 		if (!(flag&2)) {
@@ -17249,9 +17251,11 @@ int skill_vfcastfix(struct block_list *bl, double time, uint16 skill_id, uint16 
 #endif
 		}
 		if (sc->data[SC_MEMORIZE]) {
-			reduce_cast_rate += 50;
-			if ((--sc->data[SC_MEMORIZE]->val2) <= 0)
-				status_change_end(bl, SC_MEMORIZE, INVALID_TIMER);
+			if ((sd && pc_checkskill(sd, skill_id) > 0) || !sd) { // Foresight only decreases cast times from learned skills, not skills granted by items
+				reduce_cast_rate += 50;
+				if ((--sc->data[SC_MEMORIZE]->val2) <= 0)
+					status_change_end(bl, SC_MEMORIZE, INVALID_TIMER);
+			}
 		}
 		if (sc->data[SC_POEMBRAGI])
 			reduce_cast_rate += sc->data[SC_POEMBRAGI]->val2;
@@ -17310,19 +17314,17 @@ int skill_vfcastfix(struct block_list *bl, double time, uint16 skill_id, uint16 
  *------------------------------------------*/
 int skill_delayfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 {
-	int delaynodex = skill_get_delaynodex(skill_id);
-	int time = skill_get_delay(skill_id, skill_lv);
-	struct map_session_data *sd;
-	struct status_change *sc = status_get_sc(bl);
-
 	nullpo_ret(bl);
-	sd = BL_CAST(BL_PC, bl);
 
 	if (skill_id == SA_ABRACADABRA)
 		return 0; //Will use picked skill's delay.
 
 	if (bl->type&battle_config.no_skill_delay)
 		return battle_config.min_skill_delay_limit;
+
+	int delaynodex = skill_get_delaynodex(skill_id);
+	int time = skill_get_delay(skill_id, skill_lv);
+	status_change *sc = status_get_sc(bl);
 
 	if (time < 0)
 		time = -time + status_get_amotion(bl);	// If set to <0, add to attack motion.
@@ -17393,14 +17395,18 @@ int skill_delayfix(struct block_list *bl, uint16 skill_id, uint16 skill_lv)
 		}
 	}
 
-	if (!(delaynodex&4) && sd) {
-		if (sd->delayrate != 100)
-			time = time * sd->delayrate / 100;
+	if (!(delaynodex&4)) {
+		map_session_data *sd = BL_CAST(BL_PC, bl);
 
-		for (auto &it : sd->skilldelay) {
-			if (it.id == skill_id) {
-				time += it.val;
-				break;
+		if (sd) {
+			if (sd->delayrate != 100) // bonus bDelayRate
+				time += time * sd->delayrate / 100;
+
+			for (auto &it : sd->skilldelay) { // bonus2 bSkillDelay
+				if (it.id == skill_id) {
+					time += it.val;
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6135

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Mystical Amplification should not have the IgnoreStatus CastTime flag.
  * Foresight will only apply a cast reduction to learned skills, not those that are granted through item bonuses, guild skills, pets, etc.
  * Item bonus bDelayRate will now stack with other delay reduction bonuses.
  * General cleanups to variable defines.
Thanks to @Everade and @mrjnumber1!