### PR TITLE
Fixed getexp calls in quests_mora.txt

### DIFF
--- a/npc/re/quests/quests_mora.txt
+++ b/npc/re/quests/quests_mora.txt
@@ -4928,10 +4928,10 @@ L_CheckQuest:
 		delitem getarg(1),getarg(2);
 		erasequest getarg(0);
 		specialeffect2 EF_STEAL;
-		if (BaseLevel > 99)
-			getexp 0, ((JobLevel < 50)?JobLevel * JobLevel * (110/100) * 50:0);
-		else
-			getexp 0, ((JobLevel < 70)?JobLevel * JobLevel * (110/100) * 10:0);
+		if (BaseLevel > 99 && JobLevel < 50)
+			getexp 0, JobLevel * JobLevel * (110/100) * 50;
+		else if( BaseLevel < 99 && JobLevel < 70 )
+			getexp 0, JobLevel * JobLevel * (110/100) * 10;
 		getitem 6380,1; //Mora_Coin
 		close;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #6423

* **Server Mode**: Renewal

* **Description of Pull Request**: 
If a player reached job level 50 or 70 no exp would be given and the getexp call is useless.
Therefore it should be prevented.

Thanks to @mazvi
