### PR TITLE
New card subtype

### DIFF
--- a/db/import-tmpl/item_db.yml
+++ b/db/import-tmpl/item_db.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/item_db.yml
+++ b/db/item_db.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/pre-re/item_db.yml
+++ b/db/pre-re/item_db.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/pre-re/item_db_etc.yml
+++ b/db/pre-re/item_db_etc.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/pre-re/item_db_etc.yml
+++ b/db/pre-re/item_db_etc.yml
@@ -8570,6 +8570,7 @@ Body:
     AegisName: Strength1
     Name: STR+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8578,6 +8579,7 @@ Body:
     AegisName: Strength2
     Name: STR+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8586,6 +8588,7 @@ Body:
     AegisName: Strength3
     Name: STR+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8594,6 +8597,7 @@ Body:
     AegisName: Strength4
     Name: STR+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8602,6 +8606,7 @@ Body:
     AegisName: Strength5
     Name: STR+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8610,6 +8615,7 @@ Body:
     AegisName: Strength6
     Name: STR+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8618,6 +8624,7 @@ Body:
     AegisName: Strength7
     Name: STR+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8626,6 +8633,7 @@ Body:
     AegisName: Strength8
     Name: STR+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8634,6 +8642,7 @@ Body:
     AegisName: Strength9
     Name: STR+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8642,6 +8651,7 @@ Body:
     AegisName: Strength10
     Name: STR+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8650,6 +8660,7 @@ Body:
     AegisName: Inteligence1
     Name: INT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8658,6 +8669,7 @@ Body:
     AegisName: Inteligence2
     Name: INT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8666,6 +8678,7 @@ Body:
     AegisName: Inteligence3
     Name: INT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8674,6 +8687,7 @@ Body:
     AegisName: Inteligence4
     Name: INT+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8682,6 +8696,7 @@ Body:
     AegisName: Inteligence5
     Name: INT+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8690,6 +8705,7 @@ Body:
     AegisName: Inteligence6
     Name: INT+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8698,6 +8714,7 @@ Body:
     AegisName: Inteligence7
     Name: INT+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8706,6 +8723,7 @@ Body:
     AegisName: Inteligence8
     Name: INT+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8714,6 +8732,7 @@ Body:
     AegisName: Inteligence9
     Name: INT+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8722,6 +8741,7 @@ Body:
     AegisName: Inteligence10
     Name: INT+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8730,6 +8750,7 @@ Body:
     AegisName: Dexterity1
     Name: DEX+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8738,6 +8759,7 @@ Body:
     AegisName: Dexterity2
     Name: DEX+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8746,6 +8768,7 @@ Body:
     AegisName: Dexterity3
     Name: DEX+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8754,6 +8777,7 @@ Body:
     AegisName: Dexterity4
     Name: DEX+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8762,6 +8786,7 @@ Body:
     AegisName: Dexterity5
     Name: DEX+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8770,6 +8795,7 @@ Body:
     AegisName: Dexterity6
     Name: DEX+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8778,6 +8804,7 @@ Body:
     AegisName: Dexterity7
     Name: DEX+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8786,6 +8813,7 @@ Body:
     AegisName: Dexterity8
     Name: DEX+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8794,6 +8822,7 @@ Body:
     AegisName: Dexterity9
     Name: DEX+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8802,6 +8831,7 @@ Body:
     AegisName: Dexterity10
     Name: DEX+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8810,6 +8840,7 @@ Body:
     AegisName: Agility1
     Name: AGI+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8818,6 +8849,7 @@ Body:
     AegisName: Agility2
     Name: AGI+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8826,6 +8858,7 @@ Body:
     AegisName: Agility3
     Name: AGI+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8834,6 +8867,7 @@ Body:
     AegisName: Agility4
     Name: AGI+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8842,6 +8876,7 @@ Body:
     AegisName: Agility5
     Name: AGI+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8850,6 +8885,7 @@ Body:
     AegisName: Agility6
     Name: AGI+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8858,6 +8894,7 @@ Body:
     AegisName: Agility7
     Name: AGI+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8866,6 +8903,7 @@ Body:
     AegisName: Agility8
     Name: AGI+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8874,6 +8912,7 @@ Body:
     AegisName: Agility9
     Name: AGI+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8882,6 +8921,7 @@ Body:
     AegisName: Agility10
     Name: AGI+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8890,6 +8930,7 @@ Body:
     AegisName: Vitality1
     Name: VIT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8898,6 +8939,7 @@ Body:
     AegisName: Vitality2
     Name: VIT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8906,6 +8948,7 @@ Body:
     AegisName: Vitality3
     Name: VIT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8914,6 +8957,7 @@ Body:
     AegisName: Vitality4
     Name: VIT+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8922,6 +8966,7 @@ Body:
     AegisName: Vitality5
     Name: VIT+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8930,6 +8975,7 @@ Body:
     AegisName: Vitality6
     Name: VIT+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8938,6 +8984,7 @@ Body:
     AegisName: Vitality7
     Name: VIT+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8946,6 +8993,7 @@ Body:
     AegisName: Vitality8
     Name: VIT+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8954,6 +9002,7 @@ Body:
     AegisName: Vitality9
     Name: VIT+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8962,6 +9011,7 @@ Body:
     AegisName: Vitality10
     Name: VIT+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8970,6 +9020,7 @@ Body:
     AegisName: Luck1
     Name: LUK+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8978,6 +9029,7 @@ Body:
     AegisName: Luck2
     Name: LUK+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8986,6 +9038,7 @@ Body:
     AegisName: Luck3
     Name: LUK+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -8994,6 +9047,7 @@ Body:
     AegisName: Luck4
     Name: LUK+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9002,6 +9056,7 @@ Body:
     AegisName: Luck5
     Name: LUK+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9010,6 +9065,7 @@ Body:
     AegisName: Luck6
     Name: LUK+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9018,6 +9074,7 @@ Body:
     AegisName: Luck7
     Name: LUK+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9026,6 +9083,7 @@ Body:
     AegisName: Luck8
     Name: LUK+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9034,6 +9092,7 @@ Body:
     AegisName: Luck9
     Name: LUK+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9042,6 +9101,7 @@ Body:
     AegisName: Luck10
     Name: LUK+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9050,6 +9110,7 @@ Body:
     AegisName: Matk1
     Name: MATK+1%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9058,6 +9119,7 @@ Body:
     AegisName: Matk2
     Name: MATK+2%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9066,6 +9128,7 @@ Body:
     AegisName: Evasion6
     Name: FLEE+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9074,6 +9137,7 @@ Body:
     AegisName: Evasion12
     Name: FLEE+12
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9082,6 +9146,7 @@ Body:
     AegisName: Critical5
     Name: CRI+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9090,6 +9155,7 @@ Body:
     AegisName: Critical7
     Name: CRI+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9098,6 +9164,7 @@ Body:
     AegisName: Atk2
     Name: ATK+2%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9106,6 +9173,7 @@ Body:
     AegisName: Atk3
     Name: ATK+3%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -9114,108 +9182,126 @@ Body:
     AegisName: Str1_J
     Name: STR+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4769
     AegisName: Str2_J
     Name: STR+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4770
     AegisName: Str3_J
     Name: STR+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4771
     AegisName: Int1_J
     Name: INT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4772
     AegisName: Int2_J
     Name: INT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4773
     AegisName: Int3_J
     Name: INT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4774
     AegisName: Vit1_J
     Name: VIT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4775
     AegisName: Vit2_J
     Name: VIT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4776
     AegisName: Vit3_J
     Name: VIT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4777
     AegisName: Agi1_J
     Name: AGI+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4778
     AegisName: Agi2_J
     Name: AGI+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4779
     AegisName: Agi3_J
     Name: AGI+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4780
     AegisName: Dex1_J
     Name: DEX+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4781
     AegisName: Dex2_J
     Name: DEX+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4782
     AegisName: Dex3_J
     Name: DEX+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4783
     AegisName: Luk1_J
     Name: LUK+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4784
     AegisName: Luk2_J
     Name: LUK+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4785
     AegisName: Luk3_J
     Name: LUK+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 6000

--- a/db/pre-re/item_db_usable.yml
+++ b/db/pre-re/item_db_usable.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/re/item_db.yml
+++ b/db/re/item_db.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -12673,6 +12673,7 @@ Body:
     AegisName: Strength1
     Name: STR+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -12681,6 +12682,7 @@ Body:
     AegisName: Strength2
     Name: STR+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,2;
@@ -12688,6 +12690,7 @@ Body:
     AegisName: Strength3
     Name: STR+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,3;
@@ -12695,6 +12698,7 @@ Body:
     AegisName: Strength4
     Name: STR+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,4;
@@ -12702,6 +12706,7 @@ Body:
     AegisName: Strength5
     Name: STR+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,5;
@@ -12709,6 +12714,7 @@ Body:
     AegisName: Strength6
     Name: STR+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,6;
@@ -12716,6 +12722,7 @@ Body:
     AegisName: Strength7
     Name: STR+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,7;
@@ -12723,6 +12730,7 @@ Body:
     AegisName: Strength8
     Name: STR+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,8;
@@ -12730,6 +12738,7 @@ Body:
     AegisName: Strength9
     Name: STR+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,9;
@@ -12737,6 +12746,7 @@ Body:
     AegisName: Strength10
     Name: STR+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bStr,10;
@@ -12744,6 +12754,7 @@ Body:
     AegisName: Inteligence1
     Name: INT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,1;
@@ -12751,6 +12762,7 @@ Body:
     AegisName: Inteligence2
     Name: INT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,2;
@@ -12758,6 +12770,7 @@ Body:
     AegisName: Inteligence3
     Name: INT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,3;
@@ -12765,6 +12778,7 @@ Body:
     AegisName: Inteligence4
     Name: INT+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,4;
@@ -12772,6 +12786,7 @@ Body:
     AegisName: Inteligence5
     Name: INT+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,5;
@@ -12779,6 +12794,7 @@ Body:
     AegisName: Inteligence6
     Name: INT+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,6;
@@ -12786,6 +12802,7 @@ Body:
     AegisName: Inteligence7
     Name: INT+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,7;
@@ -12793,6 +12810,7 @@ Body:
     AegisName: Inteligence8
     Name: INT+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,8;
@@ -12800,6 +12818,7 @@ Body:
     AegisName: Inteligence9
     Name: INT+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,9;
@@ -12807,6 +12826,7 @@ Body:
     AegisName: Inteligence10
     Name: INT+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bInt,10;
@@ -12814,6 +12834,7 @@ Body:
     AegisName: Dexterity1
     Name: DEX+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,1;
@@ -12821,6 +12842,7 @@ Body:
     AegisName: Dexterity2
     Name: DEX+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,2;
@@ -12828,6 +12850,7 @@ Body:
     AegisName: Dexterity3
     Name: DEX+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,3;
@@ -12835,6 +12858,7 @@ Body:
     AegisName: Dexterity4
     Name: DEX+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,4;
@@ -12842,6 +12866,7 @@ Body:
     AegisName: Dexterity5
     Name: DEX+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,5;
@@ -12849,6 +12874,7 @@ Body:
     AegisName: Dexterity6
     Name: DEX+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,6;
@@ -12856,6 +12882,7 @@ Body:
     AegisName: Dexterity7
     Name: DEX+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,7;
@@ -12863,6 +12890,7 @@ Body:
     AegisName: Dexterity8
     Name: DEX+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,8;
@@ -12870,6 +12898,7 @@ Body:
     AegisName: Dexterity9
     Name: DEX+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,9;
@@ -12877,6 +12906,7 @@ Body:
     AegisName: Dexterity10
     Name: DEX+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDex,10;
@@ -12884,6 +12914,7 @@ Body:
     AegisName: Agility1
     Name: AGI+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,1;
@@ -12891,6 +12922,7 @@ Body:
     AegisName: Agility2
     Name: AGI+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,2;
@@ -12898,6 +12930,7 @@ Body:
     AegisName: Agility3
     Name: AGI+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,3;
@@ -12905,6 +12938,7 @@ Body:
     AegisName: Agility4
     Name: AGI+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,4;
@@ -12912,6 +12946,7 @@ Body:
     AegisName: Agility5
     Name: AGI+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,5;
@@ -12919,6 +12954,7 @@ Body:
     AegisName: Agility6
     Name: AGI+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,6;
@@ -12926,6 +12962,7 @@ Body:
     AegisName: Agility7
     Name: AGI+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,7;
@@ -12933,6 +12970,7 @@ Body:
     AegisName: Agility8
     Name: AGI+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,8;
@@ -12940,6 +12978,7 @@ Body:
     AegisName: Agility9
     Name: AGI+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,9;
@@ -12947,6 +12986,7 @@ Body:
     AegisName: Agility10
     Name: AGI+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAgi,10;
@@ -12954,6 +12994,7 @@ Body:
     AegisName: Vitality1
     Name: VIT+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,1;
@@ -12961,6 +13002,7 @@ Body:
     AegisName: Vitality2
     Name: VIT+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,2;
@@ -12968,6 +13010,7 @@ Body:
     AegisName: Vitality3
     Name: VIT+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,3;
@@ -12975,6 +13018,7 @@ Body:
     AegisName: Vitality4
     Name: VIT+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,4;
@@ -12982,6 +13026,7 @@ Body:
     AegisName: Vitality5
     Name: VIT+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,5;
@@ -12989,6 +13034,7 @@ Body:
     AegisName: Vitality6
     Name: VIT+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,6;
@@ -12996,6 +13042,7 @@ Body:
     AegisName: Vitality7
     Name: VIT+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,7;
@@ -13003,6 +13050,7 @@ Body:
     AegisName: Vitality8
     Name: VIT+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,8;
@@ -13010,6 +13058,7 @@ Body:
     AegisName: Vitality9
     Name: VIT+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,9;
@@ -13017,6 +13066,7 @@ Body:
     AegisName: Vitality10
     Name: VIT+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bVit,10;
@@ -13024,6 +13074,7 @@ Body:
     AegisName: Luck1
     Name: LUK+1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,1;
@@ -13031,6 +13082,7 @@ Body:
     AegisName: Luck2
     Name: LUK+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,2;
@@ -13038,6 +13090,7 @@ Body:
     AegisName: Luck3
     Name: LUK+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,3;
@@ -13045,6 +13098,7 @@ Body:
     AegisName: Luck4
     Name: LUK+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,4;
@@ -13052,6 +13106,7 @@ Body:
     AegisName: Luck5
     Name: LUK+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,5;
@@ -13059,6 +13114,7 @@ Body:
     AegisName: Luck6
     Name: LUK+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,6;
@@ -13066,6 +13122,7 @@ Body:
     AegisName: Luck7
     Name: LUK+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,7;
@@ -13073,6 +13130,7 @@ Body:
     AegisName: Luck8
     Name: LUK+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,8;
@@ -13080,6 +13138,7 @@ Body:
     AegisName: Luck9
     Name: LUK+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,9;
@@ -13087,6 +13146,7 @@ Body:
     AegisName: Luck10
     Name: LUK+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLuk,10;
@@ -13094,6 +13154,7 @@ Body:
     AegisName: Matk1
     Name: MATK+1%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatkRate,1;
@@ -13102,6 +13163,7 @@ Body:
     AegisName: Matk2
     Name: MATK+2%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatkRate,2;
@@ -13110,6 +13172,7 @@ Body:
     AegisName: Evasion6
     Name: FLEE+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bFlee,6;
@@ -13117,6 +13180,7 @@ Body:
     AegisName: Evasion12
     Name: FLEE+12
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bFlee,12;
@@ -13124,6 +13188,7 @@ Body:
     AegisName: Critical5
     Name: CRI+5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,5;
@@ -13131,6 +13196,7 @@ Body:
     AegisName: Critical7
     Name: CRI+7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,7;
@@ -13138,6 +13204,7 @@ Body:
     AegisName: Atk2
     Name: ATK+2%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddClass,Class_All,2;
@@ -13145,6 +13212,7 @@ Body:
     AegisName: Atk3
     Name: ATK+3%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddClass,Class_All,3;
@@ -13152,114 +13220,133 @@ Body:
     AegisName: Str1_J
     Name: Str + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4769
     AegisName: Str2_J
     Name: Str + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4770
     AegisName: Str3_J
     Name: Str + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4771
     AegisName: Int1_J
     Name: Int + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4772
     AegisName: Int2_J
     Name: Int + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4773
     AegisName: Int3_J
     Name: Int + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4774
     AegisName: Vit1_J
     Name: Vit + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4775
     AegisName: Vit2_J
     Name: Vit + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4776
     AegisName: Vit3_J
     Name: Vit + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4777
     AegisName: Agi1_J
     Name: Agi + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4778
     AegisName: Agi2_J
     Name: Agi + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4779
     AegisName: Agi3_J
     Name: Agi + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4780
     AegisName: Dex1_J
     Name: Dex + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4781
     AegisName: Dex2_J
     Name: Dex + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4782
     AegisName: Dex3_J
     Name: Dex + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4783
     AegisName: Luk1_J
     Name: Luk + 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4784
     AegisName: Luk2_J
     Name: Luk + 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4785
     AegisName: Luk3_J
     Name: Luk + 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
   - Id: 4786
     AegisName: Mdef2
     Name: MDEF+2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMdef,2;
@@ -13267,6 +13354,7 @@ Body:
     AegisName: Mdef4
     Name: MDEF+4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMdef,4;
@@ -13274,6 +13362,7 @@ Body:
     AegisName: Mdef6
     Name: MDEF+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMdef,6;
@@ -13281,6 +13370,7 @@ Body:
     AegisName: Mdef8
     Name: MDEF+8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMdef,8;
@@ -13288,6 +13378,7 @@ Body:
     AegisName: Mdef10
     Name: MDEF+10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMdef,10;
@@ -13295,6 +13386,7 @@ Body:
     AegisName: Def3
     Name: DEF+3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDef,3;
@@ -13302,6 +13394,7 @@ Body:
     AegisName: Def6
     Name: DEF+6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDef,6;
@@ -13309,6 +13402,7 @@ Body:
     AegisName: Def9
     Name: DEF+9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDef,9;
@@ -13316,6 +13410,7 @@ Body:
     AegisName: Def12
     Name: DEF+12
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bDef,12;
@@ -13323,6 +13418,7 @@ Body:
     AegisName: HP100
     Name: HP+100
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHP,100;
@@ -13330,6 +13426,7 @@ Body:
     AegisName: HP200
     Name: HP+200
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHP,200;
@@ -13337,6 +13434,7 @@ Body:
     AegisName: HP300
     Name: HP+300
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHP,300;
@@ -13344,6 +13442,7 @@ Body:
     AegisName: HP400
     Name: HP+400
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHP,400;
@@ -13351,6 +13450,7 @@ Body:
     AegisName: HP500
     Name: HP+500
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHP,500;
@@ -13358,6 +13458,7 @@ Body:
     AegisName: SP50
     Name: SP+50
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxSP,50;
@@ -13365,6 +13466,7 @@ Body:
     AegisName: SP100
     Name: SP+100
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxSP,100;
@@ -13372,6 +13474,7 @@ Body:
     AegisName: SP150
     Name: SP+150
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxSP,150;
@@ -13379,6 +13482,7 @@ Body:
     AegisName: Highness_Heal_3sec
     Name: Cure1Lv.
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bSkillCooldown,"AB_HIGHNESSHEAL",-3000;
@@ -13386,6 +13490,7 @@ Body:
     AegisName: Coluceo_Heal30
     Name: Catholic1Lv.
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bSkillUseSP,"AB_CHEAL",30;
@@ -13393,6 +13498,7 @@ Body:
     AegisName: Heal_Amount2
     Name: Archbishop1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bHealPower,3;
@@ -13400,6 +13506,7 @@ Body:
     AegisName: Matk3
     Name: MATK+3%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatkRate,3;
@@ -13408,6 +13515,7 @@ Body:
     AegisName: Atk_Speed1
     Name: Atk Speed1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAspd,1;
@@ -13415,6 +13523,7 @@ Body:
     AegisName: Fighting_Spirit4
     Name: Fighting Spirit4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,15;
@@ -13423,6 +13532,7 @@ Body:
     AegisName: Fighting_Spirit3
     Name: Fighting Spirit3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,12;
@@ -13431,6 +13541,7 @@ Body:
     AegisName: Fighting_Spirit2
     Name: Fighting Spirit2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,9;
@@ -13439,6 +13550,7 @@ Body:
     AegisName: Fighting_Spirit1
     Name: Fighting Spirit1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,6;
@@ -13447,6 +13559,7 @@ Body:
     AegisName: Spell4
     Name: Spell4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,15;
@@ -13455,6 +13568,7 @@ Body:
     AegisName: Spell3
     Name: Spell3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,12;
@@ -13463,6 +13577,7 @@ Body:
     AegisName: Spell2
     Name: Spell2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,9;
@@ -13471,6 +13586,7 @@ Body:
     AegisName: Spell1
     Name: Spell1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,6;
@@ -13479,6 +13595,7 @@ Body:
     AegisName: Sharp3
     Name: Sharp3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,12;
@@ -13487,6 +13604,7 @@ Body:
     AegisName: Sharp2
     Name: Sharp2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,9;
@@ -13495,6 +13613,7 @@ Body:
     AegisName: Sharp1
     Name: Sharp1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,6;
@@ -13503,6 +13622,7 @@ Body:
     AegisName: Atk1
     Name: Atk1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -13510,6 +13630,7 @@ Body:
     AegisName: Fighting_Spirit5
     Name: Fighting Spirit5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,18;
@@ -13518,6 +13639,7 @@ Body:
     AegisName: Fighting_Spirit6
     Name: Fighting Spirit6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,21;
@@ -13526,6 +13648,7 @@ Body:
     AegisName: Fighting_Spirit7
     Name: Fighting Spirit7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,24;
@@ -13534,6 +13657,7 @@ Body:
     AegisName: Fighting_Spirit8
     Name: Fighting Spirit8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,27;
@@ -13542,6 +13666,7 @@ Body:
     AegisName: Fighting_Spirit9
     Name: Fighting Spirit9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,30;
@@ -13550,6 +13675,7 @@ Body:
     AegisName: Fighting_Spirit10
     Name: Fighting Spirit10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bBaseAtk,50;
@@ -13558,6 +13684,7 @@ Body:
     AegisName: Spell5
     Name: Spell5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,18;
@@ -13566,6 +13693,7 @@ Body:
     AegisName: Spell6
     Name: Spell6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,21;
@@ -13574,6 +13702,7 @@ Body:
     AegisName: Spell7
     Name: Spell7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,24;
@@ -13582,6 +13711,7 @@ Body:
     AegisName: Spell8
     Name: Spell8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,27;
@@ -13590,6 +13720,7 @@ Body:
     AegisName: Spell9
     Name: Spell9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,30;
@@ -13598,6 +13729,7 @@ Body:
     AegisName: Spell10
     Name: Spell10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMatk,50;
@@ -13606,6 +13738,7 @@ Body:
     AegisName: Expert_Archer1
     Name: Expert Archer1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,2;
@@ -13613,6 +13746,7 @@ Body:
     AegisName: Expert_Archer2
     Name: Expert Archer2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,4;
@@ -13620,6 +13754,7 @@ Body:
     AegisName: Expert_Archer3
     Name: Expert Archer3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,6;
@@ -13627,6 +13762,7 @@ Body:
     AegisName: Expert_Archer4
     Name: Expert Archer4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,8;
@@ -13634,6 +13770,7 @@ Body:
     AegisName: Expert_Archer5
     Name: Expert Archer5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,10;
@@ -13641,6 +13778,7 @@ Body:
     AegisName: Expert_Archer6
     Name: Expert Archer6
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,12;
@@ -13648,6 +13786,7 @@ Body:
     AegisName: Expert_Archer7
     Name: Expert Archer7
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,14;
@@ -13655,6 +13794,7 @@ Body:
     AegisName: Expert_Archer8
     Name: Expert Archer8
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,16;
@@ -13662,6 +13802,7 @@ Body:
     AegisName: Expert_Archer9
     Name: Expert Archer9
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,18;
@@ -13669,6 +13810,7 @@ Body:
     AegisName: Expert_Archer10
     Name: Expert Archer10
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bLongAtkRate,20;
@@ -13677,6 +13819,7 @@ Body:
     AegisName: Atk_Speed2
     Name: Atk Speed2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bAspd,2;
@@ -13684,6 +13827,7 @@ Body:
     AegisName: Sharp4
     Name: Sharp4
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,14;
@@ -13692,6 +13836,7 @@ Body:
     AegisName: Sharp5
     Name: Sharp5
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bCritical,15;
@@ -13700,10 +13845,12 @@ Body:
     AegisName: Sea_Energy
     Name: Strength Of Ocean
     Type: Card
+    SubType: Enchant
   - Id: 4846
     AegisName: 2011Valentin_Angel
     Name: Fully Loved Stone
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -13713,6 +13860,7 @@ Body:
     AegisName: 2011Valentin_Devil
     Name: Spelled Stone
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Script: |
@@ -13722,6 +13870,7 @@ Body:
     AegisName: Immuned1
     Name: Immune Level 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bSubEle,Ele_Neutral,5;
@@ -13729,6 +13878,7 @@ Body:
     AegisName: Cranial1
     Name: Cranial Level 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -13737,6 +13887,7 @@ Body:
     AegisName: Heal_Amount3
     Name: Archbishop2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bHealPower,6;
@@ -13745,6 +13896,7 @@ Body:
     AegisName: Heal_Amount4
     Name: Archbishop3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bHealPower,12;
@@ -13753,6 +13905,7 @@ Body:
     AegisName: Heal_Amount5
     Name: Archbishop4Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bHealPower,20;
@@ -13761,6 +13914,7 @@ Body:
     AegisName: S_Str
     Name: Special Str
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13779,6 +13933,7 @@ Body:
     AegisName: S_Agi
     Name: Special Agi
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13797,6 +13952,7 @@ Body:
     AegisName: S_Vital
     Name: Special Vit
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13815,6 +13971,7 @@ Body:
     AegisName: S_Int
     Name: Special Int
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13833,6 +13990,7 @@ Body:
     AegisName: S_Dex
     Name: Special Dex
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13851,6 +14009,7 @@ Body:
     AegisName: S_Luck
     Name: Special Luk
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -13869,6 +14028,7 @@ Body:
     AegisName: Evasion1
     Name: Evasion1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bFlee,1;
@@ -13876,6 +14036,7 @@ Body:
     AegisName: Evasion3
     Name: Evasion3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bFlee,3;
@@ -13883,6 +14044,7 @@ Body:
     AegisName: MHP1
     Name: MHP+1%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHPrate,1;
@@ -13890,6 +14052,7 @@ Body:
     AegisName: MHP2
     Name: MHP+2%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHPrate,2;
@@ -13897,6 +14060,7 @@ Body:
     AegisName: Fatal1
     Name: Fatal1Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,4;
@@ -13905,6 +14069,7 @@ Body:
     AegisName: Fatal2
     Name: Fatal2Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,6;
@@ -13913,6 +14078,7 @@ Body:
     AegisName: Fatal3
     Name: Fatal3Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,8;
@@ -13921,6 +14087,7 @@ Body:
     AegisName: Fatal4
     Name: Fatal4Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,10;
@@ -13929,6 +14096,7 @@ Body:
     AegisName: MHP3
     Name: MHP+3%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHPrate,3;
@@ -13936,6 +14104,7 @@ Body:
     AegisName: MHP4
     Name: MHP+4%
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxHPrate,4;
@@ -13943,6 +14112,7 @@ Body:
     AegisName: Attack_Delay_1
     Name: DelayafterAttack1Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bAspdRate,4;
@@ -13950,6 +14120,7 @@ Body:
     AegisName: SP25
     Name: SP+25
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxSP,25;
@@ -13957,6 +14128,7 @@ Body:
     AegisName: SP75
     Name: SP+75
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus bMaxSP,75;
@@ -13964,6 +14136,7 @@ Body:
     AegisName: Attack_Delay_2
     Name: DelayafterAttack2Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bAspdRate,6;
@@ -13971,6 +14144,7 @@ Body:
     AegisName: Attack_Delay_3
     Name: DelayafterAttack3Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bAspdRate,8;
@@ -13978,10 +14152,12 @@ Body:
     AegisName: Beryl_of_Spring
     Name: Beryl Spring
     Type: Card
+    SubType: Enchant
   - Id: 4875
     AegisName: Bear's_Power
     Name: Bear's Power
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus2 "{ bonus bStr,200; bonus2 bHPLossRate,500,1000; }",20,5000,BF_WEAPON,"{ active_transform 1060,5000; specialeffect2 EF_POTION_BERSERK; showscript \"Bigfoot Power !\"; }";
     UnEquipScript: |
@@ -13990,6 +14166,7 @@ Body:
     AegisName: Runaway_Magic
     Name: Runaway Magic
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bInt,200; bonus2 bSPLossRate,200,1000; }",15,10000,BF_MAGIC,"{ specialeffect2 EF_LAMADAN; }";
     UnEquipScript: |
@@ -13998,6 +14175,7 @@ Body:
     AegisName: Speed_Of_Light
     Name: Speed of Light
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bAspdRate,100; bonus bFlee,100; bonus2 bSPLossRate,50,1000; }",10,5000,BF_WEAPON,"{ specialeffect2 EF_FLASHER; }";
     UnEquipScript: |
@@ -14006,6 +14184,7 @@ Body:
     AegisName: Muscle_Fool
     Name: Muscle Fool
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus2 "{ bonus bDef,1000; bonus2 bSPLossRate,50,1000; }",20,5000,BF_WEAPON,"{ specialeffect2 EF_MAGNUMBREAK; }";
     UnEquipScript: |
@@ -14014,6 +14193,7 @@ Body:
     AegisName: Hawkeye
     Name: Hawkeye
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bDex,200; bonus2 bSPLossRate,50,1000; }",30,5000,BF_WEAPON,"{ specialeffect2 EF_FLASHER; }";
     UnEquipScript: |
@@ -14022,6 +14202,7 @@ Body:
     AegisName: Lucky_Day
     Name: Lucky Day
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bLuk,200; bonus2 bAddMonsterDropItem,7444,10; }",15,5000,BF_WEAPON|BF_MAGIC,"{ specialeffect2 EF_MVP; showscript \"LUCKY MAX !!\"; }";
       autobonus2 "{ bonus bLuk,200; bonus2 bAddMonsterDropItem,7444,1; }",1,5000,BF_WEAPON|BF_MAGIC,"{ specialeffect2 EF_MVP; showscript \"LUCKY MAX !!\"; }";
@@ -14031,6 +14212,7 @@ Body:
     AegisName: Attack_Delay_4
     Name: Attack Delay 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bAspdRate,10;
@@ -14038,6 +14220,7 @@ Body:
     AegisName: Atk1p
     Name: ATK + 1%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -14045,6 +14228,7 @@ Body:
     AegisName: Matk1p
     Name: MATK + 1%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,1;
@@ -14052,6 +14236,7 @@ Body:
     AegisName: HIT1
     Name: HIT + 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bHit,1;
@@ -14059,6 +14244,7 @@ Body:
     AegisName: Conjure1
     Name: Spell 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,5;
@@ -14067,6 +14253,7 @@ Body:
     AegisName: Conjure2
     Name: Spell 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,10;
@@ -14075,6 +14262,7 @@ Body:
     AegisName: Conjure3
     Name: Spell 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,15;
@@ -14083,6 +14271,7 @@ Body:
     AegisName: Conjure4
     Name: Spell 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,20;
@@ -14091,6 +14280,7 @@ Body:
     AegisName: Conjure5
     Name: Spell 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,30;
@@ -14099,6 +14289,7 @@ Body:
     AegisName: Mdef1
     Name: MDEF+1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMdef,1;
@@ -14106,6 +14297,7 @@ Body:
     AegisName: Mdef3
     Name: MDEF+3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMdef,3;
@@ -14113,6 +14305,7 @@ Body:
     AegisName: Mdef5
     Name: MDEF+5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMdef,5;
@@ -14120,6 +14313,7 @@ Body:
     AegisName: Def15
     Name: DEF+15
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDef,15;
@@ -14127,6 +14321,7 @@ Body:
     AegisName: Atk4p
     Name: ATK + 4%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,4;
@@ -14134,6 +14329,7 @@ Body:
     AegisName: Atk5p
     Name: ATK + 5%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,5;
@@ -14141,6 +14337,7 @@ Body:
     AegisName: Matk2p
     Name: MATK + 2%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,2;
@@ -14148,6 +14345,7 @@ Body:
     AegisName: Matk3p
     Name: MATK + 3%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,3;
@@ -14155,6 +14353,7 @@ Body:
     AegisName: Matk4p
     Name: MATK + 4%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,4;
@@ -14162,6 +14361,7 @@ Body:
     AegisName: Matk5p
     Name: MATK + 5%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,5;
@@ -14169,6 +14369,7 @@ Body:
     AegisName: MHP5
     Name: MHP+5%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,5;
@@ -14176,6 +14377,7 @@ Body:
     AegisName: Def18
     Name: DEF+18
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDef,18;
@@ -14183,6 +14385,7 @@ Body:
     AegisName: Def21
     Name: DEF+21
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDef,21;
@@ -14190,6 +14393,7 @@ Body:
     AegisName: Atk6p
     Name: ATK + 6%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,6;
@@ -14197,6 +14401,7 @@ Body:
     AegisName: Atk7p
     Name: ATK + 7%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,7;
@@ -14204,6 +14409,7 @@ Body:
     AegisName: Matk6p
     Name: MATK + 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,6;
@@ -14211,6 +14417,7 @@ Body:
     AegisName: Matk7p
     Name: MATK + 7%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatkRate,7;
@@ -14218,6 +14425,7 @@ Body:
     AegisName: Force1
     Name: Darklord Essence Force1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14237,6 +14445,7 @@ Body:
     AegisName: Force2
     Name: Darklord Essence Force2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14256,6 +14465,7 @@ Body:
     AegisName: Force3
     Name: Darklord Essence Force3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14275,6 +14485,7 @@ Body:
     AegisName: Intellect1
     Name: Darklord Essence Intelligence1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14294,6 +14505,7 @@ Body:
     AegisName: Intellect2
     Name: Darklord Essence Intelligence2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14313,6 +14525,7 @@ Body:
     AegisName: Intellect3
     Name: Darklord Essence Intelligence3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14332,6 +14545,7 @@ Body:
     AegisName: Swiftness1
     Name: Darklord Essence Speed1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14351,6 +14565,7 @@ Body:
     AegisName: Swiftness2
     Name: Darklord Essence Speed2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14370,6 +14585,7 @@ Body:
     AegisName: Swiftness3
     Name: Darklord Essence Speed3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14389,6 +14605,7 @@ Body:
     AegisName: Tough1
     Name: Darklord Essence Vitality1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14409,6 +14626,7 @@ Body:
     AegisName: Tough2
     Name: Darklord Essence Vitality2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14429,6 +14647,7 @@ Body:
     AegisName: Tough3
     Name: Darklord Essence Vitality3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14449,6 +14668,7 @@ Body:
     AegisName: Artful1
     Name: Darklord Essence Concentration1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14468,6 +14688,7 @@ Body:
     AegisName: Artful2
     Name: Darklord Essence Concentration2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14487,6 +14708,7 @@ Body:
     AegisName: Artful3
     Name: Darklord Essence Concentration3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14506,6 +14728,7 @@ Body:
     AegisName: Fortune1
     Name: Darklord Essence Luck1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14525,6 +14748,7 @@ Body:
     AegisName: Fortune2
     Name: Darklord Essence Luck2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14544,6 +14768,7 @@ Body:
     AegisName: Fortune3
     Name: Darklord Essence Luck3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Weight: 10
     Locations:
@@ -14563,6 +14788,7 @@ Body:
     AegisName: Critical1
     Name: Cri 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritical,1;
@@ -14570,6 +14796,7 @@ Body:
     AegisName: HP50
     Name: MaxHP50
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHP,50;
@@ -14577,6 +14804,7 @@ Body:
     AegisName: SP10
     Name: MaxSP+10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSP,10;
@@ -14584,6 +14812,7 @@ Body:
     AegisName: MSP1
     Name: MSP+1%
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,1;
@@ -14591,6 +14820,7 @@ Body:
     AegisName: HEAL2
     Name: Recovery UP
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bHealPower2,2;
@@ -14598,6 +14828,7 @@ Body:
     AegisName: HEALHP1
     Name: Heal 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bHPRegenRate,10,10000;
@@ -14605,6 +14836,7 @@ Body:
     AegisName: HEALSP1
     Name: SP recovery1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bSPGainValue,1;
@@ -14614,6 +14846,7 @@ Body:
     AegisName: Tolerance_Not1
     Name: Neutral Resistance Lv1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bSubEle,Ele_Neutral,1;
@@ -14621,6 +14854,7 @@ Body:
     AegisName: Tolerance_Not2
     Name: Neutral Resistance Lv2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bSubEle,Ele_Neutral,2;
@@ -14628,6 +14862,7 @@ Body:
     AegisName: Tolerance_Not3
     Name: Neutral Resistance Lv3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bSubEle,Ele_Neutral,3;
@@ -14635,6 +14870,7 @@ Body:
     AegisName: ATK_BIG1
     Name: Attack big1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddSize,Size_Large,1;
@@ -14642,6 +14878,7 @@ Body:
     AegisName: ATK_MEDIUM1
     Name: Attack mid1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddSize,Size_Medium,1;
@@ -14649,6 +14886,7 @@ Body:
     AegisName: ATK_SMALL1
     Name: Attack small1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       bonus2 bAddSize,Size_Small,1;
@@ -14656,6 +14894,7 @@ Body:
     AegisName: Critical2
     Name: CRI Lv2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritical,2;
@@ -14663,6 +14902,7 @@ Body:
     AegisName: Critical3
     Name: CRI Lv3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritical,4;
@@ -14670,6 +14910,7 @@ Body:
     AegisName: Critical4
     Name: CRI Lv4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritical,6;
@@ -14677,6 +14918,7 @@ Body:
     AegisName: Dodge1
     Name: Parrying Lv1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFlee2,3;
@@ -14684,6 +14926,7 @@ Body:
     AegisName: Dodge2
     Name: Parrying Lv2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFlee2,4;
@@ -14691,6 +14934,7 @@ Body:
     AegisName: Dodge3
     Name: Parrying Lv3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFlee2,5;
@@ -14698,6 +14942,7 @@ Body:
     AegisName: Thrift1
     Name: Economy Lv1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bUseSPrate,-2;
@@ -14705,6 +14950,7 @@ Body:
     AegisName: Thrift2
     Name: Economy Lv2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bUseSPrate,-4;
@@ -14712,6 +14958,7 @@ Body:
     AegisName: Thrift3
     Name: Economy Lv3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bUseSPrate,-6;
@@ -14719,6 +14966,7 @@ Body:
     AegisName: Skill_Delay1
     Name: After Skill Delay Lv1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDelayrate,-2;
@@ -14726,6 +14974,7 @@ Body:
     AegisName: Skill_Delay2
     Name: After Skill Delay Lv2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDelayrate,-4;
@@ -14733,6 +14982,7 @@ Body:
     AegisName: Skill_Delay3
     Name: After Skill Delay Lv3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDelayrate,-6;
@@ -14740,6 +14990,7 @@ Body:
     AegisName: Darkness_Drop
     Name: Darkness Drop
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddEle,Ele_Dark,2;
       bonus2 bMagicAtkEle,Ele_Dark,2;
@@ -14748,6 +14999,7 @@ Body:
     AegisName: Fire_Drop
     Name: Fire Drop
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddEle,Ele_Fire,2;
       bonus2 bMagicAtkEle,Ele_Fire,2;
@@ -14756,6 +15008,7 @@ Body:
     AegisName: Water_Drop
     Name: Water Drop
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddEle,Ele_Water,2;
       bonus2 bMagicAtkEle,Ele_Water,2;
@@ -14764,6 +15017,7 @@ Body:
     AegisName: Earth_Drop
     Name: Earth Drop
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddEle,Ele_Earth,2;
       bonus2 bMagicAtkEle,Ele_Earth,2;
@@ -14772,6 +15026,7 @@ Body:
     AegisName: Holy_Drop
     Name: Holy Drop
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddEle,Ele_Holy,2;
       bonus2 bMagicAtkEle,Ele_Holy,2;
@@ -14780,6 +15035,7 @@ Body:
     AegisName: Recovery_Drop
     Name: Recovery Drop
     Type: Card
+    SubType: Enchant
     Script: |
       setarray .@skills$, "AL_HEAL", "PR_SANCTUARY", "AM_POTIONPITCHER", "AB_HIGHNESSHEAL", "AB_CHEAL";
       for( .@i = 0; .@i < getarraysize(.@skills$); .@i++ ) {
@@ -14791,42 +15047,49 @@ Body:
     AegisName: Famitsus_Power
     Name: Famitsu's Power
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHP,832;
   - Id: 4958
     AegisName: Gemini
     Name: Gemini
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-1;
   - Id: 4959
     AegisName: Sagittarius
     Name: Sagittarius
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,1;
   - Id: 4960
     AegisName: Aquarius
     Name: Aquarius
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bUseSPrate,-2;
   - Id: 4961
     AegisName: Aries
     Name: Aries
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,10;
   - Id: 4962
     AegisName: Cancer
     Name: Cancer
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,3;
   - Id: 4963
     AegisName: Taurus
     Name: Taurus
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,4;
       bonus bHit,1;
@@ -14834,30 +15097,35 @@ Body:
     AegisName: Capricorn
     Name: Capricorn
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_All,3;
   - Id: 4965
     AegisName: Pisces
     Name: Pisces
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-2;
   - Id: 4966
     AegisName: Scorpio
     Name: Scorpio
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_All,1;
   - Id: 4967
     AegisName: Leo
     Name: Leo
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,3;
   - Id: 4968
     AegisName: Virgo
     Name: Virgo
     Type: Card
+    SubType: Enchant
     Script: |
       setarray .@skills$, "AL_HEAL", "PR_SANCTUARY", "AM_POTIONPITCHER", "AB_HIGHNESSHEAL", "AB_CHEAL";
       for( .@i = 0; .@i < getarraysize(.@skills$); .@i++ ) {
@@ -14867,6 +15135,7 @@ Body:
     AegisName: Libra
     Name: Libra
     Type: Card
+    SubType: Enchant
     Script: |
       setarray .@skills$, "AL_HEAL", "PR_SANCTUARY", "AM_POTIONPITCHER", "AB_HIGHNESSHEAL", "AB_CHEAL";
       for( .@i = 0; .@i < getarraysize(.@skills$); .@i++ ) {
@@ -14877,30 +15146,35 @@ Body:
     AegisName: Reactor_P_FIRE
     Name: Fire Property Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Fire;
   - Id: 4971
     AegisName: Reactor_P_WATER
     Name: Water Property Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Water;
   - Id: 4972
     AegisName: Reactor_P_GROUND
     Name: Earth Property Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Earth;
   - Id: 4973
     AegisName: Reactor_P_WIND
     Name: Wind Property Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Wind;
   - Id: 4974
     AegisName: Reactor_T_FIRE
     Name: Fire Resistance Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubEle,Ele_Fire,25;
       bonus2 bSubEle,Ele_Water,-25;
@@ -14908,6 +15182,7 @@ Body:
     AegisName: Reactor_T_WATER
     Name: Water Resistance Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubEle,Ele_Water,25;
       bonus2 bSubEle,Ele_Wind,-25;
@@ -14915,6 +15190,7 @@ Body:
     AegisName: Reactor_T_GROUND
     Name: Earth Resistance Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubEle,Ele_Earth,25;
       bonus2 bSubEle,Ele_Fire,-25;
@@ -14922,6 +15198,7 @@ Body:
     AegisName: Reactor_T_WIND
     Name: Wind Resistance Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubEle,Ele_Wind,25;
       bonus2 bSubEle,Ele_Earth,-25;
@@ -14929,6 +15206,7 @@ Body:
     AegisName: Reactor_Cure_101
     Name: Recovery Reactor 101
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7)
          bonus2 bHPRegenRate,100,5000;
@@ -14938,6 +15216,7 @@ Body:
     AegisName: Reactor_Cure_102
     Name: Recovery Reactor 102
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7)
          bonus2 bSPRegenRate,5,5000;
@@ -14947,6 +15226,7 @@ Body:
     AegisName: Reactor_Cure_201
     Name: Recovery Reactor 201
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7)
          bonus bHPrecovRate,100;
@@ -14956,6 +15236,7 @@ Body:
     AegisName: Reactor_Cure_202
     Name: Recovery Reactor 202
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7)
          bonus bSPrecovRate,100;
@@ -14965,6 +15246,7 @@ Body:
     AegisName: Reactor_A_STR
     Name: STR Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7) {
          .@bonus = 10;
@@ -14974,6 +15256,7 @@ Body:
     AegisName: Reactor_A_INT
     Name: INT Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       if (getrefine()>=7) {
          .@bonus = 10;
@@ -14983,66 +15266,77 @@ Body:
     AegisName: Reactor_A_DEF
     Name: DEF SupplementReactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDef,100;
   - Id: 4985
     AegisName: Reactor_A_AVOI
     Name: PD Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee2,3;
   - Id: 4986
     AegisName: Reactor_A_ATK
     Name: Attack Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,20;
   - Id: 4987
     AegisName: Reactor_A_MATK
     Name: Magic Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,20;
   - Id: 4988
     AegisName: Reactor_A_MHP
     Name: HP Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
   - Id: 4989
     AegisName: Reactor_A_MSP
     Name: SP Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,3;
   - Id: 4990
     AegisName: Reactor_A_FROZ
     Name: Frozen Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bResEff,Eff_Freeze,10000;
   - Id: 4991
     AegisName: Reactor_A_ASPD
     Name: ASPD Supplement Reactor
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspd,1;
   - Id: 4992
     AegisName: HPdrain1
     Name: HP Absorb 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,10,1;
   - Id: 4993
     AegisName: SPdrain1
     Name: SP Absorb 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,1;
   - Id: 4994
     AegisName: Neev_STR_1
     Name: Rune of Strength Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -15056,6 +15350,7 @@ Body:
     AegisName: Neev_STR_2
     Name: Rune of Strength Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -15070,6 +15365,7 @@ Body:
     AegisName: Neev_STR_3
     Name: Rune of Strength_Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -15088,6 +15384,7 @@ Body:
     AegisName: Neev_AGI_1
     Name: Rune of Agility Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -15101,6 +15398,7 @@ Body:
     AegisName: Neev_AGI_2
     Name: Rune of Agility Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -15115,6 +15413,7 @@ Body:
     AegisName: Neev_AGI_3
     Name: Rune of Agility Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41221,6 +41520,7 @@ Body:
     AegisName: Neev_INT_1
     Name: Rune of Intellect Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41234,6 +41534,7 @@ Body:
     AegisName: Neev_INT_2
     Name: Rune of Intellect Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41248,6 +41549,7 @@ Body:
     AegisName: Neev_INT_3
     Name: Rune of Intellect Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41266,6 +41568,7 @@ Body:
     AegisName: Neev_DEX_1
     Name: Rune of Dexterity Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41279,6 +41582,7 @@ Body:
     AegisName: Neev_DEX_2
     Name: Rune of Dexterity Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41293,6 +41597,7 @@ Body:
     AegisName: Neev_DEX_3
     Name: Rune of Dexterity Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41311,6 +41616,7 @@ Body:
     AegisName: Neev_LUK_1
     Name: Rune of Luck Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41324,6 +41630,7 @@ Body:
     AegisName: Neev_LUK_2
     Name: Rune of Luck Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41338,6 +41645,7 @@ Body:
     AegisName: Neev_LUK_3
     Name: Rune of Luck Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41356,6 +41664,7 @@ Body:
     AegisName: Neev_VIT_1
     Name: Rune of Vitality Lv 1
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41369,6 +41678,7 @@ Body:
     AegisName: Neev_VIT_2
     Name: Rune of Vitality Lv 2
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41383,6 +41693,7 @@ Body:
     AegisName: Neev_VIT_3
     Name: Rune of Vitality Lv 3
     Type: Card
+    SubType: Enchant
     Buy: 20
     Script: |
       .@r = getrefine();
@@ -41401,12 +41712,14 @@ Body:
     AegisName: HPdrain3
     Name: HP Absorption 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,10,3;
   - Id: 29014
     AegisName: STR3INT
     Name: STR+3 INT-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bStr,3;
       bonus bInt,-3;
@@ -41414,6 +41727,7 @@ Body:
     AegisName: STR3DEX
     Name: STR+3 DEX-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bStr,3;
       bonus bDex,-3;
@@ -41421,6 +41735,7 @@ Body:
     AegisName: INT3DEX
     Name: INT+3 DEX-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bInt,3;
       bonus bDex,-3;
@@ -41428,6 +41743,7 @@ Body:
     AegisName: INT3VIT
     Name: INT+3 VIT-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bInt,3;
       bonus bVit,-3;
@@ -41435,6 +41751,7 @@ Body:
     AegisName: DEX3VIT
     Name: DEX+3 VIT-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDex,3;
       bonus bVit,-3;
@@ -41442,6 +41759,7 @@ Body:
     AegisName: DEX3AGI
     Name: DEX+3 AGI-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDex,3;
       bonus bAgi,-3;
@@ -41449,6 +41767,7 @@ Body:
     AegisName: VIT3AGI
     Name: VIT+3 AGI-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVit,3;
       bonus bAgi,-3;
@@ -41456,6 +41775,7 @@ Body:
     AegisName: VIT3LUK
     Name: VIT+3 LUK-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVit,3;
       bonus bLuk,-3;
@@ -41463,6 +41783,7 @@ Body:
     AegisName: AGI3LUK
     Name: AGI+3 LUK-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAgi,3;
       bonus bLuk,-3;
@@ -41470,6 +41791,7 @@ Body:
     AegisName: AGI3STR
     Name: AGI+3 STR-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAgi,3;
       bonus bStr,-3;
@@ -41477,6 +41799,7 @@ Body:
     AegisName: LUK3STR
     Name: LUK+3 STR-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLuk,3;
       bonus bStr,-3;
@@ -41484,6 +41807,7 @@ Body:
     AegisName: LUK3INT
     Name: LUK+3 INT-3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLuk,3;
       bonus bInt,-3;
@@ -41491,6 +41815,7 @@ Body:
     AegisName: Def20
     Name: DEF+20
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bDef,20;
@@ -41498,48 +41823,56 @@ Body:
     AegisName: EXP2
     Name: EXP+2%
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_All,2;
   - Id: 29028
     AegisName: Atk1p_Top
     Name: ATK + 1%
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_All,1;
   - Id: 29029
     AegisName: Atk1p_Bottom
     Name: ATK+1%(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_All,1;
   - Id: 29030
     AegisName: Matk1p_Top
     Name: MATK+1%
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,1;
   - Id: 29031
     AegisName: Matk1p_Bottom
     Name: MATK+1%(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,1;
   - Id: 29032
     AegisName: SPdrain1_Top
     Name: SP Absorption 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,1;
   - Id: 29033
     AegisName: Mdef4_Bottom
     Name: MDEF+4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMdef,4;
   - Id: 29040
     AegisName: Ghost_Effect
     Name: Ghost Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_C_GHOST_EFFECT,true;
     UnEquipScript: |
@@ -41548,6 +41881,7 @@ Body:
     AegisName: Twinkle_Effect
     Name: Twinkle Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_LJOSALFAR,true;
     UnEquipScript: |
@@ -41556,24 +41890,28 @@ Body:
     AegisName: Greed
     Name: Greed
     Type: Card
+    SubType: Enchant
     Script: |
       skill "BS_GREED",1;
   - Id: 29047
     AegisName: Fatal0
     Name: Fatal
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
   - Id: 29048
     AegisName: Expert_Archer0
     Name: Expert Archer
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
   - Id: 29049
     AegisName: HP100_
     Name: HP+100
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHP,100;
       if (BaseLevel>=120) {
@@ -41583,6 +41921,7 @@ Body:
     AegisName: SP50_
     Name: SP+50
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSP,50;
       if (BaseLevel>=120) {
@@ -41592,48 +41931,56 @@ Body:
     AegisName: Detoxify
     Name: Detoxify
     Type: Card
+    SubType: Enchant
     Script: |
       skill "TF_DETOXIFY",1;
   - Id: 29052
     AegisName: Recovery
     Name: Recovery
     Type: Card
+    SubType: Enchant
     Script: |
       skill "PR_STRECOVERY",1;
   - Id: 29053
     AegisName: Skill_Delay1_Top
     Name: After Skill Delay1 Upper
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-1;
   - Id: 29054
     AegisName: Skill_Delay1_Middle
     Name: After Skill Delay1 Middle
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-1;
   - Id: 29055
     AegisName: Skill_Delay1_Bottom
     Name: After Skill Delay1 Lower
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-1;
   - Id: 29056
     AegisName: FixedCasting05
     Name: Reduces Fixed Cast
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-500;
   - Id: 29057
     AegisName: Kyrie
     Name: Kyrie
     Type: Card
+    SubType: Enchant
     Script: |
       skill "PR_KYRIE",1;
   - Id: 29061
     AegisName: Mettle1
     Name: Mettle Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,4;
@@ -41642,6 +41989,7 @@ Body:
     AegisName: Mettle2
     Name: Mettle Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,8;
@@ -41650,6 +41998,7 @@ Body:
     AegisName: Mettle3
     Name: Mettle Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,12;
@@ -41658,6 +42007,7 @@ Body:
     AegisName: Mettle4
     Name: Mettle Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,16;
@@ -41666,6 +42016,7 @@ Body:
     AegisName: Mettle5
     Name: Mettle Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,20;
@@ -41674,6 +42025,7 @@ Body:
     AegisName: Mettle6
     Name: Mettle Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,24;
@@ -41682,6 +42034,7 @@ Body:
     AegisName: Mettle7
     Name: Mettle Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,28;
@@ -41690,6 +42043,7 @@ Body:
     AegisName: Mettle8
     Name: Mettle Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,32;
@@ -41698,6 +42052,7 @@ Body:
     AegisName: Mettle9
     Name: Mettle Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,36;
@@ -41706,6 +42061,7 @@ Body:
     AegisName: Mettle10
     Name: Mettle Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus2 bAddClass,Class_All,44;
@@ -41714,6 +42070,7 @@ Body:
     AegisName: MagicEessence1
     Name: Magic Essence Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-100;
@@ -41722,6 +42079,7 @@ Body:
     AegisName: MagicEessence2
     Name: Magic Essence Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-200;
@@ -41730,6 +42088,7 @@ Body:
     AegisName: MagicEessence3
     Name: Magic Essence Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-300;
@@ -41738,6 +42097,7 @@ Body:
     AegisName: MagicEessence4
     Name: Magic Essence Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-400;
@@ -41746,6 +42106,7 @@ Body:
     AegisName: MagicEessence5
     Name: Magic Essence Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-500;
@@ -41754,6 +42115,7 @@ Body:
     AegisName: MagicEessence6
     Name: Magic Essence Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-600;
@@ -41762,6 +42124,7 @@ Body:
     AegisName: MagicEessence7
     Name: Magic Essence Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-700;
@@ -41770,6 +42133,7 @@ Body:
     AegisName: MagicEessence8
     Name: Magic Essence Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-800;
@@ -41778,6 +42142,7 @@ Body:
     AegisName: MagicEessence9
     Name: Magic Essence Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-900;
@@ -41786,6 +42151,7 @@ Body:
     AegisName: MagicEessence10
     Name: Magic Essence Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bFixedCast,-1000;
@@ -41794,6 +42160,7 @@ Body:
     AegisName: Acute1
     Name: Acute Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,20;
@@ -41802,6 +42169,7 @@ Body:
     AegisName: Acute2
     Name: Acute Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,35;
@@ -41810,6 +42178,7 @@ Body:
     AegisName: Acute3
     Name: Acute Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,50;
@@ -41818,6 +42187,7 @@ Body:
     AegisName: Acute4
     Name: Acute Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,65;
@@ -41826,6 +42196,7 @@ Body:
     AegisName: Acute5
     Name: Acute Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,80;
@@ -41834,6 +42205,7 @@ Body:
     AegisName: Acute6
     Name: Acute Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,95;
@@ -41842,6 +42214,7 @@ Body:
     AegisName: Acute7
     Name: Acute Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,110;
@@ -41850,6 +42223,7 @@ Body:
     AegisName: Acute8
     Name: Acute Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,125;
@@ -41858,6 +42232,7 @@ Body:
     AegisName: Acute9
     Name: Acute Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,140;
@@ -41866,6 +42241,7 @@ Body:
     AegisName: Acute10
     Name: Acute Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bCritAtkRate,170;
@@ -41874,6 +42250,7 @@ Body:
     AegisName: MasterArcher1
     Name: Master Archer Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,4;
@@ -41882,6 +42259,7 @@ Body:
     AegisName: MasterArcher2
     Name: Master Archer Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,8;
@@ -41890,6 +42268,7 @@ Body:
     AegisName: MasterArcher3
     Name: Master Archer Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,12;
@@ -41898,6 +42277,7 @@ Body:
     AegisName: MasterArcher4
     Name: Master Archer Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,16;
@@ -41906,6 +42286,7 @@ Body:
     AegisName: MasterArcher5
     Name: Master Archer Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,20;
@@ -41914,6 +42295,7 @@ Body:
     AegisName: MasterArcher6
     Name: Master Archer Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,24;
@@ -41922,6 +42304,7 @@ Body:
     AegisName: MasterArcher7
     Name: Master Archer Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,28;
@@ -41930,6 +42313,7 @@ Body:
     AegisName: MasterArcher8
     Name: Master Archer Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,32;
@@ -41938,6 +42322,7 @@ Body:
     AegisName: MasterArcher9
     Name: Master Archer Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,36;
@@ -41946,6 +42331,7 @@ Body:
     AegisName: MasterArcher10
     Name: Master Archer Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,44;
@@ -41954,6 +42340,7 @@ Body:
     AegisName: Adamatine1
     Name: Adamantine Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,5;
@@ -41963,6 +42350,7 @@ Body:
     AegisName: Adamatine2
     Name: Adamantine Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,10;
@@ -41972,6 +42360,7 @@ Body:
     AegisName: Adamatine3
     Name: Adamantine Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,15;
@@ -41981,6 +42370,7 @@ Body:
     AegisName: Adamatine4
     Name: Adamantine Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,20;
@@ -41990,6 +42380,7 @@ Body:
     AegisName: Adamatine5
     Name: Adamantine Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,25;
@@ -41999,6 +42390,7 @@ Body:
     AegisName: Adamatine6
     Name: Adamantine Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,30;
@@ -42008,6 +42400,7 @@ Body:
     AegisName: Adamatine7
     Name: Adamantine Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,35;
@@ -42017,6 +42410,7 @@ Body:
     AegisName: Adamatine8
     Name: Adamantine Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,40;
@@ -42026,6 +42420,7 @@ Body:
     AegisName: Adamatine9
     Name: Adamantine Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,45;
@@ -42035,6 +42430,7 @@ Body:
     AegisName: Adamatine10
     Name: Adamantine Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxHPrate,55;
@@ -42044,6 +42440,7 @@ Body:
     AegisName: Affection1
     Name: Affection Lv. 1
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,3;
@@ -42052,6 +42449,7 @@ Body:
     AegisName: Affection2
     Name: Affection Lv. 2
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,6;
@@ -42060,6 +42458,7 @@ Body:
     AegisName: Affection3
     Name: Affection Lv. 3
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,9;
@@ -42068,6 +42467,7 @@ Body:
     AegisName: Affection4
     Name: Affection Lv. 4
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,12;
@@ -42076,6 +42476,7 @@ Body:
     AegisName: Affection5
     Name: Affection Lv. 5
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,15;
@@ -42084,6 +42485,7 @@ Body:
     AegisName: Affection6
     Name: Affection Lv. 6
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,18;
@@ -42092,6 +42494,7 @@ Body:
     AegisName: Affection7
     Name: Affection Lv. 7
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,21;
@@ -42100,6 +42503,7 @@ Body:
     AegisName: Affection8
     Name: Affection Lv. 8
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,24;
@@ -42108,6 +42512,7 @@ Body:
     AegisName: Affection9
     Name: Affection Lv. 9
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,27;
@@ -42116,6 +42521,7 @@ Body:
     AegisName: Affection10
     Name: Affection Lv. 10
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMaxSPrate,30;
@@ -42124,6 +42530,7 @@ Body:
     AegisName: Goddess_of_Justice_A
     Name: Goddess of Justice A
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bBaseAtk,20;
@@ -42133,6 +42540,7 @@ Body:
     AegisName: Goddess_of_Justice_S
     Name: Goddess of Justice S
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bBaseAtk,40;
@@ -42142,6 +42550,7 @@ Body:
     AegisName: Goddess_of_Mercy_A
     Name: Goddess of Mercy A
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,20;
@@ -42151,6 +42560,7 @@ Body:
     AegisName: Goddess_of_Mercy_S
     Name: Goddess of Mercy S
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bMatk,40;
@@ -42160,6 +42570,7 @@ Body:
     AegisName: Goddess_of_Insight_A
     Name: Goddess of Insight A
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,5;
@@ -42168,6 +42579,7 @@ Body:
     AegisName: Goddess_of_Insight_S
     Name: Goddess of Insight S
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       bonus bLongAtkRate,10;
@@ -42176,6 +42588,7 @@ Body:
     AegisName: Electric_Effect
     Name: Electric Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_ELECTRIC,true;
     UnEquipScript: |
@@ -42184,6 +42597,7 @@ Body:
     AegisName: Green_Floor_Effect
     Name: Green Flare Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_GREEN_FLOOR,true;
     UnEquipScript: |
@@ -42192,6 +42606,7 @@ Body:
     AegisName: Shrink_Effect
     Name: Shrink Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_SHRINK,true;
     UnEquipScript: |
@@ -42200,18 +42615,21 @@ Body:
     AegisName: EXP2MIDDLE
     Name: Experience+2%
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_All,2;
   - Id: 29146
     AegisName: Identify
     Name: Identify
     Type: Card
+    SubType: Enchant
     Script: |
       skill "MC_IDENTIFY",1;
   - Id: 29147
     AegisName: Resurrection
     Name: Resurrection
     Type: Card
+    SubType: Enchant
     Buy: 10
     Script: |
       skill "ALL_RESURRECTION",1;
@@ -42219,6 +42637,7 @@ Body:
     AegisName: Leo_Stone
     Name: Leo Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42228,6 +42647,7 @@ Body:
     AegisName: Pisces_Stone
     Name: Pisces Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42237,6 +42657,7 @@ Body:
     AegisName: Capricorn_Stone
     Name: Capricorn Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42246,6 +42667,7 @@ Body:
     AegisName: Aquarius_Stone
     Name: Aquarius Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42255,6 +42677,7 @@ Body:
     AegisName: Scorpio_Stone
     Name: Scorpio Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42264,6 +42687,7 @@ Body:
     AegisName: Taurus_Stone
     Name: Taurus Stone
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42273,42 +42697,49 @@ Body:
     AegisName: FixedCasting03
     Name: Minor Fixed Cast Reduction
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-300;
   - Id: 29155
     AegisName: LexAeterna
     Name: Lex Aeterna
     Type: Card
+    SubType: Enchant
     Script: |
       bonus3 bAutoSpell,"PR_LEXAETERNA",1,10;
   - Id: 29156
     AegisName: Casting_Top
     Name: Variable Cast Reduction Upper
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-3;
   - Id: 29157
     AegisName: Casting_Middle
     Name: Variable Cast Reduction Middle
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-3;
   - Id: 29158
     AegisName: Casting_Bottom
     Name: Variable Cast Reduction Lower
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-3;
   - Id: 29159
     AegisName: EXP2TOP
     Name: Experience + 2%
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_All,2;
   - Id: 29160
     AegisName: BlueAura_Effect
     Name: Blue Aura Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_GUMGANG,true;
     UnEquipScript: |
@@ -42317,6 +42748,7 @@ Body:
     AegisName: Pink_Glow_Effect
     Name: Pink Glow Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_CHERRYBLOSSOM,true;
     UnEquipScript: |
@@ -42325,6 +42757,7 @@ Body:
     AegisName: Shadow_Effect
     Name: Shadow Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_KAGEMUSYA,true;
     UnEquipScript: |
@@ -42333,6 +42766,7 @@ Body:
     AegisName: A-Tolerance
     Name: A-Tolerance
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubClass,Class_All,1;
       .@r = getrefine();
@@ -42342,6 +42776,7 @@ Body:
     AegisName: A-Hit
     Name: A-Hit
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,20;
       .@r = getrefine();
@@ -42358,6 +42793,7 @@ Body:
     AegisName: A-Flee
     Name: A-Flee
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,20;
       .@r = getrefine();
@@ -42374,6 +42810,7 @@ Body:
     AegisName: A-Mdef
     Name: A-Mdef
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMdef,2;
       .@r = getrefine();
@@ -42387,6 +42824,7 @@ Body:
     AegisName: S-Atk
     Name: S-Atk
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,50;
       .@r = getrefine();
@@ -42404,6 +42842,7 @@ Body:
     AegisName: S-Matk
     Name: S-Matk
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,100;
       .@r = getrefine();
@@ -42421,6 +42860,7 @@ Body:
     AegisName: S-Avoid
     Name: S-Avoid
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee2,5;
       .@r = getrefine();
@@ -42438,6 +42878,7 @@ Body:
     AegisName: S-MaxHP
     Name: S-MaxHP
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHP,2500;
       .@r = getrefine();
@@ -42455,6 +42896,7 @@ Body:
     AegisName: S-Quick
     Name: S-Quick
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       .@r = getrefine();
@@ -42472,6 +42914,7 @@ Body:
     AegisName: S-Cri
     Name: S-Cri
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritical,10;
       .@r = getrefine();
@@ -42489,6 +42932,7 @@ Body:
     AegisName: Tenji
     Name: Tenji
     Type: Card
+    SubType: Enchant
     Buy: 10
     Locations:
       Shoes: true
@@ -42508,30 +42952,35 @@ Body:
     AegisName: SPdrain2_Top
     Name: SPabsorp2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,20,1;
   - Id: 29209
     AegisName: SPdrain2
     Name: SPabsorp2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,20,1;
   - Id: 29210
     AegisName: HPdrain23
     Name: HPabsorp2 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,20,3;
   - Id: 29211
     AegisName: HPdrain23_Top
     Name: HPabsorp2 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,20,3;
   - Id: 29224
     AegisName: WhiteBody_Effect
     Name: White Body Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_WHITEBODY2,true;
     UnEquipScript: |
@@ -42540,6 +42989,7 @@ Body:
     AegisName: WaterField_Effect
     Name: Water Field Effect
     Type: Card
+    SubType: Enchant
     Script: |
       hateffect HAT_EF_WATER_BELOW2,true;
     UnEquipScript: |
@@ -42548,360 +42998,428 @@ Body:
     AegisName: ExplodingWave_Effect
     Name: Crimson Wave Effect
     Type: Card
+    SubType: Enchant
     Script: |
       /* todo */
   - Id: 29227
     AegisName: Heal
     Name: Heal
     Type: Card
+    SubType: Enchant
     Script: |
       skill "AL_HEAL",1;
   - Id: 29228
     AegisName: Steal
     Name: Steal
     Type: Card
+    SubType: Enchant
     Script: |
       skill "TF_STEAL",1;
   - Id: 29229
     AegisName: Teleport
     Name: Teleport
     Type: Card
+    SubType: Enchant
     Script: |
       skill "AL_TELEPORT",1;
   - Id: 29238
     AegisName: Evasion10
     Name: Flee+10
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,10;
   - Id: 29239
     AegisName: Hit5
     Name: Hit+5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,5;
   - Id: 29241
     AegisName: Critical10
     Name: Cri+10
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritical,10;
   - Id: 29302
     AegisName: Armor_Water
     Name: Water Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Water;
   - Id: 29303
     AegisName: Armor_Wind
     Name: Wind Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Wind;
   - Id: 29304
     AegisName: Armor_Ground
     Name: Earth Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Earth;
   - Id: 29305
     AegisName: Armor_Fire
     Name: Fire Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Fire;
   - Id: 29306
     AegisName: Armor_Darkness
     Name: Shadow Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Dark;
   - Id: 29307
     AegisName: Armor_Saint
     Name: Holy Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Holy;
   - Id: 29308
     AegisName: Armor_Undead
     Name: Undead Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Undead;
   - Id: 29309
     AegisName: Armor_Poison
     Name: Poison Element(Armor)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDefEle,Ele_Poison;
   - Id: 29310
     AegisName: Racing_RK_1
     Name: Racing(Rune Knight) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29311
     AegisName: Racing_RK_2
     Name: Racing(Rune Knight) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29312
     AegisName: Racing_RK_3
     Name: Racing(Rune Knight) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29313
     AegisName: Racing_RG_1
     Name: Racing(Royal Guard) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29314
     AegisName: Racing_RG_2
     Name: Racing(Royal Guard) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29315
     AegisName: Racing_RG_3
     Name: Racing(Royal Guard) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29316
     AegisName: Racing_MC_1
     Name: Racing(Mechanic) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29317
     AegisName: Racing_MC_2
     Name: Racing(Mechanic) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29318
     AegisName: Racing_MC_3
     Name: Racing(Mechanic) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29319
     AegisName: Racing_GN_1
     Name: Racing(Geneticist) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29320
     AegisName: Racing_GN_2
     Name: Racing(Geneticist) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29321
     AegisName: Racing_GN_3
     Name: Racing(Geneticist) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29322
     AegisName: Racing_GC_1
     Name: Racing(Guillotine Cross) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29323
     AegisName: Racing_GC_2
     Name: Racing(Guillotine Cross) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29324
     AegisName: Racing_GC_3
     Name: Racing(Guillotine Cross) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29325
     AegisName: Racing_SC_1
     Name: Racing(Shadow Chaser) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29326
     AegisName: Racing_SC_2
     Name: Racing(Shadow Chaser) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29327
     AegisName: Racing_SC_3
     Name: Racing(Shadow Chaser) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29328
     AegisName: Racing_WL_1
     Name: Racing(Warlock) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29329
     AegisName: Racing_WL_2
     Name: Racing(Warlock) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29330
     AegisName: Racing_WL_3
     Name: Racing(Warlock) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29331
     AegisName: Racing_SO_1
     Name: Racing(Sorcerer) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29332
     AegisName: Racing_SO_2
     Name: Racing(Sorcerer) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29333
     AegisName: Racing_SO_3
     Name: Racing(Sorcerer) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29334
     AegisName: Racing_AB_1
     Name: Racing(Archbishop) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29335
     AegisName: Racing_AB_2
     Name: Racing(Archbishop) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29336
     AegisName: Racing_AB_3
     Name: Racing(Archbishop) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29337
     AegisName: Racing_SR_1
     Name: Racing(Sura) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29338
     AegisName: Racing_SR_2
     Name: Racing(Sura) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29339
     AegisName: Racing_SR_3
     Name: Racing(Sura) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29340
     AegisName: Racing_RA_1
     Name: Racing(Ranger) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29341
     AegisName: Racing_RA_2
     Name: Racing(Ranger) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29342
     AegisName: Racing_RA_3
     Name: Racing(Ranger) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29343
     AegisName: Racing_WM_1
     Name: Racing(Wanderers & Minstrel) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29344
     AegisName: Racing_WM_2
     Name: Racing(Wanderers & Minstrel) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29345
     AegisName: Racing_WM_3
     Name: Racing(Wanderers & Minstrel) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29346
     AegisName: Racing_GS_1
     Name: Racing(Gunslinger) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29347
     AegisName: Racing_GS_2
     Name: Racing(Gunslinger) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29348
     AegisName: Racing_GS_3
     Name: Racing(Gunslinger) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29349
     AegisName: Racing_NJ_1
     Name: Racing(Ninja)1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29350
     AegisName: Racing_NJ_2
     Name: Racing(Ninja)2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29351
     AegisName: Racing_NJ_3
     Name: Racing(Ninja)3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29352
     AegisName: Racing_SN_1
     Name: Racing(Super Novice) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29353
     AegisName: Racing_SN_2
     Name: Racing(Super Novice) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29354
     AegisName: Racing_SN_3
     Name: Racing(Super Novice) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29355
     AegisName: Racing_SU_1
     Name: Racing(Summoner) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29356
     AegisName: Racing_SU_2
     Name: Racing(Summoner) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29357
     AegisName: Racing_SU_3
     Name: Racing(Summoner) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29358
     AegisName: Casting_Robe
     Name: Variable Casting Garment
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
   - Id: 29359
     AegisName: Fatal_Top
     Name: Fatal (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
   - Id: 29360
     AegisName: Fatal_Bottom
     Name: Fatal (Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
   - Id: 29361
     AegisName: Fatal_Robe
     Name: Fatal (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,20;
   - Id: 29362
     AegisName: DoubleAttack
     Name: Double Attack
     Type: Card
+    SubType: Enchant
     Script: |
       skill "TF_DOUBLE",3;
       bonus bDoubleRate,15;
@@ -42909,6 +43427,7 @@ Body:
     AegisName: Release_Of_Magic
     Name: Release of Truth
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bFlee2,100; bonus2 bMagicAddClass,Class_Boss,100; }",50,10000,BF_MAGIC,"{ active_transform 1639,10000 }";
       /*Unknow Rate*/
@@ -42916,84 +43435,98 @@ Body:
     AegisName: ATK5
     Name: ATK +5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,5;
   - Id: 29381
     AegisName: MATK5
     Name: MATK +5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,5;
   - Id: 29423
     AegisName: SuraStone_Top_
     Name: Champion Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("MO_IRONHAND");
   - Id: 29424
     AegisName: SuraStone_Middle_
     Name: Champion Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,2*getskilllv("MO_DODGE");
   - Id: 29425
     AegisName: SuraStone_Bottom_
     Name: Champion Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"MO_CHAINCOMBO",20;
   - Id: 29426
     AegisName: SuraStone_Robe_
     Name: SuraStone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SR_RAMPAGEBLASTER",15;
   - Id: 29427
     AegisName: SuraStone_Robe2_
     Name: Sura Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",15;
   - Id: 29428
     AegisName: RangerStone_Top_
     Name: Sniper Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("HT_STEELCROW");
   - Id: 29429
     AegisName: RangerStone_Middle_
     Name: Sniper Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillFixedCast,"SN_SHARPSHOOTING",-500;
   - Id: 29430
     AegisName: RangerStone_Bottom_
     Name: Sniper Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AC_SHOWER",20;
   - Id: 29431
     AegisName: RangerStone_Robe_
     Name: RangerStone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RA_ARROWSTORM",10;
   - Id: 29432
     AegisName: SorcererStone_Top_
     Name: Professor Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,getskilllv("SA_ADVANCEDBOOK");
   - Id: 29433
     AegisName: SorcererStone_Middle_
     Name: Professor Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillFixedCast,"PF_DOUBLECASTING",-400;
   - Id: 29434
     AegisName: SorcererStone_Bottom_
     Name: Professor Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"MG_FIREBOLT",20;
       bonus2 bSkillAtk,"MG_COLDBOLT",20;
@@ -43002,12 +43535,14 @@ Body:
     AegisName: SorcererStone_Robe_
     Name: SorcererStone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SO_PSYCHIC_WAVE",10;
   - Id: 29436
     AegisName: Dynast
     Name: Supreme King
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bStr,200; }",50,5000,BF_WEAPON,"{ active_transform 2221,5000 }";
       /*Unknow Rate*/
@@ -43015,12 +43550,14 @@ Body:
     AegisName: Z-Knockback
     Name: Z-Knockback
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bNoKnockback;
   - Id: 29439
     AegisName: Z-Immortal
     Name: Z-Immortal
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bUnbreakableHelm;
       /* fix me */
@@ -43028,6 +43565,7 @@ Body:
     AegisName: Z-Killgain
     Name: Z-Killgain
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPGainValue,2;
       .@r = getrefine();
@@ -43044,48 +43582,56 @@ Body:
     AegisName: Z-Reincarnation
     Name: Z-Reincarnation
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bRestartFullRecover;
   - Id: 29442
     AegisName: Z-NoDispell
     Name: Z-NoDispell
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bNoCastCancel2;
   - Id: 29443
     AegisName: Z-Clairvoyance
     Name: Z-Clairvoyance
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bIntravision;
   - Id: 29444
     AegisName: Z-Cast_Fixed
     Name: Z-Cast Fixed
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCastrate,-50;
   - Id: 29460
     AegisName: RuneknightStone_Top_
     Name: Lord Knight Stone (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("KN_SPEARMASTERY");
   - Id: 29461
     AegisName: RuneknightStone_Middle_
     Name: Lord Knight Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"LK_SPIRALPIERCE",15;
   - Id: 29462
     AegisName: RuneknightStone_Bottom_
     Name: Lord Knight Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,getskilllv("KN_CAVALIERMASTERY");
   - Id: 29463
     AegisName: RuneknightStone_Robe_
     Name: Rune Knight Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RK_DRAGONBREATH",10;
       bonus2 bSkillAtk,"RK_DRAGONBREATH_WATER",10;
@@ -43093,102 +43639,119 @@ Body:
     AegisName: GeneticStone_Top_
     Name: Creator Stone (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("AM_LEARNINGPOTION");
   - Id: 29465
     AegisName: GeneticStone_Middle_
     Name: Creator Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,2*getskilllv("AM_POTIONPITCHER");
   - Id: 29466
     AegisName: GeneticStone_Bottom_
     Name: Creator Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AM_ACIDTERROR",20;
   - Id: 29467
     AegisName: GeneticStone_Robe_
     Name: Genetic Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"GN_CARTCANNON",10;
   - Id: 29468
     AegisName: WarlockStone_Top_
     Name: High Wizard Stone (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,2*getskilllv("HW_MAGICPOWER");
   - Id: 29469
     AegisName: WarlockStone_Middle_
     Name: High Wizard Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WZ_METEOR",20;
   - Id: 29470
     AegisName: WarlockStone_Bottom_
     Name: High Wizard Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WZ_FIREPILLAR",20;
   - Id: 29471
     AegisName: WarlockStone_Robe_
     Name: Warlock Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WL_CRIMSONROCK",10;
   - Id: 29477
     AegisName: ShadowchaserStone_Top_
     Name: Stalker Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("RG_PLAGIARISM");
   - Id: 29478
     AegisName: ShadowchaseStone_Middle_
     Name: Stalker Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,2*getskilllv("AC_VULTURE");
   - Id: 29479
     AegisName: ShadowchaseStone_Bottom_
     Name: Stalker Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RG_RAID",20;
   - Id: 29480
     AegisName: ShadowchaserStone_Robe_
     Name: Shadow Chaser Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SC_TRIANGLESHOT",15;
   - Id: 29481
     AegisName: MechanicStone_Top_
     Name: Whitesmith Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("BS_WEAPONRESEARCH");
   - Id: 29482
     AegisName: MechanicStone_Middle_
     Name: Whitesmith Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,3*getskilllv("BS_SKINTEMPER");
   - Id: 29483
     AegisName: MechanicStone_Bottom_
     Name: Whitesmith Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WS_CARTTERMINATION",20;
   - Id: 29484
     AegisName: MechanicStone_Robe_
     Name: Mechanic Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NC_AXETORNADO",15;
   - Id: 29485
     AegisName: WanderMinstrelStone_Top_
     Name: Clown Gypsy Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       if (Sex == SEX_FEMALE)
          bonus bBaseAtk,getskilllv("DC_DANCINGLESSON")*2;
@@ -43198,6 +43761,7 @@ Body:
     AegisName: WanderMinstrelStone_Middle_
     Name: Clown Gypsy Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       if (Sex == SEX_FEMALE)
          bonus2 bSkillAtk,"DC_THROWARROW",20;
@@ -43207,18 +43771,21 @@ Body:
     AegisName: WanderMinstrelStone_Bottom_
     Name: Clown Gypsy Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CG_ARROWVULCAN",20;
   - Id: 29488
     AegisName: WanderMinstrelStone_Robe_
     Name: Wanderer Minstrel Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
   - Id: 29509
     AegisName: Hero
     Name: The Hero
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bFlee2,100; bonus2 bAddClass,Class_Boss,100; }",50,10000,BF_WEAPON;
       /*Unknow Rate*/
@@ -43226,78 +43793,91 @@ Body:
     AegisName: HighpriestStone_Top_
     Name: High Priest Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,getskilllv("HP_MEDITATIO");
   - Id: 29514
     AegisName: HighpriestStone_Middle_
     Name: High Priest Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,2*getskilllv("PR_MACEMASTERY");
   - Id: 29515
     AegisName: HighpriestStone_Bottom_
     Name: High Priest Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"PR_MAGNUS",20;
   - Id: 29516
     AegisName: ArchbishopStone_Robe_
     Name: Archbishop Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AB_ADORAMUS",15;
   - Id: 29517
     AegisName: PaladinStone_Top_
     Name: Paladin Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,(getskilllv("CR_TRUST")/2);
   - Id: 29518
     AegisName: PaladinStone_Middle_
     Name: Paladin Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,(getskilllv("KN_SPEARMASTERY")/2);
   - Id: 29519
     AegisName: PaladinStone_Bottom_
     Name: Paladin Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CR_HOLYCROSS",20;
   - Id: 29520
     AegisName: RoyalguardStone_Robe_
     Name: Royal Guard Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"LG_BANISHINGPOINT",15;
   - Id: 29521
     AegisName: AssacrossStone_Top_
     Name: Assassin Cross Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("AS_KATAR");
   - Id: 29522
     AegisName: AssacrossStone_Middle_
     Name: Assassin Cross Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,2*getskilllv("AS_LEFT");
   - Id: 29523
     AegisName: AssacrossStone_Bottom_
     Name: Assassin Cross Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AS_SONICBLOW",20;
   - Id: 29524
     AegisName: GuillcrossStone_Robe_
     Name: Assassin Cross Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",15;
   - Id: 29527
     AegisName: Improve_Orb_Def
     Name: Modification Orb(Defense)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDef,25;
@@ -43311,6 +43891,7 @@ Body:
     AegisName: Improve_Orb_Mdef
     Name: Modification Orb(Magic Defense)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMdef,2;
@@ -43324,12 +43905,14 @@ Body:
     AegisName: Improve_Orb_HealHP
     Name: Modification Orb(HP Recovery)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,20;
   - Id: 29530
     AegisName: Improve_Orb_Spirit
     Name: Modification Orb(Spirit)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -43343,6 +43926,7 @@ Body:
     AegisName: Improve_Orb_Health
     Name: Modification Orb(Stamina)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -43356,12 +43940,14 @@ Body:
     AegisName: Improve_Orb_HealSP
     Name: Modification Orb(SP Recovery)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,20;
   - Id: 29533
     AegisName: Improve_Orb_Heal
     Name: Modification Orb(Heal)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,5;
@@ -43375,6 +43961,7 @@ Body:
     AegisName: Improve_Orb_Atk
     Name: Modification Orb(Attack Power)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddClass,Class_All,5;
@@ -43388,6 +43975,7 @@ Body:
     AegisName: Improve_Orb_Matk
     Name: Modification Orb(Magic Power)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,5;
@@ -43401,6 +43989,7 @@ Body:
     AegisName: Improve_Orb_Archer
     Name: Modification Orb(Sharpshooter)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,3;
@@ -43414,6 +44003,7 @@ Body:
     AegisName: Improve_Orb_Speed
     Name: Modification Orb(Swift)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bAspd,1;
@@ -43427,6 +44017,7 @@ Body:
     AegisName: Improve_Orb_Cast
     Name: Modification Orb(Caster)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVariableCastrate,-5;
@@ -43440,6 +44031,7 @@ Body:
     AegisName: Improve_Orb_Cri
     Name: Modification Orb(Critical)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritical,10;
@@ -43453,6 +44045,7 @@ Body:
     AegisName: Improve_Orb_Delay
     Name: Modification Orb(After Skill Delay)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDelayrate,-5;
@@ -43466,6 +44059,7 @@ Body:
     AegisName: Improve_Orb_Fix
     Name: Modification Orb(Fixed Casting Time)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bFixedCast,-300;
@@ -43479,6 +44073,7 @@ Body:
     AegisName: Improve_Orb_Above
     Name: Modification Orb(Above All)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSubEle,Ele_All,5;
@@ -43495,30 +44090,35 @@ Body:
     AegisName: Improve_Orb_Life
     Name: Modification Orb(Life Drain)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,20,2;
   - Id: 29544
     AegisName: Improve_Orb_Soul
     Name: Modification Orb(Soul Drain)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,1;
   - Id: 29545
     AegisName: Improve_Orb_M_Heal
     Name: Modification Orb(Magic Healing)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bHPRegenRate,400,500; }",20,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29546
     AegisName: Improve_Orb_M_Soul
     Name: Modification Orb(Magic Soul)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bSPRegenRate,80,500; }",10,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29547
     AegisName: Improve_Orb_L_Vit
     Name: Modification Orb(Unlimited Vital)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus2 "{ bonus bVit,50; bonus2 bHPRegenRate,400,500; bonus2 bSPLossRate,1,20000; }",50,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
       autobonus2 "{ bonus bVit,50; bonus2 bHPRegenRate,400,500; bonus2 bSPLossRate,1,20000; }",50,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
@@ -43526,30 +44126,35 @@ Body:
     AegisName: Improve_Orb_L_INT
     Name: Modification Orb(Spell Buster)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bInt,50; bonus bMatkRate,15; bonus2 bAddClass,Class_All,-15; }",30,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29549
     AegisName: Improve_Orb_L_DEX
     Name: Modification Orb(Firing Shot)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bDex,50; bonus bLongAtkRate,10; bonus2 bSPLossRate,1,20000; }",30,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29550
     AegisName: Improve_Orb_L_STR
     Name: Modification Orb(Over Power)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bStr,50; bonus2 bAddClass,Class_All,15; bonus bMatkRate,-15; }",30,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29551
     AegisName: Improve_Orb_L_AGI
     Name: Modification Orb(Fatal Flash)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bAgi,50; bonus bCritAtkRate,10; bonus2 bHPLossRate,300,1000; }",30,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29552
     AegisName: Improve_Orb_L_LUK
     Name: Modification Orb(Lucky Strike)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       if (.@r>9) {
@@ -43568,155 +44173,186 @@ Body:
     AegisName: Racing_SG_1
     Name: Racing (Star Gladiator) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29580
     AegisName: Racing_SG_2
     Name: Racing (Star Gladiator) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29581
     AegisName: Racing_SG_3
     Name: Racing (Star Gladiator) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29582
     AegisName: Racing_SL_1
     Name: Racing (Soul Linker) 1Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29583
     AegisName: Racing_SL_2
     Name: Racing (Soul Linker) 2Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29584
     AegisName: Racing_SL_3
     Name: Racing (Soul Linker) 3Lv
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29587
     AegisName: Gh_md_agi
     Name: Flash
     Type: Card
+    SubType: Enchant
   - Id: 29588
     AegisName: Gh_md_str
     Name: Power
     Type: Card
+    SubType: Enchant
   - Id: 29589
     AegisName: Gh_md_dex
     Name: Celestial
     Type: Card
+    SubType: Enchant
   - Id: 29590
     AegisName: Gh_md_int
     Name: Divine Power
     Type: Card
+    SubType: Enchant
   - Id: 29591
     AegisName: Gh_md_vit
     Name: Rigid Body
     Type: Card
+    SubType: Enchant
   - Id: 29592
     AegisName: Gh_md_luk
     Name: Hundred Lucks
     Type: Card
+    SubType: Enchant
   - Id: 29594
     AegisName: Seyren_Memory
     Name: Seyren's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29595
     AegisName: Howard_Memory
     Name: Howard's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29596
     AegisName: Eremes_Memory
     Name: Eremes's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29598
     AegisName: Catherine_Memory
     Name: Catherine's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29599
     AegisName: Margaretha_Memory
     Name: Margaretha's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29600
     AegisName: Cecil_Memory
     Name: Cecil's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29601
     AegisName: Randel_Memory
     Name: Randel's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29602
     AegisName: Flamel_Memory
     Name: Flamel's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29603
     AegisName: Gertie_Memory
     Name: Gertie's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29604
     AegisName: Celia_Memory
     Name: Celia's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29605
     AegisName: Chen_Memory
     Name: Chen's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29606
     AegisName: Trentini_Memory
     Name: Trentini's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29607
     AegisName: Alphoccio_Memory
     Name: Alphoccio's Memory
     Type: Card
+    SubType: Enchant
     Buy: 20
   - Id: 29611
     AegisName: SuraStone_Bottom2_
     Name: Sura Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("AL_DP");
   - Id: 29612
     AegisName: SuraStone_Middle2_
     Name: Sura Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"MO_COMBOFINISH",15;
   - Id: 29613
     AegisName: SuraStone_Top2_
     Name: Sura Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CH_CHAINCRUSH",15;
   - Id: 29614
     AegisName: SorcererStone_Robe2_
     Name: Sorcerer Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SO_DIAMONDDUST",15;
   - Id: 29615
     AegisName: SorcererStone_Bottom2_
     Name: Sorcerer Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,2*getskilllv("SA_AUTOSPELL");
   - Id: 29616
     AegisName: SorcererStone_Middle2_
     Name: Sorcerer Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"MG_FIREBOLT",20;
       bonus2 bSkillAtk,"MG_COLDBOLT",20;
@@ -43725,6 +44361,7 @@ Body:
     AegisName: SorcererStone_Top2_
     Name: Sorcerer Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WZ_EARTHSPIKE",20;
       bonus2 bSkillAtk,"WZ_HEAVENDRIVE",20;
@@ -43732,72 +44369,84 @@ Body:
     AegisName: ShadowchaserStone_Robe2_
     Name: Shadow Chaser Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SC_FATALMENACE",15;
   - Id: 29619
     AegisName: ShadowchasStone_Bottom2_
     Name: Shadow Chaser Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHit,getskilllv("TF_MISS");
   - Id: 29620
     AegisName: ShadowchasStone_Middle2_
     Name: Shadow Chaser Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RG_BACKSTAP",15;
   - Id: 29621
     AegisName: ShadowchaserStone_Top2_
     Name: Shadow Chaser Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("RG_SNATCHER");
   - Id: 29651
     AegisName: SoulLinkerStone_Top_
     Name: Soul Linker Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,2*getskilllv("TK_SPTIME");
   - Id: 29652
     AegisName: SoulLinkerStone_Middle_
     Name: Soul Linker Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SL_SMA",20;
   - Id: 29653
     AegisName: SoulLinkerStone_Bottom_
     Name: Soul Linker Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-2*getskilllv("SL_KAAHI");
   - Id: 29654
     AegisName: SoulReaperStone_Robe_
     Name: Soul Reaper Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SP_SWHOO",20;
   - Id: 29655
     AegisName: StarGladiatorStone_Top_
     Name: Star Gladiator Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("TK_HPTIME");
   - Id: 29656
     AegisName: StarGladiatorStone_Middle_
     Name: Star Gladiator Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bFixedCastrate,"SG_FEEL",-50;
   - Id: 29657
     AegisName: StarGladiatorStone_Bottom_
     Name: Star Gladiator Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,getskilllv("SG_KNOWLEDGE");
   - Id: 29658
     AegisName: StarEmperorStone_Garment_
     Name: Star Emperor Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SJ_FALLINGSTAR",20;
       bonus2 bSkillAtk,"SJ_SOLARBURST",20;
@@ -43806,6 +44455,7 @@ Body:
     AegisName: NinjaStone_Top_
     Name: Ninja Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,2*getskilllv("NJ_NINPOU");
       bonus bBaseAtk,2*getskilllv("NJ_NINPOU");
@@ -43813,12 +44463,14 @@ Body:
     AegisName: NinjaStone_Middle_
     Name: Ninja Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NJ_HUUMA",20;
   - Id: 29661
     AegisName: NinjaStone_Bottom_
     Name: Ninja Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NJ_BAKUENRYU",20;
       bonus2 bSkillAtk,"NJ_HYOUSYOURAKU",20;
@@ -43827,36 +44479,42 @@ Body:
     AegisName: KagerouStone_Robe_
     Name: Kagerou Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"KO_HUUMARANKA",25;
   - Id: 29663
     AegisName: OboroStone_Robe_
     Name: Oboro Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NJ_KOUENKA",20;
   - Id: 29664
     AegisName: GunslingerStone_Top_
     Name: Gunslinger Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("GS_SNAKEEYE");
   - Id: 29665
     AegisName: GunslingerStone_Middle_
     Name: Gunslinger Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"GS_DESPERADO",20;
   - Id: 29666
     AegisName: GunslingerStone_Bottom_
     Name: Gunslinger Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,(getskilllv("GS_CHAINACTION")/2);
   - Id: 29667
     AegisName: GunslingerStone_Robe_
     Name: Gunslinger Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RL_HAMMER_OF_GOD",20;
       bonus2 bSkillAtk,"RL_R_TRIP",20;
@@ -43864,6 +44522,7 @@ Body:
     AegisName: DoramStone_Top_
     Name: Doram Stone (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       .@lv = getskilllv("SU_SCRATCH");
       bonus bBaseAtk,.@lv;
@@ -43872,18 +44531,21 @@ Body:
     AegisName: DoramStone_Middle_
     Name: Doram Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",20;
   - Id: 29670
     AegisName: DoramStone_Bottom_
     Name: Doram Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SU_SV_STEMSPEAR",20;
   - Id: 29671
     AegisName: DoramStone_Robe_
     Name: Doram Stone (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SU_PICKYPECK",20;
       bonus2 bSkillAtk,"SU_CN_METEOR",20;
@@ -43891,6 +44553,7 @@ Body:
     AegisName: Time_Jewely_Str_1
     Name: Temporal Jewel (STR) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,2*(.@r/2);
@@ -43900,6 +44563,7 @@ Body:
     AegisName: Time_Jewely_Str_2
     Name: Temporal Jewel (STR) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,4*(.@r/2);
@@ -43909,6 +44573,7 @@ Body:
     AegisName: Time_Jewely_Str_3
     Name: Temporal Jewel (STR) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,7*(.@r/2);
@@ -43918,6 +44583,7 @@ Body:
     AegisName: Time_Jewely_Agi_1
     Name: Temporal Jewel (AGI) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bAspdRate,(.@r/2);
@@ -43927,6 +44593,7 @@ Body:
     AegisName: Time_Jewely_Agi_2
     Name: Temporal Jewel (AGI) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bAspdRate,3*(.@r/2);
@@ -43936,6 +44603,7 @@ Body:
     AegisName: Time_Jewely_Agi_3
     Name: Temporal Jewel (AGI) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bAspdRate,5*(.@r/2);
@@ -43945,6 +44613,7 @@ Body:
     AegisName: Time_Jewely_Vit_1
     Name: Temporal Jewel (VIT) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bDef,5*(.@r/2);
@@ -43954,6 +44623,7 @@ Body:
     AegisName: Time_Jewely_Vit_2
     Name: Temporal Jewel (VIT) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bDef,7*(.@r/2);
@@ -43963,6 +44633,7 @@ Body:
     AegisName: Time_Jewely_Vit_3
     Name: Temporal Jewel (VIT) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bDef,10*(.@r/2);
@@ -43972,6 +44643,7 @@ Body:
     AegisName: Time_Jewely_Int_1
     Name: Temporal Jewel (INT) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bHealPower,(.@r/2);
@@ -43981,6 +44653,7 @@ Body:
     AegisName: Time_Jewely_Int_2
     Name: Temporal Jewel (INT) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bHealPower,3*(.@r/2);
@@ -43990,6 +44663,7 @@ Body:
     AegisName: Time_Jewely_Int_3
     Name: Temporal Jewel (INT) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bHealPower,5*(.@r/2);
@@ -43999,6 +44673,7 @@ Body:
     AegisName: Time_Jewely_Dex_1
     Name: Temporal Jewel (DEX) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,(.@r/2);
@@ -44008,6 +44683,7 @@ Body:
     AegisName: Time_Jewely_Dex_2
     Name: Temporal Jewel (DEX) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,2*(.@r/2);
@@ -44017,6 +44693,7 @@ Body:
     AegisName: Time_Jewely_Dex_3
     Name: Temporal Jewel (DEX) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,3*(.@r/2);
@@ -44026,6 +44703,7 @@ Body:
     AegisName: Time_Jewely_Luk_1
     Name: Temporal Jewel (LUK) Lv 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,3*(.@r/2);
@@ -44035,6 +44713,7 @@ Body:
     AegisName: Time_Jewely_Luk_2
     Name: Temporal Jewel (LUK) Lv 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,6*(.@r/2);
@@ -44044,6 +44723,7 @@ Body:
     AegisName: Time_Jewely_Luk_3
     Name: Temporal Jewel (LUK) Lv 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,9*(.@r/2);
@@ -47088,78 +47768,91 @@ Body:
     AegisName: Ranger_Top2
     Name: Sniper Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,getskilllv("SN_WINDWALK")/2;
   - Id: 310001
     AegisName: Ranger_Middle2
     Name: Sniper Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,(getskilllv("HT_BEASTBANE")/2);
   - Id: 310002
     AegisName: Ranger_Bottom2
     Name: Sniper Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bBaseAtk,2*getskilllv("SN_SIGHT");
   - Id: 310003
     AegisName: Ranger_Robe2
     Name: Ranger Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
   - Id: 310004
     AegisName: Mechanic_Top2
     Name: Whitesmith Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillCooldown,"NC_AXEBOOMERANG",-(100*getskilllv("WS_OVERTHRUSTMAX"));
   - Id: 310005
     AegisName: Mechanic_Middle2
     Name: Whitesmith Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WS_CARTTERMINATION",15;
   - Id: 310006
     AegisName: Mechanic_Bottom2
     Name: Whitesmith Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,getskilllv("BS_MAXIMIZE");
   - Id: 310007
     AegisName: Mechanic_Robe2
     Name: Mechanic Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NC_ARMSCANNON",15;
   - Id: 310008
     AegisName: Highpriest_Top2
     Name: High Priest Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"PR_MAGNUS",15;
   - Id: 310009
     AegisName: Highpriest_Middle2
     Name: High Priest Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_Holy,getskilllv("HP_ASSUMPTIO");
   - Id: 310010
     AegisName: Highpriest_Bottom2
     Name: High Priest Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-(getskilllv("PR_KYRIE")/2);
   - Id: 310011
     AegisName: Archbishop_Robe2
     Name: Archbishop Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AB_JUDEX",15;
   - Id: 310012
     AegisName: DesireOfDeath
     Name: Doom Desire
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bFlee,150; bonus bDelayrate,-100; }",50,10000,BF_WEAPON,"{ active_transform 1635,10000 }";
       /*Unknow Rate*/
@@ -47167,6 +47860,7 @@ Body:
     AegisName: Cassock_Str
     Name: STR Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bStr,10;
       bonus bMdef,3;
@@ -47176,6 +47870,7 @@ Body:
     AegisName: Cassock_Agi
     Name: AGI Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAgi,10;
       bonus bMdef,3;
@@ -47185,6 +47880,7 @@ Body:
     AegisName: Cassock_Vit
     Name: VIT Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVit,10;
       bonus bMdef,3;
@@ -47195,6 +47891,7 @@ Body:
     AegisName: Cassock_Dex
     Name: DEX Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDex,10;
       bonus bMdef,3;
@@ -47205,6 +47902,7 @@ Body:
     AegisName: Cassock_Int
     Name: INT Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bInt,10;
       bonus bMdef,3;
@@ -47214,6 +47912,7 @@ Body:
     AegisName: Cassock_Luk
     Name: LUK Blessing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLuk,10;
       bonus bMdef,3;
@@ -47223,6 +47922,7 @@ Body:
     AegisName: aegis_310082
     Name: Automatic Modification Orb(Defense)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDef,150;
@@ -47236,6 +47936,7 @@ Body:
     AegisName: aegis_310083
     Name: Automatic Modification Orb(Magic Defense)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMdef,15;
@@ -47249,6 +47950,7 @@ Body:
     AegisName: aegis_310084
     Name: Automatic Modification Orb(VIT)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,1;
       bonus bVit,3;
@@ -47256,6 +47958,7 @@ Body:
     AegisName: aegis_310085
     Name: Automatic Modification Orb(LUK)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,1;
       bonus bLuk,3;
@@ -47263,6 +47966,7 @@ Body:
     AegisName: aegis_310086
     Name: Automatic Modification Orb(STR)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,2;
       bonus bStr,3;
@@ -47270,6 +47974,7 @@ Body:
     AegisName: aegis_310087
     Name: Automatic Modification Orb(AGI)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,2;
       bonus bAgi,3;
@@ -47277,6 +47982,7 @@ Body:
     AegisName: aegis_310088
     Name: Automatic Modification Orb(INT)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,2;
       bonus bInt,3;
@@ -47284,6 +47990,7 @@ Body:
     AegisName: aegis_310089
     Name: Automatic Modification Orb(DEX)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,2;
       bonus bDex,3;
@@ -47291,18 +47998,21 @@ Body:
     AegisName: aegis_310090
     Name: Automatic Modification Orb(HP Recovery)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,30;
   - Id: 310091
     AegisName: aegis_310091
     Name: Automatic Modification Orb(SP Recovery)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,30;
   - Id: 310092
     AegisName: aegis_310092
     Name: Automatic Modification Orb(Spell)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       bonus bMatk,20;
@@ -47310,6 +48020,7 @@ Body:
     AegisName: aegis_310093
     Name: Automatic Modification Orb(Attack Speed)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,10;
       bonus bBaseAtk,20;
@@ -47317,6 +48028,7 @@ Body:
     AegisName: aegis_310094
     Name: Automatic Modification Orb(Fatal)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,10;
       bonus bCritical,10;
@@ -47324,6 +48036,7 @@ Body:
     AegisName: aegis_310095
     Name: Automatic Modification Orb(Expert Archer)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,10;
       bonus bHit,10;
@@ -47331,6 +48044,7 @@ Body:
     AegisName: aegis_310096
     Name: Automatic Modification Orb(Vital)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -47345,6 +48059,7 @@ Body:
     AegisName: aegis_310097
     Name: Automatic Modification Orb(Mental)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -47359,6 +48074,7 @@ Body:
     AegisName: aegis_310098
     Name: Automatic Modification Orb(Heal)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,5;
@@ -47372,6 +48088,7 @@ Body:
     AegisName: aegis_310099
     Name: Automatic Modification Orb(Attack Power)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddClass,Class_All,5;
@@ -47386,6 +48103,7 @@ Body:
     AegisName: aegis_310100
     Name: Automatic Modification Orb(Magic Power)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,5;
@@ -47400,6 +48118,7 @@ Body:
     AegisName: aegis_310101
     Name: Automatic Modification Orb(Shooter)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,3;
@@ -47413,6 +48132,7 @@ Body:
     AegisName: aegis_310102
     Name: Automatic Modification Orb(Fast)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bAspd,1;
@@ -47426,6 +48146,7 @@ Body:
     AegisName: aegis_310103
     Name: Automatic Modification Orb(Caster)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVariableCastrate,-5;
@@ -47439,6 +48160,7 @@ Body:
     AegisName: aegis_310104
     Name: Automatic Modification Orb(Critical)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritical,10;
@@ -47452,6 +48174,7 @@ Body:
     AegisName: aegis_310105
     Name: Automatic Modification Orb(Magical Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,2;
@@ -47467,6 +48190,7 @@ Body:
     AegisName: aegis_310106
     Name: Automatic Modification Orb(Attacker Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,3;
@@ -47482,6 +48206,7 @@ Body:
     AegisName: aegis_310107
     Name: Automatic Modification Orb(Range Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,3;
@@ -47497,6 +48222,7 @@ Body:
     AegisName: aegis_310108
     Name: Automatic Modification Orb(Critical Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,3;
@@ -47512,6 +48238,7 @@ Body:
     AegisName: aegis_310109
     Name: Automatic Modification Orb(Recovery Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,5;
@@ -47527,6 +48254,7 @@ Body:
     AegisName: aegis_310110
     Name: Automatic Modification Orb(After Skill Delay)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDelayrate,-4;
@@ -47540,6 +48268,7 @@ Body:
     AegisName: aegis_310111
     Name: Automatic Modification Orb(Fixed Casting)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bFixedCast,-100;
@@ -47553,6 +48282,7 @@ Body:
     AegisName: aegis_310112
     Name: Automatic Modification Orb(Above All)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSubClass,Class_Normal,7;
@@ -47570,30 +48300,35 @@ Body:
     AegisName: aegis_310113
     Name: Automatic Modification Orb(Drain Life)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,20,3;
   - Id: 310114
     AegisName: aegis_310114
     Name: Automatic Modification Orb(Drain Soul)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,2;
   - Id: 310115
     AegisName: aegis_310115
     Name: Automatic Modification Orb(Magic Healing)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bHPRegenRate,500,400; }",20,9200,BF_MAGIC;
   - Id: 310116
     AegisName: aegis_310116
     Name: Automatic Modification Orb(Magic Soul)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bSPRegenRate,120,400; }",10,9200,BF_MAGIC;
   - Id: 310117
     AegisName: aegis_310117
     Name: Automatic Modification Orb(Power Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,3;
@@ -47610,6 +48345,7 @@ Body:
     AegisName: aegis_310118
     Name: Automatic Modification Orb(Robust)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -47628,6 +48364,7 @@ Body:
     AegisName: aegis_310119
     Name: Automatic Modification Orb(Powerful)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,5;
@@ -47647,6 +48384,7 @@ Body:
     AegisName: aegis_310120
     Name: Automatic Modification Orb(All Force)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,5;
       bonus bLongAtkRate,5;
@@ -47655,42 +48393,49 @@ Body:
     AegisName: aegis_310121
     Name: Automatic Orb(Unlimited Vital)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus2 "{ bonus bVit,50; bonus2 bSPRegenRate,800,500; }",10,10000,BF_MAGIC|BF_WEAPON;
   - Id: 310122
     AegisName: aegis_310122
     Name: Automatic Orb(Spell Buster)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bMatkRate,25; bonus bInt,50; }",30,10000,BF_MAGIC;
   - Id: 310123
     AegisName: aegis_310123
     Name: Automatic Orb(Firing Shot)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bLongAtkRate,15; bonus bDex,50; }",30,10000,BF_WEAPON;
   - Id: 310124
     AegisName: aegis_310124
     Name: Automatic Orb(Over Power)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bShortAtkRate,10; bonus2 bAddClass,Class_All,15; bonus bStr,50; }",30,10000,BF_WEAPON;
   - Id: 310125
     AegisName: aegis_310125
     Name: Automatic Orb(Fatal Flash)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bCritAtkRate,15; bonus bAgi,50; }",30,10000,BF_WEAPON;
   - Id: 310126
     AegisName: aegis_310126
     Name: Automatic Orb(Lucky Strike)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bMagicAtkEle,Ele_All,15; bonus bLuk,50; }",30,10000,BF_MAGIC;
   - Id: 310127
     AegisName: aegis_310127
     Name: Automatic Orb(Dragonic Breath)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RK_DRAGONBREATH",15;
@@ -47707,6 +48452,7 @@ Body:
     AegisName: aegis_310128
     Name: Automatic Orb(Wave Break)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RK_IGNITIONBREAK",15;
@@ -47723,6 +48469,7 @@ Body:
     AegisName: aegis_310129
     Name: Automatic Orb(Hundred Spiral)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LK_SPIRALPIERCE",15;
@@ -47739,6 +48486,7 @@ Body:
     AegisName: aegis_310130
     Name: Automatic Orb(Drive Press)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_EARTHDRIVE",15;
@@ -47755,6 +48503,7 @@ Body:
     AegisName: aegis_310131
     Name: Automatic Orb(Banishing Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_BANISHINGPOINT",15;
@@ -47771,6 +48520,7 @@ Body:
     AegisName: aegis_310132
     Name: Automatic Orb(Genesis Pressure)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_RAYOFGENESIS",15;
@@ -47787,6 +48537,7 @@ Body:
     AegisName: aegis_310133
     Name: Automatic Orb(Boost Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_BOOSTKNUCKLE",15;
@@ -47803,6 +48554,7 @@ Body:
     AegisName: aegis_310134
     Name: Automatic Orb(Cold Flare)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_FLAMELAUNCHER",15;
@@ -47819,6 +48571,7 @@ Body:
     AegisName: aegis_310135
     Name: Automatic Orb(Tornado Swing)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_AXETORNADO",15;
@@ -47835,6 +48588,7 @@ Body:
     AegisName: aegis_310136
     Name: Automatic Orb(Cannon Tornado)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GN_CART_TORNADO",15;
@@ -47851,6 +48605,7 @@ Body:
     AegisName: aegis_310137
     Name: Automatic Orb(Crazy Mandragora)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillCooldown,"GN_MANDRAGORA",-300;
@@ -47867,6 +48622,7 @@ Body:
     AegisName: aegis_310138
     Name: Automatic Orb(Acid Explosion)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"CR_ACIDDEMONSTRATION",15;
@@ -47883,6 +48639,7 @@ Body:
     AegisName: aegis_310139
     Name: Automatic Orb(Sonic Impact)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_CROSSIMPACT",15;
@@ -47899,6 +48656,7 @@ Body:
     AegisName: aegis_310140
     Name: Automatic Orb(Cutter Slasher)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_CROSSRIPPERSLASHER",15;
@@ -47915,6 +48673,7 @@ Body:
     AegisName: aegis_310141
     Name: Automatic Orb(Berserk Slash)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_COUNTERSLASH",15;
@@ -47931,6 +48690,7 @@ Body:
     AegisName: aegis_310142
     Name: Automatic Orb(Fatal Raid)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SC_FATALMENACE",15;
@@ -47947,6 +48707,7 @@ Body:
     AegisName: aegis_310143
     Name: Automatic Orb(Shadow Spell)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,15;
@@ -47960,6 +48721,7 @@ Body:
     AegisName: aegis_310144
     Name: Automatic Orb(Angle Shot)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,10;
@@ -47975,6 +48737,7 @@ Body:
     AegisName: aegis_310145
     Name: Automatic Orb(Crimson Strain)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_EARTHSTRAIN",15;
@@ -47991,6 +48754,7 @@ Body:
     AegisName: aegis_310146
     Name: Automatic Orb(Jack Lightning)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15;
@@ -48007,6 +48771,7 @@ Body:
     AegisName: aegis_310147
     Name: Automatic Orb(Comet Vortex)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_TETRAVORTEX",15;
@@ -48023,6 +48788,7 @@ Body:
     AegisName: aegis_310148
     Name: Automatic Orb(Double Bolt)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"MG_LIGHTNINGBOLT",15;
@@ -48042,6 +48808,7 @@ Body:
     AegisName: aegis_310149
     Name: Automatic Orb(Warm Wave)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillCooldown,"SO_WARMER",-1000;
@@ -48058,6 +48825,7 @@ Body:
     AegisName: aegis_310150
     Name: Automatic Orb(Diamond Grave)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SO_DIAMONDDUST",15;
@@ -48074,6 +48842,7 @@ Body:
     AegisName: aegis_310151
     Name: Automatic Orb(Magnusmus)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"PR_MAGNUS",15;
@@ -48090,6 +48859,7 @@ Body:
     AegisName: aegis_310152
     Name: Automatic Orb(Holy Judex)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"AL_HOLYLIGHT",15;
@@ -48106,6 +48876,7 @@ Body:
     AegisName: aegis_310153
     Name: Automatic Orb(Duple Lica)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillCooldown,"HP_BASILICA",-2000;
@@ -48122,6 +48893,7 @@ Body:
     AegisName: aegis_310154
     Name: Automatic Orb(Tiger Empire)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SR_FALLENEMPIRE",15;
@@ -48138,6 +48910,7 @@ Body:
     AegisName: aegis_310155
     Name: Automatic Orb(Rampage Arrow)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",15;
@@ -48154,6 +48927,7 @@ Body:
     AegisName: aegis_310156
     Name: Automatic Orb(Raging Combo)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"MO_COMBOFINISH",15;
@@ -48170,6 +48944,7 @@ Body:
     AegisName: aegis_310157
     Name: Automatic Orb(Cluster)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RA_CLUSTERBOMB",15;
@@ -48183,6 +48958,7 @@ Body:
     AegisName: aegis_310158
     Name: Automatic Orb(Breeze Shooting)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritAtkRate,10;
@@ -48198,6 +48974,7 @@ Body:
     AegisName: aegis_310159
     Name: Automatic Orb(Aimed Storm)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RA_ARROWSTORM",15;
@@ -48214,6 +48991,7 @@ Body:
     AegisName: aegis_310160
     Name: Automatic Orb(Metal Echo)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WM_GREAT_ECHO",15;
@@ -48230,6 +49008,7 @@ Body:
     AegisName: aegis_310161
     Name: Automatic Orb(Reverberation)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WM_REVERBERATION",15;
@@ -48243,6 +49022,7 @@ Body:
     AegisName: aegis_310162
     Name: Automatic Orb(Vulcan Severe)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
@@ -48259,6 +49039,7 @@ Body:
     AegisName: aegis_310163
     Name: Automatic Orb(Prominence Burst)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_SOLARBURST",15;
@@ -48275,6 +49056,7 @@ Body:
     AegisName: aegis_310164
     Name: Automatic Orb(Moon Kick)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
@@ -48292,6 +49074,7 @@ Body:
     AegisName: aegis_310165
     Name: Automatic Orb(Flash Falling)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_FALLINGSTAR_ATK",15;
@@ -48308,6 +49091,7 @@ Body:
     AegisName: aegis_310166
     Name: Automatic Orb(Eswhoo)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SL_SMA",15;
@@ -48324,6 +49108,7 @@ Body:
     AegisName: aegis_310167
     Name: Automatic Orb(Espa)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SP_SPA",15;
@@ -48337,6 +49122,7 @@ Body:
     AegisName: aegis_310168
     Name: Automatic Orb(Curse Explosion)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SP_CURSEEXPLOSION",15;
@@ -48350,6 +49136,7 @@ Body:
     AegisName: aegis_310169
     Name: Automatic Orb(Des Hammer Dance)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GS_DESPERADO",15;
@@ -48369,6 +49156,7 @@ Body:
     AegisName: aegis_310170
     Name: Automatic Orb(Fire Howling Tail)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RL_FIRE_RAIN",15;
@@ -48388,6 +49176,7 @@ Body:
     AegisName: aegis_310171
     Name: Automatic Orb(Storm Buster Trip)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RL_BANISHING_BUSTER",15;
@@ -48407,6 +49196,7 @@ Body:
     AegisName: aegis_310172
     Name: Automatic Orb(Flame Ice Wind)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NJ_KOUENKA",15;
@@ -48426,6 +49216,7 @@ Body:
     AegisName: aegis_310173
     Name: Automatic Orb(Cross Slash)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"KO_JYUMONJIKIRI",15;
@@ -48439,6 +49230,7 @@ Body:
     AegisName: aegis_310174
     Name: Automatic Orb(Exploding Flake Wind)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NJ_BAKUENRYU",15;
@@ -48458,6 +49250,7 @@ Body:
     AegisName: aegis_310175
     Name: Automatic Orb(Power of Sea)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillCooldown,"SU_SHRIMPARTY",-500;
@@ -48474,6 +49267,7 @@ Body:
     AegisName: aegis_310176
     Name: Automatic Orb(Power of Land)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SU_SV_STEMSPEAR",15;
@@ -48490,6 +49284,7 @@ Body:
     AegisName: aegis_310177
     Name: Automatic Orb(Power of Life)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",15;
@@ -48506,6 +49301,7 @@ Body:
     AegisName: aegis_310178
     Name: Automatic Modification Orb(Mirror Counter)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       if (.@r>=11)
@@ -48518,6 +49314,7 @@ Body:
     AegisName: aegis_310179
     Name: Automatic Modification Orb(Reflection Reject)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       if (.@r>=11)
@@ -48530,54 +49327,63 @@ Body:
     AegisName: Warlock_Robe2
     Name: Warlock Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WL_COMET",15;
   - Id: 310181
     AegisName: Warlock_Top2
     Name: High Wizard Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WZ_METEOR",20;
   - Id: 310182
     AegisName: Warlock_Middle2
     Name: High Wizard Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_Neutral,2*getskilllv("HW_GRAVITATION");
   - Id: 310183
     AegisName: Warlock_Bottom2
     Name: High Wizard Stone II (Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatk,2*getskilllv("HW_SOULDRAIN");
   - Id: 310184
     AegisName: RoyalGuard_Robe2
     Name: Royal Guard Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"LG_RAYOFGENESIS",15;
   - Id: 310185
     AegisName: RoyalGuard_Bottom2
     Name: Paladin Stone II (Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_Holy,getskilllv("CR_GRANDCROSS");
   - Id: 310186
     AegisName: RoyalGuard_Middle2
     Name: Paladin Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"PA_PRESSURE",20;
   - Id: 310187
     AegisName: RoyalGuard_Top2
     Name: Paladin Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-getskilllv("CR_TRUST");
   - Id: 310188
     AegisName: GuillotineCross_Robe2
     Name: Guillotine Cross Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,15;
       if (getskilllv("AS_KATAR") >= 10) {
@@ -48588,114 +49394,133 @@ Body:
     AegisName: GuillotineCross_Bottom2
     Name: Assassin Cross Stone II (Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddSize,Size_All,2*getskilllv("ASC_KATAR");
   - Id: 310190
     AegisName: GuillotineCross_Middle2
     Name: Assassin Cross Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AS_SONICBLOW",20;
   - Id: 310191
     AegisName: GuillotineCross_Top2
     Name: Assassin Cross Stone II (Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-getskilllv("ASC_BREAKER");
   - Id: 310197
     AegisName: aegis_310197
     Name: Anger Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,1;
   - Id: 310198
     AegisName: aegis_310198
     Name: Anger Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,3;
   - Id: 310199
     AegisName: aegis_310199
     Name: Anger Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,5;
   - Id: 310200
     AegisName: aegis_310200
     Name: Anger Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,7;
   - Id: 310201
     AegisName: aegis_310201
     Name: Anger Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,10;
   - Id: 310202
     AegisName: aegis_310202
     Name: Horror Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,1;
   - Id: 310203
     AegisName: aegis_310203
     Name: Horror Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,3;
   - Id: 310204
     AegisName: aegis_310204
     Name: Horror Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,5;
   - Id: 310205
     AegisName: aegis_310205
     Name: Horror Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,7;
   - Id: 310206
     AegisName: aegis_310206
     Name: Horror Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,10;
   - Id: 310207
     AegisName: aegis_310207
     Name: Resentment Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,1;
   - Id: 310208
     AegisName: aegis_310208
     Name: Resentment Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
   - Id: 310209
     AegisName: aegis_310209
     Name: Resentment Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,5;
   - Id: 310210
     AegisName: aegis_310210
     Name: Resentment Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,7;
   - Id: 310211
     AegisName: aegis_310211
     Name: Resentment Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,10;
   - Id: 310212
     AegisName: aegis_310212
     Name: Regret Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,1;
       bonus bMaxSPrate,1;
@@ -48703,6 +49528,7 @@ Body:
     AegisName: aegis_310213
     Name: Regret Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,3;
       bonus bMaxSPrate,3;
@@ -48710,6 +49536,7 @@ Body:
     AegisName: aegis_310214
     Name: Regret Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
       bonus bMaxSPrate,5;
@@ -48717,6 +49544,7 @@ Body:
     AegisName: aegis_310215
     Name: Regret Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,7;
       bonus bMaxSPrate,7;
@@ -48724,6 +49552,7 @@ Body:
     AegisName: aegis_310216
     Name: Regret Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,10;
       bonus bMaxSPrate,10;
@@ -48731,96 +49560,112 @@ Body:
     AegisName: aegis_310217
     Name: Empathy Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,1;
   - Id: 310218
     AegisName: aegis_310218
     Name: Empathy Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,3;
   - Id: 310219
     AegisName: aegis_310219
     Name: Empathy Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,5;
   - Id: 310220
     AegisName: aegis_310220
     Name: Empathy Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,7;
   - Id: 310221
     AegisName: aegis_310221
     Name: Empathy Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,10;
   - Id: 310222
     AegisName: aegis_310222
     Name: Happiness Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,1;
   - Id: 310223
     AegisName: aegis_310223
     Name: Happiness Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,3;
   - Id: 310224
     AegisName: aegis_310224
     Name: Happiness Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,5;
   - Id: 310225
     AegisName: aegis_310225
     Name: Happiness Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,7;
   - Id: 310226
     AegisName: aegis_310226
     Name: Happiness Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,10;
   - Id: 310227
     AegisName: aegis_310227
     Name: Shelter Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,1;
   - Id: 310228
     AegisName: aegis_310228
     Name: Shelter Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
   - Id: 310229
     AegisName: aegis_310229
     Name: Shelter Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,5;
   - Id: 310230
     AegisName: aegis_310230
     Name: Shelter Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,7;
   - Id: 310231
     AegisName: aegis_310231
     Name: Shelter Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,10;
   - Id: 310232
     AegisName: aegis_310232
     Name: Solace Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,1;
       bonus bMaxSPrate,1;
@@ -48828,6 +49673,7 @@ Body:
     AegisName: aegis_310233
     Name: Solace Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,3;
       bonus bMaxSPrate,3;
@@ -48835,6 +49681,7 @@ Body:
     AegisName: aegis_310234
     Name: Solace Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
       bonus bMaxSPrate,5;
@@ -48842,6 +49689,7 @@ Body:
     AegisName: aegis_310235
     Name: Solace Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,7;
       bonus bMaxSPrate,7;
@@ -48849,6 +49697,7 @@ Body:
     AegisName: aegis_310236
     Name: Solace Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,10;
       bonus bMaxSPrate,10;
@@ -48856,6 +49705,7 @@ Body:
     AegisName: aegis_310237
     Name: Inverse Scale Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,10;
       bonus2 bAddRace,RC_Dragon,10;
@@ -48863,6 +49713,7 @@ Body:
     AegisName: aegis_310238
     Name: Inverse Scale Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,15;
       bonus2 bAddRace,RC_Dragon,15;
@@ -48870,6 +49721,7 @@ Body:
     AegisName: aegis_310239
     Name: Inverse Scale Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,20;
       bonus2 bAddRace,RC_Dragon,20;
@@ -48877,6 +49729,7 @@ Body:
     AegisName: aegis_310240
     Name: Inverse Scale Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,25;
       bonus2 bAddRace,RC_Dragon,25;
@@ -48884,6 +49737,7 @@ Body:
     AegisName: aegis_310241
     Name: Inverse Scale Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,35;
       bonus2 bAddRace,RC_Dragon,35;
@@ -48891,6 +49745,7 @@ Body:
     AegisName: aegis_310242
     Name: Dragon Scale Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,10;
       bonus2 bMagicAddRace,RC_Dragon,10;
@@ -48898,6 +49753,7 @@ Body:
     AegisName: aegis_310243
     Name: Dragon Scale Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,15;
       bonus2 bMagicAddRace,RC_Dragon,15;
@@ -48905,6 +49761,7 @@ Body:
     AegisName: aegis_310244
     Name: Dragon Scale Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,20;
       bonus2 bMagicAddRace,RC_Dragon,20;
@@ -48912,6 +49769,7 @@ Body:
     AegisName: aegis_310245
     Name: Dragon Scale Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,25;
       bonus2 bMagicAddRace,RC_Dragon,25;
@@ -48919,6 +49777,7 @@ Body:
     AegisName: aegis_310246
     Name: Dragon Scale Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,35;
       bonus2 bMagicAddRace,RC_Dragon,35;
@@ -48926,6 +49785,7 @@ Body:
     AegisName: aegis_310247
     Name: Divine Evil Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,10;
       bonus2 bAddRace,RC_Demon,10;
@@ -48933,6 +49793,7 @@ Body:
     AegisName: aegis_310248
     Name: Divine Evil Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,15;
       bonus2 bAddRace,RC_Demon,15;
@@ -48940,6 +49801,7 @@ Body:
     AegisName: aegis_310249
     Name: Divine Evil Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,20;
       bonus2 bAddRace,RC_Demon,20;
@@ -48947,6 +49809,7 @@ Body:
     AegisName: aegis_310250
     Name: Divine Evil Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,25;
       bonus2 bAddRace,RC_Demon,25;
@@ -48954,6 +49817,7 @@ Body:
     AegisName: aegis_310251
     Name: Divine Evil Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddRace,RC_Angel,35;
       bonus2 bAddRace,RC_Demon,35;
@@ -48961,6 +49825,7 @@ Body:
     AegisName: aegis_310252
     Name: Destructive Evil Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,10;
       bonus2 bMagicAddRace,RC_Demon,10;
@@ -48968,6 +49833,7 @@ Body:
     AegisName: aegis_310253
     Name: Destructive Evil Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,15;
       bonus2 bMagicAddRace,RC_Demon,15;
@@ -48975,6 +49841,7 @@ Body:
     AegisName: aegis_310254
     Name: Destructive Evil Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,20;
       bonus2 bMagicAddRace,RC_Demon,20;
@@ -48982,6 +49849,7 @@ Body:
     AegisName: aegis_310255
     Name: Destructive Evil Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,25;
       bonus2 bMagicAddRace,RC_Demon,25;
@@ -48989,6 +49857,7 @@ Body:
     AegisName: aegis_310256
     Name: Destructive Evil Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAddRace,RC_Angel,35;
       bonus2 bMagicAddRace,RC_Demon,35;
@@ -48996,72 +49865,84 @@ Body:
     AegisName: Runeknight_Robe2
     Name: Rune Knight Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RK_IGNITIONBREAK",15;
   - Id: 310258
     AegisName: Runeknight_Top2
     Name: Lord Knight Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,getskilllv("LK_SPIRALPIERCE");
   - Id: 310259
     AegisName: Runeknight_Middle2
     Name: Lord Knight Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"KN_BOWLINGBASH",20;
   - Id: 310260
     AegisName: Runeknight_Bottom2
     Name: Lord Knight Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"LK_SPIRALPIERCE",20;
   - Id: 310261
     AegisName: Genetic_Robe2
     Name: Creator Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"GN_CRAZYWEED",20;
   - Id: 310262
     AegisName: Genetic_Top2
     Name: Creator Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddSize,Size_All,getskilllv("AM_CANNIBALIZE");
   - Id: 310263
     AegisName: Genetic_Middle2
     Name: Creator Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CR_ACIDDEMONSTRATION",25;
   - Id: 310264
     AegisName: Genetic_Bottom2
     Name: Creator Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,(getskilllv("CR_ACIDDEMONSTRATION")/2);
   - Id: 310265
     AegisName: WandMinst_Robe2
     Name: Wanderer's Stone II (Garment)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WM_REVERBERATION",15;
   - Id: 310266
     AegisName: WandMinst_Top2
     Name: Trentini Gypsy Stone II (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CG_ARROWVULCAN",15;
   - Id: 310267
     AegisName: WandMinst_Mid2
     Name: Trentini Gypsy Stone II (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_Neutral,getskilllv("BA_MUSICALSTRIKE")+getskilllv("DC_THROWARROW");
   - Id: 310268
     AegisName: WandMinst_Bot2
     Name: Trentini Gypsy Stone II (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"BA_MUSICALSTRIKE",15;
       bonus2 bSkillAtk,"DC_THROWARROW",15;
@@ -49069,42 +49950,49 @@ Body:
     AegisName: aegis_310325
     Name: Range Stone (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
   - Id: 310326
     AegisName: aegis_310326
     Name: Range Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
   - Id: 310327
     AegisName: aegis_310327
     Name: Melee Stone (Top)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,3;
   - Id: 310328
     AegisName: aegis_310328
     Name: Melee Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,3;
   - Id: 310329
     AegisName: aegis_310329
     Name: Melee Stone (Bottom)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,3;
   - Id: 310330
     AegisName: aegis_310330
     Name: Range Stone (Middle)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
   - Id: 310478
     AegisName: Wolf_Orb_Str_1
     Name: Wolf Orb (Str) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bStr,1;
@@ -49121,6 +50009,7 @@ Body:
     AegisName: Wolf_Orb_Dex_1
     Name: Wolf Orb (Dex) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDex,1;
@@ -49137,6 +50026,7 @@ Body:
     AegisName: Wolf_Orb_Agi_1
     Name: Wolf Orb (Agi) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bAgi,1;
@@ -49153,6 +50043,7 @@ Body:
     AegisName: Wolf_Orb_Int_1
     Name: Wolf Orb (Int) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bInt,1;
@@ -49169,6 +50060,7 @@ Body:
     AegisName: Wolf_Orb_Vit_1
     Name: Wolf Orb (Vit) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVit,1;
@@ -49185,6 +50077,7 @@ Body:
     AegisName: Wolf_Orb_luk_1
     Name: Wolf Orb (Luk) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLuk,1;
@@ -49201,6 +50094,7 @@ Body:
     AegisName: Wolf_Orb_Str_2
     Name: Wolf Orb (Str) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bStr,2;
@@ -49218,6 +50112,7 @@ Body:
     AegisName: Wolf_Orb_Dex_2
     Name: Wolf Orb (Dex) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDex,2;
@@ -49235,6 +50130,7 @@ Body:
     AegisName: Wolf_Orb_Agi_2
     Name: Wolf Orb (Agi) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bAgi,2;
@@ -49252,6 +50148,7 @@ Body:
     AegisName: Wolf_Orb_Int_2
     Name: Wolf Orb (Int) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bInt,2;
@@ -49269,6 +50166,7 @@ Body:
     AegisName: Wolf_Orb_Vit_2
     Name: Wolf Orb (Vit) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVit,2;
@@ -49286,6 +50184,7 @@ Body:
     AegisName: Wolf_Orb_luk_2
     Name: Wolf Orb (Luk) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLuk,2;
@@ -49303,6 +50202,7 @@ Body:
     AegisName: Wolf_Orb_Str_3
     Name: Wolf Orb (Str) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bStr,3;
@@ -49320,6 +50220,7 @@ Body:
     AegisName: Wolf_Orb_Dex_3
     Name: Wolf Orb (Dex) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDex,3;
@@ -49337,6 +50238,7 @@ Body:
     AegisName: Wolf_Orb_Agi_3
     Name: Wolf Orb (Agi) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bAgi,3;
@@ -49354,6 +50256,7 @@ Body:
     AegisName: Wolf_Orb_Int_3
     Name: Wolf Orb (Int) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bInt,3;
@@ -49371,6 +50274,7 @@ Body:
     AegisName: Wolf_Orb_Vit_3
     Name: Wolf Orb (Vit) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVit,3;
@@ -49388,6 +50292,7 @@ Body:
     AegisName: Wolf_Orb_luk_3
     Name: Wolf Orb (Luk) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLuk,3;
@@ -49405,6 +50310,7 @@ Body:
     AegisName: Wolf_Orb_Def_1
     Name: Wolf Orb (Physical Defense) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDef,150;
@@ -49421,6 +50327,7 @@ Body:
     AegisName: Wolf_Orb_Mdef_1
     Name: Wolf Orb (Magical Defense) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMdef,15;
@@ -49437,6 +50344,7 @@ Body:
     AegisName: Wolf_Orb_Def_2
     Name: Wolf Orb (Physical Defense) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDef,200;
@@ -49453,6 +50361,7 @@ Body:
     AegisName: Wolf_Orb_Mdef_2
     Name: Wolf Orb (Magical Defense) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMdef,20;
@@ -49469,6 +50378,7 @@ Body:
     AegisName: Wolf_Orb_Def_3
     Name: Wolf Orb (Physical Defense) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDef,250;
@@ -49485,6 +50395,7 @@ Body:
     AegisName: Wolf_Orb_Mdef_3
     Name: Wolf Orb (Magical Defense) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMdef,25;
@@ -49501,6 +50412,7 @@ Body:
     AegisName: Wolf_Orb_Ran_1
     Name: Wolf Orb (Shooter) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,3;
@@ -49517,6 +50429,7 @@ Body:
     AegisName: Wolf_Orb_War_1
     Name: Wolf Orb (Warrior) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddClass,Class_All,2;
@@ -49534,6 +50447,7 @@ Body:
     AegisName: Wolf_Orb_Mag_1
     Name: Wolf Orb (Mage) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,2;
@@ -49551,6 +50465,7 @@ Body:
     AegisName: Wolf_Orb_Ran_2
     Name: Wolf Orb (Shooter) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,5;
@@ -49567,6 +50482,7 @@ Body:
     AegisName: Wolf_Orb_War_2
     Name: Wolf Orb (Warrior) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddClass,Class_All,4;
@@ -49584,6 +50500,7 @@ Body:
     AegisName: Wolf_Orb_Mag_2
     Name: Wolf Orb (Mage) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,4;
@@ -49601,6 +50518,7 @@ Body:
     AegisName: Wolf_Orb_Ran_3
     Name: Wolf Orb (Shooter) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,5;
@@ -49617,6 +50535,7 @@ Body:
     AegisName: Wolf_Orb_War_3
     Name: Wolf Orb (Warrior) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddClass,Class_All,6;
@@ -49634,6 +50553,7 @@ Body:
     AegisName: Wolf_Orb_Mag_3
     Name: Wolf Orb (Mage) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,6;
@@ -49651,6 +50571,7 @@ Body:
     AegisName: Wolf_Orb_R_Reject_1
     Name: Wolf Orb (Reflection Reject) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,2;
@@ -49667,6 +50588,7 @@ Body:
     AegisName: Wolf_Orb_R_Reject_2
     Name: Wolf Orb (Reflection Reject) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,3;
@@ -49683,6 +50605,7 @@ Body:
     AegisName: Wolf_Orb_R_Reject_3
     Name: Wolf Orb (Reflection Reject) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,4;
@@ -49699,6 +50622,7 @@ Body:
     AegisName: Wolf_Orb_Force
     Name: Wolf Orb (Power Force)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatkRate,2;
@@ -49719,6 +50643,7 @@ Body:
     AegisName: Wolf_Orb_S_Delay
     Name: Wolf Orb (Delay After Skill)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bDelayrate,-4;
@@ -49735,6 +50660,7 @@ Body:
     AegisName: Wolf_Orb_Skill_1
     Name: Wolf Orb (Dragonic Breath)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RK_DRAGONBREATH_WATER",15;
@@ -49755,6 +50681,7 @@ Body:
     AegisName: Wolf_Orb_Skill_2
     Name: Wolf Orb (Cutter Break)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RK_IGNITIONBREAK",15;
@@ -49775,6 +50702,7 @@ Body:
     AegisName: Wolf_Orb_Skill_3
     Name: Wolf Orb (Hundred Wave)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RK_HUNDREDSPEAR",15;
@@ -49795,6 +50723,7 @@ Body:
     AegisName: Wolf_Orb_Skill_4
     Name: Wolf Orb (Brand Drive)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_EARTHDRIVE",15;
@@ -49815,6 +50744,7 @@ Body:
     AegisName: Wolf_Orb_Skill_5
     Name: Wolf Orb (Vanishing Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_BANISHINGPOINT",15;
@@ -49835,6 +50765,7 @@ Body:
     AegisName: Wolf_Orb_Skill_6
     Name: Wolf Orb (Genesis Pressure)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"LG_RAYOFGENESIS",15;
@@ -49855,6 +50786,7 @@ Body:
     AegisName: Wolf_Orb_Skill_7
     Name: Wolf Orb (Boost Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_BOOSTKNUCKLE",15;
@@ -49875,6 +50807,7 @@ Body:
     AegisName: Wolf_Orb_Skill_8
     Name: Wolf Orb (Vulcan Boomerang)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_AXEBOOMERANG",15;
@@ -49895,6 +50828,7 @@ Body:
     AegisName: Wolf_Orb_Skill_9
     Name: Wolf Orb (Tornado Swing)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NC_AXETORNADO",15;
@@ -49915,6 +50849,7 @@ Body:
     AegisName: Wolf_Orb_Skill_10
     Name: Wolf Orb (Hell Tornado)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GN_CART_TORNADO",15;
@@ -49935,6 +50870,7 @@ Body:
     AegisName: Wolf_Orb_Skill_11
     Name: Wolf Orb (Crazy Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GN_CRAZYWEED",15;
@@ -49955,6 +50891,7 @@ Body:
     AegisName: Wolf_Orb_Skill_12
     Name: Wolf Orb (Acid Explosion)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"CR_ACIDDEMONSTRATION",15;
@@ -49975,6 +50912,7 @@ Body:
     AegisName: Wolf_Orb_Skill_13
     Name: Wolf Orb (Sonic Impact)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_CROSSIMPACT",15;
@@ -49995,6 +50933,7 @@ Body:
     AegisName: Wolf_Orb_Skill_14
     Name: Wolf Orb (Cutter Slasher)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_CROSSRIPPERSLASHER",15;
@@ -50015,6 +50954,7 @@ Body:
     AegisName: Wolf_Orb_Skill_15
     Name: Wolf Orb (Berserk Slash)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GC_COUNTERSLASH",15;
@@ -50035,6 +50975,7 @@ Body:
     AegisName: Wolf_Orb_Skill_16
     Name: Wolf Orb (Fatal Attack)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SC_FATALMENACE",15;
@@ -50055,6 +50996,7 @@ Body:
     AegisName: Wolf_Orb_Skill_17
     Name: Wolf Orb (Shadow Spell)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,15;
@@ -50071,6 +51013,7 @@ Body:
     AegisName: Wolf_Orb_Skill_18
     Name: Wolf Orb (Angle Shot)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,5;
@@ -50091,6 +51034,7 @@ Body:
     AegisName: Wolf_Orb_Skill_19
     Name: Wolf Orb (Crimson Strain)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_EARTHSTRAIN",15;
@@ -50111,6 +51055,7 @@ Body:
     AegisName: Wolf_Orb_Skill_20
     Name: Wolf Orb (Jack Lightning)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_CHAINLIGHTNING",15;
@@ -50131,6 +51076,7 @@ Body:
     AegisName: Wolf_Orb_Skill_21
     Name: Wolf Orb (Comet Vortex)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WL_TETRAVORTEX",15;
@@ -50151,6 +51097,7 @@ Body:
     AegisName: Wolf_Orb_Skill_22
     Name: Wolf Orb (Cloud Buster)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SO_POISON_BUSTER",15;
@@ -50171,6 +51118,7 @@ Body:
     AegisName: Wolf_Orb_Skill_23
     Name: Wolf Orb (Varetyr Wave)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SO_VARETYR_SPEAR",15;
@@ -50191,6 +51139,7 @@ Body:
     AegisName: Wolf_Orb_Skill_24
     Name: Wolf Orb (Diamond Grave)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SO_DIAMONDDUST",15;
@@ -50211,6 +51160,7 @@ Body:
     AegisName: Wolf_Orb_Skill_25
     Name: Wolf Orb (Magnusmus)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"PR_MAGNUS",15;
@@ -50231,6 +51181,7 @@ Body:
     AegisName: Wolf_Orb_Skill_26
     Name: Wolf Orb (Holy Judex)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_Holy,5;
@@ -50251,6 +51202,7 @@ Body:
     AegisName: Wolf_Orb_Skill_27
     Name: Wolf Orb (Melee Duple)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bShortAtkRate,5;
@@ -50271,6 +51223,7 @@ Body:
     AegisName: Wolf_Orb_Skill_28
     Name: Wolf Orb (Tiger Empire)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SR_FALLENEMPIRE",15;
@@ -50291,6 +51244,7 @@ Body:
     AegisName: Wolf_Orb_Skill_29
     Name: Wolf Orb (Rampage Lightning)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SR_RAMPAGEBLASTER",15;
@@ -50311,6 +51265,7 @@ Body:
     AegisName: Wolf_Orb_Skill_30
     Name: Wolf Orb (Hell Arrow)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SR_GATEOFHELL",15;
@@ -50331,6 +51286,7 @@ Body:
     AegisName: Wolf_Orb_Skill_31
     Name: Wolf Orb (Cluster)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RA_CLUSTERBOMB",15;
@@ -50347,6 +51303,7 @@ Body:
     AegisName: Wolf_Orb_Skill_32
     Name: Wolf Orb (Breeze Shooting)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritAtkRate,10;
@@ -50367,6 +51324,7 @@ Body:
     AegisName: Wolf_Orb_Skill_33
     Name: Wolf Orb (Aimed Storm)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RA_ARROWSTORM",15;
@@ -50387,6 +51345,7 @@ Body:
     AegisName: Wolf_Orb_Skill_34
     Name: Wolf Orb (Sound Metal)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_Neutral,5;
@@ -50407,6 +51366,7 @@ Body:
     AegisName: Wolf_Orb_Skill_35
     Name: Wolf Orb (Reverb)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,5;
@@ -50427,6 +51387,7 @@ Body:
     AegisName: Wolf_Orb_Skill_36
     Name: Wolf Orb (Vulcan Severe)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
@@ -50447,6 +51408,7 @@ Body:
     AegisName: Wolf_Orb_Skill_37
     Name: Wolf Orb (Prominence Burst)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_SOLARBURST",15;
@@ -50467,6 +51429,7 @@ Body:
     AegisName: Wolf_Orb_Skill_38
     Name: Wolf Orb (Moon Kick)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
@@ -50487,6 +51450,7 @@ Body:
     AegisName: Wolf_Orb_Skill_39
     Name: Wolf Orb (Flash Falling)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SJ_FALLINGSTAR_ATK",15;
@@ -50507,6 +51471,7 @@ Body:
     AegisName: Wolf_Orb_Skill_40
     Name: Wolf Orb (Eswhoo)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SL_SMA",15;
@@ -50527,6 +51492,7 @@ Body:
     AegisName: Wolf_Orb_Skill_41
     Name: Wolf Orb (Espa)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SP_SPA",15;
@@ -50543,6 +51509,7 @@ Body:
     AegisName: Wolf_Orb_Skill_42
     Name: Wolf Orb (Curse Explosion)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_Dark,5;
@@ -50563,6 +51530,7 @@ Body:
     AegisName: Wolf_Orb_Skill_43
     Name: Wolf Orb (Des Hammer Dance)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"GS_DESPERADO",15;
@@ -50587,6 +51555,7 @@ Body:
     AegisName: Wolf_Orb_Skill_44
     Name: Wolf Orb (Fire Howling Tail)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RL_FIRE_RAIN",15;
@@ -50611,6 +51580,7 @@ Body:
     AegisName: Wolf_Orb_Skill_45
     Name: Wolf Orb (Storm Buster Trip)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"RL_BANISHING_BUSTER",15;
@@ -50635,6 +51605,7 @@ Body:
     AegisName: Wolf_Orb_Skill_46
     Name: Wolf Orb (Flame Ice Wind)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NJ_KOUENKA",15;
@@ -50659,6 +51630,7 @@ Body:
     AegisName: Wolf_Orb_Skill_47
     Name: Wolf Orb (Cross Petal)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"KO_HUUMARANKA",15;
@@ -50679,6 +51651,7 @@ Body:
     AegisName: Wolf_Orb_Skill_48
     Name: Wolf Orb (Exploding Flake Wind)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"NJ_BAKUENRYU",15;
@@ -50703,6 +51676,7 @@ Body:
     AegisName: Wolf_Orb_Skill_49
     Name: Wolf Orb (Power of Sea)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillCooldown,"SU_SHRIMPARTY",-1000;
@@ -50723,6 +51697,7 @@ Body:
     AegisName: Wolf_Orb_Skill_50
     Name: Wolf Orb (Power of Land)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SU_SV_STEMSPEAR",15;
@@ -50743,6 +51718,7 @@ Body:
     AegisName: Wolf_Orb_Skill_51
     Name: Wolf Orb (Power of Life)
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",15;
@@ -50763,6 +51739,7 @@ Body:
     AegisName: Wolf_Orb_Speed_1
     Name: Wolf Orb (Speed) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bFlee,10;
@@ -50779,6 +51756,7 @@ Body:
     AegisName: Wolf_Orb_Caster_1
     Name: Wolf Orb (Caster) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVariableCastrate,-6;
@@ -50795,6 +51773,7 @@ Body:
     AegisName: Wolf_Orb_Critical_1
     Name: Wolf Orb (Critical) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritical,10;
@@ -50811,6 +51790,7 @@ Body:
     AegisName: Wolf_Orb_Guide_1
     Name: Wolf Orb (Guide Attack) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHit,20;
@@ -50827,6 +51807,7 @@ Body:
     AegisName: Wolf_Orb_Speed_2
     Name: Wolf Orb (Speed) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bFlee,20;
@@ -50843,6 +51824,7 @@ Body:
     AegisName: Wolf_Orb_Caster_2
     Name: Wolf Orb (Caster) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVariableCastrate,-8;
@@ -50859,6 +51841,7 @@ Body:
     AegisName: Wolf_Orb_Critical_2
     Name: Wolf Orb (Critical) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritical,10;
@@ -50875,6 +51858,7 @@ Body:
     AegisName: Wolf_Orb_Guide_2
     Name: Wolf Orb (Guide Attack) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHit,20;
@@ -50891,6 +51875,7 @@ Body:
     AegisName: Wolf_Orb_Speed_3
     Name: Wolf Orb (Speed) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bFlee,30;
@@ -50907,6 +51892,7 @@ Body:
     AegisName: Wolf_Orb_Caster_3
     Name: Wolf Orb (Caster) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bVariableCastrate,-8;
@@ -50924,6 +51910,7 @@ Body:
     AegisName: Wolf_Orb_Critical_3
     Name: Wolf Orb (Critical) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritical,15;
@@ -50940,6 +51927,7 @@ Body:
     AegisName: Wolf_Orb_Guide_3
     Name: Wolf Orb (Guide Attack) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHit,30;
@@ -50956,6 +51944,7 @@ Body:
     AegisName: Wolf_Orb_Above_1
     Name: Wolf Orb (Above All) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSubClass,Class_Normal,3;
@@ -50976,6 +51965,7 @@ Body:
     AegisName: Wolf_Orb_Above_2
     Name: Wolf Orb (Above All) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSubClass,Class_Normal,5;
@@ -50996,6 +51986,7 @@ Body:
     AegisName: Wolf_Orb_Above_3
     Name: Wolf Orb (Above All) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bSubClass,Class_Normal,7;
@@ -51016,6 +52007,7 @@ Body:
     AegisName: Wolf_Orb_P_Full_1
     Name: Wolf Orb (Powerful) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,2;
@@ -51040,6 +52032,7 @@ Body:
     AegisName: Wolf_Orb_P_Full_2
     Name: Wolf Orb (Powerful) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,2;
@@ -51064,6 +52057,7 @@ Body:
     AegisName: Wolf_Orb_P_Full_3
     Name: Wolf Orb (Powerful) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAtkEle,Ele_All,3;
@@ -51088,6 +52082,7 @@ Body:
     AegisName: Wolf_Orb_M_Counter_1
     Name: Wolf Orb (Mirror Counter) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,2;
@@ -51104,6 +52099,7 @@ Body:
     AegisName: Wolf_Orb_M_Counter_2
     Name: Wolf Orb (Mirror Counter) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,3;
@@ -51120,6 +52116,7 @@ Body:
     AegisName: Wolf_Orb_M_Counter_3
     Name: Wolf Orb (Mirror Counter) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bReduceDamageReturn,4;
@@ -51136,6 +52133,7 @@ Body:
     AegisName: Wolf_Orb_Hp_1
     Name: Wolf Orb (Vital) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51153,6 +52151,7 @@ Body:
     AegisName: Wolf_Orb_Sp_1
     Name: Wolf Orb (Mental) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -51170,6 +52169,7 @@ Body:
     AegisName: Wolf_Orb_Heal_1
     Name: Wolf Orb (Heal) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,3;
@@ -51186,6 +52186,7 @@ Body:
     AegisName: Wolf_Orb_Hp_2
     Name: Wolf Orb (Vital) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51203,6 +52204,7 @@ Body:
     AegisName: Wolf_Orb_Sp_2
     Name: Wolf Orb (Mental) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -51220,6 +52222,7 @@ Body:
     AegisName: Wolf_Orb_Heal_2
     Name: Wolf Orb (Heal) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,5;
@@ -51236,6 +52239,7 @@ Body:
     AegisName: Wolf_Orb_Hp_3
     Name: Wolf Orb (Vital) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51253,6 +52257,7 @@ Body:
     AegisName: Wolf_Orb_Sp_3
     Name: Wolf Orb (Mental) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -51270,6 +52275,7 @@ Body:
     AegisName: Wolf_Orb_Heal_3
     Name: Wolf Orb (Heal) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bHealPower,5;
@@ -51286,6 +52292,7 @@ Body:
     AegisName: Wolf_Orb_Robust_1
     Name: Wolf Orb (Robust) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51308,6 +52315,7 @@ Body:
     AegisName: Wolf_Orb_Robust_2
     Name: Wolf Orb (Robust) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51330,6 +52338,7 @@ Body:
     AegisName: Wolf_Orb_Robust_3
     Name: Wolf Orb (Robust) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -51352,24 +52361,28 @@ Body:
     AegisName: Wolf_Orb_F_Cast_1
     Name: Wolf Orb (Fixed Casting) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-500;
   - Id: 310601
     AegisName: Wolf_Orb_F_Cast_2
     Name: Wolf Orb (Fixed Casting) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-700;
   - Id: 310602
     AegisName: Wolf_Orb_F_Cast_3
     Name: Wolf Orb (Fixed Casting) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-1000;
   - Id: 310603
     AegisName: Wolf_Orb_M_F_1
     Name: Wolf Orb (Magical Force) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAddSize,Size_All,2;
@@ -51386,6 +52399,7 @@ Body:
     AegisName: Wolf_Orb_P_F_1
     Name: Wolf Orb (Physical Force) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,2;
@@ -51402,6 +52416,7 @@ Body:
     AegisName: Wolf_Orb_M_F_2
     Name: Wolf Orb (Magical Force) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAddSize,Size_All,3;
@@ -51418,6 +52433,7 @@ Body:
     AegisName: Wolf_Orb_P_F_2
     Name: Wolf Orb (Physical Force) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,3;
@@ -51434,6 +52450,7 @@ Body:
     AegisName: Wolf_Orb_M_F_3
     Name: Wolf Orb (Magical Force) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bMagicAddSize,Size_All,4;
@@ -51450,6 +52467,7 @@ Body:
     AegisName: Wolf_Orb_P_F_3
     Name: Wolf Orb (Physical Force) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus2 bAddSize,Size_All,4;
@@ -51466,42 +52484,49 @@ Body:
     AegisName: Wolf_Orb_Un_Vit
     Name: Wolf Orb (Unlimited Vital)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bAddClass,Class_All,25; bonus bVit,50; }",30,10000,BF_WEAPON;
   - Id: 310610
     AegisName: Wolf_Orb_Sp_Int
     Name: Wolf Orb (Spell Buster)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bMatkRate,25; bonus bInt,50; }",30,10000,BF_MAGIC;
   - Id: 310611
     AegisName: Wolf_Orb_Fi_Dex
     Name: Wolf Orb (Firing Shot)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bLongAtkRate,15; bonus bDex,50; }",30,10000,BF_WEAPON;
   - Id: 310612
     AegisName: Wolf_Orb_Ov_Str
     Name: Wolf Orb (Overpower)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bShortAtkRate,15; bonus bStr,50; }",30,10000,BF_WEAPON;
   - Id: 310613
     AegisName: Wolf_Orb_Fa_Agi
     Name: Wolf Orb (Fatal Flash)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bCritAtkRate,25; bonus bAgi,50; }",30,10000,BF_WEAPON;
   - Id: 310614
     AegisName: Wolf_Orb_Lu_Luk
     Name: Wolf Orb (Lucky Strike)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bMagicAtkEle,Ele_All,15; bonus bLuk,50; }",30,10000,BF_MAGIC;
   - Id: 310615
     AegisName: Wolf_Orb_A_Delay_1
     Name: Wolf Orb (Delay After Attack) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,4;
       bonus bBaseAtk,18;
@@ -51509,6 +52534,7 @@ Body:
     AegisName: Wolf_Orb_E_Archer_1
     Name: Wolf Orb (Expert Archer) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,4;
       bonus bHit,8;
@@ -51516,6 +52542,7 @@ Body:
     AegisName: Wolf_Orb_Fatal_1
     Name: Wolf Orb (Fatal) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,6;
       bonus bCritical,6;
@@ -51523,6 +52550,7 @@ Body:
     AegisName: Wolf_Orb_F_Spirit_1
     Name: Wolf Orb (Fighting Spirit) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,4;
       bonus bPerfectHitRate,2;
@@ -51530,6 +52558,7 @@ Body:
     AegisName: Wolf_Orb_Spell_1
     Name: Wolf Orb (Spell) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-4;
       bonus bMatk,18;
@@ -51537,6 +52566,7 @@ Body:
     AegisName: Wolf_Orb_A_Delay_2
     Name: Wolf Orb (Delay After Attack) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,6;
       bonus bBaseAtk,22;
@@ -51544,6 +52574,7 @@ Body:
     AegisName: Wolf_Orb_E_Archer_2
     Name: Wolf Orb (Expert Archer) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,6;
       bonus bHit,12;
@@ -51551,6 +52582,7 @@ Body:
     AegisName: Wolf_Orb_Fatal_2
     Name: Wolf Orb (Fatal) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,8;
       bonus bCritical,9;
@@ -51558,6 +52590,7 @@ Body:
     AegisName: Wolf_Orb_F_Spirit_2
     Name: Wolf Orb (Fighting Spirit) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,6;
       bonus bPerfectHitRate,3;
@@ -51565,6 +52598,7 @@ Body:
     AegisName: Wolf_Orb_Spell_2
     Name: Wolf Orb (Spell) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-6;
       bonus bMatk,22;
@@ -51572,6 +52606,7 @@ Body:
     AegisName: Wolf_Orb_A_Delay_3
     Name: Wolf Orb (Delay After Attack) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,8;
       bonus bBaseAtk,26;
@@ -51579,6 +52614,7 @@ Body:
     AegisName: Wolf_Orb_E_Archer_3
     Name: Wolf Orb (Expert Archer) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,8;
       bonus bHit,16;
@@ -51586,6 +52622,7 @@ Body:
     AegisName: Wolf_Orb_Fatal_3
     Name: Wolf Orb (Fatal) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,10;
       bonus bCritical,12;
@@ -51593,6 +52630,7 @@ Body:
     AegisName: Wolf_Orb_F_Spirit_3
     Name: Wolf Orb (Fighting Spirit) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,8;
       bonus bPerfectHitRate,4;
@@ -51600,6 +52638,7 @@ Body:
     AegisName: Wolf_Orb_Spell_3
     Name: Wolf Orb (Spell) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-8;
       bonus bMatk,26;
@@ -51607,6 +52646,7 @@ Body:
     AegisName: Wolf_Orb_A_Delay_4
     Name: Wolf Orb (Delay After Attack) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,10;
       bonus bBaseAtk,30;
@@ -51614,6 +52654,7 @@ Body:
     AegisName: Wolf_Orb_E_Archer_4
     Name: Wolf Orb (Expert Archer) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,10;
       bonus bHit,20;
@@ -51621,6 +52662,7 @@ Body:
     AegisName: Wolf_Orb_Fatal_4
     Name: Wolf Orb (Fatal) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,12;
       bonus bCritical,15;
@@ -51628,6 +52670,7 @@ Body:
     AegisName: Wolf_Orb_F_Spirit_4
     Name: Wolf Orb (Fighting Spirit) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,10;
       bonus bPerfectHitRate,5;
@@ -51635,6 +52678,7 @@ Body:
     AegisName: Wolf_Orb_Spell_4
     Name: Wolf Orb (Spell) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       bonus bMatk,30;
@@ -51642,78 +52686,91 @@ Body:
     AegisName: Wolf_Orb_HealHP_1
     Name: Wolf Orb (HP Recovery) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,20;
   - Id: 310636
     AegisName: Wolf_Orb_HealSP_1
     Name: Wolf Orb (SP Recovery) Level 1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,20;
   - Id: 310637
     AegisName: Wolf_Orb_HealHP_2
     Name: Wolf Orb (HP Recovery) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,30;
   - Id: 310638
     AegisName: Wolf_Orb_HealSP_2
     Name: Wolf Orb (SP Recovery) Level 2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,30;
   - Id: 310639
     AegisName: Wolf_Orb_HealHP_3
     Name: Wolf Orb (HP Recovery) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,40;
   - Id: 310640
     AegisName: Wolf_Orb_HealSP_3
     Name: Wolf Orb (SP Recovery) Level 3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,40;
   - Id: 310641
     AegisName: Wolf_Orb_HealHP_4
     Name: Wolf Orb (HP Recovery) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHPrecovRate,50;
   - Id: 310642
     AegisName: Wolf_Orb_HealSP_4
     Name: Wolf Orb (SP Recovery) Level 4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSPrecovRate,50;
   - Id: 310643
     AegisName: Wolf_Orb_Life
     Name: Wolf Orb (Drain Life)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,40,2;
   - Id: 310644
     AegisName: Wolf_Orb_Soul
     Name: Wolf Orb (Drain Soul)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,3;
   - Id: 310645
     AegisName: Wolf_Orb_M_Heal
     Name: Wolf Orb (Magic Healing)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bHPRegenRate,700,500; }",40,19000,BF_MAGIC;
   - Id: 310646
     AegisName: Wolf_Orb_M_Soul
     Name: Wolf Orb (Magic Soul)
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus2 bSPRegenRate,100,500; }",20,19000,BF_MAGIC;
   - Id: 310647
     AegisName: Wolf_Orb_A_Force
     Name: Wolf Orb (All Force)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,7;
       bonus bLongAtkRate,7;
@@ -51722,6 +52779,7 @@ Body:
     AegisName: aegis_310655
     Name: The Creation
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddSize,Size_All,15;
       bonus2 bMagicAddSize,Size_All,15;
@@ -51729,96 +52787,114 @@ Body:
     AegisName: aegis_310654
     Name: ASPD+1(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspd,1;
   - Id: 310658
     AegisName: aegis_310658
     Name: Minor Casting Reduction(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100;
   - Id: 310659
     AegisName: aegis_310659
     Name: Variable Casting Time Reduction(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-5;
   - Id: 310660
     AegisName: aegis_310660
     Name: Ranged Stone(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,4;
   - Id: 310661
     AegisName: aegis_310661
     Name: Melee Stone(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,4;
   - Id: 310662
     AegisName: aegis_310662
     Name: HP Absorbtion(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bHPDrainRate,10,1;
   - Id: 310663
     AegisName: aegis_310663
     Name: SP Absorbtion(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSPDrainRate,10,1;
   - Id: 310664
     AegisName: aegis_310664
     Name: Magic Power Stone(Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,3;
   - Id: 310665
     AegisName: aegis_310665
     Name: Magic Power Stone(Mid)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,3;
   - Id: 310666
     AegisName: aegis_310666
     Name: Magic Power Stone(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,3;
   - Id: 310667
     AegisName: aegis_310667
     Name: Magic Power Stone(Dual)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,4;
   - Id: 310668
     AegisName: Spring_Energy_1
     Name: Spring Energy(1Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310669
     AegisName: Spring_Energy_2
     Name: Spring Energy(2Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310670
     AegisName: Spring_Energy_3
     Name: Spring Energy(3Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310671
     AegisName: Spring_Warmth_1
     Name: Warmth of Spring(1Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310672
     AegisName: Spring_Warmth_2
     Name: Warmth of Spring(2Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310673
     AegisName: Spring_Warmth_3
     Name: Warmth of Spring(3Lv)
     Type: Card
+    SubType: Enchant
   - Id: 310674
     AegisName: Star_Cluster_Of_Pow1
     Name: Star Cluster of Power Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/15);
       .@g = getenchantgrade();
@@ -51844,6 +52920,7 @@ Body:
     AegisName: Star_Cluster_Of_Pow2
     Name: Star Cluster of Power Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/15);
       .@g = getenchantgrade();
@@ -51869,6 +52946,7 @@ Body:
     AegisName: Star_Cluster_Of_Pow3
     Name: Star Cluster of Power Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/15);
       .@g = getenchantgrade();
@@ -51894,6 +52972,7 @@ Body:
     AegisName: Star_Cluster_Of_Sta1
     Name: Star Cluster of Stamina Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/15);
       .@g = getenchantgrade();
@@ -51919,6 +52998,7 @@ Body:
     AegisName: Star_Cluster_Of_Sta2
     Name: Star Cluster of Stamina Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/15);
       .@g = getenchantgrade();
@@ -51944,6 +53024,7 @@ Body:
     AegisName: Star_Cluster_Of_Sta3
     Name: Star Cluster of Stamina Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/15);
       .@g = getenchantgrade();
@@ -51969,6 +53050,7 @@ Body:
     AegisName: Star_Cluster_Of_Con1
     Name: Star Cluster of Concentration Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/15);
       .@g = getenchantgrade();
@@ -51994,6 +53076,7 @@ Body:
     AegisName: Star_Cluster_Of_Con2
     Name: Star Cluster of Concentration Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/15);
       .@g = getenchantgrade();
@@ -52019,6 +53102,7 @@ Body:
     AegisName: Star_Cluster_Of_Con3
     Name: Star Cluster of Concentration Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/15);
       .@g = getenchantgrade();
@@ -52044,6 +53128,7 @@ Body:
     AegisName: Star_Cluster_Of_Crt1
     Name: Star Cluster of Creative Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/15);
       .@g = getenchantgrade();
@@ -52069,6 +53154,7 @@ Body:
     AegisName: Star_Cluster_Of_Crt2
     Name: Star Cluster of Creative Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/15);
       .@g = getenchantgrade();
@@ -52094,6 +53180,7 @@ Body:
     AegisName: Star_Cluster_Of_Crt3
     Name: Star Cluster of Creative Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/15);
       .@g = getenchantgrade();
@@ -52119,6 +53206,7 @@ Body:
     AegisName: Star_Cluster_Of_Spl1
     Name: Star Cluster of Spell Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/15);
       .@g = getenchantgrade();
@@ -52144,6 +53232,7 @@ Body:
     AegisName: Star_Cluster_Of_Spl2
     Name: Star Cluster of Spell Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/15);
       .@g = getenchantgrade();
@@ -52169,6 +53258,7 @@ Body:
     AegisName: Star_Cluster_Of_Spl3
     Name: Star Cluster of Spell Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/15);
       .@g = getenchantgrade();
@@ -52194,6 +53284,7 @@ Body:
     AegisName: Star_Cluster_Of_Wis1
     Name: Star Cluster of Wisdom Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/15);
       .@g = getenchantgrade();
@@ -52221,6 +53312,7 @@ Body:
     AegisName: Star_Cluster_Of_Wis2
     Name: Star Cluster of Wisdom Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/15);
       .@g = getenchantgrade();
@@ -52248,6 +53340,7 @@ Body:
     AegisName: Star_Cluster_Of_Wis3
     Name: Star Cluster of Wisdom Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/15);
       .@g = getenchantgrade();
@@ -52275,6 +53368,7 @@ Body:
     AegisName: Star_Of_Mettle1
     Name: Star of Mettle Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,3;
       bonus bHit,10;
@@ -52282,6 +53376,7 @@ Body:
     AegisName: Star_Of_Mettle2
     Name: Star of Mettle Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,5;
       bonus bHit,15;
@@ -52289,6 +53384,7 @@ Body:
     AegisName: Star_Of_Mettle3
     Name: Star of Mettle Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,7;
       bonus bHit,20;
@@ -52297,6 +53393,7 @@ Body:
     AegisName: Star_Of_Mettle4
     Name: Star of Mettle Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,10;
       bonus bHit,25;
@@ -52305,6 +53402,7 @@ Body:
     AegisName: Star_Of_Mettle5
     Name: Star of Mettle Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,15;
       bonus bHit,30;
@@ -52313,6 +53411,7 @@ Body:
     AegisName: Star_Of_MasterArcher1
     Name: Star of Master Archer Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,2;
       bonus2 bAddClass,Class_All,2;
@@ -52320,6 +53419,7 @@ Body:
     AegisName: Star_Of_MasterArcher2
     Name: Star of Master Archer Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
       bonus2 bAddClass,Class_All,3;
@@ -52327,6 +53427,7 @@ Body:
     AegisName: Star_Of_MasterArcher3
     Name: Star of Master Archer Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,5;
       bonus2 bAddClass,Class_All,5;
@@ -52335,6 +53436,7 @@ Body:
     AegisName: Star_Of_MasterArcher4
     Name: Star of Master Archer Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,7;
       bonus2 bAddClass,Class_All,6;
@@ -52343,6 +53445,7 @@ Body:
     AegisName: Star_Of_MasterArcher5
     Name: Star of Master Archer Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,10;
       bonus2 bAddClass,Class_All,7;
@@ -52351,6 +53454,7 @@ Body:
     AegisName: Star_Of_Sharp1
     Name: Star of Sharp Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,2;
       bonus bCritical,2;
@@ -52358,6 +53462,7 @@ Body:
     AegisName: Star_Of_Sharp2
     Name: Star of Sharp Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,3;
       bonus bCritical,3;
@@ -52365,6 +53470,7 @@ Body:
     AegisName: Star_Of_Sharp3
     Name: Star of Sharp Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,5;
       bonus bCritical,5;
@@ -52373,6 +53479,7 @@ Body:
     AegisName: Star_Of_Sharp4
     Name: Star of Sharp Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,10;
       bonus bCritical,6;
@@ -52381,6 +53488,7 @@ Body:
     AegisName: Star_Of_Sharp5
     Name: Star of Sharp Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,15;
       bonus bCritical,8;
@@ -52390,6 +53498,7 @@ Body:
     AegisName: Star_Of_Spell1
     Name: Star of Spell Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-5;
       bonus bMatk,5;
@@ -52397,6 +53506,7 @@ Body:
     AegisName: Star_Of_Spell2
     Name: Star of Spell Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-5;
       bonus bMatk,7;
@@ -52404,6 +53514,7 @@ Body:
     AegisName: Star_Of_Spell3
     Name: Star of Spell Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatk,11;
@@ -52412,6 +53523,7 @@ Body:
     AegisName: Star_Of_Spell4
     Name: Star of Spell Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       bonus bMatk,17;
@@ -52420,6 +53532,7 @@ Body:
     AegisName: Star_Of_Spell5
     Name: Star of Spell Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-15;
       bonus bMatk,25;
@@ -52428,6 +53541,7 @@ Body:
     AegisName: Star_Of_Speed1
     Name: Star of Speed Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,5;
       bonus bAspdRate,5;
@@ -52435,6 +53549,7 @@ Body:
     AegisName: Star_Of_Speed2
     Name: Star of Speed Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,10;
       bonus bAspdRate,7;
@@ -52442,6 +53557,7 @@ Body:
     AegisName: Star_Of_Speed3
     Name: Star of Speed Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,15;
       bonus bAspdRate,7;
@@ -52449,6 +53565,7 @@ Body:
     AegisName: Star_Of_Speed4
     Name: Star of Speed Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,20;
       bonus bAspdRate,10;
@@ -52457,6 +53574,7 @@ Body:
     AegisName: Star_Of_Speed5
     Name: Star of Speed Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFlee,30;
       bonus bAspdRate,15;
@@ -52465,6 +53583,7 @@ Body:
     AegisName: Star_Of_Vital1
     Name: Star of Vital Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,2;
       bonus bRes,1;
@@ -52473,6 +53592,7 @@ Body:
     AegisName: Star_Of_Vital2
     Name: Star of Vital Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,3;
       bonus bRes,2;
@@ -52481,6 +53601,7 @@ Body:
     AegisName: Star_Of_Vital3
     Name: Star of Vital Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
       bonus bRes,4;
@@ -52489,6 +53610,7 @@ Body:
     AegisName: Star_Of_Vital4
     Name: Star of Vital Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,7;
       bonus bRes,6;
@@ -52497,6 +53619,7 @@ Body:
     AegisName: Star_Of_Vital5
     Name: Star of Vital Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,10;
       bonus bRes,10;
@@ -52505,6 +53628,7 @@ Body:
     AegisName: Star_Of_Spirit1
     Name: Star of Spirit Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,5;
       bonus bMaxSPrate,3;
@@ -52513,6 +53637,7 @@ Body:
     AegisName: Star_Of_Spirit2
     Name: Star of Spirit Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,7;
       bonus bMaxSPrate,5;
@@ -52521,6 +53646,7 @@ Body:
     AegisName: Star_Of_Spirit3
     Name: Star of Spirit Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,10;
       bonus bMaxSPrate,5;
@@ -52530,6 +53656,7 @@ Body:
     AegisName: Star_Of_Spirit4
     Name: Star of Spirit Lv4
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,10;
       bonus bMaxSPrate,7;
@@ -52539,6 +53666,7 @@ Body:
     AegisName: Star_Of_Spirit5
     Name: Star of Spirit Lv5
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHealPower,15;
       bonus bMaxSPrate,10;
@@ -52548,6 +53676,7 @@ Body:
     AegisName: Nebula_Of_FS1
     Name: Nebula of Fighting Spirit Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bBaseAtk,10;
@@ -52561,6 +53690,7 @@ Body:
     AegisName: Nebula_Of_FS2
     Name: Nebula of Fighting Spirit Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bBaseAtk,15;
@@ -52574,6 +53704,7 @@ Body:
     AegisName: Nebula_Of_FS3
     Name: Nebula of Fighting Spirit Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bBaseAtk,20;
@@ -52587,6 +53718,7 @@ Body:
     AegisName: Nebula_Of_EA1
     Name: Nebula of Expert Archer Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,3;
@@ -52600,6 +53732,7 @@ Body:
     AegisName: Nebula_Of_EA2
     Name: Nebula of Expert Archer Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,5;
@@ -52613,6 +53746,7 @@ Body:
     AegisName: Nebula_Of_EA3
     Name: Nebula of Expert Archer Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,7;
@@ -52626,6 +53760,7 @@ Body:
     AegisName: Nebula_Of_SH1
     Name: Nebula of Sharp Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritAtkRate,5;
@@ -52639,6 +53774,7 @@ Body:
     AegisName: Nebula_Of_SH2
     Name: Nebula of Sharp Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritAtkRate,7;
@@ -52652,6 +53788,7 @@ Body:
     AegisName: Nebula_Of_SH3
     Name: Nebula of Sharp Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bCritAtkRate,10;
@@ -52665,6 +53802,7 @@ Body:
     AegisName: Nebula_Of_SP1
     Name: Nebula of Spell Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatk,10;
@@ -52678,6 +53816,7 @@ Body:
     AegisName: Nebula_Of_SP2
     Name: Nebula of Spell Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatk,15;
@@ -52691,6 +53830,7 @@ Body:
     AegisName: Nebula_Of_SP3
     Name: Nebula of Spell Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMatk,20;
@@ -52704,6 +53844,7 @@ Body:
     AegisName: Nebula_Of_HL1
     Name: Nebula of Healing Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,3;
@@ -52720,6 +53861,7 @@ Body:
     AegisName: Nebula_Of_HL2
     Name: Nebula of Healing Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -52736,6 +53878,7 @@ Body:
     AegisName: Nebula_Of_HL3
     Name: Nebula of Healing Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxSPrate,5;
@@ -52752,6 +53895,7 @@ Body:
     AegisName: Nebula_Of_HP1
     Name: Nebula of Health Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,3;
@@ -52768,6 +53912,7 @@ Body:
     AegisName: Nebula_Of_HP2
     Name: Nebula of Health Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,5;
@@ -52784,6 +53929,7 @@ Body:
     AegisName: Nebula_Of_HP3
     Name: Nebula of Health Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@r = getrefine();
       bonus bMaxHPrate,7;
@@ -52800,60 +53946,72 @@ Body:
     AegisName: Summer_Hot_Lv1
     Name: Summer Heat(Lv1)
     Type: Card
+    SubType: Enchant
   - Id: 310845
     AegisName: Summer_Hot_Lv2
     Name: Summer Heat(Lv2)
     Type: Card
+    SubType: Enchant
   - Id: 310846
     AegisName: Summer_Hot_Lv3
     Name: Summer Heat(Lv3)
     Type: Card
+    SubType: Enchant
   - Id: 310847
     AegisName: Summer_Cool_Lv1
     Name: Summer Coolness(Lv1)
     Type: Card
+    SubType: Enchant
   - Id: 310848
     AegisName: Summer_Cool_Lv2
     Name: Summer Coolness(Lv2)
     Type: Card
+    SubType: Enchant
   - Id: 310849
     AegisName: Summer_Cool_Lv3
     Name: Summer Coolness(Lv3)
     Type: Card
+    SubType: Enchant
   - Id: 310851
     AegisName: Mad_Bunny_Enchant_1_1
     Name: Delay after skill 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-1;
   - Id: 310852
     AegisName: Mad_Bunny_Enchant_1_2
     Name: Delay after skill 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-3;
   - Id: 310853
     AegisName: Mad_Bunny_Enchant_1_3
     Name: Delay after skill 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-5;
   - Id: 310854
     AegisName: Mad_Bunny_Enchant_2_1
     Name: Attack speed 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,5;
   - Id: 310855
     AegisName: Mad_Bunny_Enchant_2_2
     Name: Attack speed 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,7;
   - Id: 310856
     AegisName: Mad_Bunny_Enchant_2_3
     Name: Attack speed 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,10;
       bonus bAspd,1;
@@ -52861,6 +54019,7 @@ Body:
     AegisName: Mad_Bunny_Enchant_3_1
     Name: Variable casting (physical) 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-5;
       bonus bBaseAtk,3;
@@ -52868,6 +54027,7 @@ Body:
     AegisName: Mad_Bunny_Enchant_3_2
     Name: Variable casting (physical) 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-7;
       bonus bBaseAtk,5;
@@ -52875,6 +54035,7 @@ Body:
     AegisName: Mad_Bunny_Enchant_3_3
     Name: Variable casting (physical) 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       bonus bPAtk,1;
@@ -52882,6 +54043,7 @@ Body:
     AegisName: Mad_Bunny_Enchant_3_4
     Name: Variable casting (magical) 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-10;
       bonus bSmatk,1;
@@ -52889,18 +54051,21 @@ Body:
     AegisName: Mad_Bunny_Enchant_4_1
     Name: Defense 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDef,100;
   - Id: 310862
     AegisName: Mad_Bunny_Enchant_4_2
     Name: Defense 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDef,150;
   - Id: 310863
     AegisName: Mad_Bunny_Enchant_4_3
     Name: Defense 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSubEle,Ele_All,5;
       bonus bDef,200;
@@ -52908,96 +54073,112 @@ Body:
     AegisName: Mad_Bunny_Enchant_5_1
     Name: Physical 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,1;
   - Id: 310865
     AegisName: Mad_Bunny_Enchant_5_2
     Name: Physical 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,3;
   - Id: 310866
     AegisName: Mad_Bunny_Enchant_5_3
     Name: Physical 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bShortAtkRate,5;
   - Id: 310867
     AegisName: Mad_Bunny_Enchant_6_1
     Name: Long ranged 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,1;
   - Id: 310868
     AegisName: Mad_Bunny_Enchant_6_2
     Name: Long ranged 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
   - Id: 310869
     AegisName: Mad_Bunny_Enchant_6_3
     Name: Long ranged 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,5;
   - Id: 310870
     AegisName: Mad_Bunny_Enchant_7_1
     Name: Magical 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,1;
   - Id: 310871
     AegisName: Mad_Bunny_Enchant_7_2
     Name: Magical 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,3;
   - Id: 310872
     AegisName: Mad_Bunny_Enchant_7_3
     Name: Magical 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,5;
   - Id: 310873
     AegisName: Mad_Bunny_Enchant_8_1
     Name: Vital 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,3;
   - Id: 310874
     AegisName: Mad_Bunny_Enchant_8_2
     Name: Vital 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
   - Id: 310875
     AegisName: Mad_Bunny_Enchant_8_3
     Name: Vital 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,7;
   - Id: 310876
     AegisName: Mad_Bunny_Enchant_9_1
     Name: Mental 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,3;
   - Id: 310877
     AegisName: Mad_Bunny_Enchant_9_2
     Name: Mental 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,5;
   - Id: 310878
     AegisName: Mad_Bunny_Enchant_9_3
     Name: Mental 3Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,7;
   - Id: 310879
     AegisName: Mad_Bunny_Enchant_3_5
     Name: Variable casting (magical) 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatk,5;
@@ -53005,6 +54186,7 @@ Body:
     AegisName: Mad_Bunny_Enchant_3_6
     Name: Variable casting (magical) 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-5;
       bonus bMatk,3;
@@ -53012,12 +54194,14 @@ Body:
     AegisName: aegis_310881
     Name: Rune Knight Stone(Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,2*getskilllv("RK_DRAGONTRAINING");
   - Id: 310882
     AegisName: aegis_310882
     Name: Rune Knight Stone(Mid)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,(getskilllv("RK_RUNEMASTERY")/2);
       bonus bShortAtkRate,(getskilllv("RK_RUNEMASTERY")/2);
@@ -53025,36 +54209,42 @@ Body:
     AegisName: aegis_310883
     Name: Rune Knight Stone(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RK_WINDCUTTER",5*getskilllv("RK_ENCHANTBLADE");
   - Id: 310884
     AegisName: aegis_310884
     Name: Warlock Stone(Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,2*getskilllv("WL_SOULEXPANSION");
   - Id: 310885
     AegisName: aegis_310885
     Name: Warlock Stone(Mid)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100*getskilllv("WL_COMET");
   - Id: 310886
     AegisName: aegis_310886
     Name: Warlock Stone(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-getskilllv("WL_CHAINLIGHTNING");
   - Id: 310887
     AegisName: aegis_310887
     Name: Royal Guard Stone(Upper)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100*getskilllv("LG_INSPIRATION");
   - Id: 310888
     AegisName: aegis_310888
     Name: Royal Guard Stone(Mid)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,2*getskilllv("LG_PIETY");
       bonus2 bMagicAtkEle,Ele_All,2*getskilllv("LG_PIETY");
@@ -53062,84 +54252,98 @@ Body:
     AegisName: aegis_310889
     Name: Royal Guard Stone(Lower)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"LG_OVERBRAND",5*getskilllv("LG_MOONSLASHER");
   - Id: 310908
     AegisName: HeroBoots_STR
     Name: Valor of Fighter
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bStr,100; bonus bShortAtkRate,10; }",5,10000,BF_WEAPON;
   - Id: 310909
     AegisName: HeroBoots_LUK
     Name: Sharpness of Swordsman
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bLuk,100; bonus bCritAtkRate,20; }",5,10000,BF_WEAPON;
   - Id: 310910
     AegisName: HeroBoots_DEX
     Name: Will of Sharpshooter
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bDex,100; bonus bLongAtkRate,10; }",5,10000,BF_WEAPON;
   - Id: 310911
     AegisName: HeroBoots_INT
     Name: Knowledge of Wise Man
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bInt,100; bonus2 bMagicAtkEle,Ele_All,10; }",5,10000,BF_MAGIC;
   - Id: 310912
     AegisName: HeroBoots_VIT
     Name: Vigor of Warlord
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus2 "{ bonus bVit,100; bonus bMaxSPrate,10; }",5,10000,BF_WEAPON|BF_MAGIC;
   - Id: 310913
     AegisName: HeroBoots_AGI
     Name: Nimbleness of Assassin
     Type: Card
+    SubType: Enchant
     Script: |
       autobonus "{ bonus bAgi,100; bonus2 bAddClass,Class_All,10; }",5,10000,BF_WEAPON;
   - Id: 310914
     AegisName: HeroInsignia_STR
     Name: Strength
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,10;
   - Id: 310915
     AegisName: HeroInsignia_LUK
     Name: Luck
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCritAtkRate,7;
   - Id: 310916
     AegisName: HeroInsignia_DEX
     Name: Dexterity
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,7;
   - Id: 310917
     AegisName: HeroInsignia_INT
     Name: Intelligence
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,10;
   - Id: 310918
     AegisName: HeroInsignia_VIT
     Name: Vitality
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPRate,10;
   - Id: 310919
     AegisName: HeroInsignia_AGI
     Name: Agility
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspd,2;
   - Id: 310920
     AegisName: Barmund_Pow1
     Name: Power of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/20);
       .@g = getenchantgrade();
@@ -53162,6 +54366,7 @@ Body:
     AegisName: Barmund_Pow2
     Name: Power of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/20);
       .@g = getenchantgrade();
@@ -53184,6 +54389,7 @@ Body:
     AegisName: Barmund_Pow3
     Name: Power of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bPow)/20);
       .@g = getenchantgrade();
@@ -53206,6 +54412,7 @@ Body:
     AegisName: Barmund_Spl1
     Name: Spell of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/20);
       .@g = getenchantgrade();
@@ -53228,6 +54435,7 @@ Body:
     AegisName: Barmund_Spl2
     Name: Spell of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/20);
       .@g = getenchantgrade();
@@ -53250,6 +54458,7 @@ Body:
     AegisName: Barmund_Spl3
     Name: Spell of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSpl)/20);
       .@g = getenchantgrade();
@@ -53272,6 +54481,7 @@ Body:
     AegisName: Barmund_Con1
     Name: Concentration of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/20);
       .@g = getenchantgrade();
@@ -53294,6 +54504,7 @@ Body:
     AegisName: Barmund_Con2
     Name: Concentration of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/20);
       .@g = getenchantgrade();
@@ -53316,6 +54527,7 @@ Body:
     AegisName: Barmund_Con3
     Name: Concentration of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCon)/20);
       .@g = getenchantgrade();
@@ -53338,6 +54550,7 @@ Body:
     AegisName: Barmund_Crt1
     Name: Creative of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/20);
       .@g = getenchantgrade();
@@ -53361,6 +54574,7 @@ Body:
     AegisName: Barmund_Crt2
     Name: Creative of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/20);
       .@g = getenchantgrade();
@@ -53384,6 +54598,7 @@ Body:
     AegisName: Barmund_Crt3
     Name: Creative of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bCrt)/20);
       .@g = getenchantgrade();
@@ -53407,6 +54622,7 @@ Body:
     AegisName: Barmund_Wis1
     Name: Wisdom of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/20);
       .@g = getenchantgrade();
@@ -53433,6 +54649,7 @@ Body:
     AegisName: Barmund_Wis2
     Name: Wisdom of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/20);
       .@g = getenchantgrade();
@@ -53459,6 +54676,7 @@ Body:
     AegisName: Barmund_Wis3
     Name: Wisdom of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bWis)/20);
       .@g = getenchantgrade();
@@ -53485,6 +54703,7 @@ Body:
     AegisName: Barmund_Sta1
     Name: Stamina of Varmundt Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/20);
       .@g = getenchantgrade();
@@ -53511,6 +54730,7 @@ Body:
     AegisName: Barmund_Sta2
     Name: Stamina of Varmundt Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/20);
       .@g = getenchantgrade();
@@ -53537,6 +54757,7 @@ Body:
     AegisName: Barmund_Sta3
     Name: Stamina of Varmundt Lv3
     Type: Card
+    SubType: Enchant
     Script: |
       .@param = (readparam(bSta)/20);
       .@g = getenchantgrade();
@@ -53563,150 +54784,175 @@ Body:
     AegisName: PATK_1Lv
     Name: P.ATK 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPAtk,1;
   - Id: 310983
     AegisName: PATK_2Lv
     Name: P.ATK 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPAtk,2;
   - Id: 310984
     AegisName: SMATK_1Lv
     Name: S.MATK 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSmatk,1;
   - Id: 310985
     AegisName: SMATK_2Lv
     Name: S.MATK 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSmatk,2;
   - Id: 310986
     AegisName: ATK_1Lv
     Name: ATK 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,3;
   - Id: 310987
     AegisName: ATK_2Lv
     Name: ATK 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,5;
   - Id: 310988
     AegisName: MATK_1Lv
     Name: MATK 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,3;
   - Id: 310989
     AegisName: MATK_2Lv
     Name: MATK 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,5;
   - Id: 310990
     AegisName: MHP_1Lv
     Name: MHP 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,3;
   - Id: 310991
     AegisName: MHP_2Lv
     Name: MHP 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxHPrate,5;
   - Id: 310992
     AegisName: MSP_1Lv
     Name: MSP 1Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,3;
   - Id: 310993
     AegisName: MSP_2Lv
     Name: MSP 2Lv
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMaxSPrate,5;
   - Id: 310994
     AegisName: Bless_Nothing
     Name: Blessing of Formless
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Formless,5;
   - Id: 310995
     AegisName: Bless_Undead
     Name: Blessing of Undead
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Undead,5;
   - Id: 310996
     AegisName: Bless_Animal
     Name: Blessing of Brute
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Brute,5;
   - Id: 310997
     AegisName: Bless_Plant
     Name: Blessing of Plant
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Plant,5;
   - Id: 310998
     AegisName: Bless_Insect
     Name: Blessing of Insect
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Insect,5;
   - Id: 310999
     AegisName: Bless_Fish
     Name: Blessing of Fish
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Fish,5;
   - Id: 311000
     AegisName: Bless_Demon
     Name: Blessing of Demon
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Demon,5;
   - Id: 311001
     AegisName: Bless_Human
     Name: Blessing of Demihuman
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_DemiHuman,5;
   - Id: 311002
     AegisName: Bless_Angel
     Name: Blessing of Angel
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Angel,5;
   - Id: 311003
     AegisName: Bless_Dragon
     Name: Blessing of Dragon
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_Dragon,5;
   - Id: 311004
     AegisName: Bless_All
     Name: Blessing of Rune Midgarts
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bExpAddRace,RC_All,5;
   - Id: 311005
     AegisName: aegis_311005
     Name: Wondermins Stone (top)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-getskilllv("WM_LESSON");
   - Id: 311006
     AegisName: aegis_311006
     Name: Wondermin's Stone (Discontinued)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillCooldown,"WM_SEVERE_RAINSTORM",-(100*getskilllv("WM_SIRCLEOFNATURE"));
       bonus2 bSkillCooldown,"WM_METALICSOUND",-(100*getskilllv("WM_SIRCLEOFNATURE"));
@@ -53714,186 +54960,217 @@ Body:
     AegisName: aegis_311007
     Name: Wondermin's Stone (bottom)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100*getskilllv("WM_FRIGG_SONG");
   - Id: 311008
     AegisName: aegis_311008
     Name: Generic Stone (top)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bLongAtkRate,2*getskilllv("GN_CARTCANNON");
   - Id: 311009
     AegisName: aegis_311009
     Name: Generic Stone (Discontinued)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-2*getskilllv("GN_REMODELING_CART");
   - Id: 311010
     AegisName: aegis_311010
     Name: Generic Stone (Bottom)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100*getskilllv("GN_TRAINING_SWORD");
   - Id: 311011
     AegisName: aegis_311011
     Name: Sorcerer Stone (top)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bFixedCast,-100*getskilllv("SO_STRIKING");
   - Id: 311012
     AegisName: aegis_311012
     Name: Sorcerer Stone (Discontinued)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-2*getskilllv("SO_DIAMONDDUST");
   - Id: 311013
     AegisName: aegis_311013
     Name: Sorcerer Stone (bottom)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bMagicAtkEle,Ele_All,2*getskilllv("SO_EARTHGRAVE");
   - Id: 311014
     AegisName: aegis_311014
     Name: Reload Stone (Dual)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-5;
   - Id: 311015
     AegisName: aegis_311015
     Name: Creative Stone (Dual)    # !todo check english name
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrt,5;
   - Id: 311016
     AegisName: Gear_ATK
     Name: Clockwork (Atk)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bAddClass,Class_All,15+5*getenchantgrade();
   - Id: 311017
     AegisName: Gear_MATK
     Name: Clockwork (Matk)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bMatkRate,15+5*getenchantgrade();
   - Id: 311018
     AegisName: Gear_ASPD
     Name: Clockwork (Delay After Attack)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bAspdRate,15+5*getenchantgrade();
   - Id: 311019
     AegisName: Gear_CAST
     Name: Clockwork (Variable Casting)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bVariableCastrate,-15-5*getenchantgrade();
   - Id: 311020
     AegisName: Gear_SKILL
     Name: Clockwork (Delay After Skill)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bDelayrate,-10-5*getenchantgrade();
   - Id: 311021
     AegisName: Gear_POW
     Name: Clockwork (POW)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPow,3+getenchantgrade();
   - Id: 311022
     AegisName: Gear_SPL
     Name: Clockwork (SPL)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSpl,3+getenchantgrade();
   - Id: 311023
     AegisName: Gear_STA
     Name: Clockwork (STA)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSta,3+getenchantgrade();
   - Id: 311024
     AegisName: Gear_WIS
     Name: Clockwork (WIS)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bWis,3+getenchantgrade();
   - Id: 311025
     AegisName: Gear_CRT
     Name: Clockwork (CRT)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrt,3+getenchantgrade();
   - Id: 311026
     AegisName: Gear_CON
     Name: Clockwork (CON)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCon,3+getenchantgrade();
   - Id: 311027
     AegisName: Gear_PATK
     Name: Clockwork (P.Atk)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPAtk,3+getenchantgrade();
   - Id: 311028
     AegisName: Gear_SMATK
     Name: Clockwork (S.Matk)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSmatk,3+getenchantgrade();
   - Id: 311029
     AegisName: Gear_DN1
     Name: Precision Tuning Device (Storm Slash)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"DK_STORMSLASH",25+5*getenchantgrade();
   - Id: 311030
     AegisName: Gear_DN2
     Name: Precision Tuning Device (Hack and Slasher)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"DK_HACKANDSLASHER",25+5*getenchantgrade();
   - Id: 311031
     AegisName: Gear_MT1
     Name: Precision Tuning Device (Axe Stomp)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"MT_AXE_STOMP",25+5*getenchantgrade();
   - Id: 311032
     AegisName: Gear_MT2
     Name: Precision Tuning Device (Axe Tornado)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NC_AXETORNADO",35+5*getenchantgrade();
   - Id: 311033
     AegisName: Gear_BO1
     Name: Precision Tuning Device (Acidified Zone)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",25+5*getenchantgrade();
   - Id: 311034
     AegisName: Gear_BO2
     Name: Precision Tuning Device (Cart Tornado)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"GN_CART_TORNADO",35+5*getenchantgrade();
   - Id: 311035
     AegisName: Gear_SHC1
     Name: Precision Tuning Device (Impact Crater)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SHC_IMPACT_CRATER",25+5*getenchantgrade();
   - Id: 311036
     AegisName: Gear_SHC2
     Name: Precision Tuning Device (Savage Impact)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SHC_SAVAGE_IMPACT",35+5*getenchantgrade();
   - Id: 311037
     AegisName: Gear_AG1
     Name: Precision Tuning Device (Frozen Crimson)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"AG_CRIMSON_ARROW_ATK",25+5*.@g;
@@ -53902,24 +55179,28 @@ Body:
     AegisName: Gear_AG2
     Name: Precision Tuning Device (Crystal Impact)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"AG_CRYSTAL_IMPACT_ATK",25+5*getenchantgrade();
   - Id: 311039
     AegisName: Gear_ABC1
     Name: Precision Tuning Device (Abyss Square)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"ABC_ABYSS_SQUARE",25+5*getenchantgrade();
   - Id: 311040
     AegisName: Gear_ABC2
     Name: Precision Tuning Device (From the Abyss)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"ABC_FROM_THE_ABYSS",25+5*getenchantgrade();
   - Id: 311041
     AegisName: Gear_EM1
     Name: Precision Tuning Device (Conflagration Land)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"EM_CONFLAGRATION",25+5*.@g;
@@ -53928,24 +55209,28 @@ Body:
     AegisName: Gear_EM2
     Name: Precision Tuning Device (Varetyr Spear)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SO_VARETYR_SPEAR",35+5*getenchantgrade();
   - Id: 311043
     AegisName: Gear_WH1
     Name: Precision Tuning Device (Gale Storm)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WH_GALESTORM",25+5*getenchantgrade();
   - Id: 311044
     AegisName: Gear_WH2
     Name: Precision Tuning Device (Arrow Storm)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"RA_ARROWSTORM",35+5*getenchantgrade();
   - Id: 311045
     AegisName: Gear_IQ1
     Name: Precision Tuning Device (Judge Faith)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"IQ_SECOND_FAITH",25+5*.@g;
@@ -53954,6 +55239,7 @@ Body:
     AegisName: Gear_IQ2
     Name: Precision Tuning Device (Consecration Punish)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"IQ_THIRD_PUNISH",35+5*getenchantgrade();
       bonus2 bSkillAtk,"IQ_THIRD_CONSECRATION",35+5*getenchantgrade();
@@ -53961,36 +55247,42 @@ Body:
     AegisName: Gear_IG1
     Name: Precision Tuning Device (Shield Shooting)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"IG_SHIELD_SHOOTING",25+5*getenchantgrade();
   - Id: 311048
     AegisName: Gear_IG2
     Name: Precision Tuning Device (Rapid Smiting)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"PA_SHIELDCHAIN",35+5*getenchantgrade();
   - Id: 311049
     AegisName: Gear_CD1
     Name: Precision Tuning Device (Flamen)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CD_FRAMEN",25+5*getenchantgrade();
   - Id: 311050
     AegisName: Gear_CD2
     Name: Precision Tuning Device (Arbitrium)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"CD_ARBITRIUM_ATK",25+5*getenchantgrade();
   - Id: 311051
     AegisName: Gear_SKE1
     Name: Precision Tuning Device (Noon Blast)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SKE_NOON_BLAST",25+5*getenchantgrade();
   - Id: 311052
     AegisName: Gear_SKE2
     Name: Precision Tuning Device (Rising Sun)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SKE_RISING_SUN",25+5*getenchantgrade();
   - Id: 311053
@@ -53998,6 +55290,7 @@ Body:
     # Name: Precision Tuning Device (Talisman of Four Bearing God)
     Name: Precision Tuning Device (Talisman of Four Bearing
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SOA_TALISMAN_OF_FOUR_BEARING_GOD",25+5*getenchantgrade();
   - Id: 311054
@@ -54005,12 +55298,14 @@ Body:
     # Name: Precision Tuning Device (Talisman of Soul Stealing)
     Name: Precision Tuning Device (Talisman of Soul Stealin
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SOA_TALISMAN_OF_SOUL_STEALING",25+5*getenchantgrade();
   - Id: 311055
     AegisName: Gear_NW1
     Name: Precision Tuning Device (Magazine Bullet)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"NW_ONLY_ONE_BULLET",25+5*.@g;
@@ -54019,12 +55314,14 @@ Body:
     AegisName: Gear_NW2
     Name: Precision Tuning Device (Vigilante Wild)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"NW_WILD_FIRE",25+5*getenchantgrade();
   - Id: 311057
     AegisName: Gear_HN1
     Name: Precision Tuning Device (Double Bowling Blow)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"HN_MEGA_SONIC_BLOW",25+5*.@g;
@@ -54033,6 +55330,7 @@ Body:
     AegisName: Gear_HN2
     Name: Precision Tuning Device (Meteor Strike)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"HN_NAPALM_VULCAN_STRIKE",25+5*.@g;
@@ -54041,18 +55339,21 @@ Body:
     AegisName: Gear_SS1
     Name: Precision Tuning Device (Shadow Dance)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SS_KAGENOMAI",25+5*getenchantgrade();
   - Id: 311060
     AegisName: Gear_SS2
     Name: Precision Tuning Device (Darkening Cannon)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"SS_ANTENPOU",25+5*getenchantgrade();
   - Id: 311061
     AegisName: Gear_TR1
     Name: Precision Tuning Device (Rose Rhythm)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"TR_ROSEBLOSSOM_ATK",25+5*.@g;
@@ -54061,12 +55362,14 @@ Body:
     AegisName: Gear_TR2
     Name: Precision Tuning Device (Severe Rainstorm)
     Type: Card
+    SubType: Enchant
     Script: |
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",35+5*getenchantgrade();
   - Id: 311063
     AegisName: Gear_SH1
     Name: Precision Tuning Device (Chulho Strike)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"SH_HOGOGONG_STRIKE",25+5*.@g;
@@ -54075,6 +55378,7 @@ Body:
     AegisName: Gear_SH2
     Name: Precision Tuning Device (Hyunrok Breeze)
     Type: Card
+    SubType: Enchant
     Script: |
       .@g = getenchantgrade();
       bonus2 bSkillAtk,"SH_HYUN_ROKS_BREEZE",25+5*.@g;
@@ -54083,96 +55387,112 @@ Body:
     AegisName: POW_1Lv
     Name: POW Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPow,1;
   - Id: 311077
     AegisName: POW_2Lv
     Name: POW Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bPow,2;
   - Id: 311078
     AegisName: WIS_1Lv
     Name: WIS Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bWis,1;
   - Id: 311079
     AegisName: WIS_2Lv
     Name: WIS Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bWis,2;
   - Id: 311080
     AegisName: SPL_1Lv
     Name: SPL Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSpl,1;
   - Id: 311081
     AegisName: SPL_2Lv
     Name: SPL Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSpl,2;
   - Id: 311082
     AegisName: STA_1Lv
     Name: STA Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSta,1;
   - Id: 311083
     AegisName: STA_2Lv
     Name: STA Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bSta,2;
   - Id: 311084
     AegisName: CRT_1Lv
     Name: CRT Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrt,1;
   - Id: 311085
     AegisName: CRT_2Lv
     Name: CRT Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrt,2;
   - Id: 311086
     AegisName: CON_1Lv
     Name: CON Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCon,1;
   - Id: 311087
     AegisName: CON_2Lv
     Name: CON Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCon,2;
   - Id: 311088
     AegisName: CRATE_Lv1
     Name: C.RATE Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrate,1;
   - Id: 311089
     AegisName: CRATE_Lv2
     Name: C.RATE Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bCrate,2;
   - Id: 311090
     AegisName: HPLUS_Lv1
     Name: H.PLUS Lv1
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHplus,1;
   - Id: 311091
     AegisName: HPLUS_Lv2
     Name: H.PLUS Lv2
     Type: Card
+    SubType: Enchant
     Script: |
       bonus bHplus,2;
   - Id: 1000000

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -26,7 +26,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/doc/item_db.txt
+++ b/doc/item_db.txt
@@ -78,6 +78,10 @@ Kunai
 CannonBall
 ThrowWeapon
 
+For cards, the types are:
+Normal (default)
+Enchant
+
 ---------------------------------------
 
 Buy: Default buying price. When not specified, becomes double the sell price.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3055,6 +3055,7 @@ Valid types are:
 	ITEMINFO_ID             (17)   -  item ID
 	ITEMINFO_AEGISNAME      (18)   -  aegis item name
 	ITEMINFO_ARMORLEVEL     (19)   -  armor LV
+	ITEMINFO_SUBTYPE        (20)   -  Subtype
 
 See the sample in 'doc/sample/getiteminfo.txt'.
 

--- a/doc/yaml/db/item_db.yml
+++ b/doc/yaml/db/item_db.yml
@@ -9,7 +9,7 @@
 #   AegisName               Server name to reference the item in scripts and lookups, should use no spaces.
 #   Name                    Name in English for displaying as output.
 #   Type                    Item type. (Default: Etc)
-#   SubType                 Weapon or Ammo type. (Default: 0)
+#   SubType                 Weapon, Ammo or Card type. (Default: 0)
 #   Buy                     Buying price. When not specified, becomes double the sell price. (Default: 0)
 #   Sell                    Selling price. When not specified, becomes half the buy price. (Default: 0)
 #   Weight                  Item weight. Each 10 is 1 weight. (Default: 0)

--- a/npc/custom/card_seller.txt
+++ b/npc/custom/card_seller.txt
@@ -61,7 +61,7 @@ OnInit:
 			.alphabet_menu$ = .alphabet_menu$ + .@alphabet$[.@i] +" Cards:";
 			npcshopdelitem "card_mob#"+ .@alphabet$[.@i], 501;
 			for ( .@j = 0; .@j < .@nb; .@j++ ) {
-				if (callfunc( "F_IsCharm", .@id[.@j] ) == true)// Skip enchants in case someone added them as card drop
+				if (getiteminfo(.@id[.@j], ITEMINFO_SUBTYPE) == CARD_ENCHANT)// Skip enchants in case someone added them as card drop
 					continue;
 				npcshopadditem "card_mob#"+ .@alphabet$[.@i], .@id[.@j], 1000000;
 			}

--- a/npc/events/RWC_2012.txt
+++ b/npc/events/RWC_2012.txt
@@ -315,7 +315,7 @@ prontera,147,59,3	script	Goldberg#pron	878,{
 			mes "I'm sorry. But you don't have the RWC Initialization coupon. Can you check your inventory?";
 			close;
 		}
-		if (callfunc("F_IsCharm",.@equip_card[3]) == false) {
+		if (getiteminfo(.@equip_card[3], ITEMINFO_SUBTYPE) == CARD_NORMAL) {
 			mes "[Goldberg]";
 			mes "Hm... this equipment is clean. I cannot initialize it if there's nothing! Check it again.";
 			close;
@@ -328,7 +328,7 @@ prontera,147,59,3	script	Goldberg#pron	878,{
 	
 //		GetNonSlotItemSock2 .@equip_refine .@equip_id .@equip_card[0] .@equip_card[1] .@equip_card[2] .@equip_card[3]
 		for ( .@i = getiteminfo(.@equip_id, ITEMINFO_SLOT); .@i < MAX_SLOTS; .@i++ ) {
-			if (callfunc("F_IsCharm",.@equip_card[.@i]) == true)
+			if (getiteminfo(.@equip_card[.@i], ITEMINFO_SUBTYPE) == CARD_ENCHANT)
 				.@equip_card[.@i] = 0;// Armor Enchant System
 		}
 		getitem2 .@equip_id,1,1,.@equip_refine,0,.@equip_card[0],.@equip_card[1],.@equip_card[2],.@equip_card[3];

--- a/npc/re/merchants/card_separation.txt
+++ b/npc/re/merchants/card_separation.txt
@@ -120,7 +120,7 @@
 
 	if (.@Jeremy) {
 		for ( .@i = 0; .@i < MAX_SLOTS; .@i++ ) {
-			if (callfunc("F_IsCharm",.@equip_card[.@i]) == true)
+			if (getiteminfo(.@equip_card[.@i], ITEMINFO_SUBTYPE) == CARD_ENCHANT)
 				.@equip_card[.@i] = 0;// Armor Enchant System
 		}
 		if (!getarraysize(.@equip_card)) {
@@ -146,7 +146,7 @@
 		next;
 		set .@menu$,"";
 		for ( .@i = 0; .@i < MAX_SLOTS; .@i++ ) {
-			if (.@equip_card[.@i] && callfunc("F_IsCharm",.@equip_card[.@i]) == false) // Armor Enchant System
+			if (.@equip_card[.@i] && getiteminfo(.@equip_card[.@i], ITEMINFO_SUBTYPE) == CARD_NORMAL) // Armor Enchant System
 				.@menu$ = .@menu$ + "Socket " + (.@i+1) + " - " + getitemname(.@equip_card[.@i])+":";
 			else {
 				.@menu$ = .@menu$ + "^777777Socket " + (.@i+1) + " - No card^000000:";
@@ -160,7 +160,7 @@
 			close;
 		default:
 			set .@slot, .@i-2;
-			if (.@equip_card[.@slot] == 0 || callfunc("F_IsCharm",.@equip_card[.@slot]) == true) {
+			if (.@equip_card[.@slot] == 0 || getiteminfo(.@equip_card[.@slot], ITEMINFO_SUBTYPE) == CARD_ENCHANT) {
 				mes .@n$;
 				mes "This socket is not equipped with any card. Why don't you check again?";
 				close;

--- a/npc/re/merchants/enchan_ko.txt
+++ b/npc/re/merchants/enchan_ko.txt
@@ -263,14 +263,14 @@ que_ng,75,20,3	script	Artisan Tene#ko	762,{
 	// Initialization
 	if (.@select == 2) {
 		if (.@sot03_ck) {// reset only 3rd slot
-			if (callfunc("F_IsCharm",.@equip_card[2]) == false) { // Armor Enchant System
+			if (getiteminfo(.@equip_card[2], ITEMINFO_SUBTYPE) == CARD_NORMAL) { // Armor Enchant System
 				mes "[Artisan Tene]";
 				mes "The third slot is is not enchanted. Please check again."; //custom translation
 				close;
 			}
 			set .@equip_card[2],0;
 		} else {
-			if (callfunc("F_IsCharm",.@equip_card[3]) == false) { // Armor Enchant System
+			if (getiteminfo(.@equip_card[3], ITEMINFO_SUBTYPE) == CARD_NORMAL) { // Armor Enchant System
 				mes "[Artisan Tene]";
 				mes "This equipment is is not enchanted. Please check again."; //custom translation
 				close;
@@ -302,8 +302,8 @@ que_ng,75,20,3	script	Artisan Tene#ko	762,{
 	else                           set .@ko_type01,5;
 
 	//custom translations
-	if (callfunc("F_IsCharm",.@equip_card[3]) == true) { // Armor Enchant System
-		if (callfunc("F_IsCharm",.@equip_card[2]) == true) {
+	if (getiteminfo(.@equip_card[3], ITEMINFO_SUBTYPE) == CARD_ENCHANT) { // Armor Enchant System
+		if (getiteminfo(.@equip_card[2], ITEMINFO_SUBTYPE) == CARD_ENCHANT) {
 			mes "[Artisan Tene]";
 			mes "This equipment cannot be further enchanted.";
 			next;

--- a/npc/re/merchants/enchan_mal.txt
+++ b/npc/re/merchants/enchan_mal.txt
@@ -676,7 +676,7 @@ L_Socket:
 
 		// GetNonSlotItemSock2 .@equip_refine .@equip_id .@equip_card[0] .@equip_card[1] .@equip_card[2] .@equip_card[3]
 		for ( .@i = getiteminfo(.@equip_id, ITEMINFO_SLOT); .@i < MAX_SLOTS; .@i++ ) {
-			if (callfunc("F_IsCharm",.@equip_card[.@i]) == true)
+			if (getiteminfo(.@equip_card[.@i], ITEMINFO_SUBTYPE) == CARD_ENCHANT)
 				.@equip_card[.@i] = 0;// Armor Enchant System
 		}
 		getitem2 .@equip_id,1,1,.@equip_refine,0,.@equip_card[0],.@equip_card[1],.@equip_card[2],.@equip_card[3];

--- a/npc/re/merchants/enchan_mora.txt
+++ b/npc/re/merchants/enchan_mora.txt
@@ -1156,7 +1156,7 @@ L_Socket:
 
 //		GetNonSlotItemSock2 .@equip_refine .@equip_id .@equip_card[0] .@equip_card[1] .@equip_card[2] .@equip_card[3]
 		for ( .@i = getiteminfo(.@equip_id, ITEMINFO_SLOT); .@i < MAX_SLOTS; .@i++ ) {
-			if (callfunc("F_IsCharm",.@equip_card[.@i]) == true)
+			if (getiteminfo(.@equip_card[.@i], ITEMINFO_SUBTYPE) == CARD_ENCHANT)
 				.@equip_card[.@i] = 0;// Armor Enchant System
 		}
 		getitem2 .@equip_id,1,1,.@equip_refine,0,.@equip_card[0],.@equip_card[1],.@equip_card[2],.@equip_card[3];

--- a/npc/re/merchants/enchan_rockridge.txt
+++ b/npc/re/merchants/enchan_rockridge.txt
@@ -67,7 +67,7 @@ har_in01,17,74,7	script	Contraband Processor#pa	4_DR_SOLDIER,{
 	.@refine = getequiprefinerycnt(.@part);
 	setarray .@card[0], getequipcardid(.@part,0), getequipcardid(.@part,1), getequipcardid(.@part,2), getequipcardid(.@part,3);
 	copyarray .@tmp_card[0], .@card[0], 4;
-	if ((.@card[1] && callfunc("F_IsCharm",.@card[1]) == false) || (.@card[2] && callfunc("F_IsCharm",.@card[2]) == false) || (.@card[3] && callfunc("F_IsCharm",.@card[3]) == false)) {// armor enchant system custom check
+	if ((.@card[1] && getiteminfo(.@card[1], ITEMINFO_SUBTYPE) == CARD_NORMAL) || (.@card[2] && getiteminfo(.@card[2], ITEMINFO_SUBTYPE) == CARD_NORMAL) || (.@card[3] && getiteminfo(.@card[3], ITEMINFO_SUBTYPE) == CARD_NORMAL)) {// armor enchant system custom check
 		mes "[Contraband Processor]";
 		mes "Something wrong happened.";
 		close;

--- a/npc/re/merchants/enchan_upg.txt
+++ b/npc/re/merchants/enchan_upg.txt
@@ -250,7 +250,7 @@ prt_in,28,73,3	script	Devil Enchant Master#prq	63,{
 			mes "You need to bring some money to initialize!!";
 			close;
 		}
-		if (callfunc("F_IsCharm",.@equip_card[3]) == false) {
+		if (getiteminfo(.@equip_card[3], ITEMINFO_SUBTYPE) == CARD_NORMAL) {
 			mes "This item is not enchanted!";
 			close;
 		}

--- a/npc/re/merchants/enchan_verus.txt
+++ b/npc/re/merchants/enchan_verus.txt
@@ -762,10 +762,10 @@ verus04,71,106,5	script	Mass Charleston#2	4_F_CHARLESTON01,{
 		}
 	case 2:	// Reset
 		// Note: the NPC doesn't check if the equipment is already enhanced
-		if (F_IsCharm(.@card[0]) == true) .@card[0] = 0;
-		if (F_IsCharm(.@card[1]) == true) .@card[1] = 0;
-		if (F_IsCharm(.@card[2]) == true) .@card[2] = 0;
-		if (F_IsCharm(.@card[3]) == true) .@card[3] = 0;
+		if (getiteminfo(.@card[0], ITEMINFO_SUBTYPE) == CARD_ENCHANT) .@card[0] = 0;
+		if (getiteminfo(.@card[1], ITEMINFO_SUBTYPE) == CARD_ENCHANT) .@card[1] = 0;
+		if (getiteminfo(.@card[2], ITEMINFO_SUBTYPE) == CARD_ENCHANT) .@card[2] = 0;
+		if (getiteminfo(.@card[3], ITEMINFO_SUBTYPE) == CARD_ENCHANT) .@card[3] = 0;
 		specialeffect2 EF_REPAIRWEAPON;
 		mes "[Mass Charleston]";
 		mes "Reset the product's abilities.";

--- a/npc/re/quests/quests_malangdo.txt
+++ b/npc/re/quests/quests_malangdo.txt
@@ -10678,7 +10678,7 @@ mal_in01,15,16,3	script	Fallen Angel#mal	403,{
 			mes "I can't do it if you can't pay!";
 			close;
 		}
-		if (callfunc("F_IsCharm",.@equip_card[3]) == false) {
+		if (getiteminfo(.@equip_card[3], ITEMINFO_SUBTYPE) == CARD_NORMAL) {
 			mes "[Fallen Angel]";
 			mes "This equipment has not been enchanted, please check it again!";
 			close;

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -172,6 +172,16 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 			}
 
 			item->subtype = static_cast<e_ammo_type>(constant);
+		} else if (item->type == IT_CARD) {
+			std::string type_constant = "CARD_" + type;
+			int64 constant;
+
+			if (!script_get_constant(type_constant.c_str(), &constant) || constant < CARD_NORMAL || constant >= MAX_CARD_TYPE) {
+				this->invalidWarning(node["SubType"], "Invalid card type %s, defaulting to CARD_NORMAL.\n", type.c_str());
+				item->subtype = CARD_NORMAL;
+			}
+
+			item->subtype = static_cast<e_card_type>(constant);
 		} else
 			this->invalidWarning(node["SubType"], "Item sub type is not supported for this item type.\n");
 	} else {

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -913,6 +913,12 @@ enum e_ammo_type : uint8 {
 	MAX_AMMO_TYPE
 };
 
+enum e_card_type : uint8 {
+	CARD_NORMAL = 0,
+	CARD_ENCHANT,
+	MAX_CARD_TYPE
+};
+
 enum idletime_option {
 	IDLE_WALK          = 0x0001,
 	IDLE_USESKILLTOID  = 0x0002,

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -14161,6 +14161,7 @@ BUILDIN_FUNC(getiteminfo)
 		}
 		case ITEMINFO_ID: script_pushint(st, i_data->nameid); break;
 		case ITEMINFO_AEGISNAME: script_pushstrcopy(st, i_data->name.c_str()); break;
+		case ITEMINFO_SUBTYPE: script_pushint(st, i_data->subtype); break;
 		default:
 			script_pushint(st, -1);
 			break;
@@ -14247,6 +14248,7 @@ BUILDIN_FUNC(setiteminfo)
 #endif
 			break;
 		}
+		case ITEMINFO_SUBTYPE: i_data->subtype = static_cast<uint8>(value); break;
 		default:
 			script_pushint(st, -1);
 			break;

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -2059,6 +2059,7 @@ enum e_iteminfo : uint8 {
 	ITEMINFO_ID,
 	ITEMINFO_AEGISNAME,	// 18
 	ITEMINFO_ARMORLEVEL,
+	ITEMINFO_SUBTYPE,
 };
 
 class ConstantDatabase : public YamlDatabase {

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8218,6 +8218,7 @@
 	export_constant(ITEMINFO_MAGICATTACK);
 	export_constant(ITEMINFO_ID);
 	export_constant(ITEMINFO_AEGISNAME);
+	export_constant(ITEMINFO_SUBTYPE);
 
 	/* refine types */
 	export_constant(REFINE_TYPE_ARMOR);

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -4180,6 +4180,10 @@
 	export_constant(AMMO_THROWWEAPON);
 	export_constant(MAX_AMMO_TYPE);
 
+	/* card subtypes */
+	export_constant(CARD_NORMAL);
+	export_constant(CARD_ENCHANT);
+
 	/* monsterinfo types */
 	export_constant(MOB_NAME);
 	export_constant(MOB_LV);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Suggestion of implementation of card subtype to differentiate normal cards from enchanted ones.
Available Subtypes:
`CARD_NORMAL` (default in item_db)
`CARD_ENCHANT`

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
