### PR TITLE
Changes the default value of itemDB's "Override" to 100

### DIFF
--- a/db/import-tmpl/item_db.yml
+++ b/db/import-tmpl/item_db.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)

--- a/db/item_db.yml
+++ b/db/item_db.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)

--- a/db/pre-re/item_db.yml
+++ b/db/pre-re/item_db.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)

--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -1789,7 +1789,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1889,7 +1888,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2043,7 +2041,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2075,7 +2072,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2162,7 +2158,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2254,7 +2249,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4189,7 +4183,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4310,7 +4303,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4451,7 +4443,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4483,7 +4474,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4515,7 +4505,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4553,7 +4542,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4589,7 +4577,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4666,7 +4653,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4922,7 +4908,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5006,7 +4991,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5042,7 +5026,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5610,7 +5593,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5796,7 +5778,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5831,7 +5812,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5864,7 +5844,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5893,7 +5872,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5941,7 +5919,6 @@ Body:
     EquipLevelMin: 60
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -6040,7 +6017,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6106,7 +6082,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6531,7 +6506,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6638,7 +6612,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6684,7 +6657,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6718,7 +6690,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6761,7 +6732,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6795,7 +6765,6 @@ Body:
     EquipLevelMin: 65
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6830,7 +6799,6 @@ Body:
     EquipLevelMin: 60
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6859,7 +6827,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7573,7 +7540,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7675,7 +7641,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7717,7 +7682,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8545,7 +8509,6 @@ Body:
     EquipLevelMin: 48
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8629,7 +8592,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8779,7 +8741,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8820,7 +8781,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8888,7 +8848,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8922,7 +8881,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8969,7 +8927,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9314,7 +9271,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9395,7 +9351,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9570,7 +9525,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9604,7 +9558,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9636,7 +9589,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9677,7 +9629,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9716,7 +9667,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9749,7 +9699,6 @@ Body:
     EquipLevelMin: 85
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9782,7 +9731,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10442,7 +10390,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10560,7 +10507,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10690,7 +10636,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10727,7 +10672,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10764,7 +10708,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10798,7 +10741,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10892,7 +10834,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10928,7 +10869,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10960,7 +10900,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11001,7 +10940,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11043,7 +10981,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11110,7 +11047,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11148,7 +11084,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11310,7 +11245,6 @@ Body:
     EquipLevelMin: 4
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11809,7 +11743,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11966,7 +11899,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12038,7 +11970,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12071,7 +12002,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12149,7 +12079,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12176,7 +12105,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12217,7 +12145,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12573,7 +12500,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12709,7 +12635,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12742,7 +12667,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12797,7 +12721,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12838,7 +12761,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12877,7 +12799,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12904,7 +12825,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13316,7 +13236,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13364,7 +13283,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13395,7 +13313,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13478,7 +13395,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13516,7 +13432,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13545,7 +13460,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14058,7 +13972,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14106,7 +14019,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14137,7 +14049,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14220,7 +14131,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14257,7 +14167,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14284,7 +14193,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14365,7 +14273,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14411,7 +14318,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15033,7 +14939,6 @@ Body:
     ArmorLevel: 1
     View: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15139,7 +15044,6 @@ Body:
     ArmorLevel: 1
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17907,7 +17811,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -18058,7 +17961,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18081,7 +17983,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18103,7 +18004,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18253,7 +18153,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18282,7 +18181,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18312,7 +18210,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18342,7 +18239,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18371,7 +18267,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18400,7 +18295,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18427,7 +18321,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18468,7 +18361,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18498,7 +18390,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18711,7 +18602,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18734,7 +18624,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18761,7 +18650,6 @@ Body:
     EquipLevelMin: 61
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18786,7 +18674,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18829,7 +18716,6 @@ Body:
     EquipLevelMin: 50
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19351,7 +19237,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19400,7 +19285,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19419,7 +19303,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19437,7 +19320,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19546,7 +19428,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19582,7 +19463,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19609,7 +19489,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19633,7 +19512,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19653,7 +19531,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19753,7 +19630,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19781,7 +19657,6 @@ Body:
     EquipLevelMin: 61
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19806,7 +19681,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19861,7 +19735,6 @@ Body:
     EquipLevelMin: 85
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20529,7 +20402,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20638,7 +20510,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20674,7 +20545,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20701,7 +20571,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20773,7 +20642,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20909,7 +20777,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20951,7 +20818,6 @@ Body:
     EquipLevelMin: 55
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20987,7 +20853,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21510,7 +21375,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21532,7 +21396,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21636,7 +21499,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21663,7 +21525,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21714,7 +21575,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22112,7 +21972,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22144,7 +22003,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22198,7 +22056,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 48
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22220,7 +22077,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22251,7 +22107,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22460,7 +22315,6 @@ Body:
     EquipLevelMin: 1
     View: 73
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22487,7 +22341,6 @@ Body:
     EquipLevelMin: 1
     View: 56
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22512,7 +22365,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22537,7 +22389,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22562,7 +22413,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22587,7 +22437,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22612,7 +22461,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22637,7 +22485,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22662,7 +22509,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22689,7 +22535,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22715,7 +22560,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22743,7 +22587,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22771,7 +22614,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22799,7 +22641,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22898,7 +22739,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22918,7 +22758,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22952,7 +22791,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23019,7 +22857,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23133,7 +22970,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23164,7 +23000,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23194,7 +23029,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23224,7 +23058,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23253,7 +23086,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23283,7 +23115,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23400,7 +23231,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23426,7 +23256,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23452,7 +23281,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23474,7 +23302,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23500,7 +23327,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23520,7 +23346,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23571,7 +23396,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23591,7 +23415,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23611,7 +23434,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23632,7 +23454,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23842,7 +23663,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23864,7 +23684,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23885,7 +23704,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23905,7 +23723,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23925,7 +23742,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23945,7 +23761,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23965,7 +23780,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23985,7 +23799,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24005,7 +23818,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24025,7 +23837,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24045,7 +23856,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24065,7 +23875,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24197,7 +24006,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 81
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24228,7 +24036,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 61
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24251,7 +24058,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24295,7 +24101,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -24311,7 +24116,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -24328,7 +24132,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -24346,7 +24149,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -24363,7 +24165,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -24379,7 +24180,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24434,7 +24234,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 90
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24568,7 +24367,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24592,7 +24390,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24620,7 +24417,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24648,7 +24444,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24674,7 +24469,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24873,7 +24667,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24899,7 +24692,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24927,7 +24719,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24953,7 +24744,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24978,7 +24768,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -25005,7 +24794,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26568,7 +26356,6 @@ Body:
     EquipLevelMin: 50
     View: 181
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -26605,7 +26392,6 @@ Body:
     Refineable: true
     View: 183
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -26650,7 +26436,6 @@ Body:
     EquipLevelMin: 30
     View: 186
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -27133,7 +26918,6 @@ Body:
     ArmorLevel: 1
     View: 204
     Trade:
-      Override: 100
       NoSell: true
       NoCart: true
       NoGuildStorage: true
@@ -27158,7 +26942,6 @@ Body:
     ArmorLevel: 1
     View: 205
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -27496,7 +27279,6 @@ Body:
     ArmorLevel: 1
     View: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27515,7 +27297,6 @@ Body:
     ArmorLevel: 1
     View: 25
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27536,7 +27317,6 @@ Body:
     ArmorLevel: 1
     View: 8
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28325,7 +28105,6 @@ Body:
     Refineable: true
     View: 144
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28405,7 +28184,6 @@ Body:
     ArmorLevel: 1
     View: 259
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28472,7 +28250,6 @@ Body:
     Refineable: true
     View: 264
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28573,7 +28350,6 @@ Body:
     Refineable: true
     View: 38
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28599,7 +28375,6 @@ Body:
     Refineable: true
     View: 39
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28630,7 +28405,6 @@ Body:
     Refineable: true
     View: 41
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28649,7 +28423,6 @@ Body:
     Refineable: true
     View: 15
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28672,7 +28445,6 @@ Body:
     Refineable: true
     View: 142
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28694,7 +28466,6 @@ Body:
     ArmorLevel: 1
     View: 55
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28715,7 +28486,6 @@ Body:
     EquipLevelMin: 45
     View: 169
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28735,7 +28505,6 @@ Body:
     Refineable: true
     View: 149
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28761,7 +28530,6 @@ Body:
     Refineable: true
     View: 175
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28786,7 +28554,6 @@ Body:
     Refineable: true
     View: 178
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28829,7 +28596,6 @@ Body:
     Refineable: true
     View: 270
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -28856,7 +28622,6 @@ Body:
     Refineable: true
     View: 271
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28885,7 +28650,6 @@ Body:
     Refineable: true
     View: 272
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28914,7 +28678,6 @@ Body:
     Refineable: true
     View: 273
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28942,7 +28705,6 @@ Body:
     Refineable: true
     View: 274
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28970,7 +28732,6 @@ Body:
     Refineable: true
     View: 275
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28998,7 +28759,6 @@ Body:
     Refineable: true
     View: 276
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29026,7 +28786,6 @@ Body:
     Refineable: true
     View: 277
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29054,7 +28813,6 @@ Body:
     Refineable: true
     View: 278
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29078,7 +28836,6 @@ Body:
     Refineable: true
     View: 279
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29101,7 +28858,6 @@ Body:
     Refineable: true
     View: 280
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29124,7 +28880,6 @@ Body:
     Refineable: true
     View: 281
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29152,7 +28907,6 @@ Body:
     Refineable: true
     View: 282
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29181,7 +28935,6 @@ Body:
     Refineable: true
     View: 283
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29210,7 +28963,6 @@ Body:
     Refineable: true
     View: 284
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29239,7 +28991,6 @@ Body:
     Refineable: true
     View: 285
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29268,7 +29019,6 @@ Body:
     Refineable: true
     View: 286
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29294,7 +29044,6 @@ Body:
     Refineable: true
     View: 287
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -29492,7 +29241,6 @@ Body:
     Refineable: true
     View: 300
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -29517,7 +29265,6 @@ Body:
     Refineable: true
     View: 301
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -29630,7 +29377,6 @@ Body:
     Refineable: true
     View: 303
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -29670,7 +29416,6 @@ Body:
     EquipLevelMin: 1
     View: 72
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29693,7 +29438,6 @@ Body:
     EquipLevelMin: 1
     View: 15
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29717,7 +29461,6 @@ Body:
     ArmorLevel: 1
     View: 67
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29744,7 +29487,6 @@ Body:
     EquipLevelMin: 1
     View: 93
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29916,7 +29658,6 @@ Body:
     Refineable: true
     View: 309
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -29942,7 +29683,6 @@ Body:
     Refineable: true
     View: 310
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30021,7 +29761,6 @@ Body:
     EquipLevelMin: 10
     View: 311
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30046,7 +29785,6 @@ Body:
     EquipLevelMin: 30
     View: 312
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30069,7 +29807,6 @@ Body:
     EquipLevelMin: 30
     View: 313
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30087,7 +29824,6 @@ Body:
     EquipLevelMin: 70
     View: 314
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30109,7 +29845,6 @@ Body:
     EquipLevelMin: 30
     View: 315
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30126,7 +29861,6 @@ Body:
     ArmorLevel: 1
     View: 316
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30144,7 +29878,6 @@ Body:
     EquipLevelMin: 30
     View: 317
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30183,7 +29916,6 @@ Body:
     Refineable: true
     View: 318
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30204,7 +29936,6 @@ Body:
     Refineable: true
     View: 319
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30221,7 +29952,6 @@ Body:
     ArmorLevel: 1
     View: 320
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30240,7 +29970,6 @@ Body:
     ArmorLevel: 1
     View: 321
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30260,7 +29989,6 @@ Body:
     ArmorLevel: 1
     View: 138
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30353,7 +30081,6 @@ Body:
     Refineable: true
     View: 322
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30413,7 +30140,6 @@ Body:
     Refineable: true
     View: 326
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30431,7 +30157,6 @@ Body:
     ArmorLevel: 1
     View: 327
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30456,7 +30181,6 @@ Body:
     ArmorLevel: 1
     View: 328
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30481,7 +30205,6 @@ Body:
     Refineable: true
     View: 329
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30502,7 +30225,6 @@ Body:
     Refineable: true
     View: 330
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30538,7 +30260,6 @@ Body:
     Refineable: true
     View: 332
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30561,7 +30282,6 @@ Body:
     Refineable: true
     View: 333
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30591,7 +30311,6 @@ Body:
     Refineable: true
     View: 334
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30614,7 +30333,6 @@ Body:
     Refineable: true
     View: 335
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30636,7 +30354,6 @@ Body:
     EquipLevelMin: 50
     View: 336
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30656,7 +30373,6 @@ Body:
     EquipLevelMin: 35
     View: 337
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30704,7 +30420,6 @@ Body:
     Refineable: true
     View: 340
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30749,7 +30464,6 @@ Body:
     Refineable: true
     View: 261
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30786,7 +30500,6 @@ Body:
     Refineable: true
     View: 343
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30808,7 +30521,6 @@ Body:
     ArmorLevel: 1
     View: 165
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30832,7 +30544,6 @@ Body:
     Refineable: true
     View: 344
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -30972,7 +30683,6 @@ Body:
     Refineable: true
     View: 347
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31022,7 +30732,6 @@ Body:
     Refineable: true
     View: 350
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31038,7 +30747,6 @@ Body:
     Refineable: true
     View: 351
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31054,7 +30762,6 @@ Body:
     Refineable: true
     View: 352
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31075,7 +30782,6 @@ Body:
     Refineable: true
     View: 353
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31195,7 +30901,6 @@ Body:
     Refineable: true
     View: 360
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31308,7 +31013,6 @@ Body:
     Refineable: true
     View: 361
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31381,7 +31085,6 @@ Body:
     Refineable: true
     View: 206
     Trade:
-      Override: 100
       NoMail: true
       NoAuction: true
     Script: |
@@ -31400,7 +31103,6 @@ Body:
     ArmorLevel: 1
     View: 365
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31424,7 +31126,6 @@ Body:
     EquipLevelMin: 70
     View: 366
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31447,7 +31148,6 @@ Body:
     Refineable: true
     View: 367
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31469,7 +31169,6 @@ Body:
     Refineable: true
     View: 368
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31491,7 +31190,6 @@ Body:
     EquipLevelMin: 60
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31511,7 +31209,6 @@ Body:
     EquipLevelMin: 60
     View: 370
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31609,7 +31306,6 @@ Body:
     EquipLevelMin: 10
     View: 375
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31629,7 +31325,6 @@ Body:
     Refineable: true
     View: 38
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31652,7 +31347,6 @@ Body:
     Refineable: true
     View: 39
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31690,7 +31384,6 @@ Body:
     Refineable: true
     View: 377
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31710,7 +31403,6 @@ Body:
     Refineable: true
     View: 378
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31735,7 +31427,6 @@ Body:
     Refineable: true
     View: 379
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31755,7 +31446,6 @@ Body:
     Refineable: true
     View: 380
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31778,7 +31468,6 @@ Body:
     Refineable: true
     View: 381
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31799,7 +31488,6 @@ Body:
     Refineable: true
     View: 382
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31817,7 +31505,6 @@ Body:
     ArmorLevel: 1
     View: 383
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31836,7 +31523,6 @@ Body:
     Refineable: true
     View: 384
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31872,7 +31558,6 @@ Body:
     Refineable: true
     View: 386
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31891,7 +31576,6 @@ Body:
     ArmorLevel: 1
     View: 387
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31913,7 +31597,6 @@ Body:
     Refineable: true
     View: 388
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31941,7 +31624,6 @@ Body:
     Refineable: true
     View: 389
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -31983,7 +31665,6 @@ Body:
     Refineable: true
     View: 391
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32005,7 +31686,6 @@ Body:
     EquipLevelMin: 1
     View: 228
     Trade:
-      Override: 100
       NoMail: true
       NoAuction: true
     Script: |
@@ -32027,7 +31707,6 @@ Body:
     Refineable: true
     View: 392
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32048,7 +31727,6 @@ Body:
     Refineable: true
     View: 393
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32067,7 +31745,6 @@ Body:
     EquipLevelMin: 30
     View: 394
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32098,7 +31775,6 @@ Body:
     ArmorLevel: 1
     View: 188
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32147,7 +31823,6 @@ Body:
       Head_Low: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32171,7 +31846,6 @@ Body:
     Refineable: true
     View: 398
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32205,7 +31879,6 @@ Body:
     ArmorLevel: 1
     View: 400
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32300,7 +31973,6 @@ Body:
     EquipLevelMin: 70
     View: 404
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32321,7 +31993,6 @@ Body:
     EquipLevelMin: 70
     View: 405
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32340,7 +32011,6 @@ Body:
     EquipLevelMin: 30
     View: 406
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32362,7 +32032,6 @@ Body:
     Refineable: true
     View: 407
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32380,7 +32049,6 @@ Body:
     EquipLevelMin: 80
     View: 408
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32398,7 +32066,6 @@ Body:
     Refineable: true
     View: 409
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32421,7 +32088,6 @@ Body:
     Refineable: true
     View: 410
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32637,7 +32303,6 @@ Body:
     EquipLevelMin: 70
     View: 421
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32667,7 +32332,6 @@ Body:
     EquipLevelMin: 70
     View: 422
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32708,7 +32372,6 @@ Body:
     ArmorLevel: 1
     View: 424
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32785,7 +32448,6 @@ Body:
     Refineable: true
     View: 429
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32810,7 +32472,6 @@ Body:
     Refineable: true
     View: 430
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -32828,7 +32489,6 @@ Body:
     ArmorLevel: 1
     View: 431
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33132,7 +32792,6 @@ Body:
     Refineable: true
     View: 451
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33154,7 +32813,6 @@ Body:
     EquipLevelMin: 1
     View: 452
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33181,7 +32839,6 @@ Body:
     EquipLevelMin: 1
     View: 453
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33207,7 +32864,6 @@ Body:
     EquipLevelMin: 1
     View: 454
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33286,7 +32942,6 @@ Body:
     Refineable: true
     View: 455
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33341,7 +32996,6 @@ Body:
     Refineable: true
     View: 457
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33368,7 +33022,6 @@ Body:
     Refineable: true
     View: 458
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33392,7 +33045,6 @@ Body:
     EquipLevelMin: 90
     View: 459
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33417,7 +33069,6 @@ Body:
     EquipLevelMin: 90
     View: 460
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33438,7 +33089,6 @@ Body:
     ArmorLevel: 1
     View: 461
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33465,7 +33115,6 @@ Body:
     Refineable: true
     View: 473
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33502,7 +33151,6 @@ Body:
     Refineable: true
     View: 475
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33525,7 +33173,6 @@ Body:
     Refineable: true
     View: 476
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33546,7 +33193,6 @@ Body:
     Refineable: true
     View: 477
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33567,7 +33213,6 @@ Body:
     Refineable: true
     View: 478
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33589,7 +33234,6 @@ Body:
     Refineable: true
     View: 479
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33608,7 +33252,6 @@ Body:
     EquipLevelMin: 50
     View: 480
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -33705,7 +33348,6 @@ Body:
     EquipLevelMin: 70
     View: 485
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33730,7 +33372,6 @@ Body:
     Refineable: true
     View: 486
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33753,7 +33394,6 @@ Body:
     ArmorLevel: 1
     View: 102
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33780,7 +33420,6 @@ Body:
     ArmorLevel: 1
     View: 254
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33807,7 +33446,6 @@ Body:
     ArmorLevel: 1
     View: 137
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33833,7 +33471,6 @@ Body:
     Refineable: true
     View: 493
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33855,7 +33492,6 @@ Body:
     EquipLevelMin: 50
     View: 494
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33882,7 +33518,6 @@ Body:
     Refineable: true
     View: 495
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33909,7 +33544,6 @@ Body:
     Refineable: true
     View: 490
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33927,7 +33561,6 @@ Body:
     ArmorLevel: 1
     View: 487
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33946,7 +33579,6 @@ Body:
     Refineable: true
     View: 488
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33965,7 +33597,6 @@ Body:
     EquipLevelMin: 10
     View: 496
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -33988,7 +33619,6 @@ Body:
     Refineable: true
     View: 491
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34008,7 +33638,6 @@ Body:
     Refineable: true
     View: 497
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34035,7 +33664,6 @@ Body:
     Refineable: true
     View: 489
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34055,7 +33683,6 @@ Body:
     Refineable: true
     View: 492
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34104,7 +33731,6 @@ Body:
     Refineable: true
     View: 503
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34127,7 +33753,6 @@ Body:
     Refineable: true
     View: 504
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34170,7 +33795,6 @@ Body:
     Refineable: true
     View: 508
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34326,7 +33950,6 @@ Body:
     Refineable: true
     View: 514
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34357,7 +33980,6 @@ Body:
     ArmorLevel: 1
     View: 194
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34440,7 +34062,6 @@ Body:
     EquipLevelMin: 60
     View: 520
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34463,7 +34084,6 @@ Body:
     Refineable: true
     View: 521
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34490,7 +34110,6 @@ Body:
     EquipLevelMin: 30
     View: 522
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34514,7 +34133,6 @@ Body:
     Refineable: true
     View: 523
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34539,7 +34157,6 @@ Body:
     Refineable: true
     View: 524
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34573,7 +34190,6 @@ Body:
     Refineable: true
     View: 327
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34627,7 +34243,6 @@ Body:
     EquipLevelMin: 1
     View: 526
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34652,7 +34267,6 @@ Body:
     EquipLevelMin: 45
     View: 527
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34673,7 +34287,6 @@ Body:
     EquipLevelMin: 45
     View: 528
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34696,7 +34309,6 @@ Body:
     Refineable: true
     View: 530
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34780,7 +34392,6 @@ Body:
     Refineable: true
     View: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34804,7 +34415,6 @@ Body:
     Refineable: true
     View: 531
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34829,7 +34439,6 @@ Body:
     Refineable: true
     View: 532
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34854,7 +34463,6 @@ Body:
     Refineable: true
     View: 533
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34877,7 +34485,6 @@ Body:
     Refineable: true
     View: 534
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34897,7 +34504,6 @@ Body:
     Refineable: true
     View: 535
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34923,7 +34529,6 @@ Body:
     Refineable: true
     View: 536
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34975,7 +34580,6 @@ Body:
     Refineable: true
     View: 538
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -34995,7 +34599,6 @@ Body:
     Refineable: true
     View: 539
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35039,7 +34642,6 @@ Body:
     Refineable: true
     View: 541
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35145,7 +34747,6 @@ Body:
     Refineable: true
     View: 544
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35164,7 +34765,6 @@ Body:
     EquipLevelMin: 1
     View: 545
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35188,7 +34788,6 @@ Body:
     EquipLevelMin: 1
     View: 546
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35215,7 +34814,6 @@ Body:
     Refineable: true
     View: 548
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35253,7 +34851,6 @@ Body:
     Refineable: true
     View: 550
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35279,7 +34876,6 @@ Body:
     Refineable: true
     View: 551
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35334,7 +34930,6 @@ Body:
     EquipLevelMin: 10
     View: 555
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35369,7 +34964,6 @@ Body:
     Refineable: true
     View: 479
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
     Script: |
@@ -35404,7 +34998,6 @@ Body:
     Refineable: true
     View: 558
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35424,7 +35017,6 @@ Body:
     Refineable: true
     View: 560
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35450,7 +35042,6 @@ Body:
     Refineable: true
     View: 561
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35474,7 +35065,6 @@ Body:
     Refineable: true
     View: 465
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35495,7 +35085,6 @@ Body:
     Refineable: true
     View: 562
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35545,7 +35134,6 @@ Body:
     Refineable: true
     View: 563
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35627,7 +35215,6 @@ Body:
     EquipLevelMin: 1
     View: 571
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35650,7 +35237,6 @@ Body:
     EquipLevelMin: 1
     View: 572
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35691,7 +35277,6 @@ Body:
     Refineable: true
     View: 577
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35715,7 +35300,6 @@ Body:
     Refineable: true
     View: 578
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35739,7 +35323,6 @@ Body:
     Refineable: true
     View: 579
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35778,7 +35361,6 @@ Body:
     Refineable: true
     View: 587
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35904,7 +35486,6 @@ Body:
     Refineable: true
     View: 598
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -35921,7 +35502,6 @@ Body:
     Refineable: true
     View: 206
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36114,7 +35694,6 @@ Body:
     Refineable: true
     View: 616
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -36144,7 +35723,6 @@ Body:
     Refineable: true
     View: 101
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36182,7 +35760,6 @@ Body:
     Refineable: true
     View: 349
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -36241,7 +35818,6 @@ Body:
     EquipLevelMin: 1
     View: 665
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36311,7 +35887,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36330,7 +35905,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36349,7 +35923,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36368,7 +35941,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36460,7 +36032,6 @@ Body:
     EquipLevelMin: 70
     View: 43
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36483,7 +36054,6 @@ Body:
     ArmorLevel: 1
     View: 67
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36596,7 +36166,6 @@ Body:
     Refineable: true
     View: 16
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36646,7 +36215,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36669,7 +36237,6 @@ Body:
     Refineable: true
     View: 505
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36691,7 +36258,6 @@ Body:
     Refineable: true
     View: 506
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36715,7 +36281,6 @@ Body:
     Refineable: true
     View: 499
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36739,7 +36304,6 @@ Body:
     Refineable: true
     View: 500
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36859,7 +36423,6 @@ Body:
     Refineable: true
     View: 671
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36886,7 +36449,6 @@ Body:
     Refineable: true
     View: 672
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36913,7 +36475,6 @@ Body:
     Refineable: true
     View: 673
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36940,7 +36501,6 @@ Body:
     Refineable: true
     View: 674
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37092,7 +36652,6 @@ Body:
     Type: Petegg
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoCart: true
       NoGuildStorage: true
@@ -37958,7 +37517,6 @@ Body:
     EquipLevelMin: 48
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38000,7 +37558,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38035,7 +37592,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38061,7 +37617,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38273,7 +37828,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38485,7 +38039,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38536,7 +38089,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38650,7 +38202,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38691,7 +38242,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38733,7 +38283,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38785,7 +38334,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38825,7 +38373,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38847,7 +38394,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38934,7 +38480,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39114,7 +38659,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39163,7 +38707,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39201,7 +38744,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39225,7 +38767,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39664,7 +39205,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39696,7 +39236,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39726,7 +39265,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39757,7 +39295,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39786,7 +39323,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39814,7 +39350,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39854,7 +39389,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39893,7 +39427,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -39934,7 +39467,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40079,7 +39611,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40110,7 +39641,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40140,7 +39670,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40179,7 +39708,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40206,7 +39734,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40269,7 +39796,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40409,7 +39935,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40523,7 +40048,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40564,7 +40088,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40703,7 +40226,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40737,7 +40259,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40789,7 +40310,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40826,7 +40346,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40866,7 +40385,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40901,7 +40419,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -40950,7 +40467,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41008,7 +40524,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41103,7 +40618,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41253,7 +40767,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41272,7 +40785,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41291,7 +40803,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true

--- a/db/pre-re/item_db_etc.yml
+++ b/db/pre-re/item_db_etc.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -9309,7 +9309,6 @@ Body:
     Name: Ashes of Darkness
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9351,7 +9350,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9364,7 +9362,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9378,7 +9375,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9398,7 +9394,6 @@ Body:
     Name: Big Fan Of Magic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9565,7 +9560,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9609,7 +9603,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9634,7 +9627,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9648,7 +9640,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9700,7 +9691,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9768,7 +9758,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9782,7 +9771,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9796,7 +9784,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9811,7 +9798,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9824,7 +9810,6 @@ Body:
     Name: Bazett's Order
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9839,7 +9824,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9853,7 +9837,6 @@ Body:
     Name: Portable Toolbox
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9867,7 +9850,6 @@ Body:
     Name: Rough Mineral
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9881,7 +9863,6 @@ Body:
     Name: Stone Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9895,7 +9876,6 @@ Body:
     Name: Flower Of Alfheim
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9909,7 +9889,6 @@ Body:
     Name: Manuk Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9923,7 +9902,6 @@ Body:
     Name: Splendide Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9937,7 +9915,6 @@ Body:
     Name: Spirit Of Alfheim
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9956,7 +9933,6 @@ Body:
     Name: Bradium Fragments
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9970,7 +9946,6 @@ Body:
     Name: Shaggy Muffler
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10037,7 +10012,6 @@ Body:
     Name: Draco's Egg
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10104,7 +10078,6 @@ Body:
     Name: Attendance Card
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10117,7 +10090,6 @@ Body:
     Name: Report On Splendide
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10131,7 +10103,6 @@ Body:
     Name: Report On Manuk
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10241,7 +10212,6 @@ Body:
     Name: Succubus Pet Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10255,7 +10225,6 @@ Body:
     Name: Imp Pet Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10269,7 +10238,6 @@ Body:
     Name: Chung E Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10296,7 +10264,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10311,7 +10278,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10334,7 +10300,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10349,7 +10314,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10364,7 +10328,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10378,7 +10341,6 @@ Body:
     Name: Purification Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10398,7 +10360,6 @@ Body:
     Name: Nightmare Terror Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10412,7 +10373,6 @@ Body:
     Name: Loli Ruri Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10426,7 +10386,6 @@ Body:
     Name: Goblin Leader Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10440,7 +10399,6 @@ Body:
     Name: Incubus Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10454,7 +10412,6 @@ Body:
     Name: Miyabi Ningyo Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10468,7 +10425,6 @@ Body:
     Name: Giant Whisper Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10482,7 +10438,6 @@ Body:
     Name: Evil Nymph Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10496,7 +10451,6 @@ Body:
     Name: Medusa Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10510,7 +10464,6 @@ Body:
     Name: Stone Shooter Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10524,7 +10477,6 @@ Body:
     Name: Marionette Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10538,7 +10490,6 @@ Body:
     Name: Leaf Cat Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10552,7 +10503,6 @@ Body:
     Name: Dullahan Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10566,7 +10516,6 @@ Body:
     Name: Shinobi Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10580,7 +10529,6 @@ Body:
     Name: Golem Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10594,7 +10542,6 @@ Body:
     Name: Civil Servant Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10640,7 +10587,6 @@ Body:
     Name: Eternity Of Chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10653,7 +10599,6 @@ Body:
     Name: Simple Chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10666,7 +10611,6 @@ Body:
     Name: Key of The Mansion
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10680,7 +10624,6 @@ Body:
     Name: Giant Bradium Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10693,7 +10636,6 @@ Body:
     Name: Glittering Crystal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10706,7 +10648,6 @@ Body:
     Name: Special Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10721,7 +10662,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10739,7 +10679,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10990,7 +10929,6 @@ Body:
     Name: I Love You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11003,7 +10941,6 @@ Body:
     Name: Thank You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11016,7 +10953,6 @@ Body:
     Name: I Respect You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11097,7 +11033,6 @@ Body:
     Name: Delivery_Daishin_Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11111,7 +11046,6 @@ Body:
     Name: Eden Group Mark
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11156,7 +11090,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11170,7 +11103,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11183,7 +11115,6 @@ Body:
     Name: +9 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11196,7 +11127,6 @@ Body:
     Name: +8 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11209,7 +11139,6 @@ Body:
     Name: +7 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11222,7 +11151,6 @@ Body:
     Name: +6 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11235,7 +11163,6 @@ Body:
     Name: +9 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11248,7 +11175,6 @@ Body:
     Name: +8 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11261,7 +11187,6 @@ Body:
     Name: +7 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11274,7 +11199,6 @@ Body:
     Name: +6 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11287,7 +11211,6 @@ Body:
     Name: Blue Card 7
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11300,7 +11223,6 @@ Body:
     Name: Guarana Fruit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11314,7 +11236,6 @@ Body:
     Name: +11 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11327,7 +11248,6 @@ Body:
     Name: +11 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11342,7 +11262,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11357,7 +11276,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11372,7 +11290,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11563,7 +11480,6 @@ Body:
     Name: Key Of Deception
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11577,7 +11493,6 @@ Body:
     Name: Key Of Illusion
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11591,7 +11506,6 @@ Body:
     Name: Key Of Gaiety
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11605,7 +11519,6 @@ Body:
     Name: A Master's Blush
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11619,7 +11532,6 @@ Body:
     Name: A Picture Of Minstrel Song
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11632,7 +11544,6 @@ Body:
     Name: Receipt
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11645,7 +11556,6 @@ Body:
     Name: Experiment Seed
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11659,7 +11569,6 @@ Body:
     Name: Seed For Experiment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11673,7 +11582,6 @@ Body:
     Name: A Piece Of Cloth Of A Saint
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11687,7 +11595,6 @@ Body:
     Name: Shield Of King
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11701,7 +11608,6 @@ Body:
     Name: Clear Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11715,7 +11621,6 @@ Body:
     Name: Red Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11729,7 +11634,6 @@ Body:
     Name: Black Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11852,7 +11756,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11874,7 +11777,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11888,7 +11790,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12000,7 +11901,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12146,7 +12046,6 @@ Body:
     Name: Love Ball
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12164,7 +12063,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12178,7 +12076,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12192,7 +12089,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12206,7 +12102,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12220,7 +12115,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12234,7 +12128,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12248,7 +12141,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12262,7 +12154,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12276,7 +12167,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12290,7 +12180,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12305,7 +12194,6 @@ Body:
     Buy: 4020
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12318,7 +12206,6 @@ Body:
     Name: Free Cash Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12332,7 +12219,6 @@ Body:
     Name: Guidebook Exchange
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12412,7 +12298,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12535,7 +12420,6 @@ Body:
     Name: +5 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12548,7 +12432,6 @@ Body:
     Name: +5 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12803,7 +12686,6 @@ Body:
     Buy: 30000
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13957,7 +13839,6 @@ Body:
     Name: Crumb of Sobbing Starlight
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13971,7 +13852,6 @@ Body:
     Name: Sobbing Starlight
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14627,7 +14507,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14641,7 +14520,6 @@ Body:
     Name: Doodled Message
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14842,7 +14720,6 @@ Body:
     Name: Witch's Spell Scroll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14856,7 +14733,6 @@ Body:
     Name: Symbol of the Nine Realms
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14870,7 +14746,6 @@ Body:
     Name: Piece of Spirit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14884,7 +14759,6 @@ Body:
     Name: Spiritual Whispers
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14898,7 +14772,6 @@ Body:
     Name: Witch's Tonic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14912,7 +14785,6 @@ Body:
     Name: Crow Wing
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14952,7 +14824,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15083,7 +14954,6 @@ Body:
     Name: Complete Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15097,7 +14967,6 @@ Body:
     Name: Prontera Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15111,7 +14980,6 @@ Body:
     Name: Payon Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15125,7 +14993,6 @@ Body:
     Name: Morocc Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15139,7 +15006,6 @@ Body:
     Name: Geffen Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15161,7 +15027,6 @@ Body:
     Name: Commemorative Travel Card
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15184,7 +15049,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15199,7 +15063,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15214,7 +15077,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15229,7 +15091,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15252,7 +15113,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15281,7 +15141,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15302,7 +15161,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15677,7 +15535,6 @@ Body:
     Name: Letter of Recommendation
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15690,7 +15547,6 @@ Body:
     Name: Written Request(A)
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15703,7 +15559,6 @@ Body:
     Name: Written Request(B)
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15724,7 +15579,6 @@ Body:
     Name: Skull
     Type: Etc
     Trade:
-      Override: 100
       NoTrade: true
       NoCart: true
       NoStorage: true
@@ -15736,7 +15590,6 @@ Body:
     Name: Red Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15749,7 +15602,6 @@ Body:
     Name: Yellow Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15762,7 +15614,6 @@ Body:
     Name: Blue Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15775,7 +15626,6 @@ Body:
     Name: Green Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15788,7 +15638,6 @@ Body:
     Name: Black Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15801,7 +15650,6 @@ Body:
     Name: Red Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15814,7 +15662,6 @@ Body:
     Name: Yellow Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15827,7 +15674,6 @@ Body:
     Name: Blue Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15840,7 +15686,6 @@ Body:
     Name: Green Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15853,7 +15698,6 @@ Body:
     Name: Black Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15866,7 +15710,6 @@ Body:
     Name: Pile of Books
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15879,7 +15722,6 @@ Body:
     Name: Leather Pouch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16259,7 +16101,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16274,7 +16115,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16289,7 +16129,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16303,7 +16142,6 @@ Body:
     Name: Culinary Wine
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16317,7 +16155,6 @@ Body:
     Name: Delivery Package
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16331,7 +16168,6 @@ Body:
     Name: Cottage Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16345,7 +16181,6 @@ Body:
     Name: Letter to Elly
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16359,7 +16194,6 @@ Body:
     Name: Steel Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16373,7 +16207,6 @@ Body:
     Name: Yellow Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16387,7 +16220,6 @@ Body:
     Name: Golden Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16401,7 +16233,6 @@ Body:
     Name: Luxurious Button
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16415,7 +16246,6 @@ Body:
     Name: Blue Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16429,7 +16259,6 @@ Body:
     Name: Red Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16443,7 +16272,6 @@ Body:
     Name: Metal Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16457,7 +16285,6 @@ Body:
     Name: Rosimier Mansion Keys
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16471,7 +16298,6 @@ Body:
     Name: Family Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16485,7 +16311,6 @@ Body:
     Name: Woman's Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16499,7 +16324,6 @@ Body:
     Name: K.H's Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16513,7 +16337,6 @@ Body:
     Name: James's Note
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16527,7 +16350,6 @@ Body:
     Name: Man's Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16541,7 +16363,6 @@ Body:
     Name: Power Device
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16555,7 +16376,6 @@ Body:
     Name: Toy Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16569,7 +16389,6 @@ Body:
     Name: Black Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16590,7 +16409,6 @@ Body:
     Name: Allysia's Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16604,7 +16422,6 @@ Body:
     Name: Luxurious Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16655,7 +16472,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16668,7 +16484,6 @@ Body:
     Name: Green Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16688,7 +16503,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16745,7 +16559,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16764,7 +16577,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoTrade: true
       NoSell: true
       NoCart: true
@@ -16785,7 +16597,6 @@ Body:
     Name: Travel Brochure [Amatsu]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16799,7 +16610,6 @@ Body:
     Name: Travel Brochure [Kunlun]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16813,7 +16623,6 @@ Body:
     Name: Travel Brochure [Luoyang]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16827,7 +16636,6 @@ Body:
     Name: Travel Brochure [Ayothaya]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16841,7 +16649,6 @@ Body:
     Name: Amatsu Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16855,7 +16662,6 @@ Body:
     Name: Kunlun Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16869,7 +16675,6 @@ Body:
     Name: Luoyang Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16883,7 +16688,6 @@ Body:
     Name: Ayothaya Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16897,7 +16701,6 @@ Body:
     Name: Sand for Work
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16910,7 +16713,6 @@ Body:
     Name: Poring Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16960,7 +16762,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16975,7 +16776,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16990,7 +16790,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17005,7 +16804,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17020,7 +16818,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17035,7 +16832,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17048,7 +16844,6 @@ Body:
     Name: Lotus Flower
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17061,7 +16856,6 @@ Body:
     Name: Striped Candle
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17074,7 +16868,6 @@ Body:
     Name: Green Incense
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17087,7 +16880,6 @@ Body:
     Name: Longing Heart
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17100,7 +16892,6 @@ Body:
     Name: Invitation Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17113,7 +16904,6 @@ Body:
     Name: Invitation Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17126,7 +16916,6 @@ Body:
     Name: Key to the Secret Garden
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17207,7 +16996,6 @@ Body:
     Name: Wind Hammer
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17229,7 +17017,6 @@ Body:
     Name: Ashy Necklace
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17242,7 +17029,6 @@ Body:
     Name: Sparkling Necklace
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17262,7 +17048,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17277,7 +17062,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17293,7 +17077,6 @@ Body:
     Buy: 20
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17314,7 +17097,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17329,7 +17111,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17356,7 +17137,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17371,7 +17151,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17386,7 +17165,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17401,7 +17179,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17416,7 +17193,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17431,7 +17207,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17499,7 +17274,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17568,7 +17342,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17601,7 +17374,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17616,7 +17388,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17631,7 +17402,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17646,7 +17416,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17660,7 +17429,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -17670,7 +17438,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17686,7 +17453,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17717,7 +17483,6 @@ Body:
     Name: Pink Gift Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18064,7 +17829,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18120,7 +17884,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18135,7 +17898,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18173,7 +17935,6 @@ Body:
     Name: Wat Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18197,7 +17958,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18246,7 +18006,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18260,7 +18019,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18274,7 +18032,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18288,7 +18045,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18302,7 +18058,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18316,7 +18071,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18330,7 +18084,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18344,7 +18097,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18362,7 +18114,6 @@ Body:
     Name: Golden Apple
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18375,7 +18126,6 @@ Body:
     Name: The Crow of Destiny
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18418,7 +18168,6 @@ Body:
     Name: Golden Charm Apple
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18431,7 +18180,6 @@ Body:
     Name: Girl's Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18444,7 +18192,6 @@ Body:
     Name: Signature Notebook
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18537,7 +18284,6 @@ Body:
     Name: Piece of Morocc Skin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18553,7 +18299,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18568,7 +18313,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18583,7 +18327,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18600,7 +18343,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18619,7 +18361,6 @@ Body:
     Name: Continental Guard Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18637,7 +18378,6 @@ Body:
     Name: Bravery Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18649,7 +18389,6 @@ Body:
     Name: Valor Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18733,7 +18472,6 @@ Body:
     Name: Crystal Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18746,7 +18484,6 @@ Body:
     Name: Valkyrie's Gift
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18760,7 +18497,6 @@ Body:
     Name: Stained Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18773,7 +18509,6 @@ Body:
     Name: Torn Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18786,7 +18521,6 @@ Body:
     Name: Old Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18799,7 +18533,6 @@ Body:
     Name: Burnt Pieces Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18914,7 +18647,6 @@ Body:
     Buy: 20
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18933,7 +18665,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18947,7 +18678,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19009,7 +18739,6 @@ Body:
     Type: Etc
     Buy: 300000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19022,7 +18751,6 @@ Body:
     Type: Etc
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19036,7 +18764,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19050,7 +18777,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19064,7 +18790,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19078,7 +18803,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19092,7 +18816,6 @@ Body:
     Type: Etc
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19105,7 +18828,6 @@ Body:
     Name: Sharp Branch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19118,7 +18840,6 @@ Body:
     Name: Wooden Flute
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19131,7 +18852,6 @@ Body:
     Name: Jade Plate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19144,7 +18864,6 @@ Body:
     Name: Sacred Arrow
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19201,7 +18920,6 @@ Body:
     Name: Rama5 Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19214,7 +18932,6 @@ Body:
     Name: Loykrathong Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19227,7 +18944,6 @@ Body:
     Name: Constitution Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19240,7 +18956,6 @@ Body:
     Name: VV Strong Balmung
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19253,7 +18968,6 @@ Body:
     Name: Dagger Of Psychic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19266,7 +18980,6 @@ Body:
     Name: Jonathan Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19280,7 +18993,6 @@ Body:
     Name: Jillberriel Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19294,7 +19006,6 @@ Body:
     Name: Jessur Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19308,7 +19019,6 @@ Body:
     Name: Jenoss Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19322,7 +19032,6 @@ Body:
     Name: Piano Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19342,7 +19051,6 @@ Body:
     Name: Poppy Wreath
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19358,7 +19066,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19391,7 +19098,6 @@ Body:
     Name: Portable Snowman Machine
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19405,7 +19111,6 @@ Body:
     Name: Battle Test Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19420,7 +19125,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19474,7 +19178,6 @@ Body:
     Name: Krathong
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19489,7 +19192,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19505,7 +19207,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19520,7 +19221,6 @@ Body:
     Type: Etc
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19629,7 +19329,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -19639,7 +19338,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -19665,7 +19363,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19679,7 +19376,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19693,7 +19389,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19707,7 +19402,6 @@ Body:
     Name: Gift Of Lomi Ross
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19721,7 +19415,6 @@ Body:
     Name: Gift Of Juliet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19737,7 +19430,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19770,7 +19462,6 @@ Body:
     Name: Ancient Gold Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
   - Id: 7960
@@ -19778,7 +19469,6 @@ Body:
     Name: Ancient Silver Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoGuildStorage: true
   - Id: 7961
@@ -19786,7 +19476,6 @@ Body:
     Name: Weapon Exchange
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19800,7 +19489,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19814,7 +19502,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19828,7 +19515,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19842,7 +19528,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19856,7 +19541,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19870,7 +19554,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19884,7 +19567,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19898,7 +19580,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19924,7 +19605,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19938,7 +19618,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19966,7 +19645,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19981,7 +19659,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19996,7 +19673,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20011,7 +19687,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20026,7 +19701,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20041,7 +19715,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20056,7 +19729,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20071,7 +19743,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20086,7 +19757,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20101,7 +19771,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20116,7 +19785,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20131,7 +19799,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20146,7 +19813,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20161,7 +19827,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20176,7 +19841,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20191,7 +19855,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20206,7 +19869,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20221,7 +19883,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20236,7 +19897,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20251,7 +19911,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20266,7 +19925,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20281,7 +19939,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true

--- a/db/pre-re/item_db_usable.yml
+++ b/db/pre-re/item_db_usable.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -1091,7 +1091,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "SM_SELFPROVOKE",1;
@@ -1229,7 +1228,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1002;
@@ -1242,7 +1240,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1113;
@@ -1255,7 +1252,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1031;
@@ -1268,7 +1264,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1063;
@@ -1281,7 +1276,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1049;
@@ -1294,7 +1288,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1011;
@@ -1307,7 +1300,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1042;
@@ -1320,7 +1312,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1035;
@@ -1333,7 +1324,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1167;
@@ -1346,7 +1336,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1107;
@@ -1359,7 +1348,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1052;
@@ -1372,7 +1360,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1014;
@@ -1385,7 +1372,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1077;
@@ -1398,7 +1384,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1019;
@@ -1411,7 +1396,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1056;
@@ -1424,7 +1408,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1057;
@@ -1437,7 +1420,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1023;
@@ -1450,7 +1432,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1026;
@@ -1463,7 +1444,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1110;
@@ -1476,7 +1456,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1170;
@@ -1489,7 +1468,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1029;
@@ -1502,7 +1480,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1155;
@@ -1515,7 +1492,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1109;
@@ -1528,7 +1504,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1101;
@@ -1641,7 +1616,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1188;
@@ -1654,7 +1628,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1200;
@@ -1667,7 +1640,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1275;
@@ -1844,7 +1816,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "WZ_EARTHSPIKE",3;
@@ -1857,7 +1828,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "WZ_EARTHSPIKE",5;
@@ -1870,7 +1840,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_COLDBOLT",3;
@@ -1883,7 +1852,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_COLDBOLT",5;
@@ -1896,7 +1864,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBOLT",3;
@@ -1909,7 +1876,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBOLT",5;
@@ -1922,7 +1888,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_LIGHTNINGBOLT",3;
@@ -1935,7 +1900,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_LIGHTNINGBOLT",5;
@@ -1948,7 +1912,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_SOULSTRIKE",3;
@@ -1961,7 +1924,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_SOULSTRIKE",5;
@@ -1974,7 +1936,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBALL",1;
@@ -1987,7 +1948,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBALL",5;
@@ -2000,7 +1960,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREWALL",1;
@@ -2013,7 +1972,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREWALL",5;
@@ -2026,7 +1984,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FROSTDIVER",1;
@@ -2035,7 +1992,6 @@ Body:
     Name: Clothing Dye Coupon
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2049,7 +2005,6 @@ Body:
     Name: Clothing Dye Coupon II
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2088,7 +2043,6 @@ Body:
     Type: Healing
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2104,7 +2058,6 @@ Body:
     Type: Healing
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2120,7 +2073,6 @@ Body:
     Type: Healing
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2203,7 +2155,6 @@ Body:
     Type: Healing
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2396,7 +2347,6 @@ Body:
     Type: Healing
     Weight: 300
     NoUse:
-      Override: 100
       Sitting: true
   - Id: 11703
     AegisName: Mysterious_Blood
@@ -2486,7 +2436,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FROSTDIVER",5;
@@ -2499,7 +2448,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AL_HEAL",3;
@@ -2512,7 +2460,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AL_HEAL",5;
@@ -2755,7 +2702,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 9,0;
@@ -2769,7 +2715,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_SPEEDUP0,20000,25;
@@ -2782,7 +2727,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AC_CONCENTRATION",1;
@@ -2795,7 +2739,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_ATKPOTION,60000,20;
@@ -2808,7 +2751,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_MATKPOTION,60000,20;
@@ -2821,7 +2763,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "ITEM_ENCHANTARMS",2;
@@ -2834,7 +2775,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_Intravision,30000,0;
@@ -2847,7 +2787,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,9;
@@ -3955,7 +3894,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoTrade: true
       NoSell: true
       NoCart: true
@@ -4063,7 +4001,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4080,7 +4017,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4097,7 +4033,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4114,7 +4049,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4131,7 +4065,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4148,7 +4081,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4165,7 +4097,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4182,7 +4113,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4199,7 +4129,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4216,7 +4145,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4233,7 +4161,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4250,7 +4177,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4267,7 +4193,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4284,7 +4209,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4301,7 +4225,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4318,7 +4241,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4335,7 +4257,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4352,7 +4273,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4369,7 +4289,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4386,7 +4305,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4403,7 +4321,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4420,7 +4337,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4437,7 +4353,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4454,7 +4369,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4471,7 +4385,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4488,7 +4401,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4505,7 +4417,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4522,7 +4433,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4539,7 +4449,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4556,7 +4465,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4718,7 +4626,6 @@ Body:
     Name: Scroll of Magic
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4748,7 +4655,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4766,7 +4672,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4784,7 +4689,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4802,7 +4706,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4820,7 +4723,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4838,7 +4740,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4859,7 +4760,6 @@ Body:
       Duration: 60000
       Status: Reuse_Limit_C
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4876,7 +4776,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4896,7 +4795,6 @@ Body:
       Duration: 60000
       Status: Reuse_Limit_D
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4913,7 +4811,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4930,7 +4827,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4946,7 +4842,6 @@ Body:
     Type: Delayconsume
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4963,7 +4858,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4980,10 +4874,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5001,10 +4893,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5025,10 +4915,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5049,10 +4937,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5070,10 +4956,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5091,10 +4975,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5115,7 +4997,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5133,7 +5014,6 @@ Body:
     Buy: 20
     Weight: 50
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1245;
@@ -5250,7 +5130,6 @@ Body:
     Buy: 20
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,5;
@@ -5263,7 +5142,6 @@ Body:
     Buy: 20
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -5274,7 +5152,6 @@ Body:
     Type: Usable
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,5;
@@ -5460,7 +5337,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5477,7 +5353,6 @@ Body:
     Name: Miracle Tonic
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5502,7 +5377,6 @@ Body:
     Name: Leap of Fantasy
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5519,7 +5393,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5537,7 +5410,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5554,7 +5426,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5571,7 +5442,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5588,7 +5458,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5606,7 +5475,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5624,7 +5492,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5643,7 +5510,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5660,7 +5526,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5677,7 +5542,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5694,7 +5558,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5711,7 +5574,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5727,7 +5589,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5745,7 +5606,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5764,7 +5624,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -5777,7 +5636,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -5790,7 +5648,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -5876,7 +5733,6 @@ Body:
     Name: Love Angel Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5894,7 +5750,6 @@ Body:
     Name: Squirrel Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5912,7 +5767,6 @@ Body:
     Name: Gogo Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5934,7 +5788,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -5949,7 +5802,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -5981,7 +5833,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5998,7 +5849,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6015,7 +5865,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6032,7 +5881,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6049,7 +5897,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6066,7 +5913,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6083,7 +5929,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6099,7 +5944,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6115,7 +5959,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6131,7 +5974,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6144,7 +5986,6 @@ Body:
     Name: Diary Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6162,7 +6003,6 @@ Body:
     Name: Mini Heart Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6180,7 +6020,6 @@ Body:
     Name: Freshman Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6198,7 +6037,6 @@ Body:
     Name: Kid Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6216,7 +6054,6 @@ Body:
     Name: Magic Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6234,7 +6071,6 @@ Body:
     Name: JJangu Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6253,10 +6089,8 @@ Body:
     Type: Usable
     Weight: 50
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6271,10 +6105,8 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6294,10 +6126,8 @@ Body:
     Name: Guardian Angel
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6367,10 +6197,8 @@ Body:
     Name: Novice Fly Wing
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6386,10 +6214,8 @@ Body:
     Name: Novice Butterfly Wing
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6405,10 +6231,8 @@ Body:
     Name: Novice Magnifier
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6463,7 +6287,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6480,7 +6303,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6500,7 +6322,6 @@ Body:
       Amount: 3
       Inventory: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6569,10 +6390,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6600,7 +6419,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6619,7 +6437,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6638,7 +6455,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6657,7 +6473,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6675,7 +6490,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6692,7 +6506,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "ALL_REVERSEORCISH",1;
@@ -6704,7 +6517,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6723,7 +6535,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6743,10 +6554,8 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -6765,7 +6574,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -6843,7 +6651,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1513;
@@ -6856,7 +6663,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1586;
@@ -6869,7 +6675,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1505;
@@ -6878,10 +6683,8 @@ Body:
     Name: Delicious Shaved Ice
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6901,7 +6704,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1401;
@@ -6910,10 +6712,8 @@ Body:
     Name: Fit Pipe
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6933,7 +6733,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1299;
@@ -6946,7 +6745,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1416;
@@ -6959,7 +6757,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1404;
@@ -6972,7 +6769,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1504;
@@ -6985,7 +6781,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1148;
@@ -6998,7 +6793,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1495;
@@ -7007,10 +6801,8 @@ Body:
     Name: Girl's Naivety
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7030,7 +6822,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1040;
@@ -7043,7 +6834,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1379;
@@ -7056,7 +6846,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1370;
@@ -7069,7 +6858,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1837;
@@ -7079,7 +6867,6 @@ Body:
     Type: Usable
     Weight: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -7097,7 +6884,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 3,0;
@@ -7111,7 +6897,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,3;
@@ -7176,7 +6961,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7192,7 +6976,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7208,7 +6991,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7224,7 +7006,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7240,10 +7021,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7260,10 +7039,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7280,10 +7057,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7300,7 +7075,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7373,10 +7147,8 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -7399,10 +7171,8 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -7425,7 +7195,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7459,7 +7228,6 @@ Body:
     Name: 29Fruit
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7482,7 +7250,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7497,7 +7264,6 @@ Body:
     Buy: 20
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7516,7 +7282,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7566,7 +7331,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7592,7 +7356,6 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
   - Id: 12416
     AegisName: Lucky_Egg_C3
@@ -8034,10 +7797,8 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8051,10 +7812,8 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8084,7 +7843,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8103,7 +7861,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8117,7 +7874,6 @@ Body:
     Name: Caracas Ring Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8132,7 +7888,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8146,7 +7901,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8160,7 +7914,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8174,7 +7927,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8188,7 +7940,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8202,7 +7953,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8216,7 +7966,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8230,7 +7979,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8269,7 +8017,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8283,7 +8030,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8497,7 +8243,6 @@ Body:
     Name: White Slim Potion Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8510,7 +8255,6 @@ Body:
     Name: Mastela Fruit Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8523,7 +8267,6 @@ Body:
     Name: White Potion Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8536,7 +8279,6 @@ Body:
     Name: Royal Jelly Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8549,7 +8291,6 @@ Body:
     Name: Blue Herb Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8562,7 +8303,6 @@ Body:
     Name: Yggdrasil Seed Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8575,7 +8315,6 @@ Body:
     Name: Iggdrasilberry Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8618,7 +8357,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8633,7 +8371,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8648,7 +8385,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8663,7 +8399,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8707,7 +8442,6 @@ Body:
     Name: White Slim Pot Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8720,7 +8454,6 @@ Body:
     Name: Poison Bottle Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8958,7 +8691,6 @@ Body:
     Weight: 10
     EquipLevelMin: 85
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8975,7 +8707,6 @@ Body:
     Weight: 100
     EquipLevelMin: 90
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8991,7 +8722,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_GLORIA",5;
@@ -9001,7 +8731,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_MAGNIFICAT",1;
@@ -9011,7 +8740,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_IMPOSITIO",3;
@@ -9060,7 +8788,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9074,7 +8801,6 @@ Body:
     Name: Black Treasure Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9180,10 +8906,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9206,10 +8930,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9232,10 +8954,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9258,10 +8978,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9281,10 +8999,8 @@ Body:
     Classes:
       Third: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9307,10 +9023,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9330,10 +9044,8 @@ Body:
     Classes:
       Third: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9353,10 +9065,8 @@ Body:
     Classes:
       Third: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9379,10 +9089,8 @@ Body:
       Amount: 60
       Inventory: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9476,7 +9184,6 @@ Body:
     Type: Usable
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9486,7 +9193,6 @@ Body:
     Type: Usable
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9509,7 +9215,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9525,7 +9230,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9581,7 +9285,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9596,7 +9299,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9614,7 +9316,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9676,7 +9377,6 @@ Body:
     Name: Reward Job BM25
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9690,7 +9390,6 @@ Body:
     Name: Passion FB Hat Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9702,7 +9401,6 @@ Body:
     Name: Cool FB Hat Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9714,7 +9412,6 @@ Body:
     Name: Victory FB Hat Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9726,7 +9423,6 @@ Body:
     Name: Glory FB Hat Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9738,7 +9434,6 @@ Body:
     Name: Passion Hat Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9750,7 +9445,6 @@ Body:
     Name: Cool Hat Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9762,7 +9456,6 @@ Body:
     Name: Victory Hat Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9798,7 +9491,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9813,7 +9505,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9828,7 +9519,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9843,7 +9533,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9858,7 +9547,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9873,7 +9561,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9888,7 +9575,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9903,7 +9589,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9918,7 +9603,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9933,7 +9617,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9948,7 +9631,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9963,7 +9645,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9978,7 +9659,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -9993,7 +9673,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10008,7 +9687,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10023,7 +9701,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10038,7 +9715,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10053,7 +9729,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10068,7 +9743,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10083,7 +9757,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10098,7 +9771,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10113,7 +9785,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10128,7 +9799,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10143,7 +9813,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10158,7 +9827,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10173,7 +9841,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10188,7 +9855,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10211,7 +9877,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10228,7 +9893,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10243,7 +9907,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10258,7 +9921,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10273,7 +9935,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10288,7 +9949,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10303,7 +9963,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10318,7 +9977,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10334,7 +9992,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10350,7 +10007,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10366,7 +10022,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10382,7 +10037,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10398,7 +10052,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10414,7 +10067,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10430,7 +10082,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10446,7 +10097,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10462,7 +10112,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10478,7 +10127,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10494,7 +10142,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10510,7 +10157,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10526,7 +10172,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10542,7 +10187,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10558,7 +10202,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10574,7 +10217,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10590,7 +10232,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10606,7 +10247,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10622,7 +10262,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10638,7 +10277,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10654,7 +10292,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10670,7 +10307,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10686,7 +10322,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10702,7 +10337,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10718,7 +10352,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10734,7 +10367,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10750,7 +10382,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10766,7 +10397,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10782,7 +10412,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -10951,7 +10580,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10966,7 +10594,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10981,7 +10608,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -10996,7 +10622,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11011,7 +10636,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11026,7 +10650,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11040,7 +10663,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11054,7 +10676,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11068,7 +10689,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11082,7 +10702,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11096,7 +10715,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11110,7 +10728,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11363,7 +10980,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11548,7 +11164,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -11605,7 +11220,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12732,7 +12346,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12749,7 +12362,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12800,7 +12412,6 @@ Body:
     Type: Cash
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12858,7 +12469,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12869,7 +12479,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12880,7 +12489,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12891,7 +12499,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12914,7 +12521,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12927,7 +12533,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12940,7 +12545,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12953,7 +12557,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12966,7 +12569,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12979,7 +12581,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -12992,7 +12593,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13005,7 +12605,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13018,7 +12617,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13031,7 +12629,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13044,7 +12641,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13057,7 +12653,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13178,7 +12773,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13191,7 +12785,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13204,7 +12797,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13217,7 +12809,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13230,7 +12821,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13243,7 +12833,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13256,7 +12845,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13269,7 +12857,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13282,7 +12869,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13295,7 +12881,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13308,7 +12893,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13321,7 +12905,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13334,7 +12917,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13347,7 +12929,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13360,7 +12941,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13373,7 +12953,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13386,7 +12965,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13399,7 +12977,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13412,7 +12989,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13425,7 +13001,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13494,7 +13069,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13917,7 +13491,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13930,7 +13503,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13943,7 +13515,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13956,7 +13527,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13969,7 +13539,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13982,7 +13551,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -13995,7 +13563,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14008,7 +13575,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14021,7 +13587,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14034,7 +13599,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14323,7 +13887,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14340,7 +13903,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14375,7 +13937,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14396,7 +13957,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14413,7 +13973,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14430,7 +13989,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14447,7 +14005,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14464,7 +14021,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14481,7 +14037,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14503,7 +14058,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14524,7 +14078,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14545,7 +14098,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14566,7 +14118,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14587,7 +14138,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14608,7 +14158,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14628,7 +14177,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14646,7 +14194,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14664,7 +14211,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14682,7 +14228,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14700,7 +14245,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14717,7 +14261,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14734,7 +14277,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14751,7 +14293,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14768,7 +14309,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14785,7 +14325,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14802,7 +14341,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14819,7 +14357,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14836,7 +14373,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14853,7 +14389,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14870,7 +14405,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14887,7 +14421,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14904,7 +14437,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14920,7 +14452,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14950,7 +14481,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14963,7 +14493,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14976,7 +14505,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -14989,7 +14517,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15002,7 +14529,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15015,7 +14541,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15028,7 +14553,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15045,7 +14569,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15062,7 +14585,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15079,7 +14601,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15098,7 +14619,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15119,7 +14639,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15138,7 +14657,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15157,7 +14675,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15177,7 +14694,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15196,7 +14712,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15211,7 +14726,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15224,7 +14738,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15237,7 +14750,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -15250,7 +14762,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15267,7 +14778,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15284,7 +14794,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15301,7 +14810,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15321,7 +14829,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15342,7 +14849,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15363,7 +14869,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15384,7 +14889,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15405,7 +14909,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15425,7 +14928,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15442,7 +14944,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15459,7 +14960,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15476,7 +14976,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15493,7 +14992,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15510,7 +15008,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15527,7 +15024,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15544,7 +15040,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15561,7 +15056,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15576,7 +15070,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15593,7 +15086,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15610,7 +15102,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15627,7 +15118,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15652,7 +15142,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15676,7 +15165,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15700,7 +15188,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15724,7 +15211,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15748,7 +15234,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15772,7 +15257,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15789,7 +15273,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15806,7 +15289,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15823,7 +15305,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15840,7 +15321,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15857,7 +15337,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15874,7 +15353,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15891,7 +15369,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15908,7 +15385,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15925,7 +15401,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15942,7 +15417,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15959,7 +15433,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15976,7 +15449,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15993,7 +15465,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16010,7 +15481,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16027,7 +15497,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16044,7 +15513,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16061,7 +15529,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16078,7 +15545,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16095,7 +15561,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16112,7 +15577,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16129,7 +15593,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16144,7 +15607,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16161,7 +15623,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16178,7 +15639,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16195,7 +15655,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16212,7 +15671,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16229,7 +15687,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16246,7 +15703,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16263,7 +15719,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16280,7 +15735,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16297,7 +15751,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16314,7 +15767,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16331,7 +15783,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16348,7 +15799,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16365,7 +15815,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16382,7 +15831,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16400,7 +15848,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16417,7 +15864,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16434,7 +15880,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16451,7 +15896,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16468,7 +15912,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16485,7 +15928,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16502,7 +15944,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16519,7 +15960,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16536,7 +15976,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16553,7 +15992,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16570,7 +16008,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16587,7 +16024,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16605,7 +16041,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16623,7 +16058,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16641,7 +16075,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16658,7 +16091,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16675,7 +16107,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16692,7 +16123,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16709,7 +16139,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16726,7 +16155,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16743,7 +16171,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16760,7 +16187,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16777,7 +16203,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16794,7 +16219,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16811,7 +16235,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16828,7 +16251,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16845,7 +16267,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16862,7 +16283,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16879,7 +16299,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16896,7 +16315,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16913,7 +16331,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16930,7 +16347,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16947,7 +16363,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16964,7 +16379,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16981,7 +16395,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16998,7 +16411,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17015,7 +16427,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17032,7 +16443,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17049,7 +16459,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17066,7 +16475,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17083,7 +16491,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17100,7 +16507,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17117,7 +16523,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17134,7 +16539,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17151,7 +16555,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17168,7 +16571,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17185,7 +16587,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17206,7 +16607,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17227,7 +16627,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17244,7 +16643,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17261,7 +16659,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17278,7 +16675,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17295,7 +16691,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17312,7 +16707,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17329,7 +16723,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17346,7 +16739,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17363,7 +16755,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17380,7 +16771,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17397,7 +16787,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17414,7 +16803,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17431,7 +16819,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17448,7 +16835,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17465,7 +16851,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17482,7 +16867,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17499,7 +16883,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17516,7 +16899,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17533,7 +16915,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17550,7 +16931,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17567,7 +16947,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17584,7 +16963,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17601,7 +16979,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17618,7 +16995,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17635,7 +17011,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17652,7 +17027,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17669,7 +17043,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17686,7 +17059,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17703,7 +17075,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17720,7 +17091,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17737,7 +17107,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17754,7 +17123,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17771,7 +17139,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17788,7 +17155,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17805,7 +17171,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17822,7 +17187,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17839,7 +17203,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17856,7 +17219,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17873,7 +17235,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17890,7 +17251,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17907,7 +17267,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17924,7 +17283,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17941,7 +17299,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17958,7 +17315,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17975,7 +17331,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17992,7 +17347,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18009,7 +17363,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18026,7 +17379,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18043,7 +17395,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18060,7 +17411,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18077,7 +17427,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18094,7 +17443,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18111,7 +17459,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18128,7 +17475,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18145,7 +17491,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18162,7 +17507,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18179,7 +17523,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18196,7 +17539,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18213,7 +17555,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18230,7 +17571,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18247,7 +17587,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18264,7 +17603,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18281,7 +17619,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18298,7 +17635,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18315,7 +17651,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18332,7 +17667,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18349,7 +17683,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18366,7 +17699,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18383,7 +17715,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18400,7 +17731,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18417,7 +17747,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18434,7 +17763,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18451,7 +17779,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18468,7 +17795,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18485,7 +17811,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18502,7 +17827,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18519,7 +17843,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18536,7 +17859,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18553,7 +17875,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18570,7 +17891,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18587,7 +17907,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18604,7 +17923,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18621,7 +17939,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18638,7 +17955,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18655,7 +17971,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18672,7 +17987,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18689,7 +18003,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18706,7 +18019,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18723,7 +18035,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18740,7 +18051,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18757,7 +18067,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18774,7 +18083,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18791,7 +18099,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18808,7 +18115,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18825,7 +18131,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18842,7 +18147,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18859,7 +18163,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18876,7 +18179,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18893,7 +18195,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18910,7 +18211,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18927,7 +18227,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18944,7 +18243,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18961,7 +18259,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18978,7 +18275,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19001,7 +18297,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19024,7 +18319,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19047,7 +18341,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19070,7 +18363,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19093,7 +18385,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19116,7 +18407,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19139,7 +18429,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19162,7 +18451,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19185,7 +18473,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19208,7 +18495,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19231,7 +18517,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19254,7 +18539,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19271,7 +18555,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19288,7 +18571,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19305,7 +18587,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19322,7 +18603,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19339,7 +18619,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19356,7 +18635,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19373,7 +18651,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19390,7 +18667,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19407,7 +18683,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19424,7 +18699,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19441,7 +18715,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19458,7 +18731,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19475,7 +18747,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19492,7 +18763,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19509,7 +18779,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19527,7 +18796,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19544,7 +18812,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19561,7 +18828,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19578,7 +18844,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19595,7 +18860,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19612,7 +18876,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19629,7 +18892,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19646,7 +18908,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19663,7 +18924,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19680,7 +18940,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19697,7 +18956,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19714,7 +18972,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19731,7 +18988,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19748,7 +19004,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19765,7 +19020,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19782,7 +19036,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19799,7 +19052,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19816,7 +19068,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19833,7 +19084,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19850,7 +19100,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19867,7 +19116,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19884,7 +19132,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19901,7 +19148,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19918,7 +19164,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19935,7 +19180,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19952,7 +19196,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19969,7 +19212,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19986,7 +19228,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20004,7 +19245,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20022,7 +19262,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20039,7 +19278,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20056,7 +19294,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20073,7 +19310,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20090,7 +19326,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20107,7 +19342,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20124,7 +19358,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20141,7 +19374,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20158,7 +19390,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20175,7 +19406,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20192,7 +19422,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20209,7 +19438,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20226,7 +19454,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20243,7 +19470,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20260,7 +19486,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20277,7 +19502,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20294,7 +19518,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20311,7 +19534,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20328,7 +19550,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20345,7 +19566,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20362,7 +19582,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20379,7 +19598,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20396,7 +19614,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20413,7 +19630,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20430,7 +19646,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20447,7 +19662,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20464,7 +19678,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20497,7 +19710,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20566,7 +19778,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20579,7 +19790,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20592,7 +19802,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20605,7 +19814,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20618,7 +19826,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20631,7 +19838,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20644,7 +19850,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20657,7 +19862,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20670,7 +19874,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20683,7 +19886,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20696,7 +19898,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20709,7 +19910,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20722,7 +19922,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20735,7 +19934,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20748,7 +19946,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20761,7 +19958,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20774,7 +19970,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20787,7 +19982,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20800,7 +19994,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -20813,7 +20006,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21000,7 +20192,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21017,7 +20208,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21048,7 +20238,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21059,7 +20248,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21070,7 +20258,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21083,7 +20270,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21096,7 +20282,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21108,7 +20293,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21124,7 +20308,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21141,7 +20324,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21152,7 +20334,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21165,7 +20346,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21182,7 +20362,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21199,7 +20378,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21212,7 +20390,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21225,7 +20402,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21238,7 +20414,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21251,7 +20426,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21264,7 +20438,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21275,7 +20448,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21290,7 +20462,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21307,7 +20478,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21322,7 +20492,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21337,7 +20506,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21350,7 +20518,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21361,7 +20528,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21376,7 +20542,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21391,7 +20556,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21406,7 +20570,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21421,7 +20584,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21438,7 +20600,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21455,7 +20616,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21470,7 +20630,6 @@ Body:
     Name: Valentine's Emblem Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21486,7 +20645,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21506,7 +20664,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -21642,10 +20799,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21696,7 +20851,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21717,7 +20871,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "BS_GREED",1;
@@ -21742,7 +20895,6 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_EXPBOOST,1800000,25;
@@ -21753,7 +20905,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21769,7 +20920,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21786,7 +20936,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21803,7 +20952,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21820,7 +20968,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21840,7 +20987,6 @@ Body:
       Duration: 300000
       Status: Reuse_Limit_A
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21857,7 +21003,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21874,7 +21019,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21891,7 +21035,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21908,7 +21051,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21925,7 +21067,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21942,7 +21083,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22158,7 +21298,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22174,7 +21313,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22190,7 +21328,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22206,7 +21343,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22222,7 +21358,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22238,7 +21373,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22346,7 +21480,6 @@ Body:
       Duration: 180000
       Status: Reuse_Limit_B
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22356,10 +21489,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22376,7 +21507,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22390,7 +21520,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22404,7 +21533,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22417,10 +21545,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22436,10 +21562,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22455,10 +21579,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22474,10 +21596,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22513,7 +21633,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22529,7 +21648,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22545,10 +21663,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22562,7 +21678,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22572,7 +21687,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22587,7 +21701,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22603,7 +21716,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22619,7 +21731,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22635,7 +21746,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22651,10 +21761,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22677,7 +21785,6 @@ Body:
     Buy: 20000
     Weight: 1200
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22698,7 +21805,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22715,7 +21821,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22730,7 +21835,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22747,7 +21851,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22764,7 +21867,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22775,7 +21877,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22790,7 +21891,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22805,7 +21905,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22820,7 +21919,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22835,7 +21933,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22850,7 +21947,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22861,7 +21957,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22876,7 +21971,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22891,7 +21985,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22906,7 +21999,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22921,7 +22013,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true
@@ -22934,7 +22025,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoGuildStorage: true

--- a/db/re/item_db.yml
+++ b/db/re/item_db.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -1825,7 +1825,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1853,7 +1852,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1935,7 +1933,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2089,7 +2086,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2122,7 +2118,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2207,7 +2202,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2300,7 +2294,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2349,7 +2342,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2373,7 +2365,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2461,7 +2452,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2485,7 +2475,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3978,7 +3967,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4495,7 +4483,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4610,7 +4597,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4634,7 +4620,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4661,7 +4646,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4770,7 +4754,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4803,7 +4786,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4836,7 +4818,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4875,7 +4856,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -4911,7 +4891,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -4983,7 +4962,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5030,7 +5008,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5057,7 +5034,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5131,7 +5107,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -5218,7 +5193,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5289,7 +5263,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5561,7 +5534,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5644,7 +5616,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5678,7 +5649,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5823,7 +5793,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6744,7 +6713,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6779,7 +6747,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6811,7 +6778,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6927,7 +6893,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6962,7 +6927,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6998,7 +6962,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7052,7 +7015,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7181,7 +7143,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7247,7 +7208,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7319,7 +7279,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7408,7 +7367,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bBaseAtk,(getrefine()*14);
@@ -7514,7 +7472,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7548,7 +7505,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7954,7 +7910,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8061,7 +8016,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8088,7 +8042,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8119,7 +8072,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8154,7 +8106,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8199,7 +8150,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8233,7 +8183,6 @@ Body:
     EquipLevelMin: 65
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8268,7 +8217,6 @@ Body:
     EquipLevelMin: 60
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8297,7 +8245,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8391,7 +8338,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8470,7 +8416,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9481,7 +9426,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9584,7 +9528,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9627,7 +9570,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9655,7 +9597,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9686,7 +9627,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9750,7 +9690,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bBaseAtk,(getrefine()*12);
@@ -9806,7 +9745,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9858,7 +9796,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10768,7 +10705,6 @@ Body:
     EquipLevelMin: 48
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10795,7 +10731,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10862,7 +10797,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10888,7 +10822,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11021,7 +10954,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11063,7 +10995,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11157,7 +11088,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11202,7 +11132,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11550,7 +11479,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11633,7 +11561,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11661,7 +11588,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11823,7 +11749,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11858,7 +11783,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11893,7 +11817,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11935,7 +11858,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11975,7 +11897,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12008,7 +11929,6 @@ Body:
     EquipLevelMin: 85
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12042,7 +11962,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12110,7 +12029,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12169,7 +12087,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -12253,7 +12170,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12336,7 +12252,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13178,7 +13093,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13298,7 +13212,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13329,7 +13242,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13438,7 +13350,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13476,7 +13387,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13514,7 +13424,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13549,7 +13458,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13643,7 +13551,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13701,7 +13608,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13744,7 +13650,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13788,7 +13693,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13857,7 +13761,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13897,7 +13800,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14045,7 +13947,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14076,7 +13977,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14109,7 +14009,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14139,7 +14038,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14270,7 +14168,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14524,7 +14421,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -14617,7 +14513,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -14925,7 +14820,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15063,7 +14957,6 @@ Body:
     EquipLevelMin: 3
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15406,7 +15299,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15480,7 +15372,6 @@ Body:
     EquipLevelMin: 4
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15981,7 +15872,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16010,7 +15900,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16153,7 +16042,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16228,7 +16116,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16263,7 +16150,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16360,7 +16246,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16403,7 +16288,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16479,7 +16363,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16505,7 +16388,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16532,7 +16414,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16882,7 +16763,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17017,7 +16897,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17051,7 +16930,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17107,7 +16985,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17149,7 +17026,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17190,7 +17066,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17217,7 +17092,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17271,7 +17145,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17348,7 +17221,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17623,7 +17495,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17707,7 +17578,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17804,7 +17674,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18368,7 +18237,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18416,7 +18284,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18448,7 +18315,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18527,7 +18393,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18566,7 +18431,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18595,7 +18459,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18651,7 +18514,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18675,7 +18537,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18831,7 +18692,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18905,7 +18765,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19560,7 +19419,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19608,7 +19466,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19640,7 +19497,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19719,7 +19575,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19757,7 +19612,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19784,7 +19638,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19865,7 +19718,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19889,7 +19741,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20043,7 +19894,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20112,7 +19962,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20196,7 +20045,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20242,7 +20090,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20565,7 +20412,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -20663,7 +20509,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20704,7 +20549,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20843,7 +20687,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20951,7 +20794,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21013,7 +20855,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21142,7 +20983,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21752,7 +21592,6 @@ Body:
     ArmorLevel: 1
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22065,7 +21904,6 @@ Body:
     ArmorLevel: 1
     View: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22171,7 +22009,6 @@ Body:
     ArmorLevel: 1
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22276,7 +22113,6 @@ Body:
     ArmorLevel: 1
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22307,7 +22143,6 @@ Body:
     EquipLevelMin: 95
     View: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22390,7 +22225,6 @@ Body:
     Refineable: true
     View: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22465,7 +22299,6 @@ Body:
     Refineable: true
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22544,7 +22377,6 @@ Body:
     Refineable: true
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -22577,7 +22409,6 @@ Body:
     Refineable: true
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -22600,7 +22431,6 @@ Body:
     Refineable: true
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -22615,7 +22445,6 @@ Body:
     EquipLevelMin: 1
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22929,7 +22758,6 @@ Body:
     Refineable: true
     View: 4
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -23118,7 +22946,6 @@ Body:
     Refineable: true
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23151,7 +22978,6 @@ Body:
     Refineable: true
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23186,7 +23012,6 @@ Body:
     Refineable: true
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26070,7 +25895,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26187,7 +26011,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26396,7 +26219,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26419,7 +26241,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26441,7 +26262,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26592,7 +26412,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26622,7 +26441,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26654,7 +26472,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26685,7 +26502,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26715,7 +26531,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26745,7 +26560,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26774,7 +26588,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26816,7 +26629,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26847,7 +26659,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27039,7 +26850,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27064,7 +26874,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27088,7 +26897,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27116,7 +26924,6 @@ Body:
     EquipLevelMin: 61
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27142,7 +26949,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27185,7 +26991,6 @@ Body:
     EquipLevelMin: 50
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27452,7 +27257,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27716,7 +27520,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27739,7 +27542,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27775,7 +27577,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27794,7 +27595,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27812,7 +27612,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27918,7 +27717,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27955,7 +27753,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27984,7 +27781,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28009,7 +27805,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28031,7 +27826,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28100,7 +27894,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28125,7 +27918,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28148,7 +27940,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28176,7 +27967,6 @@ Body:
     EquipLevelMin: 61
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28202,7 +27992,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28257,7 +28046,6 @@ Body:
     EquipLevelMin: 85
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28362,7 +28150,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28384,7 +28171,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 7
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28405,7 +28191,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28426,7 +28211,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28454,7 +28238,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -28488,7 +28271,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -28508,7 +28290,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -28539,7 +28320,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 75
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28741,7 +28521,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29199,7 +28978,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29234,7 +29012,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29269,7 +29046,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29471,7 +29247,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29929,7 +29704,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29951,7 +29725,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29977,7 +29750,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30073,7 +29845,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30110,7 +29881,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30139,7 +29909,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30203,7 +29972,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30294,7 +30062,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30324,7 +30091,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 95
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30357,7 +30123,6 @@ Body:
     EquipLevelMin: 81
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30399,7 +30164,6 @@ Body:
     EquipLevelMin: 55
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30435,7 +30199,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30555,7 +30318,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30576,7 +30338,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 7
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30598,7 +30359,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -30619,7 +30379,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -30648,7 +30407,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -30663,7 +30421,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 75
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30697,7 +30454,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 47
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30748,7 +30504,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30812,7 +30567,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30849,7 +30603,6 @@ Body:
     Refineable: true
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 2574
     AegisName: Ur_Manteau
@@ -30904,7 +30657,6 @@ Body:
     Refineable: true
     View: 2
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       skill "BS_GREED",1;
@@ -31164,7 +30916,6 @@ Body:
     Refineable: true
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,1;
@@ -31837,7 +31588,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31860,7 +31610,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31966,7 +31715,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31993,7 +31741,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32047,7 +31794,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32438,7 +32184,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 94
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32477,7 +32222,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32538,7 +32282,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 48
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32560,7 +32303,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32591,7 +32333,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32711,7 +32452,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32806,7 +32546,6 @@ Body:
     EquipLevelMin: 1
     View: 73
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32832,7 +32571,6 @@ Body:
     EquipLevelMin: 100
     View: 56
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32858,7 +32596,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32883,7 +32620,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32908,7 +32644,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32933,7 +32668,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32958,7 +32692,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32983,7 +32716,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33009,7 +32741,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33035,7 +32766,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33063,7 +32793,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33091,7 +32820,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33119,7 +32847,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33147,7 +32874,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33246,7 +32972,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33265,7 +32990,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33282,7 +33006,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33301,7 +33024,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33318,7 +33040,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33337,7 +33058,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33362,7 +33082,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33382,7 +33101,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33415,7 +33133,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33530,7 +33247,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33562,7 +33278,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33592,7 +33307,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33622,7 +33336,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33651,7 +33364,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33681,7 +33393,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33796,7 +33507,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33822,7 +33532,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33848,7 +33557,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33871,7 +33579,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -33897,7 +33604,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33917,7 +33623,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33969,7 +33674,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33989,7 +33693,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34009,7 +33712,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34030,7 +33732,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34053,7 +33754,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34251,7 +33951,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34271,7 +33970,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34291,7 +33989,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34311,7 +34008,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34330,7 +34026,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34349,7 +34044,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34368,7 +34062,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34387,7 +34080,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34406,7 +34098,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34425,7 +34116,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34444,7 +34134,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34463,7 +34152,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34482,7 +34170,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34508,7 +34195,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 95
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34551,7 +34237,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34571,7 +34256,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34591,7 +34275,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34611,7 +34294,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34631,7 +34313,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34651,7 +34332,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34677,7 +34357,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 81
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34708,7 +34387,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 61
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34731,7 +34409,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34776,7 +34453,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHP,50;
@@ -34792,7 +34468,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -34808,7 +34483,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -34825,7 +34499,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       autobonus "{ bonus bAspdRate,2; }",10,5000,BF_NORMAL,"{ specialeffect2 EF_ENHANCE; }";
@@ -34841,7 +34514,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,1;
@@ -34856,7 +34528,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34915,7 +34586,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 90
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34936,7 +34606,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -35059,7 +34728,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35102,7 +34770,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35135,7 +34802,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35171,7 +34837,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35198,7 +34863,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35226,7 +34890,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35252,7 +34915,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35275,7 +34937,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,1;
@@ -35546,7 +35207,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35567,7 +35227,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35588,7 +35247,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35615,7 +35273,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35642,7 +35299,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35671,7 +35327,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35698,7 +35353,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35724,7 +35378,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35752,7 +35405,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35777,7 +35429,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -35793,7 +35444,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -35810,7 +35460,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       autobonus "{ bonus bMaxHPrate,2; }",10,5000,BF_NORMAL,"{ specialeffect2 EF_ENHANCE; }";
@@ -35826,7 +35475,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxSP,50;
@@ -35885,7 +35533,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36027,7 +35674,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36067,7 +35713,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 75
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36088,7 +35733,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36306,7 +35950,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 47
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36328,7 +35971,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 47
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36353,7 +35995,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36457,7 +36098,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36609,7 +36249,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36658,7 +36297,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36810,7 +36448,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMax: 120
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37006,7 +36643,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37276,7 +36912,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37295,7 +36930,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 90
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37562,7 +37196,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37588,7 +37221,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37615,7 +37247,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMax: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37647,7 +37278,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37668,7 +37298,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37690,7 +37319,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37755,7 +37383,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37991,7 +37618,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -38006,7 +37632,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -38020,7 +37645,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMatkRate,1;
@@ -38035,7 +37659,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMatkRate,1;
@@ -38155,7 +37778,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38423,7 +38045,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38456,7 +38077,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40055,7 +39675,6 @@ Body:
     Refineable: true
     View: 182
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,2;
@@ -40167,7 +39786,6 @@ Body:
     EquipLevelMin: 1
     View: 144
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40608,7 +40226,6 @@ Body:
     ArmorLevel: 1
     View: 204
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40798,7 +40415,6 @@ Body:
     Refineable: true
     View: 213
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -40825,7 +40441,6 @@ Body:
     Refineable: true
     View: 214
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bResEff,Eff_Silence,3000;
@@ -40883,7 +40498,6 @@ Body:
     Refineable: true
     View: 216
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40915,7 +40529,6 @@ Body:
     Refineable: true
     View: 218
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -40999,7 +40612,6 @@ Body:
     ArmorLevel: 1
     View: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41018,7 +40630,6 @@ Body:
     ArmorLevel: 1
     View: 25
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41039,7 +40650,6 @@ Body:
     ArmorLevel: 1
     View: 8
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41485,7 +41095,6 @@ Body:
     Refineable: true
     View: 232
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -41635,7 +41244,6 @@ Body:
     Refineable: true
     View: 239
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxSP,30;
@@ -41980,7 +41588,6 @@ Body:
     Refineable: true
     View: 264
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVariableCastrate,-3;
@@ -42062,7 +41669,6 @@ Body:
     Refineable: true
     View: 268
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -42271,7 +41877,6 @@ Body:
     Refineable: true
     View: 269
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,2;
@@ -42767,7 +42372,6 @@ Body:
     Refineable: true
     View: 298
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42976,7 +42580,6 @@ Body:
     EquipLevelMin: 1
     View: 72
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42999,7 +42602,6 @@ Body:
     EquipLevelMin: 1
     View: 15
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43023,7 +42625,6 @@ Body:
     ArmorLevel: 1
     View: 67
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43050,7 +42651,6 @@ Body:
     EquipLevelMin: 1
     View: 93
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43078,7 +42678,6 @@ Body:
     Refineable: true
     View: 264
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43271,7 +42870,6 @@ Body:
     ArmorLevel: 1
     View: 142
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43298,7 +42896,6 @@ Body:
     ArmorLevel: 1
     View: 41
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43324,7 +42921,6 @@ Body:
     ArmorLevel: 1
     View: 123
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43361,7 +42957,6 @@ Body:
     EquipLevelMin: 10
     View: 311
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,2;
@@ -43418,7 +43013,6 @@ Body:
     EquipLevelMin: 1
     View: 314
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43457,7 +43051,6 @@ Body:
     ArmorLevel: 1
     View: 316
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43542,7 +43135,6 @@ Body:
     ArmorLevel: 1
     View: 320
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43566,7 +43158,6 @@ Body:
     ArmorLevel: 1
     View: 321
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43591,7 +43182,6 @@ Body:
     ArmorLevel: 1
     View: 138
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -43769,7 +43359,6 @@ Body:
     ArmorLevel: 1
     View: 328
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43820,7 +43409,6 @@ Body:
     Refineable: true
     View: 330
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43845,7 +43433,6 @@ Body:
     Refineable: true
     View: 331
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43902,7 +43489,6 @@ Body:
     Refineable: true
     View: 334
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -43923,7 +43509,6 @@ Body:
     Refineable: true
     View: 335
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -43945,7 +43530,6 @@ Body:
     EquipLevelMin: 50
     View: 336
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43970,7 +43554,6 @@ Body:
     EquipLevelMin: 35
     View: 337
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44023,7 +43606,6 @@ Body:
     Refineable: true
     View: 340
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -44047,7 +43629,6 @@ Body:
     Refineable: true
     View: 341
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bHPrecovRate,150;
@@ -44069,7 +43650,6 @@ Body:
     Refineable: true
     View: 261
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44108,7 +43688,6 @@ Body:
     Refineable: true
     View: 343
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44130,7 +43709,6 @@ Body:
     ArmorLevel: 1
     View: 165
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44154,7 +43732,6 @@ Body:
     Refineable: true
     View: 344
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,3;
@@ -44172,7 +43749,6 @@ Body:
     EquipLevelMin: 10
     View: 345
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,2;
@@ -44193,7 +43769,6 @@ Body:
     ArmorLevel: 1
     View: 78
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44221,7 +43796,6 @@ Body:
     ArmorLevel: 1
     View: 178
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44244,7 +43818,6 @@ Body:
     ArmorLevel: 1
     View: 152
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44270,7 +43843,6 @@ Body:
     ArmorLevel: 1
     View: 187
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44297,7 +43869,6 @@ Body:
     ArmorLevel: 1
     View: 142
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44325,7 +43896,6 @@ Body:
     ArmorLevel: 1
     View: 105
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44410,7 +43980,6 @@ Body:
     Refineable: true
     View: 350
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44431,7 +44000,6 @@ Body:
     Refineable: true
     View: 351
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44452,7 +44020,6 @@ Body:
     Refineable: true
     View: 352
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44473,7 +44040,6 @@ Body:
     Refineable: true
     View: 353
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44495,7 +44061,6 @@ Body:
     EquipLevelMin: 60
     View: 354
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -44514,7 +44079,6 @@ Body:
     EquipLevelMin: 60
     View: 355
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -44533,7 +44097,6 @@ Body:
     EquipLevelMin: 60
     View: 356
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -44552,7 +44115,6 @@ Body:
     EquipLevelMin: 60
     View: 357
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -44572,7 +44134,6 @@ Body:
     EquipLevelMin: 60
     View: 358
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,2;
@@ -44592,7 +44153,6 @@ Body:
     EquipLevelMin: 60
     View: 359
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_DemiHuman,5;
@@ -44611,7 +44171,6 @@ Body:
     Refineable: true
     View: 360
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44807,7 +44366,6 @@ Body:
     ArmorLevel: 1
     View: 365
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44849,7 +44407,6 @@ Body:
     Refineable: true
     View: 367
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,1;
@@ -44869,7 +44426,6 @@ Body:
     Refineable: true
     View: 368
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bFlee,10;
@@ -44886,7 +44442,6 @@ Body:
     ArmorLevel: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bBaseAtk,5;
@@ -44903,7 +44458,6 @@ Body:
     ArmorLevel: 1
     View: 370
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMatkRate,1;
@@ -44932,7 +44486,6 @@ Body:
     Refineable: true
     View: 371
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubClass,Class_Normal,-5;
@@ -44970,7 +44523,6 @@ Body:
     EquipLevelMin: 1
     View: 373
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bBaseAtk,5;
@@ -45020,7 +44572,6 @@ Body:
     Refineable: true
     View: 38
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45043,7 +44594,6 @@ Body:
     Refineable: true
     View: 39
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45096,7 +44646,6 @@ Body:
     Refineable: true
     View: 378
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -45119,7 +44668,6 @@ Body:
     Refineable: true
     View: 379
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,3;
@@ -45155,7 +44703,6 @@ Body:
     Refineable: true
     View: 381
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -45201,7 +44748,6 @@ Body:
     Refineable: true
     View: 384
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,3;
@@ -45235,7 +44781,6 @@ Body:
     Refineable: true
     View: 386
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus3 bAutoSpell,"SA_FROSTWEAPON",1,50;
@@ -45252,7 +44797,6 @@ Body:
     ArmorLevel: 1
     View: 387
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,2;
@@ -45272,7 +44816,6 @@ Body:
     Refineable: true
     View: 388
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -45318,7 +44861,6 @@ Body:
     Refineable: true
     View: 390
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,3;
@@ -45406,7 +44948,6 @@ Body:
     ArmorLevel: 1
     View: 394
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -45436,7 +44977,6 @@ Body:
     ArmorLevel: 1
     View: 188
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45475,7 +45015,6 @@ Body:
     ArmorLevel: 1
     View: 397
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxSPrate,7;
@@ -45489,7 +45028,6 @@ Body:
     ArmorLevel: 1
     View: 572
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45531,7 +45069,6 @@ Body:
     Refineable: true
     View: 399
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,1;
@@ -45718,7 +45255,6 @@ Body:
     Refineable: true
     View: 409
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45742,7 +45278,6 @@ Body:
     Refineable: true
     View: 410
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45761,7 +45296,6 @@ Body:
     ArmorLevel: 1
     View: 6
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45788,7 +45322,6 @@ Body:
     Refineable: true
     View: 411
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -45808,7 +45341,6 @@ Body:
     ArmorLevel: 1
     View: 412
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45846,7 +45378,6 @@ Body:
     ArmorLevel: 1
     View: 414
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45869,7 +45400,6 @@ Body:
     ArmorLevel: 1
     View: 415
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45890,7 +45420,6 @@ Body:
     ArmorLevel: 1
     View: 416
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45986,7 +45515,6 @@ Body:
     ArmorLevel: 1
     View: 57
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -46011,7 +45539,6 @@ Body:
     EquipLevelMin: 50
     View: 421
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -46038,7 +45565,6 @@ Body:
     EquipLevelMin: 50
     View: 422
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -46075,7 +45601,6 @@ Body:
     ArmorLevel: 1
     View: 424
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
     Script: |
@@ -46151,7 +45676,6 @@ Body:
     Refineable: true
     View: 429
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46189,7 +45713,6 @@ Body:
     ArmorLevel: 1
     View: 431
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubEle,Ele_Fire,20;
@@ -46208,7 +45731,6 @@ Body:
     Refineable: true
     View: 432
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus3 bAutoSpell,"MC_LOUD",1,30;
@@ -46266,7 +45788,6 @@ Body:
     Refineable: true
     View: 436
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -46518,7 +46039,6 @@ Body:
     Refineable: true
     View: 451
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46540,7 +46060,6 @@ Body:
     EquipLevelMin: 1
     View: 452
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46567,7 +46086,6 @@ Body:
     EquipLevelMin: 1
     View: 453
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46594,7 +46112,6 @@ Body:
     EquipLevelMin: 1
     View: 454
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46727,7 +46244,6 @@ Body:
     Refineable: true
     View: 457
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -46754,7 +46270,6 @@ Body:
     Refineable: true
     View: 458
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -46778,7 +46293,6 @@ Body:
     EquipLevelMin: 1
     View: 459
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46801,7 +46315,6 @@ Body:
     EquipLevelMin: 1
     View: 460
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46829,7 +46342,6 @@ Body:
     Refineable: true
     View: 461
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,3;
@@ -46890,7 +46402,6 @@ Body:
     Refineable: true
     View: 464
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -46936,7 +46447,6 @@ Body:
     Refineable: true
     View: 466
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,3;
@@ -47052,7 +46562,6 @@ Body:
     Refineable: true
     View: 473
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddRace,RC_Brute,7;
@@ -47104,7 +46613,6 @@ Body:
     Refineable: true
     View: 476
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,3;
@@ -47123,7 +46631,6 @@ Body:
     Refineable: true
     View: 477
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,2;
@@ -47145,7 +46652,6 @@ Body:
     Refineable: true
     View: 478
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAspdRate,10;
@@ -47167,7 +46673,6 @@ Body:
     Refineable: true
     View: 479
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,3;
@@ -47185,7 +46690,6 @@ Body:
     EquipLevelMin: 1
     View: 480
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubClass,Class_Boss,2;
@@ -47327,7 +46831,6 @@ Body:
     ArmorLevel: 1
     View: 102
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47354,7 +46857,6 @@ Body:
     ArmorLevel: 1
     View: 254
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47381,7 +46883,6 @@ Body:
     ArmorLevel: 1
     View: 137
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47406,7 +46907,6 @@ Body:
     Refineable: true
     View: 493
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -47446,7 +46946,6 @@ Body:
     Refineable: true
     View: 495
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -47472,7 +46971,6 @@ Body:
     Refineable: true
     View: 490
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,5;
@@ -47541,7 +47039,6 @@ Body:
     Refineable: true
     View: 491
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,3;
@@ -47561,7 +47058,6 @@ Body:
     Refineable: true
     View: 497
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -47643,7 +47139,6 @@ Body:
     Refineable: true
     View: 503
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -47664,7 +47159,6 @@ Body:
     Refineable: true
     View: 504
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -47872,7 +47366,6 @@ Body:
     Refineable: true
     View: 515
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,4;
@@ -47886,7 +47379,6 @@ Body:
     ArmorLevel: 1
     View: 194
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47987,7 +47479,6 @@ Body:
     Refineable: true
     View: 521
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,3;
@@ -48028,7 +47519,6 @@ Body:
     Refineable: true
     View: 523
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -48051,7 +47541,6 @@ Body:
     Refineable: true
     View: 524
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 5531
     AegisName: B_Dragon_Hat
@@ -48067,7 +47556,6 @@ Body:
     Refineable: true
     View: 525
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -48131,7 +47619,6 @@ Body:
     Refineable: true
     View: 529
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -48154,7 +47641,6 @@ Body:
     EquipLevelMin: 1
     View: 526
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48184,7 +47670,6 @@ Body:
     EquipLevelMin: 45
     View: 527
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,3;
@@ -48204,7 +47689,6 @@ Body:
     EquipLevelMin: 45
     View: 528
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,3;
@@ -48226,7 +47710,6 @@ Body:
     Refineable: true
     View: 530
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,2;
@@ -48308,7 +47791,6 @@ Body:
     Refineable: true
     View: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -48333,7 +47815,6 @@ Body:
     Refineable: true
     View: 531
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,2;
@@ -48357,7 +47838,6 @@ Body:
     Refineable: true
     View: 532
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,2;
@@ -48380,7 +47860,6 @@ Body:
     Refineable: true
     View: 533
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSkillAtk,"WZ_HEAVENDRIVE",15+getequiprefinerycnt(EQI_HAND_R);
@@ -48399,7 +47878,6 @@ Body:
     EquipLevelMin: 1
     View: 534
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -48419,7 +47897,6 @@ Body:
     Refineable: true
     View: 535
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -48443,7 +47920,6 @@ Body:
     Refineable: true
     View: 536
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,2;
@@ -48466,7 +47942,6 @@ Body:
     Refineable: true
     View: 537
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -48515,7 +47990,6 @@ Body:
     Refineable: true
     View: 538
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,3;
@@ -48534,7 +48008,6 @@ Body:
     Refineable: true
     View: 539
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,2;
@@ -48555,7 +48028,6 @@ Body:
     Refineable: true
     View: 540
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -48579,7 +48051,6 @@ Body:
     Refineable: true
     View: 541
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,3;
@@ -48731,7 +48202,6 @@ Body:
     EquipLevelMin: 1
     View: 545
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddRace,RC_DemiHuman,10;
@@ -48748,7 +48218,6 @@ Body:
     EquipLevelMin: 1
     View: 546
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddRace,RC_DemiHuman,2;
@@ -48768,7 +48237,6 @@ Body:
     Refineable: true
     View: 548
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -48804,7 +48272,6 @@ Body:
     Refineable: true
     View: 550
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,2;
@@ -48827,7 +48294,6 @@ Body:
     Refineable: true
     View: 551
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,2;
@@ -48866,7 +48332,6 @@ Body:
     Refineable: true
     View: 553
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,2;
@@ -48887,7 +48352,6 @@ Body:
     Refineable: true
     View: 554
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddMonsterDropItemGroup,IG_Jewel,100;
@@ -48944,7 +48408,6 @@ Body:
     Refineable: true
     View: 479
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,3;
@@ -49056,7 +48519,6 @@ Body:
     Refineable: true
     View: 465
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49077,7 +48539,6 @@ Body:
     Refineable: true
     View: 562
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_Demon,3;
@@ -49102,7 +48563,6 @@ Body:
     Refineable: true
     View: 564
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubEle,Ele_Neutral,3;
@@ -49146,7 +48606,6 @@ Body:
     Refineable: true
     View: 563
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49241,7 +48700,6 @@ Body:
     EquipLevelMin: 1
     View: 568
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49277,7 +48735,6 @@ Body:
     Refineable: true
     View: 549
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bBaseAtk,10;
@@ -49301,7 +48758,6 @@ Body:
     EquipLevelMin: 1
     View: 569
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bHPRegenRate,1,10000;
@@ -49347,7 +48803,6 @@ Body:
     EquipLevelMin: 1
     View: 571
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49375,7 +48830,6 @@ Body:
     EquipLevelMin: 1
     View: 572
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49492,7 +48946,6 @@ Body:
     Refineable: true
     View: 577
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49523,7 +48976,6 @@ Body:
     Refineable: true
     View: 578
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49554,7 +49006,6 @@ Body:
     Refineable: true
     View: 579
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49629,7 +49080,6 @@ Body:
     EquipLevelMin: 60
     View: 583
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,3;
@@ -50378,7 +49828,6 @@ Body:
     Refineable: true
     View: 587
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -50454,7 +49903,6 @@ Body:
     Refineable: true
     View: 589
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus3 bAutoSpell,"SA_FLAMELAUNCHER",1,5;
@@ -50488,7 +49936,6 @@ Body:
     Refineable: true
     View: 591
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,2;
@@ -50590,7 +50037,6 @@ Body:
     Refineable: true
     View: 596
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,5;
@@ -50619,7 +50065,6 @@ Body:
     Refineable: true
     View: 597
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -50641,7 +50086,6 @@ Body:
     Refineable: true
     View: 598
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubRace,RC_Demon,10;
@@ -50661,7 +50105,6 @@ Body:
     Refineable: true
     View: 206
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50906,7 +50349,6 @@ Body:
     Refineable: true
     View: 610
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -51760,7 +51202,6 @@ Body:
     Refineable: true
     View: 616
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -51947,7 +51388,6 @@ Body:
     Refineable: true
     View: 623
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51982,7 +51422,6 @@ Body:
     Refineable: true
     View: 624
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52018,7 +51457,6 @@ Body:
     Refineable: true
     View: 625
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52053,7 +51491,6 @@ Body:
     Refineable: true
     View: 626
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52088,7 +51525,6 @@ Body:
     Refineable: true
     View: 627
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52124,7 +51560,6 @@ Body:
     Refineable: true
     View: 628
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52158,7 +51593,6 @@ Body:
     Refineable: true
     View: 629
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52193,7 +51627,6 @@ Body:
     Refineable: true
     View: 630
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52228,7 +51661,6 @@ Body:
     Refineable: true
     View: 631
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52262,7 +51694,6 @@ Body:
     EquipLevelMin: 100
     View: 632
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52296,7 +51727,6 @@ Body:
     Refineable: true
     View: 633
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52332,7 +51762,6 @@ Body:
     Refineable: true
     View: 634
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52368,7 +51797,6 @@ Body:
     Refineable: true
     View: 635
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52418,7 +51846,6 @@ Body:
     Refineable: true
     View: 637
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -52533,7 +51960,6 @@ Body:
     Refineable: true
     View: 643
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1+(getrefine()/2);
@@ -52551,7 +51977,6 @@ Body:
     EquipLevelMin: 50
     View: 644
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -52859,7 +52284,6 @@ Body:
     EquipLevelMin: 1
     View: 665
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -52898,7 +52322,6 @@ Body:
     EquipLevelMin: 1
     View: 661
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -52985,7 +52408,6 @@ Body:
     EquipLevelMin: 1
     View: 575
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53009,7 +52431,6 @@ Body:
     EquipLevelMin: 1
     View: 661
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53055,7 +52476,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53077,7 +52497,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53098,7 +52517,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53119,7 +52537,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53208,7 +52625,6 @@ Body:
     EquipLevelMin: 70
     View: 43
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53231,7 +52647,6 @@ Body:
     ArmorLevel: 1
     View: 67
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53302,7 +52717,6 @@ Body:
     ArmorLevel: 1
     View: 216
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53356,7 +52770,6 @@ Body:
     Refineable: true
     View: 16
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53398,7 +52811,6 @@ Body:
     EquipLevelMin: 20
     View: 303
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53445,7 +52857,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53473,7 +52884,6 @@ Body:
     Refineable: true
     View: 505
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53495,7 +52905,6 @@ Body:
     Refineable: true
     View: 506
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -53518,7 +52927,6 @@ Body:
     ArmorLevel: 1
     View: 498
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53538,7 +52946,6 @@ Body:
     Refineable: true
     View: 499
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53560,7 +52967,6 @@ Body:
     Refineable: true
     View: 500
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53587,7 +52993,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -53989,7 +53394,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54012,7 +53416,6 @@ Body:
     Refineable: true
     View: 671
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -54033,7 +53436,6 @@ Body:
     Refineable: true
     View: 672
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -54054,7 +53456,6 @@ Body:
     Refineable: true
     View: 673
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -54075,7 +53476,6 @@ Body:
     Refineable: true
     View: 674
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,1;
@@ -54095,7 +53495,6 @@ Body:
     Refineable: true
     View: 873
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -54509,7 +53908,6 @@ Body:
     Refineable: true
     View: 1121
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54545,7 +53943,6 @@ Body:
     Refineable: true
     View: 1122
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54580,7 +53977,6 @@ Body:
     Refineable: true
     View: 1123
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54616,7 +54012,6 @@ Body:
     Refineable: true
     View: 1124
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54657,7 +54052,6 @@ Body:
     Refineable: true
     View: 1125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54693,7 +54087,6 @@ Body:
     Refineable: true
     View: 1126
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54728,7 +54121,6 @@ Body:
     Refineable: true
     View: 1127
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -54764,7 +54156,6 @@ Body:
     Refineable: true
     View: 1128
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55530,7 +54921,6 @@ Body:
     Type: Petegg
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 9029
     AegisName: Santa_Goblin_Egg
@@ -55683,7 +55073,6 @@ Body:
     Type: Petegg
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56750,7 +56139,6 @@ Body:
     EquipLevelMin: 48
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56793,7 +56181,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56830,7 +56217,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56860,7 +56246,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56904,7 +56289,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56946,7 +56330,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56988,7 +56371,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57104,7 +56486,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57320,7 +56701,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57373,7 +56753,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57554,7 +56933,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57608,7 +56986,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57650,7 +57027,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57676,7 +57052,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57769,7 +57144,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -57817,7 +57191,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -57871,7 +57244,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57913,7 +57285,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57955,7 +57326,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -58323,7 +57693,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -58400,7 +57769,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -58515,7 +57883,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -58599,7 +57966,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -58723,7 +58089,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -58809,7 +58174,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59057,7 +58421,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -59444,7 +58807,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59476,7 +58838,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -59505,7 +58866,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59547,7 +58907,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -59574,7 +58933,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59599,7 +58957,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59624,7 +58981,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59653,7 +59009,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -59694,7 +59049,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59723,7 +59077,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59750,7 +59103,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59836,7 +59188,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59869,7 +59220,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59939,7 +59289,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -59994,7 +59343,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60027,7 +59375,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60136,7 +59483,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60627,7 +59973,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60661,7 +60006,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60693,7 +60037,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60726,7 +60069,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60759,7 +60101,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -60788,7 +60129,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60830,7 +60170,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60871,7 +60210,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -60914,7 +60252,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61020,7 +60357,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61048,7 +60384,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61076,7 +60411,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61104,7 +60438,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61441,7 +60774,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61474,7 +60806,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61507,7 +60838,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61547,7 +60877,6 @@ Body:
       Both_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -61575,7 +60904,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -61603,7 +60931,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61646,7 +60973,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -61738,7 +61064,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -61765,7 +61090,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61819,7 +61143,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61854,7 +61177,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61930,7 +61252,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -61958,7 +61279,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62074,7 +61394,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62170,7 +61489,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62366,7 +61684,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62401,7 +61718,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62436,7 +61752,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62530,7 +61845,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62562,7 +61876,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62598,7 +61911,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62634,7 +61946,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -62673,7 +61984,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62716,7 +62026,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62879,7 +62188,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62933,7 +62241,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -62972,7 +62279,6 @@ Body:
     EquipLevelMin: 80
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63013,7 +62319,6 @@ Body:
       Right_Hand: true
     WeaponLevel: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -63051,7 +62356,6 @@ Body:
     EquipLevelMin: 70
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -63098,7 +62402,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -63131,7 +62434,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63161,7 +62463,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63194,7 +62495,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63416,7 +62716,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63567,7 +62866,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -63862,7 +63160,6 @@ Body:
     EquipLevelMin: 27
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 13451
     AegisName: Ru_Blue_Sword
@@ -64027,7 +63324,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -64064,7 +63360,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -64905,7 +64200,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -64931,7 +64225,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -65000,7 +64293,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65024,7 +64316,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,1;
@@ -65040,7 +64331,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 7
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65061,7 +64351,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65082,7 +64371,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65162,7 +64450,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -65184,7 +64471,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -65209,7 +64495,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,5;
@@ -65232,7 +64517,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,1;
@@ -65257,7 +64541,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,1;
@@ -65286,7 +64569,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -65308,7 +64590,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,3;
@@ -65340,7 +64621,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 47
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65524,7 +64804,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -65570,7 +64849,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -65591,7 +64869,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -66164,7 +65441,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -66197,7 +65473,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -66233,7 +65508,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -66278,7 +65552,6 @@ Body:
     EquipLevelMax: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -66986,7 +66259,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67343,7 +66615,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67513,7 +66784,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67541,7 +66811,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67569,7 +66838,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67597,7 +66865,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67743,7 +67010,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67942,7 +67208,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67965,7 +67230,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -67988,7 +67252,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -68011,7 +67274,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -68034,7 +67296,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -68283,7 +67544,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -68368,7 +67628,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -69018,7 +68277,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -69517,7 +68775,6 @@ Body:
       Armor: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -69778,7 +69035,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -69837,7 +69093,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 26
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -69867,7 +69122,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -69900,7 +69154,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -70082,7 +69335,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -70142,7 +69394,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -70237,7 +69488,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -70367,7 +69617,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -70428,7 +69677,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -70468,7 +69716,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -70797,7 +70044,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -70955,7 +70201,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71114,7 +70359,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71268,7 +70512,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71327,7 +70570,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71357,7 +70599,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71675,7 +70916,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -71817,7 +71057,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -71843,7 +71082,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -71872,7 +71110,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -71981,7 +71218,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -72082,7 +71318,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72138,7 +71373,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72393,7 +71627,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72469,7 +71702,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72612,7 +71844,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72767,7 +71998,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72802,7 +72032,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72891,7 +72120,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -72924,7 +72152,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -73153,7 +72380,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -73193,7 +72419,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -73459,7 +72684,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -73480,7 +72704,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -73501,7 +72724,6 @@ Body:
     EquipLevelMin: 1
     View: 369
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -73557,7 +72779,6 @@ Body:
     EquipLevelMin: 1
     View: 675
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -73588,7 +72809,6 @@ Body:
     Refineable: true
     View: 676
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,10;
@@ -73628,7 +72848,6 @@ Body:
     Refineable: true
     View: 677
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,5;
@@ -73732,7 +72951,6 @@ Body:
     Refineable: true
     View: 682
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -73841,7 +73059,6 @@ Body:
     Refineable: true
     View: 686
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -73955,7 +73172,6 @@ Body:
     EquipLevelMin: 1
     View: 446
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -74000,7 +73216,6 @@ Body:
     Refineable: true
     View: 692
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -74148,7 +73363,6 @@ Body:
     ArmorLevel: 1
     View: 711
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMatk,10;
@@ -74485,7 +73699,6 @@ Body:
     ArmorLevel: 1
     View: 3
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -74504,7 +73717,6 @@ Body:
     ArmorLevel: 1
     View: 12
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -74606,7 +73818,6 @@ Body:
     Refineable: true
     View: 733
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine()/3;
@@ -74658,7 +73869,6 @@ Body:
     ArmorLevel: 1
     View: 736
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -74707,7 +73917,6 @@ Body:
     Refineable: true
     View: 738
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMaxHPrate,1+getrefine();
@@ -74787,7 +73996,6 @@ Body:
     Refineable: true
     View: 377
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,2;
@@ -74846,7 +74054,6 @@ Body:
     Refineable: true
     View: 742
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,5;
@@ -74932,7 +74139,6 @@ Body:
     Refineable: true
     View: 745
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -74956,7 +74162,6 @@ Body:
     Refineable: true
     View: 746
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,3;
@@ -75248,7 +74453,6 @@ Body:
     Refineable: true
     View: 757
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bSubClass,Class_Boss,10;
@@ -75275,7 +74479,6 @@ Body:
     Refineable: true
     View: 758
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       skill "WZ_HEAVENDRIVE",3;
@@ -75293,7 +74496,6 @@ Body:
     Refineable: true
     View: 759
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAspdRate,3;
@@ -75331,7 +74533,6 @@ Body:
     ArmorLevel: 1
     View: 760
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,2;
@@ -75349,7 +74550,6 @@ Body:
     Refineable: true
     View: 761
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,5;
@@ -75373,7 +74573,6 @@ Body:
     Refineable: true
     View: 762
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bMdef,5;
@@ -75405,7 +74604,6 @@ Body:
     ArmorLevel: 1
     View: 760
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAllStats,1;
@@ -75538,7 +74736,6 @@ Body:
     Refineable: true
     View: 770
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -75559,7 +74756,6 @@ Body:
     Refineable: true
     View: 771
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,2;
@@ -76583,7 +75779,6 @@ Body:
     Refineable: true
     View: 817
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -77471,7 +76666,6 @@ Body:
       Head_Top: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -77496,7 +76690,6 @@ Body:
     Refineable: true
     View: 14
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -77532,7 +76725,6 @@ Body:
     Refineable: true
     View: 103
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -77567,7 +76759,6 @@ Body:
     Refineable: true
     View: 209
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -77651,7 +76842,6 @@ Body:
     ArmorLevel: 1
     View: 881
     Trade:
-      Override: 100
       NoDrop: true
     EquipScript: |
       sc_start SC_MOONSTAR,INFINITE_TICK,0;
@@ -78288,7 +77478,6 @@ Body:
     EquipLevelMin: 1
     View: 902
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78317,7 +77506,6 @@ Body:
     EquipLevelMin: 1
     View: 903
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78346,7 +77534,6 @@ Body:
     EquipLevelMin: 1
     View: 904
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78524,7 +77711,6 @@ Body:
     EquipLevelMin: 1
     View: 914
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78860,7 +78046,6 @@ Body:
     Refineable: true
     View: 934
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -78920,7 +78105,6 @@ Body:
     Refineable: true
     View: 942
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78949,7 +78133,6 @@ Body:
     Refineable: true
     View: 943
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -78978,7 +78161,6 @@ Body:
     Refineable: true
     View: 944
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80564,7 +79746,6 @@ Body:
     Refineable: true
     View: 1308
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80597,7 +79778,6 @@ Body:
     Refineable: true
     View: 623
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80635,7 +79815,6 @@ Body:
     Refineable: true
     View: 624
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80674,7 +79853,6 @@ Body:
     Refineable: true
     View: 626
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80711,7 +79889,6 @@ Body:
     Refineable: true
     View: 637
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80748,7 +79925,6 @@ Body:
     Refineable: true
     View: 627
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80797,7 +79973,6 @@ Body:
     Refineable: true
     View: 628
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80833,7 +80008,6 @@ Body:
     Refineable: true
     View: 629
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80869,7 +80043,6 @@ Body:
     Refineable: true
     View: 630
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80907,7 +80080,6 @@ Body:
     Refineable: true
     View: 631
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80944,7 +80116,6 @@ Body:
     Refineable: true
     View: 633
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -80983,7 +80154,6 @@ Body:
     Refineable: true
     View: 635
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81019,7 +80189,6 @@ Body:
     Refineable: true
     View: 1141
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81056,7 +80225,6 @@ Body:
     Refineable: true
     View: 1140
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81094,7 +80262,6 @@ Body:
     Refineable: true
     View: 1142
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81384,7 +80551,6 @@ Body:
     Refineable: true
     View: 376
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -81513,7 +80679,6 @@ Body:
     Refineable: true
     View: 1308
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81538,7 +80703,6 @@ Body:
     EquipLevelMin: 1
     View: 568
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81574,7 +80738,6 @@ Body:
     Refineable: true
     View: 1308
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -81703,7 +80866,6 @@ Body:
     Refineable: true
     View: 1368
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -82243,7 +81405,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -82987,7 +82148,6 @@ Body:
     Refineable: true
     View: 1529
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -83022,7 +82182,6 @@ Body:
     Refineable: true
     View: 1530
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -83097,7 +82256,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,2;
@@ -83316,7 +82474,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83353,7 +82510,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83389,7 +82545,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83425,7 +82580,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83461,7 +82615,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83496,7 +82649,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83535,7 +82687,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83573,7 +82724,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83608,7 +82758,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83646,7 +82795,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83681,7 +82829,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83717,7 +82864,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83754,7 +82900,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83788,7 +82933,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83823,7 +82967,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83856,7 +82999,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -83890,7 +83032,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -84026,7 +83167,6 @@ Body:
       Head_Mid: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -84295,7 +83435,6 @@ Body:
     EquipLevelMax: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -84561,7 +83700,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -84595,7 +83733,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -84612,7 +83749,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDelayrate,-10;
@@ -85302,7 +84438,6 @@ Body:
       Head_Low: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -85349,7 +84484,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -85381,7 +84515,6 @@ Body:
     Refineable: true
     View: 1134
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -85410,7 +84543,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -85938,7 +85070,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -85973,7 +85104,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86008,7 +85138,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86043,7 +85172,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86078,7 +85206,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86113,7 +85240,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86148,7 +85274,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86182,7 +85307,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86217,7 +85341,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86253,7 +85376,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86289,7 +85411,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86324,7 +85445,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86359,7 +85479,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86392,7 +85511,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86424,7 +85542,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86456,7 +85573,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86489,7 +85605,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86522,7 +85637,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86555,7 +85669,6 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -86691,7 +85804,6 @@ Body:
     EquipLevelMin: 1
     View: 654
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86714,7 +85826,6 @@ Body:
     EquipLevelMin: 1
     View: 695
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86728,7 +85839,6 @@ Body:
     EquipLevelMin: 1
     View: 696
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86742,7 +85852,6 @@ Body:
     EquipLevelMin: 1
     View: 697
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86756,7 +85865,6 @@ Body:
     EquipLevelMin: 1
     View: 698
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86770,7 +85878,6 @@ Body:
     EquipLevelMin: 1
     View: 699
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86784,7 +85891,6 @@ Body:
     EquipLevelMin: 1
     View: 700
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86798,7 +85904,6 @@ Body:
     EquipLevelMin: 1
     View: 701
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86812,7 +85917,6 @@ Body:
     EquipLevelMin: 1
     View: 702
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86826,7 +85930,6 @@ Body:
     EquipLevelMin: 1
     View: 703
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86840,7 +85943,6 @@ Body:
     EquipLevelMin: 1
     View: 704
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86854,7 +85956,6 @@ Body:
     EquipLevelMin: 1
     View: 688
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86868,7 +85969,6 @@ Body:
     EquipLevelMin: 1
     View: 705
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86882,7 +85982,6 @@ Body:
     EquipLevelMin: 1
     View: 706
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86896,7 +85995,6 @@ Body:
     EquipLevelMin: 1
     View: 707
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -86910,7 +86008,6 @@ Body:
     EquipLevelMin: 1
     View: 244
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -86997,7 +86094,6 @@ Body:
     EquipLevelMin: 1
     View: 541
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87013,7 +86109,6 @@ Body:
     ArmorLevel: 1
     View: 472
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -87034,7 +86129,6 @@ Body:
     EquipLevelMin: 1
     View: 640
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -87055,7 +86149,6 @@ Body:
     EquipLevelMin: 1
     View: 114
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87073,7 +86166,6 @@ Body:
     EquipLevelMin: 1
     View: 693
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus2 bAddClass,Class_All,1;
@@ -87089,7 +86181,6 @@ Body:
     EquipLevelMin: 1
     View: 730
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87105,7 +86196,6 @@ Body:
     EquipLevelMin: 1
     View: 533
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87212,7 +86302,6 @@ Body:
     EquipLevelMin: 1
     View: 692
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87358,7 +86447,6 @@ Body:
     EquipLevelMin: 1
     View: 213
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -87374,7 +86462,6 @@ Body:
     EquipLevelMin: 1
     View: 214
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -87388,7 +86475,6 @@ Body:
     EquipLevelMin: 1
     View: 334
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -87402,7 +86488,6 @@ Body:
     EquipLevelMin: 1
     View: 524
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -87416,7 +86501,6 @@ Body:
     EquipLevelMin: 1
     View: 525
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bAgi,1;
@@ -87430,7 +86514,6 @@ Body:
     EquipLevelMin: 1
     View: 527
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,1;
@@ -87444,7 +86527,6 @@ Body:
     EquipLevelMin: 1
     View: 528
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bDex,1;
@@ -87460,7 +86542,6 @@ Body:
     EquipLevelMin: 1
     View: 530
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -87475,7 +86556,6 @@ Body:
     EquipLevelMin: 1
     View: 545
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19564
     AegisName: C_Tiger_Arhat_Mask
@@ -87488,7 +86568,6 @@ Body:
     EquipLevelMin: 1
     View: 546
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19565
     AegisName: C_Chung_Hairband
@@ -87500,7 +86579,6 @@ Body:
     EquipLevelMin: 1
     View: 583
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -87514,7 +86592,6 @@ Body:
     EquipLevelMin: 1
     View: 644
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19567
     AegisName: C_Hatta_Black
@@ -87528,7 +86605,6 @@ Body:
     EquipLevelMin: 1
     View: 676
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bVit,1;
@@ -87542,7 +86618,6 @@ Body:
     EquipLevelMin: 1
     View: 757
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -87556,7 +86631,6 @@ Body:
     EquipLevelMin: 1
     View: 758
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -87570,7 +86644,6 @@ Body:
     EquipLevelMin: 1
     View: 759
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bLuk,1;
@@ -87584,7 +86657,6 @@ Body:
     EquipLevelMin: 1
     View: 770
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bStr,1;
@@ -87598,7 +86670,6 @@ Body:
     EquipLevelMin: 1
     View: 771
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bInt,1;
@@ -87612,7 +86683,6 @@ Body:
     EquipLevelMin: 1
     View: 733
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19574
     AegisName: C_Lord_of_Death
@@ -87624,7 +86694,6 @@ Body:
     ArmorLevel: 1
     View: 742
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus bUnbreakableHelm;
@@ -87647,7 +86716,6 @@ Body:
     EquipLevelMin: 1
     View: 817
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19577
     AegisName: 10th_Anni_Poring_Hat
@@ -87751,7 +86819,6 @@ Body:
     EquipLevelMin: 1
     View: 898
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19587
     AegisName: C_King_Poring_Hat
@@ -87868,7 +86935,6 @@ Body:
     ArmorLevel: 1
     View: 490
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19599
     AegisName: C_Imp_Hat
@@ -87882,7 +86948,6 @@ Body:
     EquipLevelMin: 1
     View: 589
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       bonus3 bAutoSpell,"SA_FLAMELAUNCHER",1,5;
@@ -88349,7 +87414,6 @@ Body:
     EquipLevelMin: 1
     View: 934
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19651
     AegisName: C_RWC_Shouting_Mouth
@@ -88796,7 +87860,6 @@ Body:
     EquipLevelMin: 1
     View: 365
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19712
     AegisName: C_Little_Angel_Doll
@@ -89346,7 +88409,6 @@ Body:
     ArmorLevel: 1
     View: 526
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -89367,7 +88429,6 @@ Body:
     EquipLevelMin: 1
     View: 158
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -90210,7 +89271,6 @@ Body:
     EquipLevelMin: 1
     View: 595
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -90349,7 +89409,6 @@ Body:
     ArmorLevel: 1
     View: 1074
     Trade:
-      Override: 100
       NoDrop: true
     EquipScript: |
       sc_start SC_DECORATION_OF_MUSIC,INFINITE_TICK,0;
@@ -90733,7 +89792,6 @@ Body:
     EquipLevelMin: 1
     View: 549
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 19939
     AegisName: C_Antler
@@ -91175,7 +90233,6 @@ Body:
     EquipLevelMin: 1
     View: 1189
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91211,7 +90268,6 @@ Body:
     EquipLevelMin: 1
     View: 1193
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91229,7 +90285,6 @@ Body:
     EquipLevelMin: 1
     View: 1194
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91247,7 +90302,6 @@ Body:
     EquipLevelMin: 1
     View: 1195
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91265,7 +90319,6 @@ Body:
     EquipLevelMin: 1
     View: 1196
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91283,7 +90336,6 @@ Body:
     EquipLevelMin: 1
     View: 1197
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91491,7 +90543,6 @@ Body:
     EquipLevelMin: 1
     View: 1211
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91512,7 +90563,6 @@ Body:
     EquipLevelMin: 1
     View: 1212
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91533,7 +90583,6 @@ Body:
     EquipLevelMin: 1
     View: 1213
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91554,7 +90603,6 @@ Body:
     EquipLevelMin: 1
     View: 1214
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91793,7 +90841,6 @@ Body:
     EquipLevelMin: 1
     View: 973
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91882,7 +90929,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
     EquipScript: |
       sc_start SC_HAT_EFFECT,INFINITE_TICK,0;
@@ -91899,7 +90945,6 @@ Body:
     EquipLevelMin: 1
     View: 1228
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -91918,7 +90963,6 @@ Body:
     EquipLevelMin: 1
     View: 1229
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -91954,7 +90998,6 @@ Body:
     EquipLevelMin: 1
     View: 719
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -91971,7 +91014,6 @@ Body:
     EquipLevelMin: 1
     View: 718
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92132,7 +91174,6 @@ Body:
     EquipLevelMin: 1
     View: 1245
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92149,7 +91190,6 @@ Body:
     EquipLevelMin: 1
     View: 1246
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92166,7 +91206,6 @@ Body:
     EquipLevelMin: 1
     View: 1247
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92183,7 +91222,6 @@ Body:
     EquipLevelMin: 1
     View: 1248
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92386,7 +91424,6 @@ Body:
     EquipLevelMin: 1
     View: 1258
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92403,7 +91440,6 @@ Body:
     EquipLevelMin: 1
     View: 1259
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92628,7 +91664,6 @@ Body:
     EquipLevelMin: 1
     View: 1117
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -92647,7 +91682,6 @@ Body:
     EquipLevelMin: 1
     View: 875
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -92684,7 +91718,6 @@ Body:
     EquipLevelMin: 1
     View: 1271
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92701,7 +91734,6 @@ Body:
     EquipLevelMin: 1
     View: 1272
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92914,7 +91946,6 @@ Body:
     EquipLevelMin: 1
     View: 1277
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -92933,7 +91964,6 @@ Body:
     EquipLevelMin: 1
     View: 1278
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93088,7 +92118,6 @@ Body:
     EquipLevelMin: 1
     View: 858
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93344,7 +92373,6 @@ Body:
     EquipLevelMin: 1
     View: 1296
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93394,7 +92422,6 @@ Body:
     EquipLevelMin: 1
     View: 1297
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93413,7 +92440,6 @@ Body:
     EquipLevelMin: 1
     View: 1298
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93565,7 +92591,6 @@ Body:
     EquipLevelMin: 1
     View: 1016
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -93582,7 +92607,6 @@ Body:
     EquipLevelMin: 1
     View: 603
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -94082,7 +93106,6 @@ Body:
     EquipLevelMin: 1
     View: 1331
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       hateffect HAT_EF_BLOSSOM_FLUTTERING,true;
@@ -96204,7 +95227,6 @@ Body:
       Costume_Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96360,7 +95382,6 @@ Body:
       Costume_Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96484,7 +95505,6 @@ Body:
     ArmorLevel: 1
     View: 105
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96501,7 +95521,6 @@ Body:
     ArmorLevel: 1
     View: 119
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -96568,7 +95587,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96601,7 +95619,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96634,7 +95651,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -96719,7 +95735,6 @@ Body:
     EquipLevelMax: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -97025,7 +96040,6 @@ Body:
     Refineable: true
     View: 5
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 20728
     AegisName: Water_Dragon_Coat
@@ -97170,7 +96184,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97489,7 +96502,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97514,7 +96526,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97541,7 +96552,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97568,7 +96578,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97626,7 +96635,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -97816,7 +96824,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -98308,7 +97315,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -98339,7 +97345,6 @@ Body:
     EquipLevelMin: 130
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -98371,7 +97376,6 @@ Body:
     EquipLevelMin: 160
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -98483,7 +97487,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoAuction: true
     Script: |
       .@r = getrefine();
@@ -98838,7 +97841,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -99038,7 +98040,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -99454,7 +98455,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -99760,7 +98760,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100194,7 +99193,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       .@r = getrefine();
@@ -100321,7 +99319,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100353,7 +99350,6 @@ Body:
     EquipLevelMin: 40
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100556,7 +99552,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100688,7 +99683,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100785,7 +99779,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100819,7 +99812,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -100970,7 +99962,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -101737,7 +100728,6 @@ Body:
     EquipLevelMax: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -102060,7 +101050,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102462,7 +101451,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102523,7 +101511,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102550,7 +101537,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102577,7 +101563,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102604,7 +101589,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -102843,7 +101827,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103261,7 +102244,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103283,7 +102265,6 @@ Body:
     EquipLevelMin: 115
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103305,7 +102286,6 @@ Body:
     EquipLevelMin: 130
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103327,7 +102307,6 @@ Body:
     EquipLevelMin: 145
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103349,7 +102328,6 @@ Body:
     EquipLevelMin: 160
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -103409,7 +102387,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoAuction: true
     Script: |
       .@r = getrefine();
@@ -103690,7 +102667,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -104138,7 +103114,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -104341,7 +103316,6 @@ Body:
       Shoes: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110280,7 +109254,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110300,7 +109273,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110320,7 +109292,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110340,7 +109311,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110362,7 +109332,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110382,7 +109351,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110786,7 +109754,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110808,7 +109775,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110828,7 +109794,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110848,7 +109813,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110868,7 +109832,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -110888,7 +109851,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113707,7 +112669,6 @@ Body:
       Shadow_Armor: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113726,7 +112687,6 @@ Body:
       Shadow_Shield: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113745,7 +112705,6 @@ Body:
       Shadow_Shoes: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113765,7 +112724,6 @@ Body:
       Shadow_Right_Accessory: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113783,7 +112741,6 @@ Body:
       Shadow_Left_Accessory: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113807,7 +112764,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113831,7 +112787,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113855,7 +112810,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113879,7 +112833,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113903,7 +112856,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113927,7 +112879,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113951,7 +112902,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113975,7 +112925,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -113999,7 +112948,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -114023,7 +112971,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -114047,7 +112994,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -114071,7 +113017,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -115444,7 +114389,6 @@ Body:
     Locations:
       Shadow_Weapon: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115466,7 +114410,6 @@ Body:
     Locations:
       Shadow_Shield: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115485,7 +114428,6 @@ Body:
     Locations:
       Shadow_Armor: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115504,7 +114446,6 @@ Body:
     Locations:
       Shadow_Shoes: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115523,7 +114464,6 @@ Body:
     Locations:
       Shadow_Right_Accessory: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115542,7 +114482,6 @@ Body:
     Locations:
       Shadow_Left_Accessory: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115562,7 +114501,6 @@ Body:
       Shadow_Shield: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115582,7 +114520,6 @@ Body:
       Shadow_Armor: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115602,7 +114539,6 @@ Body:
       Shadow_Shoes: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115622,7 +114558,6 @@ Body:
       Shadow_Right_Accessory: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115642,7 +114577,6 @@ Body:
       Shadow_Left_Accessory: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115667,7 +114601,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115692,7 +114625,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115717,7 +114649,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115742,7 +114673,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115767,7 +114697,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115792,7 +114721,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115817,7 +114745,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115842,7 +114769,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115867,7 +114793,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115892,7 +114817,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115917,7 +114841,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115943,7 +114866,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115965,7 +114887,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -115987,7 +114908,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -116012,7 +114932,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -116037,7 +114956,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -116059,7 +114977,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -116081,7 +114998,6 @@ Body:
       Shadow_Weapon: true
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -116851,7 +115767,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -116976,7 +115891,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117067,7 +115981,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117095,7 +116008,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117306,7 +116218,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117372,7 +116283,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117402,7 +116312,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -117779,7 +116688,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -118549,7 +117457,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -118576,7 +117483,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -118721,7 +117627,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -118754,7 +117659,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -118885,7 +117789,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119184,7 +118087,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119265,7 +118167,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119297,7 +118198,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119425,7 +118325,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119596,7 +118495,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119846,7 +118744,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119881,7 +118778,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119917,7 +118813,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -119950,7 +118845,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -120924,7 +119818,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -120944,7 +119837,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121098,7 +119990,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -121301,7 +120192,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121546,7 +120436,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -121571,7 +120460,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121594,7 +120482,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 140
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121617,7 +120504,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 175
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121640,7 +120526,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121663,7 +120548,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 140
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121686,7 +120570,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 175
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121709,7 +120592,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121732,7 +120614,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 140
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121755,7 +120636,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 175
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121778,7 +120658,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121802,7 +120681,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -121826,7 +120704,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122050,7 +120927,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122068,7 +120944,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122086,7 +120961,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122104,7 +120978,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122122,7 +120995,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122140,7 +121012,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122158,7 +121029,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122176,7 +121046,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122194,7 +121063,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122213,7 +121081,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122232,7 +121099,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122250,7 +121116,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122268,7 +121133,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122286,7 +121150,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122304,7 +121167,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122322,7 +121184,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122340,7 +121201,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122358,7 +121218,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122376,7 +121235,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122395,7 +121253,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122414,7 +121271,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122432,7 +121288,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122450,7 +121305,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122468,7 +121322,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122486,7 +121339,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122504,7 +121356,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122522,7 +121373,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122540,7 +121390,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122558,7 +121407,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122577,7 +121425,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122596,7 +121443,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122614,7 +121460,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122632,7 +121477,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122650,7 +121494,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 115
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122668,7 +121511,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122686,7 +121528,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122704,7 +121545,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122722,7 +121562,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 145
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122740,7 +121579,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122759,7 +121597,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122900,7 +121737,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -122925,7 +121761,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123127,7 +121962,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123164,7 +121998,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123283,7 +122116,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123309,7 +122141,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123729,7 +122560,6 @@ Body:
     EquipLevelMin: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123758,7 +122588,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123916,7 +122745,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -123951,7 +122779,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -124028,7 +122855,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -124289,7 +123115,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -124509,7 +123334,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -124676,7 +123500,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125005,7 +123828,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125063,7 +123885,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125247,7 +124068,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125715,7 +124535,6 @@ Body:
     Refineable: true
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125741,7 +124560,6 @@ Body:
     Refineable: true
     View: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -125890,7 +124708,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -126278,7 +125095,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -127087,7 +125903,6 @@ Body:
     EquipLevelMin: 1
     View: 1541
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -127353,7 +126168,6 @@ Body:
     EquipLevelMin: 1
     View: 1569
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -127370,7 +126184,6 @@ Body:
     EquipLevelMin: 1
     View: 1570
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -128436,7 +127249,6 @@ Body:
     EquipLevelMin: 1
     View: 661
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -128454,7 +127266,6 @@ Body:
     EquipLevelMin: 1
     View: 415
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -128954,7 +127765,6 @@ Body:
     EquipLevelMin: 1
     View: 1051
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -128972,7 +127782,6 @@ Body:
     EquipLevelMin: 1
     View: 456
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -130502,7 +129311,6 @@ Body:
     Locations:
       Costume_Head_Top: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoStorage: true
@@ -131686,7 +130494,6 @@ Body:
     Locations:
       Costume_Head_Top: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -134269,7 +133076,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -134527,7 +133333,6 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -134898,7 +133703,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -135043,7 +133847,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 99
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -135336,7 +134139,6 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -136228,7 +135030,6 @@ Body:
       Costume_Head_Top: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -136400,7 +135201,6 @@ Body:
       Costume_Head_Low: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -136627,7 +135427,6 @@ Body:
       Costume_Head_Top: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -136835,7 +135634,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -136852,7 +135650,6 @@ Body:
     Refineable: true
     View: 2077
     Trade:
-      Override: 100
       NoDrop: True
       NoTrade: True
       NoSell: True
@@ -136946,7 +135743,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -136973,7 +135769,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -137000,7 +135795,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -137022,7 +135816,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -139075,7 +137868,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -139097,7 +137889,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -139119,7 +137910,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -139400,7 +138190,6 @@ Body:
     View: 815
     Weight: 200
     Locations:
-      Head_Mid: true
       Head_Low: true
     ArmorLevel: 1
     EquipLevelMin: 10
@@ -139680,7 +138469,6 @@ Body:
     ArmorLevel: 1
     View: 857
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -139797,7 +138585,6 @@ Body:
     ArmorLevel: 1
     View: 1643
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140065,7 +138852,6 @@ Body:
       Costume_Head_Low: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140104,7 +138890,6 @@ Body:
       Costume_Head_Low: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140123,7 +138908,6 @@ Body:
     ArmorLevel: 1
     View: 1486
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140153,7 +138937,6 @@ Body:
     ArmorLevel: 1
     View: 2146
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -140317,7 +139100,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140350,7 +139132,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140383,7 +139164,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140416,7 +139196,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140449,7 +139228,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140482,7 +139260,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140515,7 +139292,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140548,7 +139324,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140581,7 +139356,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140614,7 +139388,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140647,7 +139420,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140680,7 +139452,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140713,7 +139484,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140746,7 +139516,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140779,7 +139548,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140812,7 +139580,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140845,7 +139612,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140878,7 +139644,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140908,7 +139673,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140938,7 +139702,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140967,7 +139730,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -140998,7 +139760,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141031,7 +139792,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141064,7 +139824,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141097,7 +139856,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141130,7 +139888,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141163,7 +139920,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141196,7 +139952,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141226,7 +139981,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141256,7 +140010,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141289,7 +140042,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141322,7 +140074,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141355,7 +140106,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141388,7 +140138,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141421,7 +140170,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141454,7 +140202,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141487,7 +140234,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141520,7 +140266,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141553,7 +140298,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141586,7 +140330,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141619,7 +140362,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141652,7 +140394,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141685,7 +140426,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141718,7 +140458,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141751,7 +140490,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141784,7 +140522,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141817,7 +140554,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141850,7 +140586,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141883,7 +140618,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141916,7 +140650,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141949,7 +140682,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -141982,7 +140714,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142015,7 +140746,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142048,7 +140778,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142078,7 +140807,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142108,7 +140836,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142138,7 +140865,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142168,7 +140894,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142201,7 +140926,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142234,7 +140958,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142267,7 +140990,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142300,7 +141022,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142333,7 +141054,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142366,7 +141086,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142396,7 +141115,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142426,7 +141144,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142459,7 +141176,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142492,7 +141208,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142525,7 +141240,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142558,7 +141272,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142591,7 +141304,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142624,7 +141336,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142657,7 +141368,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142690,7 +141400,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142723,7 +141432,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142756,7 +141464,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142789,7 +141496,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142822,7 +141528,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142855,7 +141560,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142888,7 +141592,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142921,7 +141624,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142954,7 +141656,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -142987,7 +141688,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143020,7 +141720,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143053,7 +141752,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143086,7 +141784,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143119,7 +141816,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143152,7 +141848,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143182,7 +141877,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143212,7 +141906,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143242,7 +141935,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143272,7 +141964,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143305,7 +141996,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143338,7 +142028,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143371,7 +142060,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143404,7 +142092,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143437,7 +142124,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143470,7 +142156,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143500,7 +142185,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143530,7 +142214,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143563,7 +142246,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143596,7 +142278,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143626,7 +142307,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143656,7 +142336,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143686,7 +142365,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143716,7 +142394,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143746,7 +142423,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143776,7 +142452,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143972,7 +142647,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -143998,7 +142672,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144243,7 +142916,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144294,7 +142966,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144344,7 +143015,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144395,7 +143065,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144447,7 +143116,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144499,7 +143167,6 @@ Body:
     EquipLevelMin: 240
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144659,7 +143326,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144693,7 +143359,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144727,7 +143392,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144759,7 +143423,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144840,7 +143503,6 @@ Body:
     ArmorLevel: 1
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144873,7 +143535,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144919,7 +143580,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -144965,7 +143625,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145011,7 +143670,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145475,7 +144133,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145503,7 +144160,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145531,7 +144187,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145559,7 +144214,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145587,7 +144241,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145615,7 +144268,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145823,7 +144475,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145849,7 +144500,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145937,7 +144587,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145969,7 +144618,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -145996,7 +144644,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146245,7 +144892,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146372,7 +145018,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146419,7 +145064,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146466,7 +145110,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146513,7 +145156,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146659,7 +145301,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146686,7 +145327,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146713,7 +145353,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146740,7 +145379,6 @@ Body:
     EquipLevelMin: 125
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146767,7 +145405,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146794,7 +145431,6 @@ Body:
     EquipLevelMin: 150
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146962,7 +145598,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -146988,7 +145623,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147315,7 +145949,6 @@ Body:
       Garment: true
     ArmorLevel: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147343,7 +145976,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147371,7 +146003,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147403,7 +146034,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147750,7 +146380,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147796,7 +146425,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147841,7 +146469,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -147886,7 +146513,6 @@ Body:
     EquipLevelMin: 210
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148064,7 +146690,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148087,7 +146712,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148111,7 +146735,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148135,7 +146758,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148159,7 +146781,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148183,7 +146804,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148725,7 +147345,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148745,7 +147364,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148765,7 +147383,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148785,7 +147402,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -148902,7 +147518,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149231,7 +147846,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149251,7 +147865,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149271,7 +147884,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149291,7 +147903,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149311,7 +147922,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149331,7 +147941,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149352,7 +147961,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149372,7 +147980,6 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149427,7 +148034,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149449,7 +148055,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149471,7 +148076,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149493,7 +148097,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149515,7 +148118,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -149537,7 +148139,6 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 240
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150316,7 +148917,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150364,7 +148964,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150833,7 +149432,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150863,7 +149461,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150893,7 +149490,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150924,7 +149520,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -150957,7 +149552,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -151003,7 +149597,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -151205,7 +149798,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -151249,7 +149841,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -151579,7 +150170,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -151627,7 +150217,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152093,7 +150682,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152129,7 +150717,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152159,7 +150746,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152192,7 +150778,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152235,7 +150820,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152871,7 +151455,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152901,7 +151484,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -152934,7 +151516,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -153052,7 +151633,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -153368,7 +151948,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -153401,7 +151980,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -153661,7 +152239,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154239,7 +152816,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154270,7 +152846,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154304,7 +152879,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154338,7 +152912,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154375,7 +152948,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154429,7 +153001,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154485,7 +153056,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154528,7 +153098,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154626,7 +153195,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -154674,7 +153242,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -155215,7 +153782,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -155273,7 +153839,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -155934,7 +154499,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -155965,7 +154529,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156003,7 +154566,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156038,7 +154600,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156069,7 +154630,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156100,7 +154660,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156130,7 +154689,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156161,7 +154719,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156193,7 +154750,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156232,7 +154788,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156271,7 +154826,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156312,7 +154866,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156358,7 +154911,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156525,7 +155077,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156569,7 +155120,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156616,7 +155166,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -156663,7 +155212,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -157464,7 +156012,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -157510,7 +156057,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -157952,7 +156498,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -157982,7 +156527,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158015,7 +156559,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158057,7 +156600,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158426,7 +156968,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158763,7 +157304,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158797,7 +157337,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158838,7 +157377,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -158882,7 +157420,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: True
       NoTrade: True
       NoCart: True
@@ -159203,7 +157740,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -159540,7 +158076,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -159574,7 +158109,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -159615,7 +158149,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -159659,7 +158192,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: True
       NoTrade: True
       NoCart: True
@@ -159933,7 +158465,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -159980,7 +158511,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160027,7 +158557,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160497,7 +159026,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160526,7 +159054,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160556,7 +159083,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160589,7 +159115,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -160630,7 +159155,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161013,7 +159537,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161254,7 +159777,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161287,7 +159809,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161634,7 +160155,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161960,7 +160480,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -161990,7 +160509,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162023,7 +160541,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162065,7 +160582,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162105,7 +160621,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: True
       NoTrade: True
       NoCart: True
@@ -162296,7 +160811,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162523,7 +161037,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162556,7 +161069,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162792,7 +161304,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162966,7 +161477,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -162999,7 +161509,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163150,7 +161659,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163200,7 +161708,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163685,7 +162192,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163731,7 +162237,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163777,7 +162282,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -163821,7 +162325,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164154,7 +162657,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164191,7 +162693,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164222,7 +162723,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164266,7 +162766,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164305,7 +162804,6 @@ Body:
     WeaponLevel: 1
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164353,7 +162851,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164825,7 +163322,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164872,7 +163368,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164917,7 +163412,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -164964,7 +163458,6 @@ Body:
     EquipLevelMin: 100
     Refineable: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165577,7 +164070,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165606,7 +164098,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165636,7 +164127,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165666,7 +164156,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165696,7 +164185,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165729,7 +164217,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165771,7 +164258,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -165810,7 +164296,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -166130,7 +164615,6 @@ Body:
     WeaponLevel: 2
     EquipLevelMin: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -166159,7 +164643,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -166189,7 +164672,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -166229,7 +164711,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -166574,7 +165055,6 @@ Body:
     WeaponLevel: 3
     EquipLevelMin: 45
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -167189,7 +165669,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -167229,7 +165708,6 @@ Body:
     WeaponLevel: 4
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -54,7 +54,7 @@
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
 #     NoConsume             If the item is consumed on use. (Default: false)
-#     DropEffect            If the item has a special effect when on the ground. (Default: None)
+#     DropEffect            If the item has a special effect on the ground when dropped by a monster. (Default: None)
 #   Delay:                  Item use delay. (Default: null)
 #     Duration              Duration of delay in seconds.
 #     Status                Status Change used to track delay. (Default: None)
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -471,7 +471,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 745
     AegisName: Wedding_Bouquet
@@ -482,7 +481,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 746
     AegisName: Glass_Bead
@@ -577,7 +575,6 @@ Body:
     Name: A bundle of shiny hair.
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15433,7 +15430,6 @@ Body:
     Name: Ashes of Darkness
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15475,7 +15471,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15488,7 +15483,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15502,7 +15496,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15522,7 +15515,6 @@ Body:
     Name: Big Fan Of Magic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15616,14 +15608,12 @@ Body:
     Buy: 6000000
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 6025
     AegisName: Towel_Of_Memory
     Name: Towel of Memory
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15638,14 +15628,12 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 6027
     AegisName: Crystal_Of_Feardoom
     Name: Crystal Of Feardom
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15659,7 +15647,6 @@ Body:
     Name: Sealed Scroll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15673,7 +15660,6 @@ Body:
     Name: Morocc Tracing Log
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15713,7 +15699,6 @@ Body:
     Name: Weird Part
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15727,7 +15712,6 @@ Body:
     Name: Decaying Stem
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15742,7 +15726,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15755,7 +15738,6 @@ Body:
     Name: Messy File
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15770,7 +15752,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15784,7 +15765,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15797,7 +15777,6 @@ Body:
     Name: Part of a Report
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15817,7 +15796,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15831,7 +15809,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15845,7 +15822,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15858,7 +15834,6 @@ Body:
     Name: Supply Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15872,7 +15847,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15886,7 +15860,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15900,7 +15873,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15914,7 +15886,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -15928,7 +15899,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15980,7 +15950,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16048,7 +16017,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16062,7 +16030,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16076,7 +16043,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16095,7 +16061,6 @@ Body:
     Name: Bazett's Order
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16114,7 +16079,6 @@ Body:
     Name: Portable Toolbox
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16128,7 +16092,6 @@ Body:
     Name: Rough Mineral
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16142,7 +16105,6 @@ Body:
     Name: Stone Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16156,7 +16118,6 @@ Body:
     Name: Flower Of Alfheim
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16170,7 +16131,6 @@ Body:
     Name: Manuk Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16182,7 +16142,6 @@ Body:
     Name: Splendide Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16194,7 +16153,6 @@ Body:
     Name: Spirit Of Alfheim
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16213,7 +16171,6 @@ Body:
     Name: Bradium Fragments
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16227,7 +16184,6 @@ Body:
     Name: Shaggy Muffler
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16294,7 +16250,6 @@ Body:
     Name: Draco's Egg
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16361,7 +16316,6 @@ Body:
     Name: Attendance Card
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16374,7 +16328,6 @@ Body:
     Name: Report On Splendide
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16388,7 +16341,6 @@ Body:
     Name: Report On Manuk
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16498,7 +16450,6 @@ Body:
     Name: Succubus Pet Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16512,7 +16463,6 @@ Body:
     Name: Imp Pet Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16526,7 +16476,6 @@ Body:
     Name: Chung E Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16553,7 +16502,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16568,7 +16516,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16591,7 +16538,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16606,7 +16552,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16621,7 +16566,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16635,7 +16579,6 @@ Body:
     Name: Purification Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16656,7 +16599,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16670,7 +16612,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16685,7 +16626,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16699,7 +16639,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16714,7 +16653,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16729,7 +16667,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16744,7 +16681,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16759,7 +16695,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16773,7 +16708,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16788,7 +16722,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16803,7 +16736,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16818,7 +16750,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16833,7 +16764,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16848,7 +16778,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16862,7 +16791,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16907,7 +16835,6 @@ Body:
     Name: Eternity Of Chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16920,7 +16847,6 @@ Body:
     Name: Simple Chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16933,7 +16859,6 @@ Body:
     Name: Key of The Mansion
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16947,7 +16872,6 @@ Body:
     Name: Giant Bradium Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16960,7 +16884,6 @@ Body:
     Name: Glittering Crystal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -16973,7 +16896,6 @@ Body:
     Name: Special Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16988,7 +16910,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17006,7 +16927,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17019,7 +16939,6 @@ Body:
     Name: Poring Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17032,7 +16951,6 @@ Body:
     Name: Drops Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17045,7 +16963,6 @@ Body:
     Name: Poporing Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17058,7 +16975,6 @@ Body:
     Name: Lunatic Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17071,7 +16987,6 @@ Body:
     Name: Picky Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17084,7 +16999,6 @@ Body:
     Name: Peco Peco Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17097,7 +17011,6 @@ Body:
     Name: Savage Babe Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17110,7 +17023,6 @@ Body:
     Name: Spore Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17123,7 +17035,6 @@ Body:
     Name: Poison Spore Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17136,7 +17047,6 @@ Body:
     Name: Chonchon Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17149,7 +17059,6 @@ Body:
     Name: Steel Chonchon Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17162,7 +17071,6 @@ Body:
     Name: Sky Petite Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17175,7 +17083,6 @@ Body:
     Name: Deviruchi Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17188,7 +17095,6 @@ Body:
     Name: Isis Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17201,7 +17107,6 @@ Body:
     Name: Smokie Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17214,7 +17119,6 @@ Body:
     Name: Dokebi Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17227,7 +17131,6 @@ Body:
     Name: Baby Desert Wolf Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17240,7 +17143,6 @@ Body:
     Name: Yoyo Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17253,7 +17155,6 @@ Body:
     Name: Sohee Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17266,7 +17167,6 @@ Body:
     Name: Rocker Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17279,7 +17179,6 @@ Body:
     Name: Hunter Fly Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17292,7 +17191,6 @@ Body:
     Name: Orc Warrior Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17305,7 +17203,6 @@ Body:
     Name: Bapho Jr. Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17318,7 +17215,6 @@ Body:
     Name: Munak Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17331,7 +17227,6 @@ Body:
     Name: Bongun Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17344,7 +17239,6 @@ Body:
     Name: Christmas Goblin Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17357,7 +17251,6 @@ Body:
     Name: Rice Cake Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17370,7 +17263,6 @@ Body:
     Name: Zherlthsh Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17383,7 +17275,6 @@ Body:
     Name: Alice Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17518,7 +17409,6 @@ Body:
     Name: I Love You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17531,7 +17421,6 @@ Body:
     Name: Thank You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17544,7 +17433,6 @@ Body:
     Name: I Respect You
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17625,7 +17513,6 @@ Body:
     Name: Delivery Daishin Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17639,7 +17526,6 @@ Body:
     Name: Eden Group Mark
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17684,7 +17570,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17698,7 +17583,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17711,7 +17595,6 @@ Body:
     Name: +9 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17724,7 +17607,6 @@ Body:
     Name: +8 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17737,7 +17619,6 @@ Body:
     Name: +7 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17750,7 +17631,6 @@ Body:
     Name: +6 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17763,7 +17643,6 @@ Body:
     Name: +9 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17776,7 +17655,6 @@ Body:
     Name: +8 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17789,7 +17667,6 @@ Body:
     Name: +7 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17802,7 +17679,6 @@ Body:
     Name: +6 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17815,7 +17691,6 @@ Body:
     Name: Blue Card 7
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -17828,7 +17703,6 @@ Body:
     Name: Guarana Fruit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17842,7 +17716,6 @@ Body:
     Name: +11 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17855,7 +17728,6 @@ Body:
     Name: +11 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17870,7 +17742,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17885,7 +17756,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17900,7 +17770,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
   - Id: 6243
@@ -18088,7 +17957,6 @@ Body:
     Name: Key Of Deception
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18102,7 +17970,6 @@ Body:
     Name: Key Of Illusion
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18116,7 +17983,6 @@ Body:
     Name: Key Of Gaiety
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18130,7 +17996,6 @@ Body:
     Name: A Master's Blush
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18144,7 +18009,6 @@ Body:
     Name: A Picture Of Minstrel Song
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18157,7 +18021,6 @@ Body:
     Name: Receipt
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18170,7 +18033,6 @@ Body:
     Name: Experiment Seed
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18184,7 +18046,6 @@ Body:
     Name: Seed For Experiment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18198,7 +18059,6 @@ Body:
     Name: A Piece Of Cloth Of A Saint
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18212,7 +18072,6 @@ Body:
     Name: Shield Of King
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18226,7 +18085,6 @@ Body:
     Name: Clear Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18240,7 +18098,6 @@ Body:
     Name: Red Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18254,7 +18111,6 @@ Body:
     Name: Black Reagent
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18377,7 +18233,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18399,7 +18254,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18413,7 +18267,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18447,7 +18300,6 @@ Body:
     Name: Proof Of Sapha's Honor
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18460,7 +18312,6 @@ Body:
     Name: Frozen Piece Of Skin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18474,7 +18325,6 @@ Body:
     Name: Hard Bloodstain
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18488,7 +18338,6 @@ Body:
     Name: Cursed Magical Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18502,7 +18351,6 @@ Body:
     Name: Unidentified Relic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18553,7 +18401,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18582,7 +18429,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18645,7 +18491,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18742,7 +18587,6 @@ Body:
     Name: Love Lump
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18760,7 +18604,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18774,7 +18617,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18788,7 +18630,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18802,7 +18643,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18816,7 +18656,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18830,7 +18669,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18844,7 +18682,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18858,7 +18695,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18872,7 +18708,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18886,7 +18721,6 @@ Body:
     Type: Etc
     Buy: 4020
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18901,7 +18735,6 @@ Body:
     Buy: 4020
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -18914,7 +18747,6 @@ Body:
     Name: Free Cash Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18928,7 +18760,6 @@ Body:
     Name: Guidebook Exchange
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19028,7 +18859,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19040,7 +18870,6 @@ Body:
     Name: Winning Mark
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19060,7 +18889,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19090,7 +18918,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19103,7 +18930,6 @@ Body:
     Name: Lope's Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19117,7 +18943,6 @@ Body:
     Name: Research Tool Bag
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19132,7 +18957,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19146,7 +18970,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19160,7 +18983,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19174,7 +18996,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19188,7 +19009,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19203,7 +19023,6 @@ Body:
     Buy: 20
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19218,7 +19037,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19256,7 +19074,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19269,7 +19086,6 @@ Body:
     Name: PR Team Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19283,7 +19099,6 @@ Body:
     Name: Develop Team Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19297,7 +19112,6 @@ Body:
     Name: Marketing Team Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19311,7 +19125,6 @@ Body:
     Name: Operating Team Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19326,7 +19139,6 @@ Body:
     Type: Etc
     Weight: 500
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19341,7 +19153,6 @@ Body:
     Type: Etc
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19409,7 +19220,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19422,7 +19232,6 @@ Body:
     Name: Special Medal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19438,7 +19247,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19457,7 +19265,6 @@ Body:
     Name: Strange Embryo
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19471,7 +19278,6 @@ Body:
     Name: Pet Exchange
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19485,7 +19291,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19531,7 +19336,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19545,7 +19349,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19560,7 +19363,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19573,7 +19375,6 @@ Body:
     Name: Bad Canned Food Sack
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19587,7 +19388,6 @@ Body:
     Name: Adventure Card A
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19601,7 +19401,6 @@ Body:
     Name: Adventure Card B
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19615,7 +19414,6 @@ Body:
     Name: Picture Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19629,7 +19427,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19643,7 +19440,6 @@ Body:
     Type: Etc
     Weight: 3000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19657,7 +19453,6 @@ Body:
     Type: Etc
     Weight: 300
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19671,7 +19466,6 @@ Body:
     Type: Etc
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19685,7 +19479,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19699,7 +19492,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19728,7 +19520,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19742,7 +19533,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19755,7 +19545,6 @@ Body:
     Name: Octopus Hunting Skewer
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19770,7 +19559,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19785,7 +19573,6 @@ Body:
     Buy: 2
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19803,7 +19590,6 @@ Body:
     Name: Green Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19817,7 +19603,6 @@ Body:
     Name: Red Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19831,7 +19616,6 @@ Body:
     Name: White Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19845,7 +19629,6 @@ Body:
     Name: Casual Diary
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19859,7 +19642,6 @@ Body:
     Name: Honest Diary
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19874,7 +19656,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19887,7 +19668,6 @@ Body:
     Name: Etoile Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19918,7 +19698,6 @@ Body:
     Name: +5 Weapon Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19931,7 +19710,6 @@ Body:
     Name: +5 Armor Refine Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19964,7 +19742,6 @@ Body:
     Name: Hate Crate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -19978,7 +19755,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20064,7 +19840,6 @@ Body:
     Name: Poring Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20091,7 +19866,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20120,7 +19894,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20133,7 +19906,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20208,7 +19980,6 @@ Body:
     Name: Sharpened Bamboo
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20221,7 +19992,6 @@ Body:
     Name: Salt Bag
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20234,7 +20004,6 @@ Body:
     Name: The Cross
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20247,7 +20016,6 @@ Body:
     Name: Spiritual Protection
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20259,7 +20027,6 @@ Body:
     Name: Cast-Iron Caldron
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20272,7 +20039,6 @@ Body:
     Name: Purified Spirit Bone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20285,7 +20051,6 @@ Body:
     Name: Offering Bouquet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20298,7 +20063,6 @@ Body:
     Name: Evil Spirit Bone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20399,7 +20163,6 @@ Body:
     Name: Collected Sample
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20411,7 +20174,6 @@ Body:
     Name: Lost Belongings
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20513,7 +20275,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20536,7 +20297,6 @@ Body:
     Name: Old Left Lapine
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20549,7 +20309,6 @@ Body:
     Name: Golden Leaf
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20562,7 +20321,6 @@ Body:
     Name: Avant Research Data
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20577,7 +20335,6 @@ Body:
     Buy: 20
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20589,7 +20346,6 @@ Body:
     Name: Lv110 Achieved Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20602,7 +20358,6 @@ Body:
     Name: Lv120 Achieved Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20615,7 +20370,6 @@ Body:
     Name: Firm Hair
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20628,7 +20382,6 @@ Body:
     Name: Younger Bro Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20641,7 +20394,6 @@ Body:
     Name: Stained Research Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20654,7 +20406,6 @@ Body:
     Name: Piece Of Lapine Wing
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20667,7 +20418,6 @@ Body:
     Name: Courtesy Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20690,7 +20440,6 @@ Body:
     Name: Mail Package
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20704,7 +20453,6 @@ Body:
     Name: Leaf Made Wood
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20718,7 +20466,6 @@ Body:
     Name: Seed Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20732,7 +20479,6 @@ Body:
     Name: Birthday Candle
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20747,7 +20493,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20800,7 +20545,6 @@ Body:
     Name: Tiny Mouse Tail
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20814,7 +20558,6 @@ Body:
     Name: Weeds
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20839,7 +20582,6 @@ Body:
     Name: Cacao99 Recipe
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20852,7 +20594,6 @@ Body:
     Name: Choco Drink Recipe
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -20875,7 +20616,6 @@ Body:
     Name: +12 Weapon Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20888,7 +20628,6 @@ Body:
     Name: +12 Armor Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20908,7 +20647,6 @@ Body:
     Name: Cryptura Hair Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21106,7 +20844,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21121,7 +20858,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 6636
     AegisName: STRStone_Top
@@ -21228,7 +20964,6 @@ Body:
     Name: Needle And Thread
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21241,7 +20976,6 @@ Body:
     Name: Firm Pumpkin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21254,7 +20988,6 @@ Body:
     Name: Goast Free Charm
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21267,7 +21000,6 @@ Body:
     Name: Memory Of Jack
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21285,7 +21017,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 6669
     AegisName: Jade_Leaf
@@ -21300,7 +21031,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21315,7 +21045,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21328,7 +21057,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21343,7 +21071,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21358,7 +21085,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21372,7 +21098,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21394,7 +21119,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21407,7 +21131,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21422,7 +21145,6 @@ Body:
     Buy: 10
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21438,7 +21160,6 @@ Body:
     Buy: 10
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21454,7 +21175,6 @@ Body:
     Buy: 10
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21469,7 +21189,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21482,7 +21201,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21549,7 +21267,6 @@ Body:
     Buy: 10
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21565,7 +21282,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21581,7 +21297,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21597,7 +21312,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21613,7 +21327,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21629,7 +21342,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21645,7 +21357,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21661,7 +21372,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21677,7 +21387,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21697,7 +21406,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21711,7 +21419,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21725,7 +21432,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21742,7 +21448,6 @@ Body:
     Name: Heart of Soul
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21756,7 +21461,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21770,7 +21474,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21807,7 +21510,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21821,7 +21523,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21835,7 +21536,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21850,7 +21550,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21865,7 +21564,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21880,7 +21578,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21899,7 +21596,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21976,7 +21672,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -21990,7 +21685,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22004,7 +21698,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22019,7 +21712,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22053,7 +21745,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22066,7 +21757,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22079,7 +21769,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22100,7 +21789,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22115,7 +21803,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22149,7 +21836,6 @@ Body:
     Name: Tickets Ice Kingdom
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22162,7 +21848,6 @@ Body:
     Name: Summer Festival Coins
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22175,7 +21860,6 @@ Body:
     Name: Shaved Ice For Red Beans
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22188,7 +21872,6 @@ Body:
     Name: Sweet Bread
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22305,7 +21988,6 @@ Body:
     Name: Squid Skewer
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22319,7 +22001,6 @@ Body:
     Name: Source Of Fantasy
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22333,7 +22014,6 @@ Body:
     Name: Squid Barbecue
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22347,7 +22027,6 @@ Body:
     Name: Long Firewood
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22361,7 +22040,6 @@ Body:
     Name: Rose Knife
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22375,7 +22053,6 @@ Body:
     Name: Customized Plates
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22443,7 +22120,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 6814
     AegisName: Swordman_Soul
@@ -22452,7 +22128,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22467,7 +22142,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22482,7 +22156,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22497,7 +22170,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22512,7 +22184,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22527,7 +22198,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22541,7 +22211,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22554,7 +22223,6 @@ Body:
     Name: Single Union Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22568,7 +22236,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22584,7 +22251,6 @@ Body:
     Buy: 10
     Weight: 10000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22599,7 +22265,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22613,7 +22278,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22642,7 +22306,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22668,7 +22331,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22682,7 +22344,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22696,7 +22357,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22710,7 +22370,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22723,7 +22382,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22736,7 +22394,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22749,7 +22406,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22763,7 +22419,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22777,7 +22432,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22791,7 +22445,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22806,7 +22459,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22820,7 +22472,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22834,7 +22485,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22848,7 +22498,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22862,7 +22511,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22876,7 +22524,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22890,7 +22537,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22904,7 +22550,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22918,7 +22563,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22932,7 +22576,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22946,7 +22589,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22960,7 +22602,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22974,7 +22615,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -22988,7 +22628,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23002,7 +22641,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23016,7 +22654,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23030,7 +22667,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23044,7 +22680,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23058,7 +22693,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23071,7 +22705,6 @@ Body:
     Name: Piece Of Soul Rabbit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23084,7 +22717,6 @@ Body:
     Name: Large Insect Barrel
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23097,7 +22729,6 @@ Body:
     Name: Medium Insect Barrel
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23110,7 +22741,6 @@ Body:
     Name: Dust
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23124,7 +22754,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23138,7 +22767,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23152,7 +22780,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23166,7 +22793,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23180,7 +22806,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23194,7 +22819,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23208,7 +22832,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23222,7 +22845,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23236,7 +22858,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23250,7 +22871,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23264,7 +22884,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23278,7 +22897,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23298,7 +22916,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23313,7 +22930,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23327,7 +22943,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23341,7 +22956,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23432,7 +23046,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23454,7 +23067,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23468,7 +23080,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23490,7 +23101,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23505,7 +23115,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23520,7 +23129,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23534,7 +23142,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23548,7 +23155,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23563,7 +23169,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23577,7 +23182,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23591,7 +23195,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23605,7 +23208,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23619,7 +23221,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23634,7 +23235,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23664,7 +23264,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23686,7 +23285,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23700,7 +23298,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23714,7 +23311,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23728,7 +23324,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23742,7 +23337,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23756,7 +23350,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23770,7 +23363,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23784,7 +23376,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23798,7 +23389,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23813,7 +23403,6 @@ Body:
     Buy: 10
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23827,7 +23416,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23951,7 +23539,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23967,7 +23554,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23981,7 +23567,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -23995,7 +23580,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24009,7 +23593,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24028,7 +23611,6 @@ Body:
     Type: Etc
     Buy: 0
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24043,7 +23625,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24193,7 +23774,6 @@ Body:
     Name: +10 Weapon Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24206,7 +23786,6 @@ Body:
     Name: +10 Armor Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24219,7 +23798,6 @@ Body:
     Name: Warm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24232,7 +23810,6 @@ Body:
     Name: Rabbit Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24245,7 +23822,6 @@ Body:
     Name: Old Arrow
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24462,7 +24038,6 @@ Body:
     Buy: 30000
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24704,7 +24279,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24718,7 +24292,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -24732,7 +24305,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -25361,7 +24933,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 7141
     AegisName: Yggdrasilberry_Dew
@@ -25596,7 +25167,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 7171
     AegisName: Leopard_Skin
@@ -25643,7 +25213,6 @@ Body:
     Name: Crumb of Sobbing Starlight
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25657,7 +25226,6 @@ Body:
     Name: Sobbing Starlight
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25813,7 +25381,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -26322,7 +25889,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26336,7 +25902,6 @@ Body:
     Name: Doodled Message
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26537,7 +26102,6 @@ Body:
     Name: Witch's Spell Scroll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26551,7 +26115,6 @@ Body:
     Name: Symbol of the Nine Realms
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26565,7 +26128,6 @@ Body:
     Name: Piece of Spirit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26579,7 +26141,6 @@ Body:
     Name: Spiritual Whispers
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26593,7 +26154,6 @@ Body:
     Name: Witch's Tonic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26607,7 +26167,6 @@ Body:
     Name: Crow Wing
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26646,7 +26205,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26784,7 +26342,6 @@ Body:
     Name: Complete Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26798,7 +26355,6 @@ Body:
     Name: Prontera Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26812,7 +26368,6 @@ Body:
     Name: Payon Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26826,7 +26381,6 @@ Body:
     Name: Morocc Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26840,7 +26394,6 @@ Body:
     Name: Geffen Tablet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26862,7 +26415,6 @@ Body:
     Name: Commemorative Travel Card
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26885,7 +26437,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26900,7 +26451,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26915,7 +26465,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26930,7 +26479,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26953,7 +26501,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26982,7 +26529,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27003,7 +26549,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27122,7 +26667,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27387,7 +26931,6 @@ Body:
     Name: Letter of Recommendation
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27400,7 +26943,6 @@ Body:
     Name: Written Request(A)
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27413,7 +26955,6 @@ Body:
     Name: Written Request(B)
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27434,7 +26975,6 @@ Body:
     Name: Skull
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27447,7 +26987,6 @@ Body:
     Name: Red Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27460,7 +26999,6 @@ Body:
     Name: Yellow Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27473,7 +27011,6 @@ Body:
     Name: Blue Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27486,7 +27023,6 @@ Body:
     Name: Green Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27499,7 +27035,6 @@ Body:
     Name: Black Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27512,7 +27047,6 @@ Body:
     Name: Red Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27525,7 +27059,6 @@ Body:
     Name: Yellow Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27538,7 +27071,6 @@ Body:
     Name: Blue Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27551,7 +27083,6 @@ Body:
     Name: Green Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27564,7 +27095,6 @@ Body:
     Name: Black Charm Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27577,7 +27107,6 @@ Body:
     Name: Pile of Books
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -27590,7 +27119,6 @@ Body:
     Name: Leather Pouch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27970,7 +27498,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27985,7 +27512,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28000,7 +27526,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28014,7 +27539,6 @@ Body:
     Name: Culinary Wine
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28028,7 +27552,6 @@ Body:
     Name: Delivery Package
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28042,7 +27565,6 @@ Body:
     Name: Cottage Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28056,7 +27578,6 @@ Body:
     Name: Letter to Elly
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28070,7 +27591,6 @@ Body:
     Name: Steel Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28084,7 +27604,6 @@ Body:
     Name: Yellow Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28098,7 +27617,6 @@ Body:
     Name: Golden Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28112,7 +27630,6 @@ Body:
     Name: Luxurious Button
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28126,7 +27643,6 @@ Body:
     Name: Blue Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28140,7 +27656,6 @@ Body:
     Name: Red Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28154,7 +27669,6 @@ Body:
     Name: Metal Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28168,7 +27682,6 @@ Body:
     Name: Rosimier Mansion Keys
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28182,7 +27695,6 @@ Body:
     Name: Family Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28196,7 +27708,6 @@ Body:
     Name: Woman's Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28210,7 +27721,6 @@ Body:
     Name: K.H's Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28224,7 +27734,6 @@ Body:
     Name: James's Note
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28238,7 +27747,6 @@ Body:
     Name: Man's Portrait
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28252,7 +27760,6 @@ Body:
     Name: Power Device
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28266,7 +27773,6 @@ Body:
     Name: Toy Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28280,7 +27786,6 @@ Body:
     Name: Black Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28301,7 +27806,6 @@ Body:
     Name: Allysia's Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28315,7 +27819,6 @@ Body:
     Name: Luxurious Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28361,7 +27864,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28375,7 +27877,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28388,7 +27889,6 @@ Body:
     Name: Green Keycard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28408,7 +27908,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28475,7 +27974,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28497,7 +27995,6 @@ Body:
     Name: Travel Brochure [Amatsu]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28511,7 +28008,6 @@ Body:
     Name: Travel Brochure [Kunlun]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28525,7 +28021,6 @@ Body:
     Name: Travel Brochure [Luoyang]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28539,7 +28034,6 @@ Body:
     Name: Travel Brochure [Ayothaya]
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28553,7 +28047,6 @@ Body:
     Name: Amatsu Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28567,7 +28060,6 @@ Body:
     Name: Kunlun Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28581,7 +28073,6 @@ Body:
     Name: Luoyang Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28595,7 +28086,6 @@ Body:
     Name: Ayothaya Completed Photo Album
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28609,7 +28099,6 @@ Body:
     Name: Sand for Work
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28622,7 +28111,6 @@ Body:
     Name: Poring Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28672,7 +28160,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28687,7 +28174,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28702,7 +28188,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28717,7 +28202,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28732,7 +28216,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28747,7 +28230,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28760,7 +28242,6 @@ Body:
     Name: Lotus Flower
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28773,7 +28254,6 @@ Body:
     Name: Striped Candle
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28786,7 +28266,6 @@ Body:
     Name: Green Incense
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -28799,7 +28278,6 @@ Body:
     Name: Longing Heart
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28812,7 +28290,6 @@ Body:
     Name: Invitation Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28825,7 +28302,6 @@ Body:
     Name: Invitation Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28838,7 +28314,6 @@ Body:
     Name: Key to the Secret Garden
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28919,7 +28394,6 @@ Body:
     Name: Wind Hammer
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28941,7 +28415,6 @@ Body:
     Name: Ashy Necklace
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28954,7 +28427,6 @@ Body:
     Name: Sparkling Necklace
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28974,7 +28446,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28989,7 +28460,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29005,7 +28475,6 @@ Body:
     Buy: 20
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29026,7 +28495,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29041,7 +28509,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29068,7 +28535,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29083,7 +28549,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29098,7 +28563,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29113,7 +28577,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29128,7 +28591,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29143,7 +28605,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29236,7 +28697,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29305,7 +28765,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29338,7 +28797,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29353,7 +28811,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29368,7 +28825,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29383,7 +28839,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29397,7 +28852,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29411,7 +28865,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29431,7 +28884,6 @@ Body:
     Name: Registration Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29463,7 +28915,6 @@ Body:
     Name: Clean Beach Brush
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29476,7 +28927,6 @@ Body:
     Name: Trash Debris
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29534,7 +28984,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29689,7 +29138,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29704,7 +29152,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29730,7 +29177,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29745,7 +29191,6 @@ Body:
     Type: Etc
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29809,7 +29254,6 @@ Body:
     Name: Handmade Chocolate Recipe
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29822,7 +29266,6 @@ Body:
     Name: Chocolate Strawberry Recipe
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29835,7 +29278,6 @@ Body:
     Name: Chocolate Tart Recipe
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29860,7 +29302,6 @@ Body:
     Buy: 100
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29879,7 +29320,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29894,7 +29334,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29909,7 +29348,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29924,7 +29362,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29939,7 +29376,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29953,7 +29389,6 @@ Body:
     Name: HP Doctor Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29966,7 +29401,6 @@ Body:
     Name: SP Doctor Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29981,7 +29415,6 @@ Body:
     Buy: 20
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -29995,7 +29428,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7731
     AegisName: Mission_Certificate2
@@ -30003,7 +29435,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7732
     AegisName: Mission_Certificate3
@@ -30011,7 +29442,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7733
     AegisName: Mission_Certificate4
@@ -30019,7 +29449,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7734
     AegisName: Mission_Certificate5
@@ -30027,7 +29456,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7735
     AegisName: Mission_Certificate6
@@ -30035,7 +29463,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7736
     AegisName: Mission_Certificate7
@@ -30043,7 +29470,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7737
     AegisName: Mission_Certificate8
@@ -30051,7 +29477,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7738
     AegisName: Mission_Certificate9
@@ -30059,7 +29484,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7739
     AegisName: Mission_Certificate10
@@ -30067,7 +29491,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7740
     AegisName: Mission_Certificate11
@@ -30075,7 +29498,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7741
     AegisName: Mission_Certificate12
@@ -30083,7 +29505,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
   - Id: 7742
     AegisName: Kaong
@@ -30177,7 +29598,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30210,7 +29630,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30248,7 +29667,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30264,7 +29682,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30280,7 +29697,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30296,7 +29712,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30311,7 +29726,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30349,7 +29763,6 @@ Body:
     Name: Wat Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30368,7 +29781,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30382,7 +29794,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30406,7 +29817,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30420,7 +29830,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30453,7 +29862,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30467,7 +29875,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30481,7 +29888,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30495,7 +29901,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30509,7 +29914,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30523,7 +29927,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30537,7 +29940,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30551,7 +29953,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30569,7 +29970,6 @@ Body:
     Name: Golden Apple
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30582,7 +29982,6 @@ Body:
     Name: The Crow of Destiny
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30625,7 +30024,6 @@ Body:
     Name: Golden Charm Apple
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30638,7 +30036,6 @@ Body:
     Name: Girl's Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30651,7 +30048,6 @@ Body:
     Name: Signature Notebook
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30665,7 +30061,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30678,7 +30073,6 @@ Body:
     Name: Octopig's Leg
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30766,7 +30160,6 @@ Body:
     Name: Piece of Morocc Skin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30782,7 +30175,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30797,7 +30189,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30812,7 +30203,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30835,7 +30225,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30848,7 +30237,6 @@ Body:
     Name: Continental Guard Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30861,7 +30249,6 @@ Body:
     Name: Mineral Evals
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30874,7 +30261,6 @@ Body:
     Name: Bravery Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30887,7 +30273,6 @@ Body:
     Name: Valor Badge
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30972,7 +30357,6 @@ Body:
     Name: Crystal Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -30985,7 +30369,6 @@ Body:
     Name: Valkyrie's Gift
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30999,7 +30382,6 @@ Body:
     Name: Stained Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31012,7 +30394,6 @@ Body:
     Name: Torn Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31025,7 +30406,6 @@ Body:
     Name: Old Piece Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31038,7 +30418,6 @@ Body:
     Name: Burnt Pieces Of Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31153,7 +30532,6 @@ Body:
     Buy: 20
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31172,7 +30550,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31186,7 +30563,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31248,7 +30624,6 @@ Body:
     Type: Etc
     Buy: 300000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31261,7 +30636,6 @@ Body:
     Type: Etc
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31275,7 +30649,6 @@ Body:
     Type: Etc
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31289,7 +30662,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31303,7 +30675,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31317,7 +30688,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31331,7 +30701,6 @@ Body:
     Type: Etc
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31344,7 +30713,6 @@ Body:
     Name: Sharp Branch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31357,7 +30725,6 @@ Body:
     Name: Wooden Flute
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31370,7 +30737,6 @@ Body:
     Name: Jade Plate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31383,7 +30749,6 @@ Body:
     Name: Sacred Arrow
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31440,7 +30805,6 @@ Body:
     Name: Rama5 Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31453,7 +30817,6 @@ Body:
     Name: Loykrathong Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31466,7 +30829,6 @@ Body:
     Name: Constitution Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31479,7 +30841,6 @@ Body:
     Name: VV Strong Balmung
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31492,7 +30853,6 @@ Body:
     Name: Dagger Of Psychic
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31505,7 +30865,6 @@ Body:
     Name: Jonathan Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31519,7 +30878,6 @@ Body:
     Name: Jillberriel Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31533,7 +30891,6 @@ Body:
     Name: Jessur Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31547,7 +30904,6 @@ Body:
     Name: Jenoss Family Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31561,7 +30917,6 @@ Body:
     Name: Piano Key
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31581,7 +30936,6 @@ Body:
     Name: Poppy Wreath
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31597,7 +30951,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31616,7 +30969,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31630,7 +30982,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31648,7 +30999,6 @@ Body:
     Name: Portable Snowman Machine
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31662,7 +31012,6 @@ Body:
     Name: Battle Test Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31677,7 +31026,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31701,7 +31049,6 @@ Body:
     Name: Magic Potion
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31723,7 +31070,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31737,7 +31083,6 @@ Body:
     Name: He's Arsenal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31763,7 +31108,6 @@ Body:
     Name: Krathong
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31802,7 +31146,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31818,7 +31161,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31833,7 +31175,6 @@ Body:
     Type: Etc
     Weight: 1000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31947,7 +31288,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31977,7 +31317,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -31991,7 +31330,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32005,7 +31343,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32018,7 +31355,6 @@ Body:
     Name: Gift Of Lomi Ross
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32032,7 +31368,6 @@ Body:
     Name: Gift Of Juliet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32048,7 +31383,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32081,21 +31415,18 @@ Body:
     Name: Ancient Gold Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 7960
     AegisName: Ancient_Silver_Coin
     Name: Ancient Silver Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
   - Id: 7961
     AegisName: Weapon_Exchange
     Name: Weapon Exchange
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32109,7 +31440,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32123,7 +31453,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32137,7 +31466,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32151,7 +31479,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32165,7 +31492,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32179,7 +31505,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32193,7 +31518,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32207,7 +31531,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32472,7 +31795,6 @@ Body:
     Name: Varmunt's Note
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32485,7 +31807,6 @@ Body:
     Name: Expedition Report
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32498,7 +31819,6 @@ Body:
     Name: Expedition Report Vol1
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32511,7 +31831,6 @@ Body:
     Name: Expedition Report Vol2
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32524,7 +31843,6 @@ Body:
     Name: Expedition Report Vol3
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32537,7 +31855,6 @@ Body:
     Name: Expedition Report Vol4
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -32826,7 +32143,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32841,7 +32157,6 @@ Body:
     Buy: 10
     Weight: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32856,7 +32171,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32996,7 +32310,6 @@ Body:
       Ammo: true
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34033,7 +33346,6 @@ Body:
       Ammo: true
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34059,7 +33371,6 @@ Body:
       Ammo: true
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34085,7 +33396,6 @@ Body:
       Ammo: true
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34122,7 +33432,6 @@ Body:
     Locations:
       Ammo: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34141,7 +33450,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34158,7 +33466,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34365,7 +33672,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34379,7 +33685,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34393,7 +33698,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34413,7 +33717,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34427,7 +33730,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34441,7 +33743,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34455,7 +33756,6 @@ Body:
     Type: Etc
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34470,7 +33770,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34496,7 +33795,6 @@ Body:
     Flags:
       DropEffect: CLIENT
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34601,7 +33899,6 @@ Body:
     Name: Broken Trap
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34614,7 +33911,6 @@ Body:
     Name: Capture Trap
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34634,7 +33930,6 @@ Body:
     Name: Piece of Mysterious Egg
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34647,7 +33942,6 @@ Body:
     Name: Thorny Vine Flute
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34665,7 +33959,6 @@ Body:
     Name: Luxurious Cloth
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34678,7 +33971,6 @@ Body:
     Name: Boarding Pass
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34691,7 +33983,6 @@ Body:
     Name: Kahlunac
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34704,7 +33995,6 @@ Body:
     Name: Hearty Lunchbox
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34717,7 +34007,6 @@ Body:
     Name: Basilac Clam
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34731,7 +34020,6 @@ Body:
     Type: Etc
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34834,7 +34122,6 @@ Body:
     Name: Old Papyrus
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34847,7 +34134,6 @@ Body:
     Name: Old Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34860,7 +34146,6 @@ Body:
     Name: Admiral's Sword
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34873,7 +34158,6 @@ Body:
     Name: Coursera
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34886,7 +34170,6 @@ Body:
     Name: Knight Supply
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34899,7 +34182,6 @@ Body:
     Name: Ha Soju
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34912,7 +34194,6 @@ Body:
     Name: Last Breath
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34925,7 +34206,6 @@ Body:
     Name: Fox Bead
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34938,7 +34218,6 @@ Body:
     Name: Silky Hair of Rabbit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34951,7 +34230,6 @@ Body:
     Name: Captured Rabbit
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34964,7 +34242,6 @@ Body:
     Name: Rabbit's Hair
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34977,7 +34254,6 @@ Body:
     Name: Ribbon for Gift wrapping
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -34990,7 +34266,6 @@ Body:
     Name: Old Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35003,7 +34278,6 @@ Body:
     Name: Fragment of Dreams
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35015,7 +34289,6 @@ Body:
     Name: Ornament Wings Gift
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35028,182 +34301,156 @@ Body:
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25099
     AegisName: Jobmap_su
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25100
     AegisName: Jobmap_sword
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25101
     AegisName: Jobmap_magic
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25102
     AegisName: Jobmap_Merch
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25103
     AegisName: Jobmap_acol
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25104
     AegisName: Jobmap_thief
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25105
     AegisName: Jobmap_archer
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25106
     AegisName: Jobmap_taekwon
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25107
     AegisName: Jobmap_rune
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25108
     AegisName: Jobmap_royal
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25109
     AegisName: Jobmap_war
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25110
     AegisName: Jobmap_socer
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25111
     AegisName: Jobmap_mecha
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25112
     AegisName: Jobmap_gene
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25113
     AegisName: Jobmap_bishop
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25114
     AegisName: Jobmap_sura
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25115
     AegisName: Jobmap_cross
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25116
     AegisName: Jobmap_chaser
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25117
     AegisName: Jobmap_ranger
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25118
     AegisName: Jobmap_mins
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25119
     AegisName: Jobmap_wander
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25120
     AegisName: Jobmap_ninja
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25121
     AegisName: Jobmap_gun
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25122
     AegisName: Jobmap_super2
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25123
     AegisName: Jobmap_karma2
     Name: Realm Map
     Type: Etc
     Trade:
-      Override: 100
       NoCart: true
   - Id: 25127
     AegisName: Silent_Energy_Particle
@@ -35230,7 +34477,6 @@ Body:
     Name: Pumpkin Deco
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35243,7 +34489,6 @@ Body:
     Name: Dried White Stem
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35301,7 +34546,6 @@ Body:
     Name: Gift Stuffed Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35314,7 +34558,6 @@ Body:
     Name: Bridge Postured Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35327,7 +34570,6 @@ Body:
     Name: Burnt Spector Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35340,7 +34582,6 @@ Body:
     Name: Cold Blooded Queen Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35353,7 +34594,6 @@ Body:
     Name: Well Eatenl Rabbit Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35366,7 +34606,6 @@ Body:
     Name: Cute Starved Demon Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35379,7 +34618,6 @@ Body:
     Name: Doll With Warm Scarf
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35392,7 +34630,6 @@ Body:
     Name: Hugging Alice Pilow
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35405,7 +34642,6 @@ Body:
     Name: Rachel's Revolver
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35418,7 +34654,6 @@ Body:
     Name: Cherished Bouquet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35431,7 +34666,6 @@ Body:
     Name: Broken Gun Wreck
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35449,7 +34683,6 @@ Body:
     Name: Schwarz's Honor Token
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35482,7 +34715,6 @@ Body:
     Name: Borrowed Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35495,7 +34727,6 @@ Body:
     Name: Delicious Handmade Cookie
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35508,7 +34739,6 @@ Body:
     Name: Crispy Anchovy
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35521,7 +34751,6 @@ Body:
     Name: Arms Shop Ad
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35534,7 +34763,6 @@ Body:
     Name: Fresh Tea Leaves
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35547,7 +34775,6 @@ Body:
     Name: High Class Tea
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35560,7 +34787,6 @@ Body:
     Name: Very Shining Ring
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35573,7 +34799,6 @@ Body:
     Name: Old Letter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35586,7 +34811,6 @@ Body:
     Name: Sticky Mucus
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35653,7 +34877,6 @@ Body:
     Name: Blessing Star
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35666,7 +34889,6 @@ Body:
     Name: Old Rings
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35679,7 +34901,6 @@ Body:
     Name: Wood Rosary
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35692,7 +34913,6 @@ Body:
     Name: Assassin's Mark Dagger
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35705,7 +34925,6 @@ Body:
     Name: Decorated Archer's Thimble
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35718,7 +34937,6 @@ Body:
     Name: Portable Sewingbox
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35731,7 +34949,6 @@ Body:
     Name: Locket Pendant
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35750,7 +34967,6 @@ Body:
     Name: Girl's Handkerchief
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35763,7 +34979,6 @@ Body:
     Name: Fluffy Cloud
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35776,7 +34991,6 @@ Body:
     Name: Miracle Claw
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35825,7 +35039,6 @@ Body:
     Name: Tree Branch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35838,7 +35051,6 @@ Body:
     Name: Window Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35851,7 +35063,6 @@ Body:
     Name: Moonlight Kite String
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35864,7 +35075,6 @@ Body:
     Name: MoonScent Tree Branch
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35877,7 +35087,6 @@ Body:
     Name: Moon Patterned Window Paper
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35890,7 +35099,6 @@ Body:
     Name: Eden Group Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35956,7 +35164,6 @@ Body:
     Name: Crafted Stone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -35968,7 +35175,6 @@ Body:
     Name: New Normal Lubricant
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35981,7 +35187,6 @@ Body:
     Name: New Advanced Lubricant
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35999,7 +35204,6 @@ Body:
     Name: Small pile of bones
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36012,7 +35216,6 @@ Body:
     Name: Juice Mix Package
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36024,7 +35227,6 @@ Body:
     Name: Purple Ore
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36036,7 +35238,6 @@ Body:
     Name: Purple Ore Crate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36048,7 +35249,6 @@ Body:
     Name: Buffalo Bandit Mane
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36068,7 +35268,6 @@ Body:
     Name: Sprig of Holly
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36080,7 +35279,6 @@ Body:
     Name: A box containing sugar
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36094,7 +35292,6 @@ Body:
     Name: Firewood
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36135,7 +35332,6 @@ Body:
     Name: Fragment of Purple Ore
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36183,7 +35379,6 @@ Body:
     Name: Sticky Blood
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36196,7 +35391,6 @@ Body:
     Name: Mushroom Sap
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36209,7 +35403,6 @@ Body:
     Name: Wavy Mane
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36241,7 +35434,6 @@ Body:
     Name: Racing Audit Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36317,7 +35509,6 @@ Body:
     Name: Mystical Feather
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36334,7 +35525,6 @@ Body:
     Name: Product Chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36356,7 +35546,6 @@ Body:
     Name: Happy Three Leaf Clover
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36369,7 +35558,6 @@ Body:
     Name: Something Fatal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36432,7 +35620,6 @@ Body:
     Name: Late Lang Monster Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36446,7 +35633,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36460,7 +35646,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36495,7 +35680,6 @@ Body:
     Name: Shell Fragment
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36508,7 +35692,6 @@ Body:
     Name: Old Metal Pieces
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36527,7 +35710,6 @@ Body:
     Name: Ice Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36560,7 +35742,6 @@ Body:
     Name: Flat and Round Stones
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36574,7 +35755,6 @@ Body:
     Type: Etc
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36588,7 +35768,6 @@ Body:
     Type: Etc
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36602,7 +35781,6 @@ Body:
     Type: Etc
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36615,7 +35793,6 @@ Body:
     Name: Elongated noodles
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36628,7 +35805,6 @@ Body:
     Name: Noodle Festival Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36641,7 +35817,6 @@ Body:
     Name: Promotional fan
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36667,7 +35842,6 @@ Body:
     Name: Captured Savage
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36680,7 +35854,6 @@ Body:
     Name: High-quality branches
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36693,7 +35866,6 @@ Body:
     Name: Ticket to anywhere
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36706,7 +35878,6 @@ Body:
     Name: Tasty Corn
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36719,7 +35890,6 @@ Body:
     Name: Fruit lunch box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36733,7 +35903,6 @@ Body:
     Name: Small Ember
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36747,7 +35916,6 @@ Body:
     Name: Black Fur
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36760,7 +35928,6 @@ Body:
     Name: Memories of Gyoll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36845,7 +36012,6 @@ Body:
     Name: Pumpkin Decoration
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36858,7 +36024,6 @@ Body:
     Name: Dry White Stem
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36871,7 +36036,6 @@ Body:
     Name: Magical Snow Flower
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36884,7 +36048,6 @@ Body:
     Name: Warm Cotton
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36897,7 +36060,6 @@ Body:
     Name: Beginner's Equipment Exchange Voucher
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36910,7 +36072,6 @@ Body:
     Name: Beginner's Safe to 7 Weapon Certificate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -36996,7 +36157,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37009,7 +36169,6 @@ Body:
     Name: Dogly Bottle
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37104,7 +36263,6 @@ Body:
     Name: Phantom's Seal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37143,7 +36301,6 @@ Body:
     Name: Solid chocolate
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37156,7 +36313,6 @@ Body:
     Name: Almond
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37290,7 +36446,6 @@ Body:
     Name: Signed Book
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37308,7 +36463,6 @@ Body:
     Name: Stamped Notebook
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37321,7 +36475,6 @@ Body:
     Name: Though Noodles
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37334,7 +36487,6 @@ Body:
     Name: Noodle Sap
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37348,7 +36500,6 @@ Body:
     Type: Etc
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37361,7 +36512,6 @@ Body:
     Name: Ribbon Noodles
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37374,7 +36524,6 @@ Body:
     Name: Dien's Precious Envelope
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37387,7 +36536,6 @@ Body:
     Name: Identification Bracelet
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37920,7 +37068,6 @@ Body:
     Name: Episode Quest Clear Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37933,7 +37080,6 @@ Body:
     Name: Sealed Weapon Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -37946,7 +37092,6 @@ Body:
     Name: Ancient Hero's Seal-Year
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38158,7 +37303,6 @@ Body:
     Name: "[Event] Inventory Expansion Voucher"
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38171,7 +37315,6 @@ Body:
     Name: "[Limited] Inventory Expansion Voucher"
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38184,7 +37327,6 @@ Body:
     Name: Inventory Expansion Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38308,7 +37450,6 @@ Body:
     Name: Metal Weapon Exchange Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38321,7 +37462,6 @@ Body:
     Name: January Costume Exchange Coupon
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38334,7 +37474,6 @@ Body:
     Name: Smooth Noodles
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -38531,7 +37670,6 @@ Body:
     Name: Searud's Fishing Rod
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -55638,7 +54776,6 @@ Body:
     Name: 1st Job Change Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55651,7 +54788,6 @@ Body:
     Name: 2nd Job Change Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55664,7 +54800,6 @@ Body:
     Name: Transcendence Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55677,7 +54812,6 @@ Body:
     Name: Top Job Tickets
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55690,7 +54824,6 @@ Body:
     Name: Boosting Weapon Voucher
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55703,7 +54836,6 @@ Body:
     Name: Booster Armor Voucher
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55716,7 +54848,6 @@ Body:
     Name: Parfait for Children
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55790,7 +54921,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55804,7 +54934,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55818,7 +54947,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55832,7 +54960,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55846,7 +54973,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55860,7 +54986,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55874,7 +54999,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55888,7 +55012,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -55902,7 +55025,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -55917,7 +55039,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -55932,7 +55053,6 @@ Body:
     Type: Etc
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -55952,7 +55072,6 @@ Body:
     Name: Magical Soapstone
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56520,7 +55639,6 @@ Body:
     Name: Core of a Broken Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56538,7 +55656,6 @@ Body:
     Name: Parts of Broken Automatic Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56551,7 +55668,6 @@ Body:
     Name: Communication Chip of Automatic Doll
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56586,7 +55702,6 @@ Body:
     Name: Booster Weapon Voucher
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56599,7 +55714,6 @@ Body:
     Name: Booster Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56667,7 +55781,6 @@ Body:
     Name: Gas Mask
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56679,7 +55792,6 @@ Body:
     Name: Sealing Box
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56691,7 +55803,6 @@ Body:
     Name: Mandragora Incubator
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56703,7 +55814,6 @@ Body:
     Name: Piece of Impression
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56716,7 +55826,6 @@ Body:
     Name: Piece of Inspiration
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -56729,7 +55838,6 @@ Body:
     Name: "[Kachua] Mileage Coupon"
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56784,7 +55892,6 @@ Body:
     Name: Episode 16 Clear Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56797,7 +55904,6 @@ Body:
     Name: (Event) Episode 16 Clear Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56811,7 +55917,6 @@ Body:
     Name: Episode 17 Clear Ticket
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56927,7 +56032,6 @@ Body:
     Type: Etc
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -56953,7 +56057,6 @@ Body:
     Name: Kafra Coin
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57077,7 +56180,6 @@ Body:
     Name: Ymir Ore
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57090,7 +56192,6 @@ Body:
     Name: Geffen Arena Championship
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57103,7 +56204,6 @@ Body:
     Name: Minneas
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57225,7 +56325,6 @@ Body:
     Name: Very Unusual Crystal
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57238,7 +56337,6 @@ Body:
     Name: Half Flower
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57251,7 +56349,6 @@ Body:
     Name: Recording Note
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57264,7 +56361,6 @@ Body:
     Name: Document Files
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57277,7 +56373,6 @@ Body:
     Name: Water Filter
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57290,7 +56385,6 @@ Body:
     Name: Purified Water
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57303,7 +56397,6 @@ Body:
     Name: Trapped Bird
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57316,7 +56409,6 @@ Body:
     Name: Trapped Lizard
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -57329,7 +56421,6 @@ Body:
     Name: Trapped Pear
     Type: Etc
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -65,10 +65,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)
@@ -535,7 +535,6 @@ Body:
     Buy: 1650
     Weight: 50
     Trade:
-      Override: 100
       NoSell: true
     Script: |
       itemheal rand(325,405),0;
@@ -1048,7 +1047,6 @@ Body:
     Buy: 50
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1065,7 +1063,6 @@ Body:
     Buy: 200
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1105,7 +1102,6 @@ Body:
       BuyingStore: true
       Container: true
     Trade:
-      Override: 100
       NoSell: true
     Script: |
       getrandgroupitem(IG_BlueBox,1);
@@ -1139,7 +1135,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "SM_SELFPROVOKE",1;
@@ -1258,7 +1253,6 @@ Body:
       BuyingStore: true
       Container: true
     Trade:
-      Override: 100
       NoSell: true
     Script: |
       getrandgroupitem(IG_VioletBox,1);
@@ -1279,7 +1273,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1002;
@@ -1292,7 +1285,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1113;
@@ -1305,7 +1297,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1031;
@@ -1318,7 +1309,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1063;
@@ -1331,7 +1321,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1049;
@@ -1344,7 +1333,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1011;
@@ -1357,7 +1345,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1042;
@@ -1370,7 +1357,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1035;
@@ -1383,7 +1369,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1167;
@@ -1396,7 +1381,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1107;
@@ -1409,7 +1393,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1052;
@@ -1422,7 +1405,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1014;
@@ -1435,7 +1417,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1077;
@@ -1448,7 +1429,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1019;
@@ -1461,7 +1441,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1056;
@@ -1474,7 +1453,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1057;
@@ -1487,7 +1465,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1023;
@@ -1500,7 +1477,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1026;
@@ -1513,7 +1489,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1110;
@@ -1526,7 +1501,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1170;
@@ -1539,7 +1513,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1029;
@@ -1552,7 +1525,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1155;
@@ -1565,7 +1537,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1109;
@@ -1578,7 +1549,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1101;
@@ -1695,7 +1665,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1188;
@@ -1708,7 +1677,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1200;
@@ -1721,7 +1689,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1275;
@@ -1813,7 +1780,6 @@ Body:
     Name: Gold Coin
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1837,7 +1803,6 @@ Body:
     Name: Silver Coin
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -1938,7 +1903,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "WZ_EARTHSPIKE",3;
@@ -1951,7 +1915,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "WZ_EARTHSPIKE",5;
@@ -1964,7 +1927,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_COLDBOLT",3;
@@ -1977,7 +1939,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_COLDBOLT",5;
@@ -1990,7 +1951,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBOLT",3;
@@ -2003,7 +1963,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBOLT",5;
@@ -2016,7 +1975,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_LIGHTNINGBOLT",3;
@@ -2029,7 +1987,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_LIGHTNINGBOLT",5;
@@ -2042,7 +1999,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_SOULSTRIKE",3;
@@ -2055,7 +2011,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_SOULSTRIKE",5;
@@ -2068,7 +2023,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBALL",1;
@@ -2081,7 +2035,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREBALL",5;
@@ -2094,7 +2047,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREWALL",1;
@@ -2107,7 +2059,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FIREWALL",5;
@@ -2120,7 +2071,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FROSTDIVER",1;
@@ -2129,7 +2079,6 @@ Body:
     Name: Clothing Dye Coupon
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2142,7 +2091,6 @@ Body:
     Name: Clothing Dye Coupon II
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2157,7 +2105,6 @@ Body:
     Buy: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2175,7 +2122,6 @@ Body:
     Buy: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2194,7 +2140,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2219,7 +2164,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2242,7 +2186,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2287,10 +2230,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2307,10 +2248,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2328,10 +2267,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2348,10 +2285,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2391,7 +2326,6 @@ Body:
     Buy: 550
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2408,7 +2342,6 @@ Body:
     Buy: 1200
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2425,7 +2358,6 @@ Body:
     Buy: 5000
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2441,7 +2373,6 @@ Body:
     Type: Healing
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2457,7 +2388,6 @@ Body:
     Type: Healing
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2546,7 +2476,6 @@ Body:
     Type: Healing
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -2592,7 +2521,6 @@ Body:
     Type: Healing
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2912,7 +2840,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2929,7 +2856,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2946,7 +2872,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -2963,7 +2888,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -3028,7 +2952,6 @@ Body:
     Buy: 10
     Weight: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3045,7 +2968,6 @@ Body:
     Buy: 10
     Weight: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3061,7 +2983,6 @@ Body:
     Type: Healing
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3078,7 +2999,6 @@ Body:
     Buy: 10
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3095,7 +3015,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3112,7 +3031,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3129,7 +3047,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3149,7 +3066,6 @@ Body:
     Buy: 10
     Weight: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3166,7 +3082,6 @@ Body:
     Buy: 10
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3183,7 +3098,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3200,7 +3114,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3217,7 +3130,6 @@ Body:
     Buy: 10
     Weight: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3234,7 +3146,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3251,7 +3162,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3268,7 +3178,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3285,7 +3194,6 @@ Body:
     Buy: 10
     Weight: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3308,7 +3216,6 @@ Body:
     Buy: 10
     Weight: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3325,7 +3232,6 @@ Body:
     Buy: 10
     Weight: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3342,7 +3248,6 @@ Body:
     Buy: 10
     Weight: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3359,7 +3264,6 @@ Body:
     Buy: 10
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -3577,7 +3481,6 @@ Body:
     Type: Healing
     Weight: 300
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       unitskilluseid getcharid(3),"AL_BLESSING",7;
@@ -3676,7 +3579,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "MG_FROSTDIVER",5;
@@ -3689,7 +3591,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AL_HEAL",3;
@@ -3702,7 +3603,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AL_HEAL",5;
@@ -3945,7 +3845,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 9,0;
@@ -3959,7 +3858,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_SPEEDUP0,20000,25;
@@ -3972,7 +3870,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "AC_CONCENTRATION",1;
@@ -3985,7 +3882,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_ATKPOTION,60000,20;
@@ -3998,7 +3894,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_MATKPOTION,60000,20;
@@ -4011,7 +3906,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "ITEM_ENCHANTARMS",2;
@@ -4024,7 +3918,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       sc_start SC_Intravision,30000,0;
@@ -4037,7 +3930,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,9;
@@ -5155,7 +5047,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5270,7 +5161,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5287,7 +5177,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5304,7 +5193,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5321,7 +5209,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5338,7 +5225,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5355,7 +5241,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5372,7 +5257,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5389,7 +5273,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5406,7 +5289,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5423,7 +5305,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5440,7 +5321,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5457,7 +5337,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5474,7 +5353,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5491,7 +5369,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5508,7 +5385,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5525,7 +5401,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5542,7 +5417,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5559,7 +5433,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5576,7 +5449,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5593,7 +5465,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5610,7 +5481,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5627,7 +5497,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5644,7 +5513,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5661,7 +5529,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5678,7 +5545,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5695,7 +5561,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5712,7 +5577,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5729,7 +5593,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5746,7 +5609,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5763,7 +5625,6 @@ Body:
     Buy: 2
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -5932,7 +5793,6 @@ Body:
     Name: Scroll of Magic
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5963,7 +5823,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5981,7 +5840,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -5999,7 +5857,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6017,7 +5874,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6035,7 +5891,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6053,7 +5908,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6074,7 +5928,6 @@ Body:
       Duration: 60000
       Status: Reuse_Limit_C
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6091,7 +5944,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6111,7 +5963,6 @@ Body:
       Duration: 60000
       Status: Reuse_Limit_D
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6128,7 +5979,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6145,7 +5995,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6161,7 +6010,6 @@ Body:
     Type: Delayconsume
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6178,7 +6026,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6195,10 +6042,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6216,10 +6061,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6240,10 +6083,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6264,10 +6105,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6285,10 +6124,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6306,10 +6143,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6330,7 +6165,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6348,7 +6182,6 @@ Body:
     Buy: 20
     Weight: 50
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1245;
@@ -6465,7 +6298,6 @@ Body:
     Buy: 20
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,5;
@@ -6478,7 +6310,6 @@ Body:
     Buy: 20
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -6489,7 +6320,6 @@ Body:
     Type: Usable
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,5;
@@ -6502,7 +6332,6 @@ Body:
     Buy: 20
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6519,7 +6348,6 @@ Body:
     Buy: 20
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6691,7 +6519,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6708,7 +6535,6 @@ Body:
     Name: Miracle Tonic
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6733,7 +6559,6 @@ Body:
     Name: Leap of Fantasy
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6750,7 +6575,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6768,7 +6592,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6786,7 +6609,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6803,7 +6625,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6820,7 +6641,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6838,7 +6658,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6856,7 +6675,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6875,7 +6693,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6891,7 +6708,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6907,7 +6723,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6923,7 +6738,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6939,7 +6753,6 @@ Body:
     Buy: 2
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -6954,7 +6767,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6972,7 +6784,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -6991,7 +6802,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7008,7 +6818,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7025,7 +6834,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7115,7 +6923,6 @@ Body:
     Name: Love Angel Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7133,7 +6940,6 @@ Body:
     Name: Squirrel Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7151,7 +6957,6 @@ Body:
     Name: Gogo Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7173,7 +6978,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -7188,7 +6992,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 5,0;
@@ -7220,7 +7023,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7237,7 +7039,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7254,7 +7055,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7271,7 +7071,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7288,7 +7087,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7305,7 +7103,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7322,7 +7119,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7338,7 +7134,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7354,7 +7149,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7370,7 +7164,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7383,7 +7176,6 @@ Body:
     Name: Diary Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7401,7 +7193,6 @@ Body:
     Name: Mini Heart Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7419,7 +7210,6 @@ Body:
     Name: Freshman Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7437,7 +7227,6 @@ Body:
     Name: Kid Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7455,7 +7244,6 @@ Body:
     Name: Magic Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7473,7 +7261,6 @@ Body:
     Name: JJangu Magic Powder
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7492,10 +7279,8 @@ Body:
     Type: Usable
     Weight: 50
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7510,10 +7295,8 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7533,10 +7316,8 @@ Body:
     Name: Guardian Angel
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7552,7 +7333,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7589,7 +7369,6 @@ Body:
     Type: Usable
     Weight: 300
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7605,7 +7384,6 @@ Body:
     Type: Usable
     Weight: 300
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7621,7 +7399,6 @@ Body:
     Type: Usable
     Weight: 300
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7636,7 +7413,6 @@ Body:
     Type: Healing
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7651,10 +7427,8 @@ Body:
     Name: Novice Fly Wing
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7669,10 +7443,8 @@ Body:
     Name: Novice Butterfly Wing
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7687,10 +7459,8 @@ Body:
     Name: Novice Magnifier
     Type: Delayconsume
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7746,7 +7516,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7763,7 +7532,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7781,7 +7549,6 @@ Body:
       Amount: 3
       Inventory: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -7851,10 +7618,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -7929,7 +7694,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "ALL_REVERSEORCISH",1;
@@ -7962,7 +7726,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       skilleffect "AL_BLESSING",0;
@@ -8045,7 +7808,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1513;
@@ -8058,7 +7820,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1586;
@@ -8071,7 +7832,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1505;
@@ -8080,10 +7840,8 @@ Body:
     Name: Delicious Shaved Ice
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8102,7 +7860,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1401;
@@ -8111,10 +7868,8 @@ Body:
     Name: Fit Pipe
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8133,7 +7888,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1299;
@@ -8146,7 +7900,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1416;
@@ -8159,7 +7912,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1404;
@@ -8172,7 +7924,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1504;
@@ -8185,7 +7936,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1148;
@@ -8198,7 +7948,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1495;
@@ -8207,10 +7956,8 @@ Body:
     Name: Girl's Naivety
     Type: Usable
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8229,7 +7976,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1040;
@@ -8242,7 +7988,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1379;
@@ -8255,7 +8000,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1370;
@@ -8268,7 +8012,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       pet 1837;
@@ -8289,7 +8032,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 3,0;
@@ -8303,7 +8045,6 @@ Body:
     Flags:
       BuyingStore: true
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       percentheal 0,3;
@@ -8371,7 +8112,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8389,7 +8129,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8407,7 +8146,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8425,7 +8163,6 @@ Body:
     Type: Delayconsume
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -8443,10 +8180,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8465,10 +8200,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8487,10 +8220,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8511,7 +8242,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8589,7 +8319,6 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       .@rnd = rand(1,9);
@@ -8609,7 +8338,6 @@ Body:
     Buy: 20
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       .@rnd = rand(1,9);
@@ -8629,7 +8357,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8663,7 +8390,6 @@ Body:
     Name: 29Fruit
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8682,7 +8408,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8699,7 +8424,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8717,7 +8441,6 @@ Body:
     Buy: 20
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8736,7 +8459,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8753,7 +8475,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8798,7 +8519,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8824,10 +8544,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -8844,7 +8562,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9319,10 +9036,8 @@ Body:
     Flags:
       Container: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9340,10 +9055,8 @@ Body:
     Flags:
       Container: true
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -9375,7 +9088,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9401,7 +9113,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9417,7 +9128,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9435,7 +9145,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9449,7 +9158,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9463,7 +9171,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9477,7 +9184,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9491,7 +9197,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9505,7 +9210,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9519,7 +9223,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9533,7 +9236,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9547,7 +9249,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9563,7 +9264,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9596,7 +9296,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9614,7 +9313,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9655,7 +9353,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9688,7 +9385,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9705,7 +9401,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9722,7 +9417,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9739,7 +9433,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9756,7 +9449,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9773,7 +9465,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9791,7 +9482,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9809,7 +9499,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9827,7 +9516,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9845,7 +9533,6 @@ Body:
     Flags:
       BuyingStore: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9881,7 +9568,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9898,7 +9584,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9915,7 +9600,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9958,7 +9642,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -9975,7 +9658,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10030,7 +9712,6 @@ Body:
     Name: White Slim Potion Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10045,7 +9726,6 @@ Body:
     Name: Mastela Fruit Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10060,7 +9740,6 @@ Body:
     Name: White Potion Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10075,7 +9754,6 @@ Body:
     Name: Royal Jelly Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10090,7 +9768,6 @@ Body:
     Name: Blue Herb Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10105,7 +9782,6 @@ Body:
     Name: Yggdrasil Seed Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10120,7 +9796,6 @@ Body:
     Name: Iggdrasilberry Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10190,7 +9865,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10209,7 +9883,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10228,7 +9901,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10247,7 +9919,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -10272,7 +9943,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10308,7 +9978,6 @@ Body:
     Name: White Slim Pot Box2
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10323,7 +9992,6 @@ Body:
     Name: Deadly Poison Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10425,7 +10093,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10439,7 +10106,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10453,7 +10119,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10468,7 +10133,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10483,7 +10147,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10498,7 +10161,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10513,7 +10175,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10528,7 +10189,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10589,7 +10249,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10605,7 +10264,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10622,7 +10280,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10644,7 +10301,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10668,7 +10324,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10686,7 +10341,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10704,7 +10358,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10722,7 +10375,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10740,7 +10392,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10758,7 +10409,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10776,7 +10426,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10793,7 +10442,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10830,7 +10478,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10849,7 +10496,6 @@ Body:
       Duration: 180000
       Status: Reuse_Limit_B
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10883,7 +10529,6 @@ Body:
     Name: Treasure Chest Summoned
     Type: Delayconsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10937,7 +10582,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -10970,7 +10614,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11100,7 +10743,6 @@ Body:
       Duration: 3000
       Status: All_Riding_Reuse_Limit
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11138,7 +10780,6 @@ Body:
     Name: Sapa Feat Cert Pack
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11201,7 +10842,6 @@ Body:
     Buy: 20
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11226,7 +10866,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11242,7 +10881,6 @@ Body:
     Buy: 20
     Weight: 500
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11259,7 +10897,6 @@ Body:
     Buy: 20
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11276,7 +10913,6 @@ Body:
     Buy: 20
     Weight: 2000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11293,7 +10929,6 @@ Body:
     Buy: 20
     Weight: 500
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11312,7 +10947,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11327,7 +10961,6 @@ Body:
     Name: Fruit Of Mastela 100 Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11350,7 +10983,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11365,7 +10997,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11413,7 +11044,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11436,7 +11066,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11454,7 +11083,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11475,7 +11103,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11493,7 +11120,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11516,7 +11142,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11554,7 +11179,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11575,7 +11199,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11596,7 +11219,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11617,7 +11239,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11638,7 +11259,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11659,7 +11279,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11680,7 +11299,6 @@ Body:
       Duration: 10000
       Status: Reuse_Limit_Mtf
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11750,7 +11368,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -11772,7 +11389,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11882,7 +11498,6 @@ Body:
       Duration: 900000
       Status: Reuse_Limit_Aspd_Potion
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -11899,7 +11514,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12051,7 +11665,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12077,7 +11690,6 @@ Body:
     Weight: 10
     EquipLevelMin: 85
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12094,7 +11706,6 @@ Body:
     Weight: 100
     EquipLevelMin: 90
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12110,7 +11721,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_GLORIA",5;
@@ -12120,7 +11730,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_MAGNIFICAT",1;
@@ -12130,7 +11739,6 @@ Body:
     Type: Delayconsume
     Weight: 100
     NoUse:
-      Override: 100
       Sitting: true
     Script: |
       itemskill "PR_IMPOSITIO",3;
@@ -12179,7 +11787,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -12193,7 +11800,6 @@ Body:
     Name: Black Treasure Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12281,10 +11887,8 @@ Body:
       Duration: 120000
       Status: Reuse_Refresh
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12305,10 +11909,8 @@ Body:
       Duration: 30000
       Status: Reuse_Crushstrike
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12329,10 +11931,8 @@ Body:
       Duration: 60000
       Status: Reuse_Millenniumshield
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12350,10 +11950,8 @@ Body:
     Buy: 100
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12371,10 +11969,8 @@ Body:
     Buy: 100
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12392,10 +11988,8 @@ Body:
     Buy: 100
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12413,10 +12007,8 @@ Body:
     Buy: 100
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12437,10 +12029,8 @@ Body:
       Duration: 1000
       Status: Reuse_Stormblast
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12458,10 +12048,8 @@ Body:
     Buy: 100
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12562,7 +12150,6 @@ Body:
     Type: Usable
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12580,7 +12167,6 @@ Body:
     Type: Usable
     Buy: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12617,7 +12203,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12763,7 +12348,6 @@ Body:
     Name: Reward Job BM25
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12903,7 +12487,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12916,7 +12499,6 @@ Body:
     Name: Character Position Change Coupon
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -12951,7 +12533,6 @@ Body:
     Name: Character Name Change Coupon
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13001,7 +12582,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13016,7 +12596,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13051,7 +12630,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13080,7 +12658,6 @@ Body:
     Name: Time Guardian Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13094,7 +12671,6 @@ Body:
     Name: Beginner Kit Box
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13110,7 +12686,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13125,7 +12700,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13147,7 +12721,6 @@ Body:
     Type: Usable
     EquipLevelMin: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13167,7 +12740,6 @@ Body:
     Type: Usable
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13182,7 +12754,6 @@ Body:
     Type: Usable
     EquipLevelMin: 120
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13204,7 +12775,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13220,7 +12790,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13285,7 +12854,6 @@ Body:
     Type: Usable
     EquipLevelMin: 60
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13300,7 +12868,6 @@ Body:
     Type: Usable
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13318,7 +12885,6 @@ Body:
     Type: Usable
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13336,7 +12902,6 @@ Body:
     Type: Usable
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13433,7 +12998,6 @@ Body:
     Type: Usable
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13453,7 +13017,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13468,7 +13031,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13520,7 +13082,6 @@ Body:
     Name: Amatsu_Butterfly_Wing
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -13544,7 +13105,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13629,7 +13189,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13646,7 +13205,6 @@ Body:
     Type: Cash
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13728,7 +13286,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13745,7 +13302,6 @@ Body:
     Type: Delayconsume
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13762,7 +13318,6 @@ Body:
     Type: Delayconsume
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13779,7 +13334,6 @@ Body:
     Type: Delayconsume
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13797,7 +13351,6 @@ Body:
     Flags:
       NoConsume: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13814,7 +13367,6 @@ Body:
     Type: Cash
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13898,7 +13450,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13917,7 +13468,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13936,7 +13486,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13955,7 +13504,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13974,7 +13522,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -13993,7 +13540,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14012,7 +13558,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14031,7 +13576,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14050,7 +13594,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14069,7 +13612,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14088,7 +13630,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14107,7 +13648,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14126,7 +13666,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14145,7 +13684,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14164,7 +13702,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14183,7 +13720,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14202,7 +13738,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14221,7 +13756,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14240,7 +13774,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14259,7 +13792,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14278,7 +13810,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14297,7 +13828,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14316,7 +13846,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14335,7 +13864,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       getgroupitem(IG_Pet_Egg_Scroll_Box1);
@@ -14348,7 +13876,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       getgroupitem(IG_Pet_Egg_Scroll_Box2);
@@ -14361,7 +13888,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       getgroupitem(IG_Pet_Egg_Scroll1);
@@ -14374,7 +13900,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       getgroupitem(IG_Pet_Egg_Scroll2);
@@ -14387,7 +13912,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14404,7 +13928,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14423,7 +13946,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14442,7 +13964,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14461,7 +13982,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14480,7 +14000,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14499,7 +14018,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14518,7 +14036,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14537,7 +14054,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14556,7 +14072,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14575,7 +14090,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14593,7 +14107,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14611,7 +14124,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14629,7 +14141,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14647,7 +14158,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14665,7 +14175,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14683,7 +14192,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14701,7 +14209,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14719,7 +14226,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14737,7 +14243,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14755,7 +14260,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14773,7 +14277,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14792,7 +14295,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14811,7 +14313,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14829,7 +14330,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14847,7 +14347,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14865,7 +14364,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14883,7 +14381,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14902,7 +14399,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14920,7 +14416,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14938,7 +14433,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14956,7 +14450,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14974,7 +14467,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -14992,7 +14484,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15011,7 +14502,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15030,7 +14520,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15049,7 +14538,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15068,7 +14556,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15087,7 +14574,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15106,7 +14592,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15125,7 +14610,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15145,7 +14629,6 @@ Body:
       Duration: 300000
       Status: Reuse_Limit_Recall
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15165,7 +14648,6 @@ Body:
       Duration: 300000
       Status: Reuse_Limit_Recall
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15185,7 +14667,6 @@ Body:
       Duration: 300000
       Status: Reuse_Limit_Recall
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15204,7 +14685,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15223,7 +14703,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15242,7 +14721,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15261,7 +14739,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15280,7 +14757,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15299,7 +14775,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15316,7 +14791,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15333,7 +14807,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15350,7 +14823,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15367,7 +14839,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15384,7 +14855,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15401,7 +14871,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15420,7 +14889,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15439,7 +14907,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15458,7 +14925,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15477,7 +14943,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15496,7 +14961,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15515,7 +14979,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15533,7 +14996,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15551,7 +15013,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15569,7 +15030,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15587,7 +15047,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15605,7 +15064,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15623,7 +15081,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15642,7 +15099,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15661,7 +15117,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15680,7 +15135,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15699,7 +15153,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15718,7 +15171,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15737,7 +15189,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15756,7 +15207,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15773,7 +15223,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15792,7 +15241,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15811,7 +15259,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15830,7 +15277,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15849,7 +15295,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15868,7 +15313,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15887,7 +15331,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15906,7 +15349,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15925,7 +15367,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15944,7 +15385,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15963,7 +15403,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -15982,7 +15421,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16001,7 +15439,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16020,7 +15457,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16039,7 +15475,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16058,7 +15493,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16077,7 +15511,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16096,7 +15529,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16115,7 +15547,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16134,7 +15565,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16153,7 +15583,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16172,7 +15601,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16191,7 +15619,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16210,7 +15637,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16229,7 +15655,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16248,7 +15673,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16267,7 +15691,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16286,7 +15709,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16305,7 +15727,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16324,7 +15745,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16343,7 +15763,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16362,7 +15781,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16381,7 +15799,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16400,7 +15817,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16419,7 +15835,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16438,7 +15853,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16457,7 +15871,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16476,7 +15889,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16495,7 +15907,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16514,7 +15925,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16533,7 +15943,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16552,7 +15961,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16571,7 +15979,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16590,7 +15997,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16609,7 +16015,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16628,7 +16033,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16647,7 +16051,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16666,7 +16069,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16685,7 +16087,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16704,7 +16105,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16723,7 +16123,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16742,7 +16141,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16761,7 +16159,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16780,7 +16177,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16799,7 +16195,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16818,7 +16213,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16837,7 +16231,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16854,7 +16247,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16871,7 +16263,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16888,7 +16279,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16905,7 +16295,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16922,7 +16311,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16939,7 +16327,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16956,7 +16343,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16973,7 +16359,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -16990,7 +16375,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17007,7 +16391,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17024,7 +16407,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17043,7 +16425,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17062,7 +16443,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17081,7 +16461,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17100,7 +16479,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17119,7 +16497,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17138,7 +16515,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17157,7 +16533,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17176,7 +16551,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17195,7 +16569,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17214,7 +16587,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17233,7 +16605,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17252,7 +16623,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17271,7 +16641,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17290,7 +16659,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17309,7 +16677,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17328,7 +16695,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17347,7 +16713,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17366,7 +16731,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17385,7 +16749,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17404,7 +16767,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17423,7 +16785,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17442,7 +16803,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17461,7 +16821,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17480,7 +16839,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17499,7 +16857,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17518,7 +16875,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17537,7 +16893,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17556,7 +16911,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17575,7 +16929,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17594,7 +16947,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17613,7 +16965,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17632,7 +16983,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17651,7 +17001,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17670,7 +17019,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17689,7 +17037,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17708,7 +17055,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17727,7 +17073,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17746,7 +17091,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17765,7 +17109,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17784,7 +17127,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17803,7 +17145,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17822,7 +17163,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17841,7 +17181,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17860,7 +17199,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17879,7 +17217,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17898,7 +17235,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17917,7 +17253,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17936,7 +17271,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17955,7 +17289,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17974,7 +17307,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -17993,7 +17325,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18012,7 +17343,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18031,7 +17361,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18050,7 +17379,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18069,7 +17397,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18088,7 +17415,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18107,7 +17433,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18126,7 +17451,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18145,7 +17469,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18164,7 +17487,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18183,7 +17505,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18202,7 +17523,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18221,7 +17541,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18240,7 +17559,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18259,7 +17577,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18278,7 +17595,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18297,7 +17613,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18316,7 +17631,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18335,7 +17649,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18354,7 +17667,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18373,7 +17685,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18392,7 +17703,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18411,7 +17721,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18430,7 +17739,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18449,7 +17757,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18468,7 +17775,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18487,7 +17793,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18506,7 +17811,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18525,7 +17829,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18544,7 +17847,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18563,7 +17865,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18582,7 +17883,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18601,7 +17901,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18620,7 +17919,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18639,7 +17937,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18658,7 +17955,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18677,7 +17973,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18696,7 +17991,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18715,7 +18009,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18734,7 +18027,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18753,7 +18045,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18772,7 +18063,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18791,7 +18081,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18810,7 +18099,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18829,7 +18117,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18848,7 +18135,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18867,7 +18153,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18886,7 +18171,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18905,7 +18189,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18924,7 +18207,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18943,7 +18225,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18962,7 +18243,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -18981,7 +18261,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19000,7 +18279,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19019,7 +18297,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19038,7 +18315,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19057,7 +18333,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19076,7 +18351,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19095,7 +18369,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19114,7 +18387,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19133,7 +18405,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19152,7 +18423,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19171,7 +18441,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19190,7 +18459,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19209,7 +18477,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19228,7 +18495,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19247,7 +18513,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19266,7 +18531,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19285,7 +18549,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19304,7 +18567,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19323,7 +18585,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19341,7 +18602,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19359,7 +18619,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19377,7 +18636,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19395,7 +18653,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19413,7 +18670,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19431,7 +18687,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19449,7 +18704,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19467,7 +18721,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19485,7 +18738,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19503,7 +18755,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19521,7 +18772,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19539,7 +18789,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19557,7 +18806,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19576,7 +18824,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19595,7 +18842,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19614,7 +18860,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19633,7 +18878,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19652,7 +18896,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19671,7 +18914,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19688,7 +18930,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19707,7 +18948,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19726,7 +18966,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19745,7 +18984,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19764,7 +19002,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19783,7 +19020,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19802,7 +19038,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19821,7 +19056,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19840,7 +19074,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19859,7 +19092,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19878,7 +19110,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19897,7 +19128,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19916,7 +19146,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19935,7 +19164,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19954,7 +19182,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19973,7 +19200,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -19992,7 +19218,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20011,7 +19236,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20029,7 +19253,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20047,7 +19270,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20065,7 +19287,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20083,7 +19304,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20102,7 +19322,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20121,7 +19340,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20140,7 +19358,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20159,7 +19376,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20178,7 +19394,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20197,7 +19412,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20216,7 +19430,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20235,7 +19448,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20254,7 +19466,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20273,7 +19484,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20292,7 +19502,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20311,7 +19520,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20330,7 +19538,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20349,7 +19556,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20368,7 +19574,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20387,7 +19592,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20406,7 +19610,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20425,7 +19628,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20444,7 +19646,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20463,7 +19664,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20482,7 +19682,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20501,7 +19700,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20520,7 +19718,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20539,7 +19736,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20558,7 +19754,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20577,7 +19772,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20596,7 +19790,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20615,7 +19808,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20634,7 +19826,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20653,7 +19844,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20673,7 +19863,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20692,7 +19881,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20712,7 +19900,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20731,7 +19918,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20750,7 +19936,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20769,7 +19954,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20788,7 +19972,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20807,7 +19990,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20826,7 +20008,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20845,7 +20026,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20865,7 +20045,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20884,7 +20063,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20903,7 +20081,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20922,7 +20099,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20941,7 +20117,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20960,7 +20135,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20979,7 +20153,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -20998,7 +20171,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21017,7 +20189,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21036,7 +20207,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21055,7 +20225,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21074,7 +20243,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21093,7 +20261,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21112,7 +20279,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21131,7 +20297,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21150,7 +20315,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21169,7 +20333,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21188,7 +20351,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21207,7 +20369,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21226,7 +20387,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21245,7 +20405,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21264,7 +20423,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21283,7 +20441,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21302,7 +20459,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21321,7 +20477,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21340,7 +20495,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21359,7 +20513,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21378,7 +20531,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21397,7 +20549,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21416,7 +20567,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21435,7 +20585,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21454,7 +20603,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21473,7 +20621,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21492,7 +20639,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21511,7 +20657,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21530,7 +20675,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21549,7 +20693,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21568,7 +20711,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21592,7 +20734,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21616,7 +20757,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21640,7 +20780,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21661,7 +20800,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21680,7 +20818,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21699,7 +20836,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21718,7 +20854,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21737,7 +20872,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21756,7 +20890,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21775,7 +20908,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21794,7 +20926,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21813,7 +20944,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21832,7 +20962,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21859,7 +20988,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21880,7 +21008,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21901,7 +21028,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21921,7 +21047,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21941,7 +21066,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21962,7 +21086,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -21983,7 +21106,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22004,7 +21126,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22025,7 +21146,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22044,7 +21164,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22063,7 +21182,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22082,7 +21200,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22101,7 +21218,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22120,7 +21236,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22139,7 +21254,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22158,7 +21272,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22177,7 +21290,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22196,7 +21308,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22215,7 +21326,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22234,7 +21344,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22253,7 +21362,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22272,7 +21380,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22291,7 +21398,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22310,7 +21416,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22329,7 +21434,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22348,7 +21452,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22367,7 +21470,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22386,7 +21488,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22405,7 +21506,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22424,7 +21524,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22443,7 +21542,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22462,7 +21560,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22481,7 +21578,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22500,7 +21596,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22520,7 +21615,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22540,7 +21634,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22559,7 +21652,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22580,7 +21672,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22603,7 +21694,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22622,7 +21712,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22641,7 +21730,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22660,7 +21748,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22679,7 +21766,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22698,7 +21784,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22717,7 +21802,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22736,7 +21820,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22756,7 +21839,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22776,7 +21858,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22796,7 +21877,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22816,7 +21896,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22836,7 +21915,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22856,7 +21934,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22878,7 +21955,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22898,7 +21974,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22918,7 +21993,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22938,7 +22012,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22958,7 +22031,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22977,7 +22049,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -22996,7 +22067,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23015,7 +22085,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23034,7 +22103,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23053,7 +22121,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23072,7 +22139,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23091,7 +22157,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23110,7 +22175,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23129,7 +22193,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23148,7 +22211,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23167,7 +22229,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23186,7 +22247,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23204,7 +22264,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23236,7 +22295,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23255,7 +22313,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23274,7 +22331,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23293,7 +22349,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23312,7 +22367,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23331,7 +22385,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23350,7 +22403,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23369,7 +22421,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23388,7 +22439,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23407,7 +22457,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23427,7 +22476,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23447,7 +22495,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23467,7 +22514,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23487,7 +22533,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23507,7 +22552,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23527,7 +22571,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23546,7 +22589,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23565,7 +22607,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23584,7 +22625,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23603,7 +22643,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23622,7 +22661,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23641,7 +22679,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23660,7 +22697,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23679,7 +22715,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23698,7 +22733,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23717,7 +22751,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23736,7 +22769,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23755,7 +22787,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23774,7 +22805,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23793,7 +22823,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23812,7 +22841,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23834,7 +22862,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23857,7 +22884,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23880,7 +22906,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23903,7 +22928,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23926,7 +22950,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23948,7 +22971,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23967,7 +22989,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -23986,7 +23007,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24005,7 +23025,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24024,7 +23043,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24043,7 +23061,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24062,7 +23079,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24081,7 +23097,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24100,7 +23115,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24119,7 +23133,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24136,7 +23149,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24155,7 +23167,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24174,7 +23185,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24193,7 +23203,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24212,7 +23221,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24231,7 +23239,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24250,7 +23257,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24269,7 +23275,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24288,7 +23293,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24307,7 +23311,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24326,7 +23329,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24345,7 +23347,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24365,7 +23366,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24384,7 +23384,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24403,7 +23402,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24422,7 +23420,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24441,7 +23438,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24460,7 +23456,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24479,7 +23474,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24498,7 +23492,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24517,7 +23510,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24536,7 +23528,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24555,7 +23546,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24574,7 +23564,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24593,7 +23582,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24612,7 +23600,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24631,7 +23618,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24650,7 +23636,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24669,7 +23654,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24688,7 +23672,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24707,7 +23690,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24726,7 +23708,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24745,7 +23726,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24762,7 +23742,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24781,7 +23760,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24800,7 +23778,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24819,7 +23796,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24838,7 +23814,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24857,7 +23832,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24876,7 +23850,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24895,7 +23868,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24914,7 +23886,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24933,7 +23904,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24952,7 +23922,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24971,7 +23940,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -24990,7 +23958,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25009,7 +23976,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25028,7 +23994,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25048,7 +24013,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25067,7 +24031,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25086,7 +24049,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25105,7 +24067,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25124,7 +24085,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25143,7 +24103,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25162,7 +24121,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25181,7 +24139,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25200,7 +24157,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25219,7 +24175,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25238,7 +24193,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25257,7 +24211,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25277,7 +24230,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25297,7 +24249,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25317,7 +24268,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25336,7 +24286,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25355,7 +24304,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25374,7 +24322,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25393,7 +24340,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25412,7 +24358,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25431,7 +24376,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25450,7 +24394,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25469,7 +24412,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25488,7 +24430,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25507,7 +24448,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25526,7 +24466,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25545,7 +24484,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25564,7 +24502,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25583,7 +24520,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25602,7 +24538,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25621,7 +24556,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25640,7 +24574,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25659,7 +24592,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25678,7 +24610,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25697,7 +24628,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25716,7 +24646,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25735,7 +24664,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25754,7 +24682,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25773,7 +24700,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25792,7 +24718,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25811,7 +24736,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25830,7 +24754,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25849,7 +24772,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25868,7 +24790,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25887,7 +24808,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25906,7 +24826,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25925,7 +24844,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25944,7 +24862,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25967,7 +24884,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -25990,7 +24906,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26009,7 +24924,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26028,7 +24942,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26047,7 +24960,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26066,7 +24978,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26085,7 +24996,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26104,7 +25014,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26123,7 +25032,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26142,7 +25050,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26161,7 +25068,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26180,7 +25086,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26199,7 +25104,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26218,7 +25122,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26237,7 +25140,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26256,7 +25158,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26275,7 +25176,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26294,7 +25194,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26313,7 +25212,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26332,7 +25230,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26351,7 +25248,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26370,7 +25266,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26389,7 +25284,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26408,7 +25302,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26427,7 +25320,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26446,7 +25338,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26465,7 +25356,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26484,7 +25374,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26503,7 +25392,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26522,7 +25410,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26541,7 +25428,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26560,7 +25446,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26579,7 +25464,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26598,7 +25482,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26617,7 +25500,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26636,7 +25518,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26655,7 +25536,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26674,7 +25554,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26693,7 +25572,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26712,7 +25590,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26731,7 +25608,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26750,7 +25626,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26769,7 +25644,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26788,7 +25662,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26807,7 +25680,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26826,7 +25698,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26845,7 +25716,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26864,7 +25734,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26883,7 +25752,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26902,7 +25770,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26921,7 +25788,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26940,7 +25806,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26959,7 +25824,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26978,7 +25842,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -26997,7 +25860,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27016,7 +25878,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27035,7 +25896,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27054,7 +25914,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27073,7 +25932,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27092,7 +25950,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27111,7 +25968,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27130,7 +25986,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27149,7 +26004,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27168,7 +26022,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27187,7 +26040,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27206,7 +26058,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27225,7 +26076,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27244,7 +26094,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27263,7 +26112,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27282,7 +26130,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27301,7 +26148,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27320,7 +26166,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27339,7 +26184,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27358,7 +26202,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27377,7 +26220,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27396,7 +26238,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27415,7 +26256,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27434,7 +26274,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27453,7 +26292,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27472,7 +26310,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27491,7 +26328,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27510,7 +26346,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27529,7 +26364,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27548,7 +26382,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27567,7 +26400,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27586,7 +26418,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27605,7 +26436,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27624,7 +26454,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27643,7 +26472,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27662,7 +26490,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27681,7 +26508,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27700,7 +26526,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27719,7 +26544,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27738,7 +26562,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27757,7 +26580,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27776,7 +26598,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27795,7 +26616,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27814,7 +26634,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27833,7 +26652,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27852,7 +26670,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27871,7 +26688,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27890,7 +26706,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27909,7 +26724,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27928,7 +26742,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27947,7 +26760,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27966,7 +26778,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -27985,7 +26796,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28010,7 +26820,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28035,7 +26844,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28060,7 +26868,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28085,7 +26892,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28110,7 +26916,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28135,7 +26940,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28160,7 +26964,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28185,7 +26988,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28210,7 +27012,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28235,7 +27036,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28260,7 +27060,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28285,7 +27084,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28304,7 +27102,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28323,7 +27120,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28342,7 +27138,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28361,7 +27156,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28380,7 +27174,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28399,7 +27192,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28418,7 +27210,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28437,7 +27228,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28456,7 +27246,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28475,7 +27264,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28494,7 +27282,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28513,7 +27300,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28532,7 +27318,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28551,7 +27336,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28570,7 +27354,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28590,7 +27373,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28609,7 +27391,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28628,7 +27409,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28647,7 +27427,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28666,7 +27445,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28685,7 +27463,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28704,7 +27481,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28723,7 +27499,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28742,7 +27517,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28761,7 +27535,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28780,7 +27553,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28799,7 +27571,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28818,7 +27589,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28837,7 +27607,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28856,7 +27625,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28875,7 +27643,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28894,7 +27661,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28913,7 +27679,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28932,7 +27697,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28951,7 +27715,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28970,7 +27733,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -28989,7 +27751,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29008,7 +27769,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29027,7 +27787,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29046,7 +27805,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29065,7 +27823,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29084,7 +27841,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29103,7 +27859,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29123,7 +27878,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29143,7 +27897,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29162,7 +27915,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29181,7 +27933,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29200,7 +27951,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29219,7 +27969,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29238,7 +27987,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29257,7 +28005,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29276,7 +28023,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29295,7 +28041,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29314,7 +28059,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29333,7 +28077,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29352,7 +28095,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29371,7 +28113,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29390,7 +28131,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29409,7 +28149,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29428,7 +28167,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29447,7 +28185,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29466,7 +28203,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29485,7 +28221,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29504,7 +28239,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29523,7 +28257,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29542,7 +28275,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29561,7 +28293,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29580,7 +28311,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29599,7 +28329,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29618,7 +28347,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29637,7 +28365,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29656,7 +28383,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29675,7 +28401,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29691,7 +28416,6 @@ Body:
     Type: Cash
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29707,7 +28431,6 @@ Body:
     Type: Cash
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29724,7 +28447,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29743,7 +28465,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29762,7 +28483,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29779,7 +28499,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29796,7 +28515,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29813,7 +28531,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29830,7 +28547,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29847,7 +28563,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29864,7 +28579,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29881,7 +28595,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29900,7 +28613,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29920,7 +28632,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29940,7 +28651,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29960,7 +28670,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -29980,7 +28689,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30000,7 +28708,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30020,7 +28727,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30040,7 +28746,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30060,7 +28765,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30080,7 +28784,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30100,7 +28803,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30119,7 +28821,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30138,7 +28839,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30157,7 +28857,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30176,7 +28875,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30195,7 +28893,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30214,7 +28911,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30233,7 +28929,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30252,7 +28947,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30271,7 +28965,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30287,7 +28980,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30303,7 +28995,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30319,7 +29010,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30335,7 +29025,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30351,7 +29040,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30367,7 +29055,6 @@ Body:
     Type: Cash
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30384,7 +29071,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30399,7 +29085,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30414,7 +29099,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30429,7 +29113,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30444,7 +29127,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30459,7 +29141,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30474,7 +29155,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30491,7 +29171,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30508,7 +29187,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30525,7 +29203,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30542,7 +29219,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30559,7 +29235,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30576,7 +29251,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30593,7 +29267,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30610,7 +29283,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30629,7 +29301,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30646,7 +29317,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30663,7 +29333,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30680,7 +29349,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30697,7 +29365,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30717,7 +29384,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30741,7 +29407,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30760,7 +29425,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30776,7 +29440,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30792,7 +29455,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30808,7 +29470,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30824,7 +29485,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30840,7 +29500,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30859,7 +29518,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30878,7 +29536,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30897,7 +29554,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30916,7 +29572,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30935,7 +29590,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30954,7 +29608,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30973,7 +29626,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -30992,7 +29644,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31011,7 +29662,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31028,7 +29678,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31047,7 +29696,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31066,7 +29714,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31085,7 +29732,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31102,7 +29748,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31119,7 +29764,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31136,7 +29780,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31153,7 +29796,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31170,7 +29812,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31187,7 +29828,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31204,7 +29844,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31221,7 +29860,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31238,7 +29876,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31255,7 +29892,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31274,7 +29910,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31293,7 +29928,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31312,7 +29946,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31331,7 +29964,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31350,7 +29982,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31369,7 +30000,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31388,7 +30018,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31407,7 +30036,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31426,7 +30054,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31445,7 +30072,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31524,7 +30150,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31543,7 +30168,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31562,7 +30186,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31581,7 +30204,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31600,7 +30222,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31619,7 +30240,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31638,7 +30258,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31657,7 +30276,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31676,7 +30294,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31695,7 +30312,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31714,7 +30330,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31733,7 +30348,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31752,7 +30366,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31771,7 +30384,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31788,7 +30400,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31805,7 +30416,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31822,7 +30432,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31839,7 +30448,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31856,7 +30464,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31873,7 +30480,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31890,7 +30496,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31907,7 +30512,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31924,7 +30528,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31941,7 +30544,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31958,7 +30560,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31975,7 +30576,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -31992,7 +30592,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32011,7 +30610,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32030,7 +30628,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32049,7 +30646,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32068,7 +30664,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32087,7 +30682,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32106,7 +30700,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32125,7 +30718,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32144,7 +30736,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32163,7 +30754,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32182,7 +30772,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32201,7 +30790,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32220,7 +30808,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32288,7 +30875,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32307,7 +30893,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32326,7 +30911,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32345,7 +30929,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32404,7 +30987,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32421,7 +31003,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32436,7 +31017,6 @@ Body:
     Name: Sky Fortress Ticket
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32452,7 +31032,6 @@ Body:
     Name: Sky Fortress Ticket
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32470,7 +31049,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32487,7 +31065,6 @@ Body:
     Buy: 800
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32531,7 +31108,6 @@ Body:
       Wizard: true
     EquipLevelMin: 40
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32564,7 +31140,6 @@ Body:
       Wizard: true
     EquipLevelMin: 85
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32580,7 +31155,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32596,7 +31170,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32612,7 +31185,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32628,7 +31200,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32644,7 +31215,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32660,7 +31230,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32676,7 +31245,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32692,7 +31260,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32708,7 +31275,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32724,10 +31290,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32743,7 +31307,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32759,7 +31322,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32775,7 +31337,6 @@ Body:
     Type: Healing
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32791,7 +31352,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32807,7 +31367,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32823,7 +31382,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32839,7 +31397,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32855,10 +31412,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32875,7 +31430,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32891,7 +31445,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32908,10 +31461,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32928,7 +31479,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32944,7 +31494,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32961,7 +31510,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32978,7 +31526,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -32995,7 +31542,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33015,7 +31561,6 @@ Body:
       Duration: 300000
       Status: Reuse_Limit_A
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33032,7 +31577,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33049,7 +31593,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33066,7 +31609,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33083,7 +31625,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33100,7 +31641,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33117,7 +31657,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33134,7 +31673,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33151,7 +31689,6 @@ Body:
     Buy: 2
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33166,7 +31703,6 @@ Body:
     Buy: 2
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33181,7 +31717,6 @@ Body:
     Buy: 2
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33196,7 +31731,6 @@ Body:
     Buy: 2
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33211,7 +31745,6 @@ Body:
     Buy: 2
     Weight: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33226,7 +31759,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33244,7 +31776,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33262,7 +31793,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33280,7 +31810,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33298,7 +31827,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33316,7 +31844,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33334,7 +31861,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33352,7 +31878,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33370,7 +31895,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33388,7 +31912,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33406,7 +31929,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33424,7 +31946,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33442,7 +31963,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33460,7 +31980,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33478,7 +31997,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33496,7 +32014,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33514,7 +32031,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33532,7 +32048,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33549,7 +32064,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33565,7 +32079,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33581,7 +32094,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33597,7 +32109,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33613,7 +32124,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33629,7 +32139,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
     Script: |
       pet 1208;
@@ -33640,7 +32149,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33658,7 +32166,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33676,7 +32183,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33694,7 +32200,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33712,7 +32217,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33730,7 +32234,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33747,7 +32250,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33763,7 +32265,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33779,7 +32280,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33795,7 +32295,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33811,7 +32310,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33830,7 +32328,6 @@ Body:
       Duration: 180000
       Status: Reuse_Limit_B
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33847,10 +32344,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33867,7 +32362,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33884,7 +32378,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33901,7 +32394,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33917,10 +32409,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33936,10 +32426,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33955,10 +32443,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33974,10 +32460,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -33992,7 +32476,6 @@ Body:
     Name: Unsealed Magic Spell
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34023,7 +32506,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34039,7 +32521,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34055,10 +32536,8 @@ Body:
     Type: Delayconsume
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34074,7 +32553,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34091,7 +32569,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34110,7 +32587,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34127,7 +32603,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34144,7 +32619,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34161,7 +32635,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34178,10 +32651,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34221,7 +32692,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34238,7 +32708,6 @@ Body:
     Type: Delayconsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34258,7 +32727,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34274,7 +32742,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34293,7 +32760,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34311,7 +32777,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34329,7 +32794,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34347,7 +32811,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34365,7 +32828,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34383,7 +32845,6 @@ Body:
     Buy: 1
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34401,7 +32862,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34437,7 +32897,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34452,7 +32911,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34496,7 +32954,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34550,7 +33007,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34564,7 +33020,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34587,7 +33042,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34602,7 +33056,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34627,7 +33080,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34642,7 +33094,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34666,7 +33117,6 @@ Body:
     Type: Cash
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34705,7 +33155,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34727,7 +33176,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34744,7 +33192,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34761,7 +33208,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34778,7 +33224,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34795,7 +33240,6 @@ Body:
     Type: Delayconsume
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34811,7 +33255,6 @@ Body:
     Type: Delayconsume
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34828,7 +33271,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34846,7 +33288,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34868,7 +33309,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34890,7 +33330,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34912,7 +33351,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34934,7 +33372,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34951,7 +33388,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34973,7 +33409,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -34995,7 +33430,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35014,7 +33448,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35031,7 +33464,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35049,7 +33481,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35082,7 +33513,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35099,7 +33529,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35116,7 +33545,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35134,7 +33562,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35151,10 +33578,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35171,10 +33596,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35191,10 +33614,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35211,10 +33632,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35231,10 +33650,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35251,10 +33668,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35271,10 +33686,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35290,10 +33703,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35309,10 +33720,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35328,10 +33737,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35347,10 +33754,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35366,10 +33771,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35386,10 +33789,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35406,10 +33807,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35429,10 +33828,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35450,10 +33847,8 @@ Body:
     Buy: 2
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35471,10 +33866,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35490,10 +33883,8 @@ Body:
     Type: Usable
     Weight: 10
     NoUse:
-      Override: 100
       Sitting: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35512,7 +33903,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35531,7 +33921,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35550,7 +33939,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35569,7 +33957,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35588,7 +33975,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35607,7 +33993,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35626,7 +34011,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35645,7 +34029,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35664,7 +34047,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35683,7 +34065,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35710,7 +34091,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35729,7 +34109,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35748,7 +34127,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35767,7 +34145,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35786,7 +34163,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35805,7 +34181,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35824,7 +34199,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoSell: true
       NoCart: true
@@ -35839,7 +34213,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35858,7 +34231,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35877,7 +34249,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35896,7 +34267,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35945,7 +34315,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35964,7 +34333,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -35983,7 +34351,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36016,7 +34383,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36035,7 +34401,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36062,7 +34427,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36089,7 +34453,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36108,7 +34471,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36127,7 +34489,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36146,7 +34507,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36163,7 +34523,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36180,7 +34539,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36197,7 +34555,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36214,7 +34571,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36278,7 +34634,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36297,7 +34652,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36316,7 +34670,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36335,7 +34688,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36354,7 +34706,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36373,7 +34724,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36392,7 +34742,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36411,7 +34760,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36430,7 +34778,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36449,7 +34796,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36468,7 +34814,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36487,7 +34832,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36506,7 +34850,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36525,7 +34868,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36544,7 +34886,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36563,7 +34904,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36582,7 +34922,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36601,7 +34940,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36620,7 +34958,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36639,7 +34976,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36658,7 +34994,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36677,7 +35012,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36696,7 +35030,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36715,7 +35048,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36734,7 +35066,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36753,7 +35084,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36772,7 +35102,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36791,7 +35120,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36810,7 +35138,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36829,7 +35156,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36848,7 +35174,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36867,7 +35192,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36886,7 +35210,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36905,7 +35228,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -36924,7 +35246,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37002,7 +35323,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37020,7 +35340,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37038,7 +35357,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37056,7 +35374,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37075,7 +35392,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37104,7 +35420,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37124,7 +35439,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37142,7 +35456,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37160,7 +35473,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37178,7 +35490,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37195,7 +35506,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37212,7 +35522,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37231,7 +35540,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37251,7 +35559,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37271,7 +35578,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37291,7 +35597,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37311,7 +35616,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37330,7 +35634,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37349,7 +35652,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37368,7 +35670,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37387,7 +35688,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37404,7 +35704,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37421,7 +35720,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37440,7 +35738,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37460,7 +35757,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37732,7 +36028,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37751,7 +36046,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37768,7 +36062,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37787,7 +36080,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37854,7 +36146,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37871,7 +36162,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37898,7 +36188,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37915,7 +36204,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37932,7 +36220,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37949,7 +36236,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37966,7 +36252,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -37983,7 +36268,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38000,7 +36284,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38017,7 +36300,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38034,7 +36316,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38063,7 +36344,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38082,7 +36362,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38145,7 +36424,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38383,7 +36661,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38481,7 +36758,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38498,7 +36774,6 @@ Body:
     Buy: 20
     EquipLevelMin: 47
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38525,7 +36800,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38544,7 +36818,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38563,7 +36836,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38609,7 +36881,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38626,7 +36897,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38669,7 +36939,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38733,7 +37002,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38749,7 +37017,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38765,7 +37032,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38781,7 +37047,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38810,7 +37075,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -38830,7 +37094,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39280,7 +37543,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39299,7 +37561,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39319,7 +37580,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39339,7 +37599,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39359,7 +37618,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39379,7 +37637,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39399,7 +37656,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39419,7 +37675,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39439,7 +37694,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39459,7 +37713,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39479,7 +37732,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39499,7 +37751,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39519,7 +37770,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39589,7 +37839,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39609,7 +37858,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39629,7 +37877,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39649,7 +37896,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39669,7 +37915,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39689,7 +37934,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39709,7 +37953,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39729,7 +37972,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39750,7 +37992,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39788,7 +38029,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39804,7 +38044,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39821,7 +38060,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39836,7 +38074,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39861,7 +38098,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39876,7 +38112,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39891,7 +38126,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39908,7 +38142,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39925,7 +38158,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39942,7 +38174,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39959,7 +38190,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39976,7 +38206,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -39993,7 +38222,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40012,7 +38240,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40035,7 +38262,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40054,7 +38280,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40075,7 +38300,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40094,7 +38318,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40115,7 +38338,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40134,7 +38356,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40192,7 +38413,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40228,7 +38448,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40247,7 +38466,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40386,7 +38604,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40405,7 +38622,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40422,7 +38638,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40597,7 +38812,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40616,7 +38830,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40635,7 +38848,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40654,7 +38866,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40673,7 +38884,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40692,7 +38902,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40711,7 +38920,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -40992,7 +39200,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41031,7 +39238,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41050,7 +39256,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41069,7 +39274,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41088,7 +39292,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41107,7 +39310,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41126,7 +39328,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41145,7 +39346,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41164,7 +39364,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41183,7 +39382,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41202,7 +39400,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41220,7 +39417,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41237,7 +39433,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41254,7 +39449,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41271,7 +39465,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41288,7 +39481,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41305,7 +39497,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41322,7 +39513,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41339,7 +39529,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41356,7 +39545,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41373,7 +39561,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41410,7 +39597,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41510,7 +39696,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41545,7 +39730,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41564,7 +39748,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41602,7 +39785,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41715,7 +39897,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41761,7 +39942,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41776,7 +39956,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41792,7 +39971,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41821,7 +39999,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41865,7 +40042,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41932,7 +40108,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41949,7 +40124,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41966,7 +40140,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -41983,7 +40156,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42009,7 +40181,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42027,7 +40198,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42126,7 +40296,6 @@ Body:
     Weight: 10
     Defense: 4
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42152,7 +40321,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42176,7 +40344,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42193,7 +40360,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42212,7 +40378,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42231,7 +40396,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42250,7 +40414,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42269,7 +40432,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42314,7 +40476,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42332,7 +40493,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42349,7 +40509,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42366,7 +40525,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42383,7 +40541,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42402,7 +40559,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42419,7 +40575,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42438,7 +40593,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42457,7 +40611,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42476,7 +40629,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42495,7 +40647,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42512,7 +40663,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42529,7 +40679,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42546,7 +40695,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42565,7 +40713,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42584,7 +40731,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42605,7 +40751,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42623,7 +40768,6 @@ Body:
     Flags:
       UniqueId: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42640,7 +40784,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42657,7 +40800,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42674,7 +40816,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42691,7 +40832,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42708,7 +40848,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42725,7 +40864,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42740,7 +40878,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42755,7 +40892,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42772,7 +40908,6 @@ Body:
     Buy: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42816,7 +40951,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42833,7 +40967,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42850,7 +40983,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42891,7 +41023,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42912,7 +41043,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42942,7 +41072,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42959,7 +41088,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -42976,7 +41104,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43004,7 +41131,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43023,7 +41149,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43306,7 +41431,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43323,7 +41447,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43351,7 +41474,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43370,7 +41492,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43400,7 +41521,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43417,7 +41537,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43434,7 +41553,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43451,7 +41569,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43478,7 +41595,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43497,7 +41613,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43514,7 +41629,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43531,7 +41645,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43549,7 +41662,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43577,7 +41689,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43596,7 +41707,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43615,7 +41725,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43632,7 +41741,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43649,7 +41757,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43667,7 +41774,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43695,7 +41801,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43712,7 +41817,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43729,7 +41833,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43746,7 +41849,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43763,7 +41865,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43780,7 +41881,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43808,7 +41908,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43835,7 +41934,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43852,7 +41950,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43879,7 +41976,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43898,7 +41994,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43918,7 +42013,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43945,7 +42039,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43962,7 +42055,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43980,7 +42072,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -43997,7 +42088,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44017,7 +42107,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44037,7 +42126,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44060,7 +42148,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44083,7 +42170,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44100,7 +42186,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44117,7 +42202,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44134,7 +42218,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44153,7 +42236,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44172,7 +42254,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44190,7 +42271,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44208,7 +42288,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44228,7 +42307,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44249,7 +42327,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44275,7 +42352,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44293,7 +42369,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44313,7 +42388,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44334,7 +42408,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44351,7 +42424,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44369,7 +42441,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44396,7 +42467,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44424,7 +42494,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44443,7 +42512,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44462,7 +42530,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44479,7 +42546,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44496,7 +42562,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44513,7 +42578,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44539,7 +42603,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44557,7 +42620,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44575,7 +42637,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44592,7 +42653,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44682,7 +42742,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44700,7 +42759,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44718,7 +42776,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44736,7 +42793,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44754,7 +42810,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44772,7 +42827,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44790,7 +42844,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44817,7 +42870,6 @@ Body:
     Delay:
       Duration: 1200000
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44835,7 +42887,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44853,7 +42904,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -44869,7 +42919,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -44915,7 +42964,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44942,7 +42990,6 @@ Body:
     Buy: 10
     EquipLevelMin: 80
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44960,7 +43007,6 @@ Body:
     Buy: 10
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44978,7 +43024,6 @@ Body:
     Buy: 10
     EquipLevelMin: 120
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -44996,7 +43041,6 @@ Body:
     Buy: 10
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45014,7 +43058,6 @@ Body:
     Buy: 10
     EquipLevelMin: 140
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45032,7 +43075,6 @@ Body:
     Buy: 10
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45050,7 +43092,6 @@ Body:
     Buy: 10
     EquipLevelMin: 160
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45070,7 +43111,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45122,7 +43162,6 @@ Body:
     Weight: 200
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45151,7 +43190,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45168,7 +43206,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45208,7 +43245,6 @@ Body:
       Duration: 5000
       Status: Reuse_Limit_Luxanima
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45225,7 +43261,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45240,7 +43275,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45259,7 +43293,6 @@ Body:
       Mage: true
       Swordman: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45275,7 +43308,6 @@ Body:
     Buy: 10
     Weight: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45291,7 +43323,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45308,7 +43339,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45325,7 +43355,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45340,7 +43369,6 @@ Body:
     Buy: 10
     Weight: 30
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45355,7 +43383,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45376,7 +43403,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45391,7 +43417,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45406,7 +43431,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45421,7 +43445,6 @@ Body:
     Buy: 10
     Weight: 70
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45439,7 +43462,6 @@ Body:
     Buy: 10
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45459,7 +43481,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
       NoCart: true
   - Id: 22556
@@ -45469,7 +43490,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
       NoCart: true
   - Id: 22557
@@ -45479,7 +43499,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoSell: true
       NoCart: true
   - Id: 22558
@@ -45516,7 +43535,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoCart: true
       NoStorage: true
       NoGuildStorage: true
@@ -45529,7 +43547,6 @@ Body:
     Buy: 5000
     Weight: 100
     Trade:
-      Override: 100
       NoMail: true
       NoAuction: true
     Script: |
@@ -45550,7 +43567,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45574,7 +43590,6 @@ Body:
     Type: Cash
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45596,7 +43611,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45660,7 +43674,6 @@ Body:
     Type: Usable
     Buy: 2
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45679,7 +43692,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45694,7 +43706,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45707,7 +43718,6 @@ Body:
     Name: Ghost Scroll
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45744,7 +43754,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -45775,7 +43784,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45791,7 +43799,6 @@ Body:
     Type: Usable
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -45969,7 +43976,6 @@ Body:
     Buy: 10
     Weight: 200
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46047,7 +44053,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46064,7 +44069,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46081,7 +44085,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46098,7 +44101,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46140,7 +44142,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -46174,7 +44175,6 @@ Body:
     Name: Record Fragment
     Type: Healing
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46190,7 +44190,6 @@ Body:
     Name: Record Fragment
     Type: Healing
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46206,7 +44205,6 @@ Body:
     Name: Record Fragment
     Type: Healing
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46222,7 +44220,6 @@ Body:
     Name: Record Fragment
     Type: Healing
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46238,7 +44235,6 @@ Body:
     Name: Record Fragment
     Type: Healing
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46265,7 +44261,6 @@ Body:
     Type: Cash
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46327,7 +44322,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -46351,7 +44345,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46371,7 +44364,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46389,7 +44381,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46558,7 +44549,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46600,7 +44590,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46617,7 +44606,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46634,7 +44622,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46653,7 +44640,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46742,7 +44728,6 @@ Body:
     Weight: 100
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46760,7 +44745,6 @@ Body:
     Weight: 200
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46779,7 +44763,6 @@ Body:
     Weight: 200
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46798,7 +44781,6 @@ Body:
     Weight: 200
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46818,7 +44800,6 @@ Body:
     Weight: 200
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46840,7 +44821,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46861,7 +44841,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46879,7 +44858,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46896,7 +44874,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       callfunc "F_CashStore";
   - Id: 22819
@@ -46905,7 +44882,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46932,7 +44908,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46969,7 +44944,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -46987,7 +44961,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47005,7 +44978,6 @@ Body:
     Weight: 50
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47042,7 +45014,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47069,7 +45040,6 @@ Body:
     Classes:
       All: false
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47087,7 +45057,6 @@ Body:
     Weight: 10
     EquipLevelMin: 1
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47104,7 +45073,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -47150,7 +45118,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47167,7 +45134,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47184,7 +45150,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47201,7 +45166,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47218,7 +45182,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47235,7 +45198,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47252,7 +45214,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47269,7 +45230,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47286,7 +45246,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47303,7 +45262,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47320,7 +45278,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47337,7 +45294,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47364,7 +45320,6 @@ Body:
     Weight: 100
     EquipLevelMin: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47383,7 +45338,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -47399,7 +45353,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47416,7 +45369,6 @@ Body:
     Buy: 10
     Weight: 50
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47439,7 +45391,6 @@ Body:
     Type: Usable
     Buy: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -47463,7 +45414,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47480,7 +45430,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47497,7 +45446,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47514,7 +45462,6 @@ Body:
     Buy: 10
     Weight: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47531,7 +45478,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47550,7 +45496,6 @@ Body:
     Buy: 10
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47567,7 +45512,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47583,7 +45527,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47600,7 +45543,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47617,7 +45559,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47642,7 +45583,6 @@ Body:
     Type: Usable
     Buy: 20
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -47659,7 +45599,6 @@ Body:
     Buy: 20
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47692,7 +45631,6 @@ Body:
     Name: "[Sale] Battle Manual and Bubble Gum"
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47724,7 +45662,6 @@ Body:
     Name: Infinite Cat Hand Ticket
     Type: Delayconsume
     Trade:
-      Override: 100
     Script: |
       callfunc "F_CashStore";
   - Id: 23001
@@ -47742,7 +45679,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47774,7 +45710,6 @@ Body:
     Name: "[Sale] Slim White Potion Box"
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47793,7 +45728,6 @@ Body:
       Duration: 3000
       Status: Reuse_Limit_G
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47808,7 +45742,6 @@ Body:
     Name: "[Sale] Yggdrasil Seed Box"
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47823,7 +45756,6 @@ Body:
     Name: "[Sale] Mystic Powder"
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47840,7 +45772,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47859,7 +45790,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47879,7 +45809,6 @@ Body:
       Duration: 180000
       Status: Reuse_Limit_B
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -47899,7 +45828,6 @@ Body:
       Duration: 180000
       Status: Reuse_Limit_B
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48011,7 +45939,6 @@ Body:
     Name: Small Leather Bag
     Type: Usable
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -48159,7 +46086,6 @@ Body:
     Buy: 2
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48242,7 +46168,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48258,7 +46183,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_DEX_CASH,1800000,15;
       sc_start SC_HITFOOD,600000,rand(11,33);
@@ -48268,7 +46192,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_LUK_CASH,1800000,15;
       sc_start SC_CRIFOOD,600000,rand(11,33);
@@ -48278,7 +46201,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_STR_CASH,1800000,15;
       sc_start SC_ATKPOTION,600000,rand(11,111);
@@ -48288,7 +46210,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_VIT_CASH,1800000,15;
       bonus_script "{ bonus bHPRecovRate,rand(11,33); }",1800,1;
@@ -48298,7 +46219,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_AGI_CASH,1800000,15;
       sc_start SC_FLEEFOOD,600000,rand(11,33);
@@ -48308,7 +46228,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
     Script: |
       sc_start SC_FOOD_INT_CASH,1800000,15;
       sc_start SC_MATKPOTION,600000,rand(11,111);
@@ -48407,7 +46326,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48426,7 +46344,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48445,7 +46362,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48463,7 +46379,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48482,7 +46397,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48507,7 +46421,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48528,7 +46441,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48564,7 +46476,6 @@ Body:
     EquipLevelMin: 1
     EquipLevelMax: 98
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -48646,19 +46557,18 @@ Body:
     Type: Usable
     Weight: 0
     Flags:
-        Container: true
+      Container: true
     Trade:
-        Override: 100
-        NoDrop: true
-        NoTrade: true
-        NoSell: true
-        NoCart: true
-        NoGuildStorage: true
-        NoMail: true
-        NoAuction: true
+      NoDrop: true
+      NoTrade: true
+      NoSell: true
+      NoCart: true
+      NoGuildStorage: true
+      NoMail: true
+      NoAuction: true
     Script: |
-        getitem(1646,1);
-        getitem(22104,1);
+      getitem(1646,1);
+      getitem(22104,1);
   - Id: 23295
     AegisName: Lian_Bundle_B
     Name: Lian Bundle A
@@ -48666,7 +46576,6 @@ Body:
     Flags:
       Container: true
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48693,7 +46602,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -48731,7 +46639,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -48776,7 +46683,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49548,7 +47454,6 @@ Body:
     Type: Usable
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -49939,7 +47844,6 @@ Body:
     Name: Metal Weapon +7 Refinement Ticket
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49956,7 +47860,6 @@ Body:
     Buy: 20
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49973,7 +47876,6 @@ Body:
     Buy: 20
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -49990,7 +47892,6 @@ Body:
     Buy: 20
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50007,7 +47908,6 @@ Body:
     Buy: 20
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50024,7 +47924,6 @@ Body:
     Buy: 20
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50041,7 +47940,6 @@ Body:
     Buy: 20
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50058,7 +47956,6 @@ Body:
     Buy: 20
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50075,7 +47972,6 @@ Body:
     Buy: 20
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50092,7 +47988,6 @@ Body:
     Buy: 20
     EquipLevelMin: 125
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50109,7 +48004,6 @@ Body:
     Buy: 20
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50126,7 +48020,6 @@ Body:
     Buy: 20
     EquipLevelMin: 150
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50142,7 +48035,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50504,7 +48396,6 @@ Body:
     Name: Illusion Reinforcement Cube
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -50519,7 +48410,6 @@ Body:
     Name: Automatic Reinforcement Cube
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoSell: true
@@ -50674,7 +48564,6 @@ Body:
     Name: Booster Weapon Phase 1 Upgrade Package
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50689,7 +48578,6 @@ Body:
     Name: Booster Weapon Phase 2 Upgrade Package
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50705,7 +48593,6 @@ Body:
     Type: DelayConsume
     EquipLevelMin: 100
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50721,7 +48608,6 @@ Body:
     Type: DelayConsume
     EquipLevelMin: 130
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50783,7 +48669,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50799,7 +48684,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50815,7 +48699,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -50831,7 +48714,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51272,7 +49154,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51481,7 +49362,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51496,7 +49376,6 @@ Body:
     Type: DelayConsume
     Weight: 10
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51598,7 +49477,6 @@ Body:
     Name: Booster Modification Stone(Physical)
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true
@@ -51613,7 +49491,6 @@ Body:
     Name: Booster Modification Stone(Magical)
     Type: DelayConsume
     Trade:
-      Override: 100
       NoDrop: true
       NoTrade: true
       NoCart: true

--- a/doc/yaml/db/item_db.yml
+++ b/doc/yaml/db/item_db.yml
@@ -48,10 +48,10 @@
 #     Storage               If the stack is applied to the player's storage. (Default: false)
 #     GuildStorage          If the stack is applied to the player's guild storage. (Default: false)
 #   NoUse:                  Conditions when the item is unusable. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     Sitting               If the item can not be used while sitting. (Default: false)
 #   Trade:                  Trade restrictions. (Default: null)
-#     Override              Group level to override these conditions.
+#     Override              Group level to override these conditions. (Default: 100)
 #     NoDrop                If the item can not be dropped. (Default: false)
 #     NoTrade               If the item can not be traded. (Default: false)
 #     TradePartner          If the item can not be traded to the player's partner. (Default: false)

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -856,7 +856,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 			item->item_usage.override = override;
 		} else {
 			if (!exists)
-				item->item_usage.override = 0;
+				item->item_usage.override = 100;
 		}
 
 		if (this->nodeExists(nouseNode, "Sitting")) {
@@ -872,7 +872,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 		}
 	} else {
 		if (!exists) {
-			item->item_usage.override = 0;
+			item->item_usage.override = 100;
 			item->item_usage.sitting = false;
 		}
 	}
@@ -894,7 +894,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 			item->gm_lv_trade_override = override;
 		} else {
 			if (!exists)
-				item->gm_lv_trade_override = 0;
+				item->gm_lv_trade_override = 100;
 		}
 
 		if (this->nodeExists(tradeNode, "NoDrop")) {
@@ -1006,7 +1006,7 @@ uint64 ItemDatabase::parseBodyNode(const YAML::Node &node) {
 		}
 	} else {
 		if (!exists) {
-			item->gm_lv_trade_override = 0;
+			item->gm_lv_trade_override = 100;
 			item->flag.trade_restriction.drop = false;
 			item->flag.trade_restriction.trade = false;
 			item->flag.trade_restriction.trade_partner = false;

--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -2947,7 +2947,8 @@ static bool itemdb_read_db(const char* file) {
 		if (it_nouse != item_nouse.end()) {
 			body << YAML::Key << "NoUse";
 			body << YAML::BeginMap;
-			body << YAML::Key << "Override" << YAML::Value << it_nouse->second.override;
+            if (it_nouse->second.override != 100)
+				body << YAML::Key << "Override" << YAML::Value << it_nouse->second.override;
 			body << YAML::Key << "Sitting" << YAML::Value << "true";
 			body << YAML::EndMap;
 		}
@@ -2957,7 +2958,8 @@ static bool itemdb_read_db(const char* file) {
 		if (it_trade != item_trade.end()) {
 			body << YAML::Key << "Trade";
 			body << YAML::BeginMap;
-			body << YAML::Key << "Override" << YAML::Value << it_trade->second.override;
+            if (it_trade->second.override != 100)
+				body << YAML::Key << "Override" << YAML::Value << it_trade->second.override;
 			if (it_trade->second.drop)
 				body << YAML::Key << "NoDrop" << YAML::Value << it_trade->second.drop;
 			if (it_trade->second.trade)

--- a/src/tool/csv2yaml.cpp
+++ b/src/tool/csv2yaml.cpp
@@ -2947,7 +2947,7 @@ static bool itemdb_read_db(const char* file) {
 		if (it_nouse != item_nouse.end()) {
 			body << YAML::Key << "NoUse";
 			body << YAML::BeginMap;
-            if (it_nouse->second.override != 100)
+			if (it_nouse->second.override != 100)
 				body << YAML::Key << "Override" << YAML::Value << it_nouse->second.override;
 			body << YAML::Key << "Sitting" << YAML::Value << "true";
 			body << YAML::EndMap;
@@ -2958,7 +2958,7 @@ static bool itemdb_read_db(const char* file) {
 		if (it_trade != item_trade.end()) {
 			body << YAML::Key << "Trade";
 			body << YAML::BeginMap;
-            if (it_trade->second.override != 100)
+			if (it_trade->second.override != 100)
 				body << YAML::Key << "Override" << YAML::Value << it_trade->second.override;
 			if (it_trade->second.drop)
 				body << YAML::Key << "NoDrop" << YAML::Value << it_trade->second.drop;


### PR DESCRIPTION
* **Addressed Issue(s)**:  -

* **Server Mode**: 
Pre-Renewal
Renewal

* **Description of Pull Request**: 
Changed the default of NoUse's and Trade's **Override** setting from **0** to **100**.
Removed all the Override definitions that are with that no longer required.
