### PR TITLE
Removes an extra sanity check for cardfix bonuses

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -675,7 +675,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 	s_defele = (tsd) ? (enum e_element)status_get_element(src) : ELE_NONE;
 
 //Official servers apply the cardfix value on a base of 1000 and round down the reduction/increase
-#define APPLY_CARDFIX(damage, fix) { (damage) = (damage) - (int64)(((damage) * (1000 - min(max(0, fix), 1000))) / 1000); }
+#define APPLY_CARDFIX(damage, fix) { (damage) = (damage) - (int64)(((damage) * (1000 - max(0, fix))) / 1000); }
 
 	switch( attack_type ) {
 		case BF_MAGIC:


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6579

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Partial revert to ad2660b.
  * Cardfix bonuses can go above 1000.
Thanks to @kaninhot004!