### PR TITLE
Removes the extra check in node["Drops"] (quest_db)

### DIFF
--- a/src/map/quest.cpp
+++ b/src/map/quest.cpp
@@ -318,11 +318,6 @@ uint64 QuestDatabase::parseBodyNode(const YAML::Node &node) {
 		const YAML::Node &drops = node["Drops"];
 
 		for (const YAML::Node &dropNode : drops) {
-			if (quest->objectives.size() >= MAX_QUEST_OBJECTIVES) {
-				this->invalidWarning(dropNode, "Drops list exceeds the maximum of %d, skipping.\n", MAX_QUEST_OBJECTIVES);
-				return 0;
-			}
-
 			uint32 mob_id = 0; // Can be 0 which means all monsters
 
 			if (this->nodeExists(dropNode, "Mob")) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The Drops data is not affected by `quest->objectives`, this check can be removed. `quest->dropitem` doesn't need a limit
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
