### PR TITLE
Added script command mercenary_delete

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10044,8 +10044,8 @@ This command is typically used in item scripts of mercenary scrolls.
 
 *mercenary_delete {<char id>{,<reply>}};
 
-This command remove mercenary from a player.
-The parameter 'reply' can be one or the following value:
+This command removes the mercenary from a player.
+The parameter 'reply' can be one of the following values:
 
 	0 - Mercenary soldier's duty hour is over, faith increased by 1. (default)
 	1 - Your mercenary soldier has been killed, faith decreased by 1.

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19749,17 +19749,22 @@ BUILDIN_FUNC(mercenary_delete)
 	struct map_session_data *sd;
 	int type = 0;
 
-	if( !script_charid2sd(2, sd) || sd->md == NULL )
-		return SCRIPT_CMD_SUCCESS;
+	if( !script_charid2sd(2, sd) )
+		return SCRIPT_CMD_FAILURE;
+
+	if( sd->md == nullptr ) {
+		ShowWarning("buildin_mercenary_delete: Tried to delete a non existant mercenary from player '%s' (AID: %u, CID: %u)\n", sd->status.name, sd->status.account_id, sd->status.char_id);
+		return SCRIPT_CMD_FAILURE;
+	}
 
 	if( script_hasdata(st, 3) ) {
 		type = script_getnum(st, 3);
 		if( type < 0 || type > 3 ) {
-			ShowWarning("script: buildin_mercenary_delete: invalid type value of %d, default to 0.\n", type);
-			type = 0;
+			ShowWarning("buildin_mercenary_delete: invalid type value of %d.\n", type);
+			return SCRIPT_CMD_FAILURE;
 		}
 	}
-
+	
 	mercenary_delete(sd->md, type);
 
 	return SCRIPT_CMD_SUCCESS;


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
Yes, `unitkill` are able to remove a mercenary but I believe this isn't the correct way.
example: kRO, when npc script remove a mercenary, it doesn't output a message say mercenary is killed, nor show you the dead animation.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable to remove/kill mercenary from a player and auto assign faith (loyalty) value if any.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
