### PR TITLE
Apply view_range_rate to mob's view range again. Fixes #6311

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4896,7 +4896,7 @@ void MobDatabase::loadingFinished() {
 			mob->range2 = max(1, mob->range2 * battle_config.view_range_rate / 100);
 
 		if (battle_config.chase_range_rate != 100)
-			mob->range3 = cap_value(mob->range3, mob->range2, mob->range3 * battle_config.chase_range_rate / 100);
+			mob->range3 = max(mob->range2, mob->range3 * battle_config.chase_range_rate / 100);
 
 		// Tests showed that chase range is effectively 2 cells larger than expected [Playtester]
 		mob->range3 += 2;


### PR DESCRIPTION
Thanks to @zyudimosha

* **Addressed Issue(s)**: #6311

* **Server Mode**: Both

* **Description of Pull Request**: Use `max` instead of `cap_value` to limit the mob view range.