### PR TITLE
Fixed a map-server crash

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19003,7 +19003,8 @@ void skill_clear_unitgroup(struct block_list *src)
 
 	nullpo_retv(ud);
 
-	for (auto it = ud->skillunits.begin(); it != ud->skillunits.end(); it++) {
+	// The after loop statement might look stupid, but this prevents iteration problems, if an entry was deleted
+	for (auto it = ud->skillunits.begin(); it != ud->skillunits.end(); it = ud->skillunits.begin()) {
 		skill_delunitgroup(*it);
 	}
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: #6220

* **Server Mode**: Both

* **Description of Pull Request**: 
Vector iteration caused a problem once again. Instead of rewriting the whole code I came up with the crazy idea to just use the first element of the vector on each iteration until no entry is left anymore.

Thanks to @AsurielRO, @Atemo, @aleos89 and @vstumpf
