### PR TITLE
Fixed an issue with skill db conversion

### DIFF
--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -1998,8 +1998,8 @@ static bool skill_parse_row_skilldb(char* split[], int columns, int current) {
 
 			for (int i = 1; i < MAX_AMMO_TYPE; i++) {
 				if (temp & 1 << i) {
-					constant = constant_lookup(i, "A_");
-					constant.erase(0, 2);
+					constant = constant_lookup(i, "AMMO_");
+					constant.erase(0, 5);
 					body << YAML::Key << name2Upper(constant) << YAML::Value << "true";
 					temp ^= 1 << i;
 				}


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
With 6bc0dff the csv2yaml tool does not use deprecated constants anymore.
In our conversion logic we still used them though and therefore conversion might crash.

Thanks to @Rytech2
