### PR TITLE
Fixed walking NPCs with monster sprites

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -125,9 +125,9 @@ int unit_walktoxy_sub(struct block_list *bl)
 		clif_walkok((TBL_PC*)bl);
 	}
 #if PACKETVER >= 20170726
-	// If this is a walking NPC and it will use a non NPC sprite
-	else if( bl->type == BL_NPC && !npcdb_checkid( status_get_viewdata( bl )->class_ ) ){
-		// Respawn the NPC with the other unit type
+	// If this is a walking NPC and it will use a player sprite
+	else if( bl->type == BL_NPC && pcdb_checkid( status_get_viewdata( bl )->class_ ) ){
+		// Respawn the NPC as player unit
 		unit_refresh( bl, true );
 	}
 #endif
@@ -457,9 +457,9 @@ static TIMER_FUNC(unit_walktoxy_timer)
 
 	if (bl->x == ud->to_x && bl->y == ud->to_y) {
 #if PACKETVER >= 20170726
-		// If this was a walking NPC and it used a non NPC sprite
-		if( bl->type == BL_NPC && !npcdb_checkid( status_get_viewdata( bl )->class_ ) ){
-			// Respawn the NPC with the other unit type
+		// If this was a walking NPC and it used a player sprite
+		if( bl->type == BL_NPC && pcdb_checkid( status_get_viewdata( bl )->class_ ) ){
+			// Respawn the NPC as NPC unit
 			unit_refresh( bl, false );
 		}
 #endif


### PR DESCRIPTION
* **Addressed Issue(s)**: #6312

* **Server Mode**: Both

* **Description of Pull Request**: 
NPCs that use monster sprites also need to be respawned as monsters once they start walking.

Thanks to @Everade
