### PR TITLE
Fixes a potential map crash for atcommand mapflag

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8410,7 +8410,6 @@ ACMD_FUNC(mapflag) {
 		if( mapflag != MF_INVALID ){
 			std::vector<e_mapflag> disabled_mf = { MF_NOSAVE,
 												MF_PVP_NIGHTMAREDROP,
-												MF_RESTRICTED,
 												MF_NOCOMMAND,
 												MF_BEXP,
 												MF_JEXP,
@@ -8418,8 +8417,8 @@ ACMD_FUNC(mapflag) {
 												MF_SKILL_DAMAGE,
 												MF_SKILL_DURATION };
 
-			if (flag && std::find(disabled_mf.begin(), disabled_mf.end(), mapflag) != disabled_mf.end()) {
-				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be enabled as it requires unique values.", flag_name);
+			if (mapflag == MF_RESTRICTED || (flag > 0 && util::vector_exists(disabled_mf, mapflag))) {
+				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be changed as it requires unique values.", flag_name);
 				clif_displaymessage(sd->fd,atcmd_output);
 			} else {
 				map_setmapflag(sd->bl.m, mapflag, flag != 0);

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -8410,6 +8410,7 @@ ACMD_FUNC(mapflag) {
 		if( mapflag != MF_INVALID ){
 			std::vector<e_mapflag> disabled_mf = { MF_NOSAVE,
 												MF_PVP_NIGHTMAREDROP,
+												MF_RESTRICTED,
 												MF_NOCOMMAND,
 												MF_BEXP,
 												MF_JEXP,
@@ -8417,8 +8418,8 @@ ACMD_FUNC(mapflag) {
 												MF_SKILL_DAMAGE,
 												MF_SKILL_DURATION };
 
-			if (mapflag == MF_RESTRICTED || (flag > 0 && util::vector_exists(disabled_mf, mapflag))) {
-				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be changed as it requires unique values.", flag_name);
+			if (flag > 0 && util::vector_exists(disabled_mf, mapflag)) {
+				sprintf(atcmd_output,"[ @mapflag ] %s flag cannot be enabled as it requires unique values.", flag_name);
 				clif_displaymessage(sd->fd,atcmd_output);
 			} else {
 				map_setmapflag(sd->bl.m, mapflag, flag != 0);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4745,13 +4745,23 @@ bool map_setmapflag_sub(int16 m, enum e_mapflag mapflag, bool status, union u_ma
 			mapdata->flag[mapflag] = status;
 			break;
 		case MF_RESTRICTED:
-			nullpo_retr(false, args);
+			if (!status) {
+				if (args == nullptr) {
+					mapdata->zone = 0;
+				} else {
+					mapdata->zone ^= (1 << (args->flag_val + 1)) << 3;
+				}
 
-			mapdata->flag[mapflag] = status;
-			if (!status)
-				mapdata->zone ^= (1 << (args->flag_val + 1)) << 3;
-			else
+				// Don't completely disable the mapflag's status if other zones are active
+				if (mapdata->zone == 0) {
+					mapdata->flag[mapflag] = status;
+				}
+			} else {
+				nullpo_retr(false, args);
+
 				mapdata->zone |= (1 << (args->flag_val + 1)) << 3;
+				mapdata->flag[mapflag] = status;
+			}
 			break;
 		case MF_NOCOMMAND:
 			if (status) {


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6254

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * MF_RESTRICTED is now fully disabled from atcommand mapflag as it requires specific arguments to be enabled/disabled.
Thanks to @xEasycore!