### PR TITLE
Adds missing effect to ID29463 Rune Knight Stone (Garment)

### DIFF
--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -42938,6 +42938,7 @@ Body:
     Type: Card
     Script: |
       bonus2 bSkillAtk,"RK_DRAGONBREATH",10;
+      bonus2 bSkillAtk,"RK_DRAGONBREATH_WATER",10;
   - Id: 29464
     AegisName: GeneticStone_Top_
     Name: Creator Stone (Top)

--- a/sql-files/item_db_re_etc.sql
+++ b/sql-files/item_db_re_etc.sql
@@ -4241,7 +4241,7 @@ REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VAL
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29460,'RuneknightStone_Top_','Lord Knight Stone (Top)','Card','bonus bBaseAtk,2*getskilllv("KN_SPEARMASTERY");');
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29461,'RuneknightStone_Middle_','Lord Knight Stone (Middle)','Card','bonus2 bSkillAtk,"LK_SPIRALPIERCE",15;');
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29462,'RuneknightStone_Bottom_','Lord Knight Stone (Bottom)','Card','bonus bAspdRate,getskilllv("KN_CAVALIERMASTERY");');
-REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29463,'RuneknightStone_Robe_','Rune Knight Stone (Garment)','Card','bonus2 bSkillAtk,"RK_DRAGONBREATH",10;');
+REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29463,'RuneknightStone_Robe_','Rune Knight Stone (Garment)','Card','bonus2 bSkillAtk,"RK_DRAGONBREATH",10;\nbonus2 bSkillAtk,"RK_DRAGONBREATH_WATER",10;');
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29464,'GeneticStone_Top_','Creator Stone (Top)','Card','bonus bBaseAtk,2*getskilllv("AM_LEARNINGPOTION");');
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29465,'GeneticStone_Middle_','Creator Stone (Middle)','Card','bonus bHealPower,2*getskilllv("AM_POTIONPITCHER");');
 REPLACE INTO `item_db_re` (`id`,`name_aegis`,`name_english`,`type`,`script`) VALUES (29466,'GeneticStone_Bottom_','Creator Stone (Bottom)','Card','bonus2 bSkillAtk,"AM_ACIDTERROR",20;');


### PR DESCRIPTION
* **Server Mode**: 
Renewal

* **Description of Pull Request**: 
  Adds missing effect to ID29463 Rune Knight Stone (Garment).
  The damage bonus for Dragon's Breath (Water) was missing.
