### PR TITLE
Fix missing condition for HW_GANBANTEIN

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -17078,7 +17078,7 @@ struct s_skill_condition skill_get_requirement(struct map_session_data* sd, uint
 					else {
 						if( sd->special_state.no_gemstone || (sc && sc->data[SC_INTOABYSS]) )
 						{	// All gem skills except Hocus Pocus and Ganbantein can cast for free with Mistress card -helvetica
-							if( skill_id != SA_ABRACADABRA )
+							if (skill_id != SA_ABRACADABRA && skill_id != HW_GANBANTEIN)
 		 						req.itemid[i] = req.amount[i] = 0;
 							else if( --req.amount[i] < 1 )
 								req.amount[i] = 1; // Hocus Pocus always use at least 1 gem


### PR DESCRIPTION
* Adds a condition for HW_GANBANTEIN since it's one of the skills that can be cast with no gemstone when equipped with Mistress Card.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6358 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adds a condition for HW_GANBANTEIN since it's one of the skills that can be cast with no gemstone when equipped with Mistress Card.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
