### PR TITLE
Fixed autobonus on the same equip slot

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10804,7 +10804,7 @@ bool pc_equipitem(struct map_session_data *sd,short n,int req_pos,bool equipswit
 	return true;
 }
 
-void pc_deleteautobonus( struct map_session_data& sd, std::vector<s_autobonus>& bonus, int position ){
+static void pc_deleteautobonus( std::vector<s_autobonus>& bonus, int position ){
 	std::vector<s_autobonus>::iterator it = bonus.begin();
 
 	while( it != bonus.end() ){
@@ -10845,9 +10845,9 @@ static void pc_unequipitem_sub(struct map_session_data *sd, int n, int flag) {
 	int i, iflag;
 	bool status_calc = false;
 
-	pc_deleteautobonus( *sd, sd->autobonus, sd->inventory.u.items_inventory[n].equip );
-	pc_deleteautobonus( *sd, sd->autobonus2, sd->inventory.u.items_inventory[n].equip );
-	pc_deleteautobonus( *sd, sd->autobonus3, sd->inventory.u.items_inventory[n].equip );
+	pc_deleteautobonus( sd->autobonus, sd->inventory.u.items_inventory[n].equip );
+	pc_deleteautobonus( sd->autobonus2, sd->inventory.u.items_inventory[n].equip );
+	pc_deleteautobonus( sd->autobonus3, sd->inventory.u.items_inventory[n].equip );
 
 	sd->inventory.u.items_inventory[n].equip = 0;
 	if (!(flag & 4))

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2772,8 +2772,17 @@ static void pc_bonus_item_drop(std::vector<s_add_drop> &drop, t_itemid nameid, u
  * @param onskill: Skill used to trigger autobonus
  * @return True on success or false otherwise
  */
-bool pc_addautobonus(std::vector<s_autobonus> &bonus, const char *script, short rate, unsigned int dur, uint16 flag, const char *other_script, unsigned int pos, bool onskill)
-{
+bool pc_addautobonus(std::vector<s_autobonus> &bonus, const char *script, short rate, unsigned int dur, uint16 flag, const char *other_script, unsigned int pos, bool onskill){
+	// Check if the same bonus already exists
+	for( std::vector<s_autobonus>::iterator it = bonus.begin(); it != bonus.end(); it++ ){
+		s_autobonus& autobonus = *it;
+
+		// Compare based on position and bonus script
+		if( autobonus.pos == pos && strcmp( script, autobonus.bonus_script ) == 0 ){
+			return false;
+		}
+	}
+
 	if (bonus.size() == MAX_PC_BONUS) {
 		ShowWarning("pc_addautobonus: Reached max (%d) number of autobonus per character!\n", MAX_PC_BONUS);
 		return false;
@@ -2789,15 +2798,6 @@ bool pc_addautobonus(std::vector<s_autobonus> &bonus, const char *script, short 
 				flag |= BF_SKILL; //These two would never trigger without BF_SKILL
 			if (flag&BF_WEAPON)
 				flag |= BF_NORMAL | BF_SKILL;
-		}
-	}
-
-	for( std::vector<s_autobonus>::iterator it = bonus.begin(); it != bonus.end(); it++ ){
-		s_autobonus& autobonus = *it;
-
-		// Check if the same bonus already exists
-		if( autobonus.pos == pos && strcmp( script, autobonus.bonus_script ) == 0 ){
-			return false;
 		}
 	}
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -323,7 +323,6 @@ struct map_session_data {
 		t_itemid autolootid[AUTOLOOTITEM_SIZE]; // [Zephyrus]
 		unsigned short autoloottype;
 		unsigned int autolooting : 1; //performance-saver, autolooting state for @alootid
-		unsigned int autobonus; //flag to indicate if an autobonus is activated. [Inkfish]
 		unsigned int gmaster_flag : 1;
 		unsigned int prevend : 1;//used to flag wheather you've spent 40sp to open the vending or not.
 		unsigned int warping : 1;//states whether you're in the middle of a warp processing

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -240,6 +240,8 @@ struct s_autobonus {
 	char *bonus_script, *other_script;
 	int active;
 	unsigned int pos;
+
+	~s_autobonus();
 };
 
 /// Timed bonus 'bonus_script' struct [Cydh]

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -9636,9 +9636,6 @@ BUILDIN_FUNC(autobonus)
 	else
 		pos = sd->inventory.u.items_inventory[current_equip_item_index].equip;
 
-	if((sd->state.autobonus&pos) == pos)
-		return SCRIPT_CMD_SUCCESS;
-
 	rate = script_getnum(st,3);
 	dur = script_getnum(st,4);
 	bonus_script = script_getstr(st,2);
@@ -9676,9 +9673,6 @@ BUILDIN_FUNC(autobonus2)
 	else
 		pos = sd->inventory.u.items_inventory[current_equip_item_index].equip;
 
-	if((sd->state.autobonus&pos) == pos)
-		return SCRIPT_CMD_SUCCESS;
-
 	rate = script_getnum(st,3);
 	dur = script_getnum(st,4);
 	bonus_script = script_getstr(st,2);
@@ -9715,9 +9709,6 @@ BUILDIN_FUNC(autobonus3)
 		pos = current_equip_combo_pos;
 	else
 		pos = sd->inventory.u.items_inventory[current_equip_item_index].equip;
-
-	if((sd->state.autobonus&pos) == pos)
-		return SCRIPT_CMD_SUCCESS;
 
 	rate = script_getnum(st,3);
 	dur = script_getnum(st,4);


### PR DESCRIPTION
* **Addressed Issue(s)**: #2079

* **Server Mode**: Both

* **Description of Pull Request**: 
If two different autobonuses would be triggered from the same equipment slot, only one of them would work.
With this now all autobonuses of a slot will work.

Thanks to @LunarSHINING for reporting and testing
Thanks to @Tokeiburu for the initial report
