### PR TITLE
Added Custom Weight Check on quests_13_2

### DIFF
--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -50,6 +50,7 @@
 //= 2.7a Added Izlude RE coordinates. [Euphy]
 //= 2.8 Added GM management function. [Euphy]
 //= 2.9 Added custom weight check. Fixes issue #910. [Jeybla]
+//= 2.9a Added custom inventory check. To overcome failure to get gems. [Mazvi]
 //============================================================ 
 
 // Cat Paw Addition :: cat_enhance
@@ -4482,7 +4483,7 @@ function	script	jewel_13_2	{
 	}
 	else if (ep13_2_rhea == 5) {
 		getinventorylist;
-		if ( @inventorylist_count > 98 ) { //Need this check to solve the bug that failed to get the item.
+		if ( @inventorylist_count > 98 ) { //Need this check to solve/prevent the bug that failed to get the item.
 		mes "Your inventory slot is full. Please free up your inventory.";
 		close;
 		}

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -4481,6 +4481,11 @@ function	script	jewel_13_2	{
 		close;
 	}
 	else if (ep13_2_rhea == 5) {
+		getinventorylist;
+		if ( @inventorylist_count > 98 ) { //Need this check to solve the bug that failed to get the item.
+		mes "Your inventory slot is full. Please free up your inventory.";
+		close;
+		}
 		.@num = getarg(1);
 		if (checkquest(8240+.@num) == -1) {
 			mes "- Under a round pile of earth, -";

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -4485,6 +4485,7 @@ function	script	jewel_13_2	{
 		//Custom Weight Check
 		if (!checkweight(7575,2)) {
 		mes "Sorry, your inventory is full!";
+		close;
 		}
 		.@num = getarg(1);
 		if (checkquest(8240+.@num) == -1) {

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -50,7 +50,7 @@
 //= 2.7a Added Izlude RE coordinates. [Euphy]
 //= 2.8 Added GM management function. [Euphy]
 //= 2.9 Added custom weight check. Fixes issue #910. [Jeybla]
-//= 2.9a Added custom inventory check. To overcome failure to get gems. [Mazvi]
+//= 2.9a Added custom weight check. To overcome failure to get gems. [Mazvi]
 //============================================================ 
 
 // Cat Paw Addition :: cat_enhance
@@ -4482,10 +4482,9 @@ function	script	jewel_13_2	{
 		close;
 	}
 	else if (ep13_2_rhea == 5) {
-		getinventorylist;
-		if ( @inventorylist_count > 98 ) { //Need this check to solve/prevent the bug that failed to get the item.
-		mes "Your inventory slot is full. Please free up your inventory.";
-		close;
+		//Custom Weight Check
+		if (!checkweight(7575,2)) {
+		mes "Sorry, your inventory is full!";
 		}
 		.@num = getarg(1);
 		if (checkquest(8240+.@num) == -1) {

--- a/npc/quests/quests_13_2.txt
+++ b/npc/quests/quests_13_2.txt
@@ -4484,8 +4484,8 @@ function	script	jewel_13_2	{
 	else if (ep13_2_rhea == 5) {
 		//Custom Weight Check
 		if (!checkweight(7575,2)) {
-		mes "Sorry, your inventory is full!";
-		close;
+		    mes "Sorry, your inventory is full!";
+		    close;
 		}
 		.@num = getarg(1);
 		if (checkquest(8240+.@num) == -1) {


### PR DESCRIPTION
Added Custom Weight Check on quests_13_2

Need this check to solve the bug that failed to get the item if inventory is full.

Because if it fails then the user will not be able to get it again because it is considered to have completed the quest. 

Special Thanks to: @RagnaWay @Atemo @secretdataz 

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
