### PR TITLE
View incorrect casing on Wing_Headphone(5963)

### DIFF
--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -55052,7 +55052,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Refineable: true
-    view: 1347
+    View: 1347
     Script: |
       .@r = getrefine();
       bonus bInt,3;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
* #6442  Wing_Headphone(5963) `View` property is not consistent with spec in `item_db_equip.yml`.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
- Renewal

* **Description of Pull Request**: 
Change of spelling of view to match casing for spec

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Change case on View to match other entries.
