### PR TITLE
Fixes checkquest calls in Magic Book Seller Quest

### DIFF
--- a/npc/re/quests/magic_books.txt
+++ b/npc/re/quests/magic_books.txt
@@ -3,7 +3,7 @@
 //===== By: ================================================== 
 //= Masao, Muad_Dib (translation)
 //===== Current Version: ===================================== 
-//= 1.1a
+//= 1.3
 //===== Compatible With: ===================================== 
 //= rAthena Project
 //===== Description: ========================================= 
@@ -16,6 +16,7 @@
 //= 1.1b Fixed the rand part in "Mysterious Documents" to match
 //=	 Aegis & fixed a bracket issue. [Capuche]
 //= 1.2 Updates Magic Books gained from Lea. [Aleos]
+//= 1.3 Fixes checkquest calls. [Everade]
 //============================================================ 
 
 // Main Quest :: war_book


### PR DESCRIPTION
* **Addressed Issue(s)**:
Fixes https://github.com/rathena/rathena/issues/6316

* **Server Mode**:
Renewal

* **Description of Pull Request**:
Corrects checkquest calls to account for playtime in the Magic Book Seller Quest. This fixes the issue of getting stuck forever when the quest timer ran out, because of returning different values than expected.
