### PR TITLE
Fix SC_CHANGE not using max matk

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2260,8 +2260,10 @@ static int64 battle_calc_base_damage(struct block_list *src, struct status_data 
 	sd = BL_CAST(BL_PC, src);
 
 	if (!sd) { //Mobs/Pets
-		if (sc != NULL && sc->data[SC_CHANGE] != NULL)
+#ifndef RENEWAL
+		if (sc != nullptr && sc->data[SC_CHANGE] != nullptr)
 			return status->matk_max; // [Aegis] simply uses raw max matk for base damage when Mental Charge active
+#endif
 		if(flag&4) {
 			atkmin = status->matk_min;
 			atkmax = status->matk_max;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2260,6 +2260,8 @@ static int64 battle_calc_base_damage(struct block_list *src, struct status_data 
 	sd = BL_CAST(BL_PC, src);
 
 	if (!sd) { //Mobs/Pets
+		if (sc != NULL && sc->data[SC_CHANGE] != NULL)
+			return status->matk_max; // [Aegis] simply uses raw max matk for base damage when Mental Charge active
 		if(flag&4) {
 			atkmin = status->matk_min;
 			atkmax = status->matk_max;


### PR DESCRIPTION
* Thanks to Hercules for the fix;

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fix SC_CHANGE (HLIF mental change skill) to use max MATK on pre-renewal;

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
