### PR TITLE
Updates Golden Thief Bug card behavior

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34211,6 +34211,8 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
+    Flags:
+      IgnoreGtb: true
     Range: 9
     Hit: Single
     HitCount: 1

--- a/doc/skill_db.txt
+++ b/doc/skill_db.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20200324
+//= 20220126
 //===== Description: =========================================
 //= Explanation of the skill_db.yml file and structure.
 //============================================================
@@ -102,6 +102,7 @@ IgnoreWugBite				- Ignore RA_WUGBITE.
 IgnoreAutoGuard				- Not blocked by SC_AUTOGUARD (When TargetType is Weapon only).
 IgnoreCicada				- Not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (When TargetType is Weapon only).
 ShowScale					- Shows AoE area while casting
+IgnoreGtb					- Not blocked by Golden Thief Bug card.
 
 ---------------------------------------
 

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8250,6 +8250,7 @@
 	export_constant(INF2_IGNOREAUTOGUARD);
 	export_constant(INF2_IGNORECICADA);
 	export_constant(INF2_SHOWSCALE);
+	export_constant(INF2_IGNOREGTB);
 
 	/* skill no near npc flags */
 	export_constant(SKILL_NONEAR_WARPPORTAL);

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -107,6 +107,7 @@ enum e_skill_inf2 : uint8 {
 	INF2_IGNOREAUTOGUARD , // Skill is not blocked by SC_AUTOGUARD (physical-skill only)
 	INF2_IGNORECICADA, // Skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 	INF2_SHOWSCALE, // Skill shows AoE area while casting
+	INF2_IGNOREGTB, // Skill ignores effect of GTB
 	INF2_MAX,
 };
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10284,6 +10284,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			else if ((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self
 					(skill->inf == INF_SELF_SKILL && src != bl)) // Self skills should get blocked on all targets except self
 				return 0;
+
+		}
 	}
 
 	rate = cap_value(rate, 0, 10000);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10278,8 +10278,12 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	if (status_isimmune(bl)) {
 		std::shared_ptr<s_skill_db> skill = skill_db.find(battle_getcurrentskill(src));
 
-		if (skill != nullptr && skill->nameid != AG_DEADLY_PROJECTION && skill->skill_type == BF_MAGIC)
-			return 0;
+		if (skill != nullptr && skill->skill_type == BF_MAGIC) {
+			if (skill->inf2[INF2_IGNOREGTB]) // Specific skill to bypass
+				;
+			else if ((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self
+					(skill->inf == INF_SELF_SKILL && src != bl)) // Self skills should get blocked on all targets except self
+				return 0;
 	}
 
 	rate = cap_value(rate, 0, 10000);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10284,7 +10284,6 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			else if ((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self
 					(skill->inf == INF_SELF_SKILL && src != bl)) // Self skills should get blocked on all targets except self
 				return 0;
-
 		}
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10278,6 +10278,9 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	if (status_isimmune(bl)) {
 		std::shared_ptr<s_skill_db> skill = skill_db.find(battle_getcurrentskill(src));
 
+		if (skill == nullptr) // Check for ground-type skills using the status when a player moves through units
+			skill = skill_db.find(status_sc2skill(type));
+
 		if (skill != nullptr && skill->skill_type == BF_MAGIC && // Basic magic skill
 			!skill->inf2[INF2_IGNOREGTB] && // Specific skill to bypass
 			((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10278,13 +10278,11 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	if (status_isimmune(bl)) {
 		std::shared_ptr<s_skill_db> skill = skill_db.find(battle_getcurrentskill(src));
 
-		if (skill != nullptr && skill->skill_type == BF_MAGIC) {
-			if (skill->inf2[INF2_IGNOREGTB]) // Specific skill to bypass
-				;
-			else if ((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self
-					(skill->inf == INF_SELF_SKILL && src != bl)) // Self skills should get blocked on all targets except self
-				return 0;
-		}
+		if (skill != nullptr && skill->skill_type == BF_MAGIC && // Basic magic skill
+			!skill->inf2[INF2_IGNOREGTB] && // Specific skill to bypass
+			((skill->inf == INF_ATTACK_SKILL || skill->inf == INF_GROUND_SKILL || skill->inf == INF_SUPPORT_SKILL) || // Target skills should get blocked even when cast on self
+			 (skill->inf == INF_SELF_SKILL && src != bl))) // Self skills should get blocked on all targets except self
+			return 0;
 	}
 
 	rate = cap_value(rate, 0, 10000);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5918

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Target magic skills should get blocked even when cast on self.
  * Self magic skills should get blocked on all targets except self.
  * Adds an IgnoreGtb skill flag to explicitly allow a skill to bypass these checks.
Thanks to @Playtester!