### PR TITLE
Fix yamlupgrade compiler error on linux

### DIFF
--- a/src/tool/yamlupgrade.cpp
+++ b/src/tool/yamlupgrade.cpp
@@ -230,7 +230,7 @@ static bool upgrade_achievement_db(std::string file, const uint32 source_version
 static bool upgrade_item_db(std::string file, const uint32 source_version) {
 	size_t entries = 0;
 
-	for( auto &input : inNode["Body"] ){
+	for( auto input : inNode["Body"] ){
 		// If under version 2
 		if( source_version < 2 ){
 			// Add armor level to all equipments


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

* **Server Mode**: Both

* **Description of Pull Request**: 
There's a compiler error on Linux in yamlupgrade.
```
yamlupgrade.cpp: In function 'bool upgrade_item_db(std::string, uint32)':
yamlupgrade.cpp:233:34: error: cannot bind non-const lvalue reference of type 'YAML::detail::iterator_value&' to an rvalue of type 'YAML::detail::iterator_base<YAML::detail::iterator_value>::value_type' {aka 'YAML::detail::iterator_value'}
  233 |  for( auto& input : inNode["Body"] ){
```
By removing the reference, we make a copy of every node (yikes). It's slower, but since this rarely gets ran, it should be ok.