### PR TITLE
Yet another autospell fix

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -192,6 +192,13 @@ struct weapon_data {
 	std::vector<s_addrace2> addrace3;
 };
 
+enum e_autospell_flags{
+	AUTOSPELL_FORCE_SELF = 0x0,
+	AUTOSPELL_FORCE_TARGET = 0x1,
+	AUTOSPELL_FORCE_RANDOM_LEVEL = 0x2,
+	AUTOSPELL_FORCE_ALL = 0x3
+};
+
 /// AutoSpell bonus struct
 struct s_autospell {
 	uint16 id, lv, trigger_skill;

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8205,6 +8205,12 @@
 	export_constant(REFINE_TYPE_SHADOW_ARMOR);
 	export_constant(REFINE_TYPE_SHADOW_WEAPON);
 
+	/* autospell flags */
+	export_constant(AUTOSPELL_FORCE_SELF);
+	export_constant(AUTOSPELL_FORCE_TARGET);
+	export_constant(AUTOSPELL_FORCE_RANDOM_LEVEL);
+	export_constant(AUTOSPELL_FORCE_ALL);
+
 	#undef export_constant
 	#undef export_constant2
 	#undef export_parameter

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2188,7 +2188,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 
 			uint16 autospl_skill_lv = it.lv ? it.lv : 1;
 
-			if (it.flag & 2)
+			if (it.flag & AUTOSPELL_FORCE_RANDOM_LEVEL)
 				autospl_skill_lv = rnd_value( 1, autospl_skill_lv );
 
 			rate = (!sd->state.arrow_atk) ? it.rate : it.rate / 2;
@@ -2196,7 +2196,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 			if (rnd()%1000 >= rate)
 				continue;
 
-			block_list *tbl = (it.flag & 1) ? src : bl;
+			block_list *tbl = (it.flag & AUTOSPELL_FORCE_TARGET) ? bl : src;
 			e_cast_type type = skill_get_casttype(skill);
 
 			if (type == CAST_GROUND) {
@@ -2300,15 +2300,19 @@ int skill_onskillusage(struct map_session_data *sd, struct block_list *bl, uint1
 
 		sd->state.autocast = 0;
 
-		if( skill > 0 && bl == nullptr )
+		// DANGER DANGER: here force target actually means use yourself as target!
+		block_list *tbl = (it.flag & AUTOSPELL_FORCE_TARGET) ? &sd->bl : bl;
+
+		if( tbl == nullptr ){
 			continue; // No target
+		}
+
 		if( rnd()%1000 >= it.rate )
 			continue;
 
-		block_list *tbl = (it.flag & 1) ? &sd->bl : bl;
 		uint16 skill_lv = it.lv ? it.lv : 1;
 
-		if (it.flag & 2)
+		if (it.flag & AUTOSPELL_FORCE_RANDOM_LEVEL)
 			skill_lv = rnd_value( 1, skill_lv ); //random skill_lv
 
 		e_cast_type type = skill_get_casttype(skill);
@@ -2504,7 +2508,7 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 
 			uint16 autospl_skill_id = it.id, autospl_skill_lv = it.lv ? it.lv : 1;
 
-			if (it.flag & 2)
+			if (it.flag & AUTOSPELL_FORCE_RANDOM_LEVEL)
 				autospl_skill_lv = rnd_value( 1, autospl_skill_lv );
 
 			int autospl_rate = it.rate;
@@ -2523,7 +2527,7 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 			if (rnd()%1000 >= autospl_rate)
 				continue;
 
-			block_list *tbl = (it.flag & 1) ? bl : src;
+			block_list *tbl = (it.flag & AUTOSPELL_FORCE_TARGET) ? bl : src;
 			e_cast_type type = skill_get_casttype(autospl_skill_id);
 
 			if (type == CAST_GROUND && !skill_pos_maxcount_check(bl, tbl->x, tbl->y, autospl_skill_id, autospl_skill_lv, BL_PC, false))


### PR DESCRIPTION
* **Addressed Issue(s)**: #6337

* **Server Mode**: Both

* **Description of Pull Request**: 
Increased readability by adding constants.
The real problem was that autospell and autospell onskill used different values for the same logical operation.

Thanks to @renniw
