### PR TITLE
Disallow changing to 4th on pre-renewal

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1631,7 +1631,7 @@ bool pc_authok(struct map_session_data *sd, uint32 login_id2, time_t expiration_
 
 	//Set the map-server used job id. [Skotlex]
 	uint64 class_ = pc_jobid2mapid(sd->status.class_);
-	if (class_ == -1) { //Invalid class?
+	if (class_ == -1 || !job_db.exists(sd->status.class_)) { //Invalid class?
 		ShowError("pc_authok: Invalid class %d for player %s (%d:%d). Class was changed to novice.\n", sd->status.class_, sd->status.name, sd->status.account_id, sd->status.char_id);
 		sd->status.class_ = JOB_NOVICE;
 		sd->class_ = MAPID_NOVICE;
@@ -10077,6 +10077,11 @@ bool pc_jobchange(struct map_session_data *sd,int job, char upper)
 
 	if ((unsigned short)b_class == sd->class_)
 		return false; //Nothing to change.
+
+	// If the job does not exist in the job db, dont allow changing to it
+	if( !job_db.exists( job ) ){
+		return false;
+	}
 
 	// changing from 1st to 2nd job
 	if ((b_class&JOBL_2) && !(sd->class_&JOBL_2) && (sd->class_&MAPID_UPPERMASK) != MAPID_SUPER_NOVICE) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #6434

* **Server Mode**: Pre-Renewal

* **Description of Pull Request**: 
Disables changing to jobs that dont exist in the job database.
If a player logs in with a job that does not exist in the job database the job will be changed to Novice.

Thanks to @Shaktohh
