### PR TITLE
Fix for sura skills (RAMPAGEBLASTER / RIDEINLIGHTNING)

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2382,10 +2382,10 @@ static int battle_range_type(struct block_list *src, struct block_list *target, 
 			break;
 #ifdef RENEWAL
 		case KN_BRANDISHSPEAR:
-		case SR_RAMPAGEBLASTER:
-			// Renewal changes to ranged physical damage
-			return BF_LONG;
+		// Renewal changes to ranged physical damage
 #endif
+		case SR_RAMPAGEBLASTER:
+			return BF_LONG;
 		case NJ_KIRIKAGE:
 			// Cast range mimics NJ_SHADOWJUMP but damage is considered melee
 		case GC_CROSSIMPACT:


### PR DESCRIPTION
* **Addressed Issue(s)**: -
* **Server Mode**: Re
* **Description of Pull Request**: 

SR_RAMPAGEBLASTER should have range type damage.

> 내용 : 자신 주변 범위 7 x 7 셀 내의 모든 적에게 원거리 물리 데미지를 준다. 기 구체 3개를 소모하며, [폭기]상태에서만 사용할 수 있다.
시전자의 베이스 레벨 및 습득한 폭기의 스킬 레벨 만큼 데미지가 추가로 증가된다.

SR_RIDEINLIGHTNING should deal more hits.

> [Level 1] : 공격력 40%/ 90%(너클)/범위 3 x 3/1회 공격
[Level 2] : 공격력 80%/ 180%(너클)/범위 3 x 3/2회 공격
[Level 3] : 공격력 120%/270%(너클)/범위 5 x 5/3회 공격
[Level 4] : 공격력 160%/360%(너클)/범위 5 x 5/4회 공격
[Level 5] : 공격력 200%/450%(너클)/범위 7 x 7/5회 공격

Without fix it deal 2 hits = required spheres, on any skill level.