### PR TITLE
Changes the default value of the conf item_enabled_npc to no

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -90,8 +90,8 @@ allow_consume_restricted_item: no
 allow_equip_restricted_item: yes
 
 // Allow changing of equipment while interacting with NPCs? (Note 1)
-// Default: yes
-item_enabled_npc: yes
+// Default: no
+item_enabled_npc: no
 
 // Allow map_flooritem to check if item is droppable? (Note 1)
 // If yes, undroppable items will be destroyed instead of appearing on the map when a player's inventory is full.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/6566

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Changes the default value of the conf `item_enabled_npc` to `no` toprevent players to swap equipment/use consumables while interacting with npc.
Note: Was the previous setting from rAthena legacy or PRE-renewal behaviour? Should we add a setting for PRE-renewal?

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
