### PR TITLE
Fix packet size calculation for normal barter shops

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -22801,7 +22801,7 @@ void clif_parse_barter_buy( int fd, struct map_session_data* sd ){
 
 	struct PACKET_CZ_NPC_BARTER_PURCHASE* p = (struct PACKET_CZ_NPC_BARTER_PURCHASE*)RFIFOP( fd, 0 );
 
-	uint16 entries = ( p->packetLength - sizeof( struct PACKET_CZ_NPC_EXPANDED_BARTER_PURCHASE ) ) / sizeof( struct PACKET_CZ_NPC_EXPANDED_BARTER_PURCHASE_sub );
+	uint16 entries = ( p->packetLength - sizeof( struct PACKET_CZ_NPC_BARTER_PURCHASE ) ) / sizeof( struct PACKET_CZ_NPC_BARTER_PURCHASE_sub );
 
 	// Empty purchase list
 	if( entries == 0 ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6545 

* **Server Mode**: Both

* **Description of Pull Request**: 
We were using the expanded barter packet size to calculate the number of entries of a normal barter packet.
Instead, use the correct packet.
