### PR TITLE
Fixed invalid purchase history

### DIFF
--- a/src/map/vending.cpp
+++ b/src/map/vending.cpp
@@ -227,7 +227,7 @@ void vending_purchasereq(struct map_session_data* sd, int aid, int uid, const ui
 		// vending item
 		pc_additem(sd, &vsd->cart.u.items_cart[idx], amount, LOG_TYPE_VENDING);
 		vsd->vending[vend_list[i]].amount -= amount;
-		z += ((double)vsd->vending[i].value * (double)amount);
+		z += ((double)vsd->vending[vend_list[i]].value * (double)amount);
 
 		if( vsd->vending[vend_list[i]].amount ) {
 			if( Sql_Query( mmysql_handle, "UPDATE `%s` SET `amount` = %d WHERE `vending_id` = %d and `cartinventory_id` = %d", vending_items_table, vsd->vending[vend_list[i]].amount, vsd->vender_id, vsd->cart.u.items_cart[idx].id ) != SQL_SUCCESS ) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #6284

* **Server Mode**: Both

* **Description of Pull Request**: 
If the items were bought in a random order, this would mess up the purchase history.

Thanks to @Lelouzh
