### PR TITLE
elemental: Add std::hash specialization for e_elemental_skillmode

### DIFF
--- a/src/map/elemental.hpp
+++ b/src/map/elemental.hpp
@@ -26,6 +26,14 @@ enum e_elemental_skillmode : uint8 {
 	EL_SKILLMODE_AGGRESSIVE = 0x4,
 };
 
+#if __cplusplus < 201402L
+namespace std {
+	template <> struct hash<e_elemental_skillmode> {
+		size_t operator() (const e_elemental_skillmode& t) const { return size_t(t); }
+	};
+}
+#endif
+
 ///Enum of Elemental ID
 enum elemental_elementalid  : uint16 {
 	// Sorcerer's Elementals


### PR DESCRIPTION
* **Addressed Issue(s)**: #6591

* **Description of Pull Request**: 

Required for e_elemental_skillmode to be used as a key in std::unordered_map, pre-C++14.

Build tested on macOS 12.1 (Monterey), with Apple clang version 13.0.0.