### PR TITLE
Fixed monster attack calculations

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6105,13 +6105,17 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 #endif
 	}
 
-#ifndef RENEWAL
-	if(tsd) { // Card Fix for target (tsd), 2 is not added to the "left" flag meaning "target cards only"
+#ifdef RENEWAL
+	// In renewal only do it for non player attacks
+	if( tsd && !sd ){
+#else
+	if( tsd ){
+#endif
+		// Card Fix for target (tsd), 2 is not added to the "left" flag meaning "target cards only"
 		wd.damage += battle_calc_cardfix(BF_WEAPON, src, target, nk, right_element, left_element, wd.damage, 0, wd.flag);
 		if(is_attack_left_handed(src, skill_id))
 			wd.damage2 += battle_calc_cardfix(BF_WEAPON, src, target, nk, right_element, left_element, wd.damage2, 1, wd.flag);
 	}
-#endif
 
 	// only do 1 dmg to plant, no need to calculate rest
 	if(infdef){


### PR DESCRIPTION
* **Addressed Issue(s)**: #6273

* **Server Mode**: Renewal

* **Description of Pull Request**: 
Added back a calculation that was removed for renewal, but only for non-player attacks.

Thanks to @Zeloss, @zyudimosha, @sonniez, @Everade and @limitro
