### PR TITLE
Fix SC_WINKCHARM behavior

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -395,6 +395,9 @@ static TIMER_FUNC(unit_walktoxy_timer)
 	int y = bl->y;
 
 	enum directions dir = ud->walkpath.path[ud->walkpath.path_pos];
+	if (!(dir >= DIR_NORTH && dir < DIR_MAX)) // SC_WINKCHARM mobs always have DIR_CENTER direction, which has -1 value. To avoid dump values in dirx / diry array we need to return 0. [Tydus1]
+		return 0;
+
 	ud->dir = dir;
 
 	int dx = dirx[dir];

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -388,16 +388,13 @@ static TIMER_FUNC(unit_walktoxy_timer)
 	if(ud->walkpath.path_pos>=ud->walkpath.path_len)
 		return 0;
 
-	if(ud->walkpath.path[ud->walkpath.path_pos]>=DIR_MAX)
-		return 1;
+	if (ud->walkpath.path[ud->walkpath.path_pos] < DIR_NORTH || ud->walkpath.path[ud->walkpath.path_pos] >= DIR_MAX) // SC_WINKCHARM mobs always have DIR_CENTER direction, which has -1 value. To avoid dump values in dirx / diry array we need to return 0. [Tydus1]
+		return 0;
 
 	int x = bl->x;
 	int y = bl->y;
 
 	enum directions dir = ud->walkpath.path[ud->walkpath.path_pos];
-	if (!(dir >= DIR_NORTH && dir < DIR_MAX)) // SC_WINKCHARM mobs always have DIR_CENTER direction, which has -1 value. To avoid dump values in dirx / diry array we need to return 0. [Tydus1]
-		return 0;
-
 	ud->dir = dir;
 
 	int dx = dirx[dir];


### PR DESCRIPTION
* Adds a check to prevent func unit_walktoxy_timer to use DIR_CENTER direction (which has -1 value) on SC_WINKCHARMed mobs. Using this direction may cause dump values when accessing dirx or diry array;

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6371 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adds a check to prevent func unit_walktoxy_timer to use DIR_CENTER direction (which has -1 value) on SC_WINKCHARMed mobs. Using this direction may cause dump values when accessing dirx or diry array;

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
