### PR TITLE
Fixed pc_checkskill in pre-renewal

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6579,7 +6579,16 @@ uint8 pc_checkskill(struct map_session_data *sd, uint16 skill_id)
 	uint16 idx = 0;
 	if (sd == NULL)
 		return 0;
+
+#ifdef RENEWAL
 	if ((idx = skill_get_index(skill_id)) == 0) {
+#else
+	if( ( idx = skill_get_index_( skill_id, skill_id >= RK_ENCHANTBLADE, __FUNCTION__, __FILE__, __LINE__ ) ) == 0 ){
+		if( skill_id >= RK_ENCHANTBLADE ){
+			// Silently fail for now -> future update planned
+			return 0;
+		}
+#endif
 		ShowError("pc_checkskill: Invalid skill id %d (char_id=%d).\n", skill_id, sd->status.char_id);
 		return 0;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #6433 

* **Server Mode**: Pre-Renewal

* **Description of Pull Request**: 
Added a check to fail pc_checkskill calls to 3rd and 4th class skills silently.
This is a temporary fix and will be replaced with something better later on.

Thanks to @Shaktohh and @aleos89
