### PR TITLE
Updates getenchantgrade()

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3108,7 +3108,7 @@ If <type> is false the command only returns the count of unidentified items.
 
 ---------------------------------------
 
-*getenchantgrade({<equipment slot>})
+*getenchantgrade({<equipment slot>,<char_id>})
 
 This function will return the enchantgrade of the equipment from which the
 function is called or the specified equipment slot. If nothing is
@@ -3116,7 +3116,8 @@ equipped there, it returns -1.
 
 Valid equipment slots are:
 
-EQI_COMPOUND_ON (-1)      - Item slot that calls this script (In context of item script) (default)
+EQI_COMPOUND_ON      - Item slot that calls this script (In context of item script) (default)
+
 For a list of others equipment slots see 'getequipid'.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3108,12 +3108,16 @@ If <type> is false the command only returns the count of unidentified items.
 
 ---------------------------------------
 
-*getenchantgrade()
+*getenchantgrade({<equipment slot>})
 
 This function will return the enchantgrade of the equipment from which the
-function is called.
+function is called or the specified equipment slot. If nothing is
+equipped there, it returns -1.
 
-This function is intended for use in item scripts.
+Valid equipment slots are:
+
+EQI_COMPOUND_ON (-1)      - Item slot that calls this script (In context of item script) (default)
+For a list of others equipment slots see 'getequipid'.
 
 ---------------------------------------
 //

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -25458,33 +25458,32 @@ BUILDIN_FUNC(refineui){
 BUILDIN_FUNC(getenchantgrade){
 	struct map_session_data *sd;
 
-	if( !script_rid2sd( sd ) ){
-		return SCRIPT_CMD_FAILURE;
-	}
-
-	int i, num;
-
-	if (script_hasdata(st, 2))
-		num = script_getnum(st, 2);
-	else
-		num = EQI_COMPOUND_ON;
-
-	if (num == EQI_COMPOUND_ON)
-		i = current_equip_item_index;
-	else if (equip_index_check(num))
-		i = pc_checkequip(sd, equip_bitmask[num]);
-	else {
-		ShowError( "buildin_getenchantgrade: Unknown equip index '%d'\n", num );
+	if (!script_charid2sd(3, sd)) {
 		script_pushint(st,-1);
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	item* itm = &sd->inventory.u.items_inventory[i];
+	int index, position;
 
-	if (i >= 0 && i < MAX_INVENTORY && itm != 0)
-		script_pushint(st, itm->enchantgrade);
+	if (script_hasdata(st, 2))
+		position = script_getnum(st, 2);
 	else
+		position = EQI_COMPOUND_ON;
+
+	if (position == EQI_COMPOUND_ON)
+		index = current_equip_item_index;
+	else if (equip_index_check(position))
+		index = pc_checkequip(sd, equip_bitmask[position]);
+	else {
+		ShowError( "buildin_getenchantgrade: Unknown equip index '%d'\n", position );
+		script_pushint(st,-1);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	if (index < 0 || index >= MAX_INVENTORY || sd->inventory.u.items_inventory[index].nameid == 0)
 		script_pushint(st, -1);
+	else
+		script_pushint(st, sd->inventory.u.items_inventory[index].enchantgrade);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -26212,7 +26211,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(rentalcountitem, "rentalcountitem2", "viiiiiii?"),
 	BUILDIN_DEF2(rentalcountitem, "rentalcountitem3", "viiiiiiirrr?"),
 
-	BUILDIN_DEF(getenchantgrade, "?"),
+	BUILDIN_DEF(getenchantgrade, "??"),
 
 	BUILDIN_DEF(mob_setidleevent, "is"),
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -25462,11 +25462,29 @@ BUILDIN_FUNC(getenchantgrade){
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if( current_equip_item_index == -1 ){
+	int i, num;
+
+	if (script_hasdata(st, 2))
+		num = script_getnum(st, 2);
+	else
+		num = EQI_COMPOUND_ON;
+
+	if (num == EQI_COMPOUND_ON)
+		i = current_equip_item_index;
+	else if (equip_index_check(num))
+		i = pc_checkequip(sd, equip_bitmask[num]);
+	else {
+		ShowError( "buildin_getenchantgrade: Unknown equip index '%d'\n", num );
+		script_pushint(st,-1);
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	script_pushint( st, sd->inventory.u.items_inventory[current_equip_item_index].enchantgrade );
+	item* itm = &sd->inventory.u.items_inventory[i];
+
+	if (i >= 0 && i < MAX_INVENTORY && itm != 0)
+		script_pushint(st, itm->enchantgrade);
+	else
+		script_pushint(st, -1);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -26194,7 +26212,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF2(rentalcountitem, "rentalcountitem2", "viiiiiii?"),
 	BUILDIN_DEF2(rentalcountitem, "rentalcountitem3", "viiiiiiirrr?"),
 
-	BUILDIN_DEF(getenchantgrade, ""),
+	BUILDIN_DEF(getenchantgrade, "?"),
 
 	BUILDIN_DEF(mob_setidleevent, "is"),
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Some combo requires to retrieve the grade of a specific an equipment slot, this PR updates `getenchantgrade` script command with `<equipement slot>` as optional argument (default `EQI_COMPOUND_ON` like the original command).

Example: https://www.divine-pride.net/database/item/490167
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
