### PR TITLE
Updates Poisonous Smoke behavior

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -19571,7 +19571,7 @@ Body:
     Unit:
       Id: Poisonsmoke
       Layout: 2
-      Interval: 1000
+      Interval: 2000
       Target: Enemy
       Flag:
         NoOverlap: true

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -14583,8 +14583,8 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 			break;
 
 		case UNT_POISONSMOKE:
-			if( battle_check_target(ss,bl,BCT_ENEMY) > 0 && !(tsc && tsc->data[sg->val2]) && rnd()%100 < 20 )
-				sc_start(ss,bl,(sc_type)sg->val2,100,sg->val3,skill_get_time2(GC_POISONINGWEAPON, 1));
+			if( battle_check_target(ss,bl,BCT_ENEMY) > 0 && !(tsc && tsc->data[sg->val2]) && rnd()%100 < 50 )
+				sc_start4(ss,bl,(sc_type)sg->val2,100,sg->val3,0,1,0,skill_get_time2(GC_POISONINGWEAPON, 1));
 			break;
 
 		case UNT_EPICLESIS:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6199

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Adjusts the interval to every 2 seconds.
  * Adjusts the success rate to 50%.
  * Fixes the Poison Weapon effect not applying the 'enemy' status to those inside of Poisonous Smoke.
Thanks to @Everade!