### PR TITLE
Non spotted mobs shouldn't walk

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -292,3 +292,8 @@ achievement_mob_share: no
 // Should slaves teleport back to their master if they get too far during chase? (Note 1)
 // Default (Official): no
 slave_stick_with_master: no
+
+// Do monsters walk when they haven't been spotted? (Note 1)
+// Default (Official): no
+// rAthena legacy: yes
+mob_walk_onspawn: no

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9988,6 +9988,7 @@ static const struct _battle_data {
 	{ "save_body_style",                    &battle_config.save_body_style,                 1,      0,      1,              },
 	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
 	{ "monster_stuck_warning",              &battle_config.mob_stuck_warning,               0,      0,      1,              },
+	{ "mob_walk_onspawn",             		 &battle_config.mob_walk_onspawn,               0,      0,      1,              },
 	{ "skill_eightpath_algorithm",          &battle_config.skill_eightpath_algorithm,       1,      0,      1,              },
 	{ "skill_eightpath_same_cell",          &battle_config.skill_eightpath_same_cell,       1,      0,      1,              },
 	{ "death_penalty_maxlv",                &battle_config.death_penalty_maxlv,             0,      0,      3,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -619,6 +619,7 @@ struct Battle_Config
 	int save_body_style;
 	int mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
 	int mob_stuck_warning; //Show warning if a monster is stuck too long
+	int mob_walk_onspawn;
 	int skill_eightpath_algorithm; //Official path algorithm
 	int skill_eightpath_same_cell;
 	int death_penalty_maxlv;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1157,7 +1157,7 @@ int mob_spawn (struct mob_data *md)
 	if (battle_config.mob_walk_onspawn)
 		md->next_walktime = tick+rnd()%1000+MIN_RANDOMWALKTIME;
 	else
-		md->next_walktime = 0;
+		md->next_walktime = -1;
 	md->last_linktime = tick;
 	md->dmgtick = tick - 5000;
 	md->last_pcneartime = 0;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1154,7 +1154,10 @@ int mob_spawn (struct mob_data *md)
 
 	md->state.aggressive = status_has_mode(&md->status,MD_ANGRY)?1:0;
 	md->state.skillstate = MSS_IDLE;
-	md->next_walktime = tick+rnd()%1000+MIN_RANDOMWALKTIME;
+	if (battle_config.mob_walk_onspawn)
+		md->next_walktime = tick+rnd()%1000+MIN_RANDOMWALKTIME;
+	else
+		md->next_walktime = 0;
 	md->last_linktime = tick;
 	md->dmgtick = tick - 5000;
 	md->last_pcneartime = 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/6580

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

On rAthena, monsters, after being spawn, walk randomly on the map without any conditions.
On the official server, after spawning, monsters are inactive on the map until the player finds them. The difference is noticeable in memorial dungeons where monsters spawn at given coordinates.


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
