### PR TITLE
Suggestion: NPC name as parameter in enablenpc

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6573,8 +6573,8 @@ Examples:
 
 ---------------------------------------
 
-*disablenpc "<NPC object name>";
-*enablenpc "<NPC object name>";
+*disablenpc {"<NPC object name>"};
+*enablenpc {"<NPC object name>"};
 
 These two commands will disable and enable, respectively, an NPC object
 specified by name. The disabled NPC will disappear from sight and will no longer
@@ -6591,8 +6591,8 @@ copies, and then disable all except one.
 
 ---------------------------------------
 
-*hideonnpc "<NPC object name>";
-*hideoffnpc "<NPC object name>";
+*hideonnpc {"<NPC object name>"};
+*hideoffnpc {"<NPC object name>"};
 
 These commands will make the NPC object specified display as hidden/visible,
 even though not actually disabled per se. Hidden as in thief Hide skill, but
@@ -6612,8 +6612,8 @@ This command will fully unload a NPC object and all of it's duplicates.
 
 ---------------------------------------
  
-*cloakonnpc "<NPC object name>"{,<character ID>};
-*cloakoffnpc "<NPC object name>"{,<character ID>};
+*cloakonnpc {"<NPC object name>"{,<character ID>}};
+*cloakoffnpc {"<NPC object name>"{,<character ID>}};
 
 These commands will make the NPC object specified display as cloaked/uncloaked,
 even though not actually disabled.
@@ -6626,7 +6626,7 @@ If no <character ID> is specified it will display to the area.
 
 ---------------------------------------
 
-*isnpccloaked "<NPC object name>"{,<character ID>};
+*isnpccloaked {"<NPC object name>"{,<character ID>}};
 
 Returns true if the NPC has been cloaked to the attached player or given
 <character ID>, false otherwise. This works in association with cloakonnpc

--- a/npc/airports/airships.txt
+++ b/npc/airports/airships.txt
@@ -24,11 +24,11 @@ airplane,243,73,0	script	#AirshipWarp-1	45,1,1,{
 OnInit:
 OnHide:
 	specialeffect EF_BASH;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnUnhide:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	specialeffect EF_SUMMONSLAVE;
 	end;
 
@@ -670,11 +670,11 @@ OnTouch_:
 OnInit:
 OnHide:
 	specialeffect EF_BASH;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 	
 OnUnhide:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	specialeffect EF_SUMMONSLAVE;
 	end;
 }

--- a/npc/custom/official/GeffenMagicTournament.txt
+++ b/npc/custom/official/GeffenMagicTournament.txt
@@ -853,10 +853,10 @@ OnTouch:
 
 OnInstanceInit:
 OnDisable:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	end;
 }
 
@@ -913,7 +913,7 @@ OnInstanceInit:
 
 OnInstanceInit:
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	end;
 }
 

--- a/npc/guild2/agit_main_se.txt
+++ b/npc/guild2/agit_main_se.txt
@@ -1055,7 +1055,7 @@ OnInit:
 						close2;
 						donpcevent "df"+.@num+"#"+strnpcinfo(4)+"::OnEnable";
 						specialeffect EF_ICECRASH;
-						disablenpc strnpcinfo(0);
+						disablenpc();
 						setd .@var$+"["+(.@num-1)+"]",0;
 						set .@df_all,getd(.@var$+"[0]")+getd(.@var$+"[1]");
 						if (!.@df_all) {
@@ -1092,11 +1092,11 @@ OnInit:
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	specialeffect EF_MAPPILLAR2;
 	end;
 }
@@ -1297,7 +1297,7 @@ OnEnable:
 							delitem 984,5; //Oridecon
 							close2;
 							donpcevent "RL"+.@num+"#"+strnpcinfo(4)+"::OnEnable";
-							disablenpc strnpcinfo(0);
+							disablenpc();
 							if (.@num == 1) set .@str$,"1st";
 							else if (.@num == 2) set .@str$,"2nd";
 							else if (.@num == 3) set .@str$,"3rd";
@@ -1336,11 +1336,11 @@ OnEnable:
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 

--- a/npc/instances/EndlessTower.txt
+++ b/npc/instances/EndlessTower.txt
@@ -1248,11 +1248,11 @@ OnTimer5000:
 	end;
 
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	callfunc "F_Tower_Monster",
 		atoi(replacestr(strnpcinfo(0),"FGate102tower","")) + 1,
 		strnpcinfo(4),

--- a/npc/instances/NydhoggsNest.txt
+++ b/npc/instances/NydhoggsNest.txt
@@ -2004,11 +2004,11 @@ OnEnable:
 
 2@nyd,115,278,0	script	nyd_2f_red	-1,5,5,{
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp1")+"::OnEnable";
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp2")+"::OnEnable";
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp3")+"::OnEnable";
@@ -2020,7 +2020,7 @@ OnDisable:
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp1")+"::OnDisable";
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp2")+"::OnDisable";
 	donpcevent instance_npcname(strnpcinfo(0)+"_warp3")+"::OnDisable";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnTouch:
@@ -2042,18 +2042,18 @@ OnTouch:
 	end;
 
 OnTimer10000:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	stopnpctimer;
 	end;
 }
 
 2@nyd,6,6,0	script	nyd_2f_red_c	-1,{
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	initnpctimer;
 	set .@map$, instance_mapname("2@nyd");
 	set .@label$, instance_npcname(strnpcinfo(0))+"::OnMyMobDead";
@@ -2105,7 +2105,7 @@ OnDisable:
 	stopnpctimer;
 	killmonster instance_mapname("2@nyd"),instance_npcname(strnpcinfo(0))+"::OnMyMobDead"; //custom
 	donpcevent instance_npcname(substr(strnpcinfo(0),0,getstrlen(strnpcinfo(0))-3))+"::OnDisable";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnTimer180000:
@@ -2118,11 +2118,11 @@ OnTimer180000:
 2@nyd,130,298,0	script	nyd_2f_red_warp1	-1,6,6,{
 OnInstanceInit:
 OnDisable:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	end;
 
 OnTouch:

--- a/npc/instances/OrcsMemory.txt
+++ b/npc/instances/OrcsMemory.txt
@@ -685,16 +685,16 @@ OnTimer23910:
 	else
 		donpcevent instance_npcname("Torch#"+.@id[0]+"-"+(.@id[1]+1))+"::OnEnable";
 	initnpctimer;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnInstanceInit:
 	if (strnpcinfo(0) != "Torch#2-1" && strnpcinfo(0) != "Torch#3-1")
-		disablenpc instance_npcname(strnpcinfo(0));
+		disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	end;
 
 OnTimer100:

--- a/npc/instances/SealedShrine.txt
+++ b/npc/instances/SealedShrine.txt
@@ -891,7 +891,7 @@ OnInstanceInit:
 			specialeffect2 EF_HOLYHIT;
 			getitem 6001,1; //Essence_Of_Fire
 			mes "The symbol of inheritor shines. Then a small crystal falls into my hand from the torch.";
-			disablenpc instance_npcname(strnpcinfo(0));
+			disablenpc();
 			close;
 		}
 		else if (('ins_baphomet == 3) && (countitem(6001) > 10)) {
@@ -914,7 +914,7 @@ OnInstanceInit:
 	}
 
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 1@cata,267,210,0	duplicate(Bobbing Torch#SS)	Bobbing Torch#1	844
@@ -1093,7 +1093,7 @@ OnTouch_:
 	}
 	if (.@seal_check == 2) erasequest 3041;
 	specialeffect EF_LEXDIVINA;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	set .@map$, instance_mapname("2@cata");
 	if (strnpcinfo(2) == "0") areamobuseskill .@map$,79,81,10,1929,"NPC_INVINCIBLEOFF",1,0,0,ET_HELP,0;
 	else if (strnpcinfo(2) == "2") areamobuseskill .@map$,123,109,10,1929,"NPC_INVINCIBLEOFF",1,0,0,ET_HELP,0;
@@ -1110,7 +1110,7 @@ OnTouch_:
 	close;
 
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 2@cata,79,81,0	duplicate(Magical Seal#SS)	Magical Seal#0	844

--- a/npc/jobs/2-1/assassin.txt
+++ b/npc/jobs/2-1/assassin.txt
@@ -2257,7 +2257,7 @@ OnTouch_:
 	end;
 
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 in_moc_16,156,87,1	duplicate(#moc_assin_dup)	[Huey]	55

--- a/npc/other/monster_race.txt
+++ b/npc/other/monster_race.txt
@@ -208,7 +208,7 @@ OnInit:
 -	script	Runner_main	-1,{
 OnEnable:
 	emotion ET_SURPRISE;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	getmapxy(.@m$,.@x,.@y,BL_NPC);
 	setarray .@mob[1], 1725,1726,1727,1728,1730,1729;
 	.@n = atoi( strnpcinfo(2) );
@@ -216,7 +216,7 @@ OnEnable:
 	end;
 
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	killmonster "p_track01",strnpcinfo(0)+"::OnMyMobDead";
 	end;
 
@@ -243,7 +243,7 @@ OnTouchNPC:
 	
 OnInit:
 	if (strnpcinfo(2) != "" )
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	end;
 }
 p_track01,30,38,0	duplicate(Runner_main)	Runner No. 1#1	-1,1,0
@@ -783,7 +783,7 @@ OnTouchNPC:
 	end;
 	
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -799,7 +799,7 @@ OnTouchNPC:
 	end;
 	
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -814,7 +814,7 @@ OnTouchNPC:
 	end;
 	
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -829,7 +829,7 @@ OnTouchNPC:
 	end;
 	
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -1690,7 +1690,7 @@ function	MN	{
 }
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	setarray .@n[1], 1725,1726,1727,1728,1730,1729;
 	getmapxy(.@m$,.@x,.@y,BL_NPC);
 	.@i = MN;
@@ -1728,7 +1728,7 @@ OnDisable:
 
 OnInit:
 	if ( strnpcinfo(2) != "main" )
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	end;
 }
 p_track02,30,38,0	duplicate(mob1#main)	#poring1	139,0,0
@@ -1822,7 +1822,7 @@ OnDisable:
 	}
 	
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 

--- a/npc/other/turbo_track.txt
+++ b/npc/other/turbo_track.txt
@@ -29,7 +29,7 @@ function	script	F_tt	{
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	enablewaitingroomevent strnpcinfo(0);
 	end;
 
@@ -2044,7 +2044,7 @@ OnTouch_:
 	
 OnInit:
 	set .@w$,callfunc("F_tt");
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 turbo_e_4,11,266,0	duplicate(Flasher#tt_main)	Flasher_Exit_1#e4	45,1,1

--- a/npc/quests/quests_13_1.txt
+++ b/npc/quests/quests_13_1.txt
@@ -8432,7 +8432,7 @@ mid_camp,88,100,55	script	Cat Paw Mining Agent	876,{
 		else if (.@rhea_ran == 16) getitem 993,1; //Yellow_Live
 		else getitem 6048,1; //Unidentified_Mineral
 		initnpctimer;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		end;
 	}
 	else {
@@ -8443,7 +8443,7 @@ mid_camp,88,100,55	script	Cat Paw Mining Agent	876,{
 	end;
 
 OnTimer120000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -13696,11 +13696,11 @@ OnTimer11000:
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -427,7 +427,7 @@ man_fild02,132,47,4	duplicate(Cat Paw Agent#spl)	Cat Paw Agent#man	421
 		else if (.@rhea_ran == 17) getitem 6080,1; //Manuk_Coin
 		else getitem 6048,1; //Unidentified_Mineral
 		initnpctimer;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		end;
 	}
 	else {
@@ -438,7 +438,7 @@ man_fild02,132,47,4	duplicate(Cat Paw Agent#spl)	Cat Paw Agent#man	421
 	end;
 
 OnTimer120000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -3282,23 +3282,23 @@ mid_camp,192,239,4	script	Wanted Sign#ep13_2ect01	857,{
 	if ((ep13_2_dayegg == 1) && (countitem(6093) < 10)) {
 		mes "We just got fresh eggs from the dragon nest.";
 		getitem 6093,1; //Egg_Of_Draco
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		close;
 	}
 	end;
 
 OnTimer420000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -3317,23 +3317,23 @@ nyd_dun02,68,256,0	script	Dragon Egg#ep13_degg_1	463,{
 	if ((ep13_2_dayegg == 1) && (countitem(6093) < 10)) {
 		mes "We just got fresh eggs from the dragon nest.";
 		getitem 6093,1; //Egg_Of_Draco
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		close;
 	}
 	end;
 
 OnTimer240000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 nyd_dun02,68,256,0	duplicate(Dragon Egg#ep13_degg_1)	Dragon Egg#ep13_degg11	463
@@ -3348,23 +3348,23 @@ nyd_dun02,201,166,0	script	Dragon Egg#ep13_degg_2	463,{
 	if ((ep13_2_dayegg == 1) && (countitem(6093) < 10)) {
 		mes "We just got fresh eggs from the dragon nest.";
 		getitem 6093,1; //Egg_Of_Draco
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		close;
 	}
 	end;
 
 OnTimer120000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 nyd_dun02,201,166,0	duplicate(Dragon Egg#ep13_degg_2)	Dragon Egg#ep13_degg16	463
@@ -4907,7 +4907,7 @@ mjolnir_12,220,37,0	duplicate(mjo_no_find)	#mj12_find_3	-1,5,5
 					else getitem 6077,2; //Rough_Mineral
 					close2;
 					donpcevent strnpcinfo(0)+"_t::OnEnable";
-					disablenpc strnpcinfo(0);
+					disablenpc();
 					end;
 				}
 			case 2:
@@ -4923,7 +4923,7 @@ mjolnir_12,220,37,0	duplicate(mjo_no_find)	#mj12_find_3	-1,5,5
 	end;
 
 OnInit:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnTouch_:
@@ -5257,7 +5257,7 @@ OnTouch_:
 					else if (.@stst == 1) getitem 6077,2; //Rough_Mineral
 					else getitem 6077,1; //Rough_Mineral
 					donpcevent strnpcinfo(0)+"_t::OnEnable";
-					disablenpc strnpcinfo(0);
+					disablenpc();
 					close;
 				}
 			case 2:
@@ -5273,7 +5273,7 @@ OnTouch_:
 	end;
 
 OnInit:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnTouch_:
@@ -5390,7 +5390,7 @@ OnTouch_:
 					else if (.@stst == 1) getitem 6077,2; //Rough_Mineral
 					else getitem 6077,1; //Rough_Mineral
 					donpcevent strnpcinfo(0)+"_t::OnEnable";
-					disablenpc strnpcinfo(0);
+					disablenpc();
 					close;
 				}
 			case 2:
@@ -5406,7 +5406,7 @@ OnTouch_:
 	end;
 
 OnInit:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnTouch_:
@@ -6974,7 +6974,7 @@ OnTouch_:
 
 -	script	ep13_warp_s_0	-1,{
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 OnTimer2000:
 OnTimer4000:
@@ -6988,18 +6988,18 @@ OnTimer8000:
 
 OnTimer10000:
 	specialeffect EF_STEAL;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnDisable:
 	specialeffect EF_WIND;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
 -	script	ep13_warp_s_1	-1,{
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 OnTimer2000:
 OnTimer4000:
@@ -7014,18 +7014,18 @@ OnTimer10000:
 
 OnTimer12000:
 	specialeffect EF_STEAL;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnDisable:
 	specialeffect EF_WIND;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
 -	script	ep13_warp_s_2	-1,{
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 OnTimer2000:
 OnTimer4000:
@@ -7041,12 +7041,12 @@ OnTimer12000:
 
 OnTimer15000:
 	specialeffect EF_STEAL;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnDisable:
 	specialeffect EF_WIND;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 

--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -2688,11 +2688,11 @@ OnTouch:
 
 -	script	Baehideun#main	-1,{
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	.@c = charat(strnpcinfo(0),9);
 	if (checkre(0)) {
 		switch (.@c) {
@@ -2720,7 +2720,7 @@ OnTimer300000:
 OnDisable:
 	$@mos1_edq = 0;
 	stopnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnMyMobDead:
@@ -7162,14 +7162,14 @@ OnTimer300000:
 
 OnEnable:
 	initnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnTimer120000:
 OnDisable:
 	stopnpctimer;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 mosk_dun01,50,256,3	duplicate(mos_rus#main)	Gray Wolf#rus05	4_RUS_DWOLF
@@ -8271,13 +8271,13 @@ mosk_fild02,157,233,0	script	Shepherdess#rus10	1_F_04,{
 
 OnDisable:
 	initnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnTimer60000:
 OnEnable:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 mosk_fild02,151,188,0	duplicate(PTree#rusmain)	Pointed Tree#rus11	HIDDEN_NPC
@@ -10027,7 +10027,7 @@ OnTouch_:
 				specialeffect EF_TELEPORTATION2;
 				next;
 				mes "- You cast the spell in a hurry and the cow is surronded by the light and disappears !! -";
-				disablenpc strnpcinfo(0);
+				disablenpc();
 				enablenpc "Cow#rus3"+ .@other_npc[0];
 				next;
 			} else {
@@ -10037,7 +10037,7 @@ OnTouch_:
 				emotion ET_THINK;
 				next;
 				mes "- The cow, seems to gibe at you, looks at you quickly and runs to bushes !! -";
-				disablenpc strnpcinfo(0);
+				disablenpc();
 				if (rand(2))
 					enablenpc "Cow#rus3"+ .@other_npc[0];
 				else
@@ -10049,7 +10049,7 @@ OnTouch_:
 			mes "Akkkk?! Eh!? The s-spell...";
 			next;
 			mes "- You hesitate, the cow, seems to gibe at you, passes by you and runs to bushes !! -";
-			disablenpc strnpcinfo(0);
+			disablenpc();
 			if (rand(2))
 				enablenpc "Cow#rus3"+ .@other_npc[0];
 			else

--- a/npc/quests/seals/god_weapon_creation.txt
+++ b/npc/quests/seals/god_weapon_creation.txt
@@ -811,7 +811,7 @@ OnDisable:
 
 que_god01,154,67,0	script	god_failwarp#1	-1,4,7,{
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTouch_:
 	warp "prontera",156,324;

--- a/npc/quests/thana_quest.txt
+++ b/npc/quests/thana_quest.txt
@@ -1681,10 +1681,10 @@ tha_t08,90,153,0	script	Shining Crystal#tt_r1	844,{
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 tha_t08,90,62,0	duplicate(Shining Crystal#tt_r1)	Shining Crystal#tt_r2	844
@@ -1715,10 +1715,10 @@ tha_t08,49,153,0	script	Shining Crystal#tt_y1	844,{
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 tha_t08,90,150,0	duplicate(Shining Crystal#tt_y1)	Shining Crystal#tt_y2	844
@@ -1749,10 +1749,10 @@ tha_t08,49,65,0	script	Shining Crystal#tt_b1	844,{
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 tha_t08,49,150,0	duplicate(Shining Crystal#tt_b1)	Shining Crystal#tt_b2	844
@@ -1783,10 +1783,10 @@ tha_t08,90,65,0	script	Shining Crystal#tt_g1	844,{
 
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 tha_t08,49,62,0	duplicate(Shining Crystal#tt_g1)	Shining Crystal#tt_g2	844

--- a/npc/re/cities/malaya.txt
+++ b/npc/re/cities/malaya.txt
@@ -150,10 +150,10 @@ OnInit:
 		donpcevent "Unidentified Creature#"+.@npc$[.@i]+"::"+((.@i == .@rand)?"OnEnable":"OnDisable");
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnBingx2:
 	switch(atoi(strnpcinfo(2))) {
@@ -196,10 +196,10 @@ ma_scene01,195,92,4	duplicate(Unidentified Creature#i)	Unidentified Creature#09	
 -	script	Unidentified Creature#j	-1,{
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnBingx2:
 	switch(atoi(strnpcinfo(2))) {

--- a/npc/re/instances/BangungotHospital.txt
+++ b/npc/re/instances/BangungotHospital.txt
@@ -452,7 +452,7 @@ OnEnable2:
 OnEnable3:
 	.@i = atoi(charat(strnpcinfo(2),4))+1;
 	donpcevent instance_npcname("#Ward" + .@i + " Entry") + "::OnEnable1";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnMyMobDead:
 	initnpctimer;
@@ -473,7 +473,7 @@ OnTimer1000:
 	stopnpctimer;
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 1@ma_h,57,147,0	duplicate(#Ward1 Entry)	#Ward2 Entry	HIDDEN_WARP_NPC //3,3
@@ -915,7 +915,7 @@ OnTouch:
 	donpcevent instance_npcname("#Boss Room Entry_time") + "::OnEnable";
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 1@ma_h,132,171,0	duplicate(#Boss Room Entry_a)	#Boss Room Entry_b	HIDDEN_WARP_NPC,10,10

--- a/npc/re/instances/CharlestonCrisis.txt
+++ b/npc/re/instances/CharlestonCrisis.txt
@@ -1766,14 +1766,14 @@ OnTouch_:
 			donpcevent instance_npcname("GeneratorBroadcast#1") + "::OnStart";
 			disablenpc instance_npcname("Charleston 1#2");
 			enablenpc instance_npcname("Charleston 1#3");
-			disablenpc instance_npcname( strnpcinfo(0) );
+			disablenpc();
 		}
 		close;
 	}
 	if ('ep15_1_mcd01 == 6 || 'ep15_1_mcd01 == 5) {
 		mes "You turned on the generator. The sounds of turning wheels can be heard.";
 		'ep15_1_mcd01++;
-		disablenpc instance_npcname( strnpcinfo(0) );
+		disablenpc();
 		close;
 	}
 	end;
@@ -1890,7 +1890,7 @@ OnTouch_:
 1@mcd,127,262,0	script	mob#1	HIDDEN_WARP_NPC,5,5,{
 	end;
 OnTouch_:
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	switch( atoi(strnpcinfo(2)) ) {
 	case 1:
 		areamonster 'map_name$,106,246,115,256,"Security robot", 3128,5;	// KICK_AND_KICK

--- a/npc/re/instances/DevilTower.txt
+++ b/npc/re/instances/DevilTower.txt
@@ -534,7 +534,7 @@ OnTimer26000:
 	if ('devil_tower == 1) {
 		delitem 7641,1;
 		specialeffect EF_ENTRY;
-		disablenpc instance_npcname( strnpcinfo(0) );
+		disablenpc();
 		enablenpc instance_npcname( strnpcinfo(1) + "#" + replacestr( strnpcinfo(2), "_1", "" ) );
 		specialeffect EF_ENTRY,AREA, instance_npcname( strnpcinfo(1) + "#" + replacestr( strnpcinfo(2), "_1", "" ) );
 		mes "It worked.";
@@ -1276,7 +1276,7 @@ OnDisable:
 	stopnpctimer;
 	killmonster 'map_tnm2$, instance_npcname(strnpcinfo(0)) + "::OnMobDead";	// note : officially still alive
 	killmonster 'map_tnm2$, instance_npcname("#devil_seal_dead") + "::OnSeal_" + strnpcinfo(2);	// note : officially still alive
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnStop:
 	stopnpctimer;
@@ -1294,7 +1294,7 @@ OnMobDead:
 1@tnm2,1,1,0	script	seal_reach_center#DIR_NORTHWEST	HIDDEN_WARP_NPC,{
 	end;
 OnStart:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	initnpctimer;
 	end;
 OnTimer2000:
@@ -1305,7 +1305,7 @@ OnTimer4000:
 	npctalk "Thanatos: Stop him! Prevent him from coming closer!!!", 'thanatos$;
 	mapannounce 'map_tnm2$, "Thanatos: Stop him! Prevent him from coming closer!!!", bc_map,0xFF00;
 	stopnpctimer;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 1@tnm2,1,1,0	duplicate(seal_reach_center#DIR_NORTHWEST)	seal_reach_center#DIR_SOUTHWEST	HIDDEN_WARP_NPC

--- a/npc/re/instances/EclageInterior.txt
+++ b/npc/re/instances/EclageInterior.txt
@@ -149,7 +149,7 @@ OnInstanceInit:
 
 OnInstanceInit:
 	'mob_summoned = 0;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:

--- a/npc/re/instances/FacewormsNest.txt
+++ b/npc/re/instances/FacewormsNest.txt
@@ -2049,7 +2049,7 @@ OnTouch_:
 	initnpctimer;
 	end;
 OnTimer45000:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	stopnpctimer;
 	end;
 OnMyMobDead:
@@ -2137,7 +2137,7 @@ OnTouch_:
 	initnpctimer;
 	end;
 OnTimer15000:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	stopnpctimer;
 	end;
 OnMyMobDead:

--- a/npc/re/instances/HazyForest.txt
+++ b/npc/re/instances/HazyForest.txt
@@ -207,7 +207,7 @@ function	script	F_Mora_Mist	{
 		mes "You chop down the tree, which was blocking the path of the maze, "+((getarg(3,0))?"clearing the way out of the forest.":"so now you can continue.");
 		mapannounce .@map$,getarg(1),bc_map,"0xccffcc"; //FW_NORMAL 12 0 0
 		enablenpc instance_npcname(getarg(0));
-		disablenpc instance_npcname(strnpcinfo(0));
+		disablenpc();
 		if (getarg(4,0))
 			initnpctimer;
 		close;
@@ -451,7 +451,7 @@ OnMyMobDead:
 
 1@mist,73,290,0	script	Mysterious Flower#1	844,{
 	specialeffect EF_LEVEL99_4;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	getitem 12561,1; //Mysterious_Seed
 	end;
 }

--- a/npc/re/instances/HorrorToyFactory.txt
+++ b/npc/re/instances/HorrorToyFactory.txt
@@ -510,7 +510,7 @@ OnTouch_:
 	end;
 
 OnTimer45000:
-	enablenpc instance_npcname( strnpcinfo(0) );
+	enablenpc();
 	killmonster 'xm_d_map$, instance_npcname( strnpcinfo(0) ) +"::OnMyMobDead";
 	stopnpctimer;
 	end;
@@ -753,7 +753,7 @@ OnStart:
 			break;
 		}
 		sleep2 3000;
-		disablenpc instance_npcname( strnpcinfo(0) );
+		disablenpc();
 		if ('worker[.@num] == 0) {
 			'worker[.@num] = 1;
 			donpcevent instance_npcname("#fac2wpc") + "::OnStart";
@@ -1360,7 +1360,7 @@ OnStart:
 
 1@xm_d,210,141,3	script	Packaged Present#1	4_TREASURE_BOX,{
 	specialeffect EF_COIN;
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	initnpctimer;
 	end;
 

--- a/npc/re/instances/LastRoom.txt
+++ b/npc/re/instances/LastRoom.txt
@@ -319,7 +319,7 @@ OnTouch:
 	sscanf( strnpcinfo(2), "lrboom%d", .@num );
 	areamonster 'map_name$,178,34,198,54, "Machine Component", (3251 + ((.@num-1) % 2)), 3;
 	mapannounce 'map_name$, "System message : Intruder detected in Zone 2.",bc_map,"0xFF0000";
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 }
 1@uns,164,97,0	duplicate(#lrboom1)	#lrboom2	4_CRACK,2,2

--- a/npc/re/instances/MalangdoCulvert.txt
+++ b/npc/re/instances/MalangdoCulvert.txt
@@ -597,12 +597,12 @@ function	script	F_mal_missing	{
 		disablenpc instance_npcname("Culvert Entrance#"+.@i$);
 		disablenpc instance_npcname("Missing, the Cleaner#"+.@i$+"o");
 		donpcevent instance_npcname("Monster Hole#"+.@i$)+"::OnClear";
-		disablenpc instance_npcname(strnpcinfo(0));
+		disablenpc();
 		close;
 	}
 	close;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 
@@ -712,13 +712,13 @@ OnClear:
 1@pump,36,111,4	script	#Culvert_n1	844,14,14,{ //temporary workaround for ALL_SAMEMAP
 	progressbar "0xFFFF00",10;
 	stopnpctimer;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	set .@label$, instance_npcname(strnpcinfo(0))+"::OnMyMobDead";
 	set .@map$, instance_mapname("1@pump");
 	set .@index, atoi(charat(strnpcinfo(2),9));
@@ -758,7 +758,7 @@ OnClear:
 OnTimer49500:	//OnTimer50000 clashes with the timer in "Missing, the Cleaner#h".
 	donpcevent instance_npcname("Missing, the Cleaner#n")+"::OnAddSeaweed";
 	donpcevent instance_npcname(strnpcinfo(0))+"::OnClear";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnTouch:
 	specialeffect EF_MAPPILLAR2;
@@ -773,10 +773,10 @@ OnTouch:
 1@pump,1,1,4	script	Boss Creation#n	-1,{
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	initnpctimer;
 	end;
 OnTimer100:
@@ -875,7 +875,7 @@ OnMyMobDead:
 	mes "If Tomas closes this down, we will lose our jobs!";
 	close;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 }
 
@@ -972,13 +972,13 @@ OnTimer425000:
 2@pump,53,114,4	script	#Culvert_h1	844,14,14,{ //temporary workaround for ALL_SAMEMAP
 	progressbar "0xFFFF00",15;
 	stopnpctimer;
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	set .@label$, instance_npcname(strnpcinfo(0))+"::OnMyMobDead";
 	set .@map$, instance_mapname("2@pump");
 	set .@index, atoi(substr(strnpcinfo(2),9,getstrlen(strnpcinfo(2))-1));
@@ -1012,7 +1012,7 @@ OnClear:
 OnTimer39500:	//OnTimer40000 clashes with the timer in "Missing, the Cleaner#h".
 	donpcevent instance_npcname("Missing, the Cleaner#h")+"::OnAddSeaweed";
 	donpcevent instance_npcname(strnpcinfo(0))+"::OnClear";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnTouch:
 	specialeffect EF_MAPPILLAR2;

--- a/npc/re/instances/MorseCave.txt
+++ b/npc/re/instances/MorseCave.txt
@@ -273,7 +273,7 @@ OnTouch:
 	if (getnpctimer(0) > 0)
 		end;
 	initnpctimer;
-	//disablenpc instance_npcname( strnpcinfo(0) );
+	//disablenpc();
 	hideonnpc instance_npcname( strnpcinfo(0) );
 	specialeffect EF_ICEWALL;
 	end;
@@ -380,7 +380,7 @@ OnInstanceInit:
 1@rev,34,120,0	script	#RZ Memorial Effect 1	HIDDEN_WARP_NPC,4,4,{
 	end;
 OnInstanceInit:
-	//disablenpc instance_npcname( strnpcinfo(0) );
+	//disablenpc();
 	hideonnpc instance_npcname( strnpcinfo(0) );
 	initnpctimer;
 	end;

--- a/npc/re/instances/OctopusCave.txt
+++ b/npc/re/instances/OctopusCave.txt
@@ -239,7 +239,7 @@ OnInstanceInit:
 	donpcevent instance_npcname(strnpcinfo(0))+"::OnDisable";
 	end;
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	set .@label$, instance_npcname(strnpcinfo(0))+"::OnMyMobDead";
 	set .@i, atoi(charat(strnpcinfo(0),8));
 	set .@map$, instance_mapname("1@cash");
@@ -300,7 +300,7 @@ OnEnable:
 	end;
 OnDisable:
 	killmonster instance_mapname("1@cash"),instance_npcname(strnpcinfo(0))+"::OnMyMobDead"; // Not in official script.
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnTouch_:
 	if (getd("."+strnpcinfo(0)+instance_id())) end;
@@ -664,7 +664,7 @@ OnMyMobDead:
 1@cash,190,208,0	script	oct_exit_1	45,2,2,{
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 OnTouch:
 	mes "Do you want to go out from the octopus dungeon?";

--- a/npc/re/instances/OldGlastHeim.txt
+++ b/npc/re/instances/OldGlastHeim.txt
@@ -777,7 +777,7 @@ OnTouch_:
 	getmapxy .@map$,.@x,.@y, BL_NPC;
 	specialeffect EF_VENOMDUST;
 	monster .@map$,.@x,.@y,"Maggot",2467,.@mobs;
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 }
 1@gl_k,233,123,4	duplicate(A dead man#1)	A dead man#2	4_M_DIEMAN,5,5
@@ -1076,7 +1076,7 @@ OnTimer69000:
 2@gl_k,118,141,0	script	#ogh_2-1	HIDDEN_WARP_NPC,20,20,{
 	end;
 OnTouch_:
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	.@hidden_name$ = strnpcinfo(2);
 	.@event_type = atoi( charat(.@hidden_name$,4) );
 	if (.@event_type == 2)
@@ -1092,11 +1092,11 @@ OnTouch_:
 	initnpctimer;
 	end;
 OnTimer30000:
-	enablenpc instance_npcname( strnpcinfo(0) );
+	enablenpc();
 	stopnpctimer;
 	end;
 OnStop:
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	stopnpctimer;
 	end;
 }
@@ -1253,7 +1253,7 @@ OnTouch_:
 2@gl_k,143,260,4	script	Decomposed body#1	4_M_DIEMAN,5,5,{
 	end;
 OnTouch_:
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	.@i = rand(1,10);
 	if (.@i == 1) .@mobs = 3;
 	else if (.@i == 2) .@mobs = 4;
@@ -1266,7 +1266,7 @@ OnTouch_:
 	initnpctimer;
 	end;
 OnTimer45000:
-	enablenpc instance_npcname( strnpcinfo(0) );
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -1570,7 +1570,7 @@ OnTouch:
 	end;
 OnEvent:
 	initnpctimer;
-	enablenpc instance_npcname( strnpcinfo(0) );
+	enablenpc();
 	.@num = atoi( replacestr(strnpcinfo(2), "Buff", "") );
 	if (.@num == 1)
 		npctalk "Varmundt's Ghost: Amdarais may use a strong magic shield! Stay close to me and I'll protect you!";
@@ -1583,7 +1583,7 @@ OnEvent:
 	end;
 OnTimer10000:
 	stopnpctimer;
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 }
 2@gl_k,165,247,3	duplicate(Varmundt's Ghost#Buff1)	Varmundt's Ghost#Buff2	4_M_BARMUND,2,2
@@ -1710,7 +1710,7 @@ OnTimer10000:
 		makeitem 6608,1,"this",129,138;
 		break;
 	}
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 }
 1@gl_k,159,136,3	duplicate(Strange crack#2)	Strange crack#3	CLEAR_NPC

--- a/npc/re/instances/RitualOfBlessing.txt
+++ b/npc/re/instances/RitualOfBlessing.txt
@@ -712,7 +712,7 @@ OnInstanceInit:
 2@mir,96,83,0	script	dummy_npc_rituel_disabled	-1,{
 	end;
 OnInstanceInit:
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 }
 2@mir,88,74,3	duplicate(dummy_npc_rituel_disabled)	Ian Walther#ian02	1_M_JOBTESTER

--- a/npc/re/instances/RoomOfConsciousness.txt
+++ b/npc/re/instances/RoomOfConsciousness.txt
@@ -408,7 +408,7 @@ OnTimer16500:
 	donpcevent instance_npcname("eq#mir3") + "::OnStart";
 OnStop:
 	stopnpctimer;
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	disablenpc instance_npcname( "Iris#" + strnpcinfo(2) );
 	'touch_mob = 0;
 	'random_letter$ = "";

--- a/npc/re/instances/SarahAndFenrir.txt
+++ b/npc/re/instances/SarahAndFenrir.txt
@@ -2038,7 +2038,7 @@ OnMobDead:
 OnTouch:
 	getmapxy .@map$,.@x,.@y, BL_NPC;
 	monster .@map$,.@x,.@y, "Mutant Gargoyle",3197,1, instance_npcname( strnpcinfo(0) ) + "::OnMobDead";	// MM_M_GARGOYLE
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	end;
 OnMobDead:
 	end;

--- a/npc/re/instances/SkyFortress.txt
+++ b/npc/re/instances/SkyFortress.txt
@@ -949,7 +949,7 @@ OnTouch:
 	mes "- Dreary warp -";
 	mes "- is brought up -";
 	mes "- shining in black -";
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	enablenpc instance_npcname("Activated Warp#" + strnpcinfo(2));
 	close;
 }
@@ -1132,7 +1132,7 @@ OnTouch:
 	sleep2 3000;
 	if (is_party_leader() == false)
 		end;
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	mes "- In that treasure box, -";
 	.@r = rand(100);
 	if (.@r < 32) {
@@ -1948,11 +1948,11 @@ OnEvent:
 	specialeffect EF_GUMGANG4;
 	progressbar_npc "000000",4;
 	specialeffect EF_NPC_EARTHQUAKE;
-	cloakoffnpc instance_npcname( strnpcinfo(0) );
+	cloakoffnpc();
 	initnpctimer;
 	end;
 OnTimer1000:
-	cloakonnpc instance_npcname( strnpcinfo(0) );
+	cloakonnpc();
 	end;
 OnTimer2000:
 	stopnpctimer;

--- a/npc/re/instances/WernerLaboratoryCentralRoom.txt
+++ b/npc/re/instances/WernerLaboratoryCentralRoom.txt
@@ -513,7 +513,7 @@ OnTouch:
 		.@label$ = instance_npcname("#security_device_lab") + "::OnRight2";
 		break;
 	}
-	disablenpc instance_npcname( strnpcinfo(0) );
+	disablenpc();
 	areamonster .@map$, (.@x-2), (.@y-2), (.@x+2), (.@y+2), "Special Guard", 3622, .@mob_count, .@label$;	// EP16_2_MM_S_GUARDS
 	end;
 }

--- a/npc/re/instances/WolfchevLaboratory.txt
+++ b/npc/re/instances/WolfchevLaboratory.txt
@@ -628,16 +628,16 @@ que_lhz,140,231,1	script	Human Guinea pig#01	2224,{
 	end;
 
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnDisable:
 	specialeffect EF_FLASHER;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 que_lhz,147,231,0	duplicate(Human Guinea pig#01)	Human Guinea pig#02	2224
@@ -1530,7 +1530,7 @@ OnMyMobDead:
 		progressbar "0xffff00", 20;
 		stopnpctimer;
 		donpcevent instance_npcname("Lab2#2_2")+"::OnDisableValve1";
-		disablenpc instance_npcname(strnpcinfo(0));
+		disablenpc();
 		end;
 	} else {
 		mes "Let your party leader handle the valve.";
@@ -1538,11 +1538,11 @@ OnMyMobDead:
 	}
 
 OnInstanceInit:
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnEnable:
-	enablenpc instance_npcname(strnpcinfo(0));
+	enablenpc();
 	initnpctimer;
 	end;
 
@@ -1991,7 +1991,7 @@ OnEnable:
 
 OnDisable:
 	killmonster instance_mapname("1@lhz"),instance_npcname(strnpcinfo(0))+"::OnMyMobDead";
-	disablenpc instance_npcname(strnpcinfo(0));
+	disablenpc();
 	end;
 
 OnMyMobDead:

--- a/npc/re/jobs/3-1/guillotine_cross.txt
+++ b/npc/re/jobs/3-1/guillotine_cross.txt
@@ -3042,10 +3042,10 @@ OnTimer5000:
 	end;
 OnInit:
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 
@@ -3399,10 +3399,10 @@ job3_guil03,2,4,0	duplicate(#3rdgc_sunchal_kill01)	#3rdgc_sunchal_kill03	844
 job3_guil03,64,68,3	script	#3rdgc_gojung_kill01	456,7,7,{
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnStop:
 	mapannounce "job3_guil03","Guard : Am I imagining things? I just heard something.",bc_map,"0xA8A8A8"; //FW_NORMAL 12 0 0
@@ -3416,7 +3416,7 @@ OnTouch_:
 	setarray .@x[1],64,86,83;
 	setarray .@y[1],68,63,36;
 	mapannounce "job3_guil03","Guard : Who are you?!",bc_map,"0x7b68ee"; //FW_NORMAL 12 0 0
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	monster "job3_guil03",.@x[.@i],.@y[.@i],"Guard",1985,1,strnpcinfo(0)+"::OnMyMobDead";
 	initnpctimer;
 	end;

--- a/npc/re/jobs/3-1/ranger.txt
+++ b/npc/re/jobs/3-1/ranger.txt
@@ -1577,10 +1577,10 @@ OnTimer133000:
 
 -	script	Egg Bomb#0	-1,{
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	getmapxy(.@map$,.@x,.@y,BL_NPC);
 	monster "job3_rang02",.@x,.@y,"Egg Bomb",1047,1,strnpcinfo(0)+"::OnMyMobDead";
@@ -1594,7 +1594,7 @@ OnEnable:
 OnDisable:
 	stopnpctimer;
 	killmonster "job3_rang02",strnpcinfo(0)+"::OnMyMobDead";
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnMyMobDead:
 	set $@job_rang_point03, $@job_rang_point03+1;

--- a/npc/re/jobs/3-1/warlock.txt
+++ b/npc/re/jobs/3-1/warlock.txt
@@ -801,10 +801,10 @@ OnDisable:
 
 -	script	The chamber of magic#2	-1,{
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	monster "job3_war02",23,32,"Magic Monster",2047,1,strnpcinfo(0)+"::OnMyMobDead";
 	monster "job3_war02",23,21,"Magic Monster",2048,1,strnpcinfo(0)+"::OnMyMobDead";
 	monster "job3_war02",34,32,"Magic Monster",2049,1,strnpcinfo(0)+"::OnMyMobDead";
@@ -819,7 +819,7 @@ OnReset:
 	killmonster "job3_war02",strnpcinfo(0)+"::OnMyMobDead";
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnMyMobDead:
 	if (mobcount("job3_war02",strnpcinfo(0)+"::OnMyMobDead") < 1) {

--- a/npc/re/jobs/3-2/genetic.txt
+++ b/npc/re/jobs/3-2/genetic.txt
@@ -963,7 +963,7 @@ job3_gen01,91,48,3	script	Demi Calberine#gen	982,{
 		mes "- You found a little metal fragment. -";
 		set job_gen, job_gen+1;
 		specialeffect EF_BASH;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		close;
 	} else if (job_gen == 74) {
@@ -972,7 +972,7 @@ job3_gen01,91,48,3	script	Demi Calberine#gen	982,{
 	}
 	end;
 OnTimer7000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }

--- a/npc/re/jobs/3-2/minstrel.txt
+++ b/npc/re/jobs/3-2/minstrel.txt
@@ -815,14 +815,14 @@ OnTimer300000:
 yuno,146,168,0	script	Karian#cmd2	486,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	stopnpctimer;
 	end;
 OnTimer100000:

--- a/npc/re/jobs/3-2/royal_guard.txt
+++ b/npc/re/jobs/3-2/royal_guard.txt
@@ -455,7 +455,7 @@ gl_church,173,88,0	script	Delicate trace#01	844,{
 			getitem 7049,1; //Stone
 		else {
 			mes "While investigating, the topography breaks. It would be better to dig other places for a while.";
-			disablenpc strnpcinfo(0);
+			disablenpc();
 			initnpctimer;
 			close;
 		}
@@ -463,7 +463,7 @@ gl_church,173,88,0	script	Delicate trace#01	844,{
 	mes "There is a trace that someone has already dug here.";
 	close;
 OnTimer60000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 OnTimer1000:
 OnTimer20000:

--- a/npc/re/jobs/3-2/wanderer.txt
+++ b/npc/re/jobs/3-2/wanderer.txt
@@ -1032,7 +1032,7 @@ OnInit:
 -	script	#wander_xmas	-1,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 xmas,149,135,3	duplicate(#wander_xmas)	Guitar Song#xmas	479

--- a/npc/re/jobs/novice/academy.txt
+++ b/npc/re/jobs/novice/academy.txt
@@ -120,7 +120,7 @@ iz_int,56,32,3	script	Wounded Swordsman#intro_npc02_iz_int	4_TOWER_02,{
 
 OnInit:
 	questinfo( QTYPE_QUEST, QMARK_YELLOW, "!isbegin_quest(21001) && Class == Job_Novice" );
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 iz_int01,56,32,3	duplicate(Wounded Swordsman#intro_npc02_iz_int)	Wounded Swordsman#intro_npc02_iz_int01	4_TOWER_02

--- a/npc/re/merchants/nightmare_biolab.txt
+++ b/npc/re/merchants/nightmare_biolab.txt
@@ -1714,7 +1714,7 @@ lhz_dun_n,75,121,0	script	#Alphoccio_Basil_A1	HIDDEN_WARP_NPC,3,3,{
 	end;
 OnTouch:
 	specialeffect EF_BAT2;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	end;
 OnTimer1000:
@@ -1974,7 +1974,7 @@ OnTimer1000:
 	end;
 OnTimer40000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 

--- a/npc/re/other/achievements.txt
+++ b/npc/re/other/achievements.txt
@@ -280,7 +280,7 @@ yuno_fild11,141,357,4	duplicate(ach_treasure#touch)	#wp120061	HIDDEN_WARP_NPC,5,
 	cloakonnpc strnpcinfo(0), getcharid(0);
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 

--- a/npc/re/other/global_npcs.txt
+++ b/npc/re/other/global_npcs.txt
@@ -16,17 +16,3 @@ OnInit:
 	cloakonnpc();
 	end;
 }
-
--	script	dummy_disabled_instance_npc	-1,{
-	end;
-OnInstanceInit:
-	disablenpc();
-	end;
-}
-
--	script	dummy_cloaked_instance_npc	-1,{
-	end;
-OnInstanceInit:
-	cloakonnpc();
-	end;
-}

--- a/npc/re/other/global_npcs.txt
+++ b/npc/re/other/global_npcs.txt
@@ -13,6 +13,20 @@
 -	script	dummy_cloaked_npc	-1,{
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
+	end;
+}
+
+-	script	dummy_disabled_instance_npc	-1,{
+	end;
+OnInstanceInit:
+	disablenpc();
+	end;
+}
+
+-	script	dummy_cloaked_instance_npc	-1,{
+	end;
+OnInstanceInit:
+	cloakonnpc();
 	end;
 }

--- a/npc/re/quests/quests_15_1.txt
+++ b/npc/re/quests/quests_15_1.txt
@@ -3315,7 +3315,7 @@ verus03,127,36,4	script	???#EP15_1D_01	4_CRACK,{
 		}
 		close2;
 		initnpctimer;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	}
 	end;
 
@@ -3326,7 +3326,7 @@ OnTimer120000:
 	if (rand(1,2) != 1)
 		end;
 OnTimer150000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -3559,7 +3559,7 @@ verus04,187,219,4	script	Thicket#EP15_1D_01	4_CREEPER,{
 			mes "Gathered the herb.";
 		}
 		close2;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 	}
 	end;
@@ -3571,7 +3571,7 @@ OnTimer240000:
 	if (rand(1,2) != 1)
 		end;
 OnTimer300000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -3914,13 +3914,13 @@ verus03,127,145,0	script	Machine Remnant#atnd01	4_ENERGY_RED,3,3,{
 		getitem 6756,1;// Condensed_Energy
 		mes "Collected Condensed Energy!";
 		initnpctimer;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	}
 	close;
 
 OnTimer30000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 OnTouch_:

--- a/npc/re/quests/quests_15_2.txt
+++ b/npc/re/quests/quests_15_2.txt
@@ -2287,7 +2287,7 @@ un_bunker,382,335,3	script	Box#e152p00	4_ENERGY_BLUE,{
 			close;
 		}
 		progressbar "ffff00",3;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		if (.@npc_name$ == "Box") {
 			mes "Found a Memory Record in the box.";
@@ -2346,14 +2346,14 @@ un_bunker,382,335,3	script	Box#e152p00	4_ENERGY_BLUE,{
 		close;
 	}
 	progressbar "ffff00",3;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	mes "Found a Memory Record.";
 	getitem 6824,1;	// Lab_Memory_Record
 	close;
 
 OnTimer30000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -2407,7 +2407,7 @@ verus02,60,30,1	script	Strewn paper#e152a01	4_ENERGY_BLUE,{
 
 OnTimer60000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 
 S_Type:
@@ -2424,7 +2424,7 @@ S_Type:
 		close;
 	}
 	progressbar "ffff00",3;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	getitem 6757,1;// Memory_Record
 

--- a/npc/re/quests/quests_16_1.txt
+++ b/npc/re/quests/quests_16_1.txt
@@ -2081,7 +2081,7 @@ prt_lib,80,79,3	script	Kronecker G. Heine#ep16_01_lib01	4_EP16_GRANZ,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	cloakonnpc "Kronecker G. Heine#ep16_01_lib02";
 	cloakonnpc "Nyhill M. Heine#ep16_lib01";
 	end;
@@ -2723,7 +2723,7 @@ prt_lib_q,88,90,1	script	Swaying Space#evt_gate02	4_ENERGY_RED,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -4356,7 +4356,7 @@ prt_cas_q,18,136,3	script	Spica Nerius#ep16_room02	4_EP16_SPICA,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	cloakonnpc "Nyhill M. Heine#ep16_nroom01";
 	end;
 }
@@ -4364,7 +4364,7 @@ OnInit:
 prt_cas_q,23,187,3	script	Mysterious Person#ep16wal	4_M_04,{
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -7859,7 +7859,7 @@ prt_cas_q,92,182,7	script	Myer Roegenburg#ep16lug	4_EP16_MEYER,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8653,7 +8653,7 @@ prontera,269,73,5	script	Ordinary Man#ep16lug02	4_M_04,{
 	close;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -11893,7 +11893,7 @@ prt_cas_q,94,7,7	script	Isaac Wigner#ep16wig	4_EP16_ISAAC,{
 prt_cas_q,80,23,5	script	Jurgen Wigner#ep16wig00	4_M_4THPRIN1,{
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 prt_cas_q,93,10,4	duplicate(Jurgen Wigner#ep16wig00)	Maid#ep16wig01	1_F_04
@@ -14846,7 +14846,7 @@ prt_q,221,193,4	script	Village Lad#EP161HO01	4_M_03,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -14953,7 +14953,7 @@ prt_q,77,98,8	script	Village Lad#EP161HO03	4_M_03,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15127,7 +15127,7 @@ prt_q,276,242,4	script	Girl#EP161GU01	4_F_RUSCHILD,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15333,7 +15333,7 @@ prt_q,229,317,6	script	Girl#EP161GU03	4_F_RUSCHILD,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15430,7 +15430,7 @@ prt_q,55,347,6	script	Rosa Erinin#EP161GU07	4W_F_01,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 prt_q,57,346,4	duplicate(Rosa Erinin#EP161GU07)	Girl#EP161GU06	4_F_RUSCHILD
@@ -15533,7 +15533,7 @@ prt_q,68,336,4	script	Soldier#EP161HU02	4_M_GEF_SOLDIER,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15597,7 +15597,7 @@ prt_q,79,102,8	script	Soldier#EP161HU03	4_M_GEF_SOLDIER,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15667,7 +15667,7 @@ prt_q,38,261,6	script	Eryus#EP161BU01	4_F_03,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15774,7 +15774,7 @@ prt_q,231,310,4	script	Eryus#EP161BU02	4_F_03,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15814,7 +15814,7 @@ prt_q,108,164,4	script	Female#EP161BU03	4W_F_01,{
 	close;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15875,7 +15875,7 @@ prt_q,229,310,6	script	Female#EP161BU04	4W_F_01,{
 	end;
 
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -15911,7 +15911,7 @@ OnTouch_:
 	monster "prt_q",.@x,.@y,"Resurrected Corpse",1015,1, strnpcinfo(0) + "::OnMyMobDead";// ZOMBIE
 	monster "prt_q",.@x,.@y,"Maggot",1194,1, strnpcinfo(0) + "::OnMyMobDead";// ARCLOUSE
 	monster "prt_q",.@x,.@y,"Fly",1035,1, strnpcinfo(0) + "::OnMyMobDead";// HUNTER_FLY
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	end;
 OnMyMobDead:
@@ -15919,7 +15919,7 @@ OnMyMobDead:
 OnTimer180000:
 	killmonster "prt_q", strnpcinfo(0) + "::OnMyMobDead";
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 prt_q,214,85,6	duplicate(Dead Villager#EP161DIE01)	Dead Villager#EP161DIE02	4_M_LIEMAN,2,2
@@ -15959,7 +15959,7 @@ OnTouch_:
 	monster "prt_q",.@x,.@y,"Resurrected Corpse",1015,1, strnpcinfo(0) + "::OnMyMobDead";// ZOMBIE
 	monster "prt_q",.@x,.@y,"Maggot",1194,1, strnpcinfo(0) + "::OnMyMobDead";// ARCLOUSE
 	monster "prt_q",.@x,.@y,"Fly",1035,1, strnpcinfo(0) + "::OnMyMobDead";// HUNTER_FLY
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 OnMyMobDead:
 	if (mobcount( "prt_q", strnpcinfo(0) + "::OnMyMobDead" ) < 1)
@@ -15967,7 +15967,7 @@ OnMyMobDead:
 	end;
 OnTimer300000:
 	stopnpctimer;
-	cloakoffnpc strnpcinfo(0);
+	cloakoffnpc();
 	end;
 }
 prt_q,88,279,2	duplicate(Dead Villager#EP161DIE01)	Dead Villager#EP161DIE07	4_M_LIEMAN,2,2
@@ -17201,7 +17201,7 @@ prt_prison,205,139,4	script	Dark Shape#EP161A01	4_GHOST_STAND,{
 	.@num = atoi( replacestr( strnpcinfo(2), "EP161A0", "" ) );
 	setarray .@npc_num[1],1,2,3,4,5;
 	deletearray .@npc_num[.@num],1;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	enablenpc "Dark Shape#EP161A0" + .@npc_num[ rand(1,4) ];// enable another npc randomly
 	close;
 
@@ -17210,7 +17210,7 @@ OnInit:
 	if (.num_enabled == 0)
 		.num_enabled = rand(1,5);
 	if (.num_enabled != .@npc_num)
-		disablenpc strnpcinfo(0);// disable 4/5 npcs
+		disablenpc();// disable 4/5 npcs
 	end;
 }
 prt_prison,153,175,4	duplicate(Dark Shape#EP161A01)	Dark Shape#EP161A02	4_GHOST_STAND
@@ -17585,7 +17585,7 @@ prt_prison,118,247,4	script	Rubbish heap#EP161C01	4_ENERGY_BLACK,{
 					setquest 5435;// [Repeat]Cleaning is complete.
 			}
 			initnpctimer;
-			disablenpc strnpcinfo(0);
+			disablenpc();
 		}
 		close;
 	}
@@ -17601,12 +17601,12 @@ OnTimer240000:
 OnTimer270000:
 	if (rand(1,2) == 1) {
 		stopnpctimer;
-		enablenpc strnpcinfo(0);
+		enablenpc();
 	}
 	end;
 OnTimer300000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 prt_prison,171,247,4	duplicate(Rubbish heap#EP161C01)	Rubbish heap#EP161C02	4_ENERGY_BLACK
@@ -17912,7 +17912,7 @@ prt_prison,146,268,4	script	Torch#EP161EB01	CLEAR_NPC,{
 			mes "You carefully collected the light but it scattered.";
 		}
 		initnpctimer;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	}
 	close;
 
@@ -17923,12 +17923,12 @@ OnTimer120000:
 OnTimer150000:
 	if (rand(1,2) == 1) {
 		stopnpctimer;
-		enablenpc strnpcinfo(0);
+		enablenpc();
 	}
 	end;
 OnTimer180000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 prt_prison,177,268,4	duplicate(Torch#EP161EB01)	Torch#EP161EB02	CLEAR_NPC

--- a/npc/re/quests/quests_16_2.txt
+++ b/npc/re/quests/quests_16_2.txt
@@ -2093,7 +2093,7 @@ einbech,218,82,5	script	Gonie#16nego02	4_M_FALLENGONY,{
 	mes "......";
 	close3;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -2187,7 +2187,7 @@ einbech,217,82,3	script	Lazy#16nego03	4_M_LAZY,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -2235,7 +2235,7 @@ rebel_in,23,43,5	script	Gonie#16nego03	4_M_FALLENGONY,{
 	cloakonnpc "Gonie#16nego03", getcharid(0);
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -2250,7 +2250,7 @@ rebel_in,23,42,3	script	Lucky#16nego01	4_M_ROOKIE,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3250,7 +3250,7 @@ ein_in01,269,285,5	script	Nihil#ep162_02	4_EP16_NIHIL,{
 		callfunc( "F_Terra_Gloria_Inn" );
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3276,7 +3276,7 @@ ein_in01,274,278,3	script	Lazy#ep162_01	4_M_LAZY,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3298,7 +3298,7 @@ ein_in01,272,282,3	script	Rookie#ep162_01	4_M_ROOKIE,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3316,7 +3316,7 @@ ein_in01,271,284,3	script	Skia#ep162_05	4_EP16_SKIA,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3335,7 +3335,7 @@ ein_in01,269,282,1	script	Philopontess#ep162_03	4_M_PHILOFONTES,{
 		callfunc( "F_Terra_Gloria_Inn" );
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -5509,7 +5509,7 @@ rebel_in,119,68,7	script	Rebellion Guard leader#4	4_M_REBELLION,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -5620,7 +5620,7 @@ rebel_in,121,69,8	script	Dien#162gmbs2	4_F_DIENE,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8530,7 +8530,7 @@ rebel_in,78,66,6	script	Arivero Yurhik#TFQ02	4_M_GUNSLINGER,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8604,7 +8604,7 @@ rebel_in,78,63,6	script	Rebellion leader#TFQ15	4_M_RUPERT,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8732,7 +8732,7 @@ einbech,212,212,6	script	Arivero Yurhik#TFQ04	4_M_GUNSLINGER,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8842,7 +8842,7 @@ lighthalzen,135,233,6	script	Arivero Yurhik#TFQ07	4_M_GUNSLINGER,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -8923,7 +8923,7 @@ yuno,204,226,6	script	Arivero Yurhik#TFQ10	4_M_GUNSLINGER,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -9028,7 +9028,7 @@ einbroch,262,42,4	script	Arivero Yurhik#TFQ13	4_M_GUNSLINGER,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -10586,7 +10586,7 @@ einbech,34,209,3	script	Empty bench#16.2rm2	HIDDEN_NPC,{
 			mes "After waiting for a while, you reclaimed the Anchovy cookies.";
 			mes "Go to another bench or wait for a while.";
 			initnpctimer;
-			disablenpc strnpcinfo(0);
+			disablenpc();
 			close;
 		}
 		if (strnpcinfo(0) == "Empty bench#16.2rm2")
@@ -10613,7 +10613,7 @@ einbech,34,209,3	script	Empty bench#16.2rm2	HIDDEN_NPC,{
 
 OnTimer30000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 einbech,144,98,3	duplicate(Empty bench#16.2rm2)	Empty bench#16.2rm3	HIDDEN_NPC
@@ -11854,11 +11854,11 @@ ein_fild09,70,175,5	script	Suspicious Heap of Earth#1	4_SOIL,{
 	else if (.@r == 7) unittalk $@mobid[0], "So you are abandoning me again? Then let me kill you first!";
 	else if (.@r == 8) unittalk $@mobid[0], "It's been cold and I was lonely waiting for you... Let us die together.";
 	initnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTimer300000:
 	stopnpctimer;
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 }
 ein_fild09,136,157,5	duplicate(Suspicious Heap of Earth#1)	Suspicious Heap of Earth#2	4_SOIL
@@ -13384,7 +13384,7 @@ slabw01,235,137,3	script	Suspicious cabinet#hide01	4_ENERGY_WHITE,{
 	}
 	unittalk getcharid(3), "" + strcharinfo(0) + " : .. This looks suspicious!", bc_self;
 	progressbar "000000",3;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	enablenpc "Hiding researcher#" + strnpcinfo(2);
 	npctalk "Arrrgh!", "Hiding researcher#" + strnpcinfo(2);
 	cutin "16loo_02.bmp",0;
@@ -13411,7 +13411,7 @@ slabw01,235,137,3	script	Suspicious cabinet#hide01	4_ENERGY_WHITE,{
 	cutin "",255;
 	end;
 OnTimer30000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	disablenpc "Hiding researcher#" + strnpcinfo(2);
 	stopnpctimer;
 	end;
@@ -13420,7 +13420,7 @@ OnTimer30000:
 slabw01,235,137,3	script	Hiding researcher#hide01	4_M_ALCHE_A,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 

--- a/npc/re/quests/quests_dewata.txt
+++ b/npc/re/quests/quests_dewata.txt
@@ -1605,11 +1605,11 @@ dew_fild01,259,48,4	script	Poby#dew_drink	538,{
 	donpcevent strnpcinfo(0)+"::OnDisable";
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	end;
 OnTimer60000:

--- a/npc/re/quests/quests_dicastes.txt
+++ b/npc/re/quests/quests_dicastes.txt
@@ -6660,7 +6660,7 @@ mid_campin,165,127,5	script	Hibba Agip#ep133_is07	459,{
 	mes "I should go now.";
 	close2;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;	
 }
 

--- a/npc/re/quests/quests_eclage.txt
+++ b/npc/re/quests/quests_eclage.txt
@@ -11372,7 +11372,7 @@ ecl_tdun02,99,63,5	script	Rosi#No.1	4_F_HUWOMAN,1,1,{
 	end;
 OnInit:
 	if (strnpcinfo(2) != "No.1")
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	end;
 OnTouch:
 	mes "[Rosi]";
@@ -11429,7 +11429,7 @@ ecl_tdun01,11,62,5	script	Euncheong#No.1	4_M_HUBOY,1,1,{
 	end;
 OnInit:
 	if (strnpcinfo(2) != "No.1")
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	end;
 OnTouch:
 	mes "[Euncheong]";

--- a/npc/re/quests/quests_malangdo.txt
+++ b/npc/re/quests/quests_malangdo.txt
@@ -1383,11 +1383,11 @@ mal_in02,140,94,0	script	Bob#mal	553,{
 	mes "- not enough supporters yet. -";
 	close;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
 	set .off,0;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 malangdo,114,157,0	duplicate(Crack#mal0)	Crack#mal1	550
@@ -1404,15 +1404,15 @@ malangdo,162,183,0	duplicate(Crack#mal0)	Crack#mal10	550
 -	script	Crackt0#mal	-1,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
 	stopnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTimer1000:
 	donpcevent "Crack#mal"+substr(strnpcinfo(1),6,getstrlen(strnpcinfo(1))-1)+"::OnDisable";
@@ -1921,11 +1921,11 @@ mal_in01,116,168,0	script	Dry Machine#mal	563,{
 	mes "- But it's just sand... -";
 	close;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
 	set .off,0;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 malangdo,221,139,0	duplicate(Suspicious Sand Pile#0)	Suspicious Sand Pile#1	557
@@ -1941,15 +1941,15 @@ malangdo,242,175,0	duplicate(Suspicious Sand Pile#0)	Suspicious Sand Pile#10	557
 
 -	script	Water Sand0#mal	-1,{
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
 	stopnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTimer1000:
 	donpcevent "Suspicious Sand Pile#"+substr(strnpcinfo(1),10,getstrlen(strnpcinfo(1))-1)+"::OnDisable";

--- a/npc/re/quests/quests_malaya.txt
+++ b/npc/re/quests/quests_malaya.txt
@@ -1477,7 +1477,7 @@ malaya,62,274,0	script	Sand Trap#malaya	557,{
 	mes "someone scattered on the sea water.";
 	close2;
 	progressbar "0xffff00", 5;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	getitem 6501, 1; // Salt_Bag
 	mes "[" + strcharinfo(0) + "]";
@@ -1485,7 +1485,7 @@ malaya,62,274,0	script	Sand Trap#malaya	557,{
 	close;
 
 OnTimer30000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -1509,7 +1509,7 @@ ma_fild01,178,206,0	script	Black Bamboo#malaya	844,4,4,{
 	mes "If some of it is cut off and sharpened, I think it will suffice for the Sharpened Bamboo Imelda wanted.";
 	close2;
 	progressbar "0xffff00", 3;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	getitem 6500, 1; //Sharp_Bamboo
 	mes "[" + strcharinfo(0) + "]";
@@ -1521,7 +1521,7 @@ OnTouch_:
 	}
 	end;
 OnTimer30000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -3137,7 +3137,7 @@ ma_fild01,251,93,3	script	Lost Child#malaya01	576,{
 		setquest 7389;
 		erasequest 7388;
 		close2;
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		if (strnpcinfo(0) == "Lost Child#malaya01") {
 			enablenpc "Lost Child#malaya02";
 		} else if (strnpcinfo(0) == "Lost Child#malaya01") {
@@ -3171,7 +3171,7 @@ ma_fild01,251,93,3	script	Lost Child#malaya01	576,{
 	
 OnInit:
 	if (strnpcinfo(0) != "Lost Child#malaya01")
-		disablenpc strnpcinfo(0);
+		disablenpc();
 }
 ma_fild01,114,141,3	duplicate(Lost Child#malaya01)	Lost Child#malaya02	576
 ma_fild01,130,314,3	duplicate(Lost Child#malaya01)	Lost Child#malaya03	576
@@ -4552,13 +4552,13 @@ OnInit:
 		mes "[" + strcharinfo(0) + "]";
 		mes "It's warm as a mother's bosom.";
 		getitem 6519,1; //Collected_Sample
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 		close;
 	}
 	end;
 OnTimer20000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }
@@ -7958,15 +7958,15 @@ malaya,59,84,4	duplicate(MalayaStick)	Suspicious Wooden Stick::MalayaStick10	858
 -	script	Tent#ma	-1,{ //557
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
 	stopnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTimer1000:
 	donpcevent "MalayaStick"+replacestr(strnpcinfo(1),"Tent","")+"::OnDisable";
@@ -9120,13 +9120,13 @@ ma_fild01,164,231,6	script	Beat Catching Boy#pin10	577,{
 	close;
 OnInit:
 	if (!$malaya_pintados_00)
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 ma_fild01,170,228,4	duplicate(Beat Catching Boy#pin10)	Beat Catching Boy#pin11	577

--- a/npc/re/quests/quests_mora.txt
+++ b/npc/re/quests/quests_mora.txt
@@ -379,11 +379,11 @@ OnTouch:
 	donpcevent "Bush"+.@i+"Timer::OnEnable";
 	close;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	donpcevent "Bush"+charat(strnpcinfo(2),9)+"Timer::OnDisable";
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 
@@ -430,14 +430,14 @@ OnTouch:
 -	script	#mora_fairy	-1,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	stopnpctimer;
 	end;
 OnTimer5000:
@@ -485,15 +485,15 @@ spl_fild02,186,260,6	duplicate(#mora_fairy)	Fairy#cmd63	439
 -	script	#mora_bush_timer	-1,{
 	end;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	initnpctimer;
 	end;
 OnDisable:
 	stopnpctimer;
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 OnTimer1000:
 	donpcevent "Bush#ep14_1_bs"+charat(strnpcinfo(0),4)+"::OnDisable";
@@ -4171,11 +4171,11 @@ OnFullon:
 	}
 	end;
 OnEnable:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 OnDisable:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	initnpctimer;
 	end;
 OnReset:

--- a/npc/re/quests/quests_rockridge.txt
+++ b/npc/re/quests/quests_rockridge.txt
@@ -1214,7 +1214,7 @@ OnInit:
 rockrdg1,160,306,3	script	Johnny James#revt04	10213,{
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 rockrdg1,168,306,3	duplicate(Johnny James#revt04)	Albert Ford#revt08	10214
@@ -2117,7 +2117,7 @@ rockrdg2,295,309,3	script	Albert Ford#rockrdg2	10214,{
 	}
 	end;
 OnInit:
-	cloakonnpc strnpcinfo(0);
+	cloakonnpc();
 	end;
 }
 
@@ -3700,12 +3700,12 @@ harboro2,52,261,3	script	Red Pipe#1	4_ENERGY_RED,{
 		completequest .@quest_id;
 		if (isbegin_quest(12405) == 2 && isbegin_quest(12406) == 2 && isbegin_quest(12407) == 2 && isbegin_quest(12408) == 2)
 			setquest 12409;// Pipes Maintained
-		disablenpc strnpcinfo(0);
+		disablenpc();
 		initnpctimer;
 	}
 	end;
 OnTimer30000:
-	enablenpc strnpcinfo(0);
+	enablenpc();
 	stopnpctimer;
 	end;
 }

--- a/npc/re/quests/woe_te/te_goditem_alde1.txt
+++ b/npc/re/quests/woe_te/te_goditem_alde1.txt
@@ -370,9 +370,9 @@ S_Fuse:
 
 OnInit:
 	if ($2012_tegod_kafra == 3 || agitcheck3())// 3 -> quest failed
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	else
-		enablenpc strnpcinfo(0);
+		enablenpc();
 	end;
 }
 
@@ -996,7 +996,7 @@ OnCommandOn:
 OnCommandOff:
 	setnpcdisplay strnpcinfo(0),CLEAR_NPC;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 te_aldecas1,227,35,3	duplicate(#end_aira_alde01)	#end_kuluna_alde01	CLEAR_NPC

--- a/npc/re/quests/woe_te/te_goditem_prt01.txt
+++ b/npc/re/quests/woe_te/te_goditem_prt01.txt
@@ -370,9 +370,9 @@ S_Fuse:
 
 OnInit:
 	if ($2012_tegod_gloria == 3 || agitcheck3())// 3 -> quest failed
-		disablenpc strnpcinfo(0);
+		disablenpc();
 	else
-		enablenpc strnpcinfo(0);
+		enablenpc();
 	end;
 }
 
@@ -993,7 +993,7 @@ OnCommandOn:
 OnCommandOff:
 	setnpcdisplay strnpcinfo(0),CLEAR_NPC;
 OnInit:
-	disablenpc strnpcinfo(0);
+	disablenpc();
 	end;
 }
 te_prtcas01,205,205,3	duplicate(#end_aira_prt01)	#end_kuluna_prt01	CLEAR_NPC

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4744,8 +4744,10 @@ ACMD_FUNC(shownpc)
 		return -1;
 	}
 
-	if (npc_name2id(NPCname) != NULL) {
-		npc_enable(NPCname, 1);
+	npc_data* nd = npc_name2id(NPCname);
+
+	if (nd) {
+		npc_enable(nd, 1);
 		clif_displaymessage(fd, msg_txt(sd,110)); // Npc Enabled.
 	} else {
 		clif_displaymessage(fd, msg_txt(sd,111)); // This NPC doesn't exist.
@@ -4770,12 +4772,14 @@ ACMD_FUNC(hidenpc)
 		return -1;
 	}
 
-	if (npc_name2id(NPCname) == NULL) {
+	npc_data* nd = npc_name2id(NPCname);
+
+	if (!nd) {
 		clif_displaymessage(fd, msg_txt(sd,111)); // This NPC doesn't exist.
 		return -1;
 	}
 
-	npc_enable(NPCname, 0);
+	npc_enable(nd, 0);
 	clif_displaymessage(fd, msg_txt(sd,112)); // Npc Disabled.
 	return 0;
 }

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -262,7 +262,7 @@ bool npc_enable_target(npc_data* nd, uint32 char_id, int flag)
 		map_session_data *sd = map_charid2sd(char_id);
 	
 		if (!sd) {
-			ShowError("npc_enable: Attempted to %s a NPC on an invalid target %d.\n", (flag & 8) ? "show" : "hide", char_id);
+			ShowError("npc_enable: Attempted to %s a NPC '%s' on an invalid target %d.\n", (flag & 8) ? "show" : "hide", nd->name, char_id);
 			return false;
 		}
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -254,20 +254,15 @@ static int npc_cloaked_sub(struct block_list *bl, va_list ap)
 /*==========================================
  * Disable / Enable NPC
  *------------------------------------------*/
-bool npc_enable_target(const char* name, uint32 char_id, int flag)
+bool npc_enable_target(npc_data* nd, uint32 char_id, int flag)
 {
-	struct npc_data* nd = npc_name2id(name);
-
-	if (!nd) {
-		ShowError("npc_enable: Attempted to %s a non-existing NPC '%s' (flag=%d).\n", (flag&11) ? "show" : "hide", name, flag);
-		return false;
-	}
+	nullpo_ret(nd);
 
 	if (char_id > 0 && (flag & 24)) {
 		map_session_data *sd = map_charid2sd(char_id);
 	
 		if (!sd) {
-			ShowError("npc_enable: Attempted to %s a NPC '%s' on an invalid target %d.\n", (flag & 8) ? "show" : "hide", name, char_id);
+			ShowError("npc_enable: Attempted to %s a NPC on an invalid target %d.\n", (flag & 8) ? "show" : "hide", char_id);
 			return false;
 		}
 

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -1289,8 +1289,8 @@ void npc_setcells(struct npc_data* nd);
 void npc_unsetcells(struct npc_data* nd);
 bool npc_movenpc(struct npc_data* nd, int16 x, int16 y);
 bool npc_is_cloaked(struct npc_data* nd, struct map_session_data* sd);
-bool npc_enable_target(const char* name, uint32 char_id, int flag);
-#define npc_enable(name, flag) npc_enable_target(name, 0, flag)
+bool npc_enable_target(npc_data* nd, uint32 char_id, int flag);
+#define npc_enable(nd, flag) npc_enable_target(nd, 0, flag)
 void npc_setdisplayname(struct npc_data* nd, const char* newname);
 void npc_setclass(struct npc_data* nd, short class_);
 struct npc_data* npc_name2id(const char* name);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11647,7 +11647,7 @@ BUILDIN_FUNC(getareadropitem)
  *------------------------------------------*/
 BUILDIN_FUNC(enablenpc)
 {
-	npc_data* nd = nullptr;
+	npc_data* nd;
 	int flag = 0;
 	int char_id = script_hasdata(st, 3) ? script_getnum(st, 3) : 0;
 	const char* command = script_getfuncname(st);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -11647,40 +11647,38 @@ BUILDIN_FUNC(getareadropitem)
  *------------------------------------------*/
 BUILDIN_FUNC(enablenpc)
 {
-	const char *str = script_getstr(st,2);
-	if (npc_enable(str,1))
-		return SCRIPT_CMD_SUCCESS;
+	npc_data* nd = nullptr;
+	int flag = 0;
+	int char_id = script_hasdata(st, 3) ? script_getnum(st, 3) : 0;
+	const char* command = script_getfuncname(st);
 
-	return SCRIPT_CMD_FAILURE;
-}
+	if (script_hasdata(st, 2))
+		nd = npc_name2id(script_getstr(st,2));
+	else
+		nd = map_id2nd(st->oid);
 
-/*==========================================
- *------------------------------------------*/
-BUILDIN_FUNC(disablenpc)
-{
-	const char *str = script_getstr(st,2);
-	if (npc_enable(str,0))
-		return SCRIPT_CMD_SUCCESS;
+	if (!strcmp(command,"enablenpc"))
+		flag = 1;
+	else if (!strcmp(command,"disablenpc"))
+		flag = 0;
+	else if (!strcmp(command,"hideoffnpc"))
+		flag = 2;
+	else if (!strcmp(command,"hideonnpc"))
+		flag = 4;
+	else if (!strcmp(command,"cloakoffnpc"))
+		flag = 8;
+	else if (!strcmp(command,"cloakonnpc"))
+		flag = 16;
 
-	return SCRIPT_CMD_FAILURE;
-}
+	if (!nd) {
+		if (script_hasdata(st, 2))
+			ShowError("buildin_%s: Attempted to %s a non-existing NPC '%s' (flag=%d).\n", (flag&11) ? "show" : "hide", command, script_getstr(st,2), flag);
+		else
+			ShowError("buildin_%s: Attempted to %s a non-existing NPC (flag=%d).\n", (flag&11) ? "show" : "hide", command, flag);
+		return SCRIPT_CMD_FAILURE;
+	}
 
-/*==========================================
- *------------------------------------------*/
-BUILDIN_FUNC(hideoffnpc)
-{
-	const char *str = script_getstr(st,2);
-	if (npc_enable(str,2))
-		return SCRIPT_CMD_SUCCESS;
-
-	return SCRIPT_CMD_FAILURE;
-}
-/*==========================================
- *------------------------------------------*/
-BUILDIN_FUNC(hideonnpc)
-{
-	const char *str = script_getstr(st,2);
-	if (npc_enable(str,4))
+	if (npc_enable_target(nd, char_id, flag))
 		return SCRIPT_CMD_SUCCESS;
 
 	return SCRIPT_CMD_FAILURE;
@@ -25038,28 +25036,20 @@ BUILDIN_FUNC(convertpcinfo) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
-BUILDIN_FUNC(cloakoffnpc)
-{
-	if (npc_enable_target(script_getstr(st, 2), script_hasdata(st, 3) ? script_getnum(st, 3) : 0, 8))
-		return SCRIPT_CMD_SUCCESS;
-
-	return SCRIPT_CMD_FAILURE;
-}
-
-BUILDIN_FUNC(cloakonnpc)
-{
-	if (npc_enable_target(script_getstr(st, 2), script_hasdata(st, 3) ? script_getnum(st, 3) : 0, 16))
-		return SCRIPT_CMD_SUCCESS;
-
-	return SCRIPT_CMD_FAILURE;
-}
-
 BUILDIN_FUNC(isnpccloaked)
 {
-	struct npc_data *nd = npc_name2id(script_getstr(st, 2));
+	npc_data *nd;
+
+	if (script_hasdata(st, 2))
+		nd = npc_name2id(script_getstr(st, 2));
+	else
+		nd = map_id2nd(st->oid);
 
 	if (!nd) {
-		ShowError("buildin_isnpccloaked: %s is a non-existing NPC.\n", script_getstr(st, 2));
+		if (script_hasdata(st, 2))
+			ShowError("buildin_isnpccloaked: %s is a non-existing NPC.\n", script_getstr(st, 2));
+		else
+			ShowError("buildin_isnpccloaked: non-existing NPC.\n");
 		return SCRIPT_CMD_FAILURE;
 	}
 
@@ -25330,10 +25320,12 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(getunits, "getmapunits", "is?"),
 	BUILDIN_DEF2(getunits, "getareaunits", "isiiii?"),
 	BUILDIN_DEF(getareadropitem,"siiiiv"),
-	BUILDIN_DEF(enablenpc,"s"),
-	BUILDIN_DEF(disablenpc,"s"),
-	BUILDIN_DEF(hideoffnpc,"s"),
-	BUILDIN_DEF(hideonnpc,"s"),
+	BUILDIN_DEF(enablenpc,"?"),
+	BUILDIN_DEF2(enablenpc, "disablenpc", "?"),
+	BUILDIN_DEF2(enablenpc, "hideoffnpc", "?"),
+	BUILDIN_DEF2(enablenpc, "hideonnpc", "?"),
+	BUILDIN_DEF2(enablenpc, "cloakoffnpc", "??"),
+	BUILDIN_DEF2(enablenpc, "cloakonnpc", "??"),
 	BUILDIN_DEF(sc_start,"iii???"),
 	BUILDIN_DEF2(sc_start,"sc_start2","iiii???"),
 	BUILDIN_DEF2(sc_start,"sc_start4","iiiiii???"),
@@ -25794,9 +25786,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(achievement_condition,"i"),
 	BUILDIN_DEF(getvariableofinstance,"ri"),
 	BUILDIN_DEF(convertpcinfo,"vi"),
-	BUILDIN_DEF(cloakoffnpc, "s?"),
-	BUILDIN_DEF(cloakonnpc, "s?"),
-	BUILDIN_DEF(isnpccloaked, "s?"),
+	BUILDIN_DEF(isnpccloaked, "??"),
 
 	BUILDIN_DEF(rentalcountitem, "v?"),
 	BUILDIN_DEF2(rentalcountitem, "rentalcountitem2", "viiiiiii?"),


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

This is a suggestion to make the required NPC name parameter optional (the default name will be the npc attached to the script) for the commands 
- enablenpc
- disablenpc
- hideonnpc
- hideoffnpc
- cloakonnpc
- cloakoffnpc
- isnpccloaked
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
