### PR TITLE
Fixes Tuna Belly and Shrimp Party behaviors

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -12322,9 +12322,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			heal = 0;
 		else if (status_get_hp(bl) != status_get_max_hp(bl))
 			heal = ((2 * skill_lv - 1) * 10) * status_get_max_hp(bl) / 100;
-		status_heal(bl, heal, 0, 1|2|4);
-
 		clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
+		status_heal(bl, heal, 0, 1|2|4);
 	}
 		break;
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -6213,8 +6213,6 @@ void status_calc_regen(struct block_list *bl, struct status_data *status, struct
 			val += 3 + 3 * skill;
 
 		if (sc && sc->count) {
-			if (sc->data[SC_SHRIMPBLESSING])
-				val *= 150 / 100;
 			if (sc->data[SC_ANCILLA])
 				val += sc->data[SC_ANCILLA]->val2 / 100;
 			if (sc->data[SC_INCREASE_MAXSP])
@@ -6398,6 +6396,8 @@ void status_calc_regen_rate(struct block_list *bl, struct regen_data *regen, str
 		regen->rate.hp *= 2;
 		regen->rate.sp *= 2;
 	}
+	if (sc->data[SC_SHRIMPBLESSING])
+		regen->rate.sp += 50;
 #ifdef RENEWAL
 	if (sc->data[SC_NIBELUNGEN]) {
 		if (sc->data[SC_NIBELUNGEN]->val2 == RINGNBL_HPREGEN)


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6611

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Resolves an issue with Tuna Belly not sending the visual update to healed players.
  * Resolves Shrimp Party SP recovery not increasing the heal rate.
Thanks to @Balferian!