### PR TITLE
Remove Maximum Power-Thrust buff on weapon unequip. Fixes #6277

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10989,7 +10989,9 @@ bool pc_unequipitem(struct map_session_data *sd, int n, int flag) {
 		skill_enchant_elemental_end(&sd->bl, SC_NONE);
 		status_change_end(&sd->bl, SC_FEARBREEZE, INVALID_TIMER);
 		status_change_end(&sd->bl, SC_EXEEDBREAK, INVALID_TIMER);
+#ifdef RENEWAL
 		status_change_end(&sd->bl, SC_MAXOVERTHRUST, INVALID_TIMER);
+#endif
 	}
 
 	// On armor change

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -10989,6 +10989,7 @@ bool pc_unequipitem(struct map_session_data *sd, int n, int flag) {
 		skill_enchant_elemental_end(&sd->bl, SC_NONE);
 		status_change_end(&sd->bl, SC_FEARBREEZE, INVALID_TIMER);
 		status_change_end(&sd->bl, SC_EXEEDBREAK, INVALID_TIMER);
+		status_change_end(&sd->bl, SC_MAXOVERTHRUST, INVALID_TIMER);
 	}
 
 	// On armor change


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6277

* **Server Mode**: Both

* **Description of Pull Request**:  Remove Maximum Power-Thrust buff on weapon unequip.

* ** To-do: 

- [x] Confirm if this PR should affect pre-renewal