### PR TITLE
Walking npc and official_cell_stack_limit

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -628,7 +628,8 @@ static TIMER_FUNC(unit_walktoxy_timer)
 		ud->to_x = bl->x;
 		ud->to_y = bl->y;
 
-		if (!ud->state.ignore_cell_stack_limit
+		if (bl->type != BL_NPC	// walking npc ignores cell stack limit
+			&& !ud->state.ignore_cell_stack_limit
 			&& battle_config.official_cell_stack_limit > 0
 			&& map_count_oncell(bl->m, x, y, BL_CHAR|BL_NPC, 1) > battle_config.official_cell_stack_limit) {
 			//Walked on occupied cell, call unit_walktoxy again


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Walking npsc shouldn't be bothered by official_cell_stack_limit (check if a cell is occupied), they should stop as the given coordinates
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
