### PR TITLE
Fixed a map-server crash when freeing non-existent script arrays

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -2973,6 +2973,8 @@ unsigned int script_array_highest_key(struct script_state *st, struct map_sessio
 int script_free_array_db(DBKey key, DBData *data, va_list ap)
 {
 	struct script_array *sa = static_cast<script_array *>(db_data2ptr(data));
+	if ( sa == nullptr ) { // non-existent array, nothing to empty
+		return SCRIPT_CMD_SUCCESS;
 	aFree(sa->members);
 	ers_free(array_ers, sa);
 	return SCRIPT_CMD_SUCCESS;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6230 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes a map-server crash when freeing non-existent script arrays

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
