### PR TITLE
Corrected property name on skill_db.yml header doc

### DIFF
--- a/db/import-tmpl/skill_db.yml
+++ b/db/import-tmpl/skill_db.yml
@@ -115,7 +115,7 @@
 #         Amount              Ammo amount required at specific skill level.
 #     State                   Special state required to cast. (Default: None)
 #     Status:                 Status change required to cast. (Default: nullptr)
-#     SphereCost:             Spirit sphere required to cast. (Default: 0)
+#     SpiritSphereCost:       Spirit sphere required to cast. (Default: 0)
 #       - Level               Skill level.
 #         Amount              Spirit sphere required at specific skill level.
 #     ItemCost:               Item required to cast. (Default: 0)

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -115,7 +115,7 @@
 #         Amount              Ammo amount required at specific skill level.
 #     State                   Special state required to cast. (Default: None)
 #     Status:                 Status change required to cast. (Default: nullptr)
-#     SphereCost:             Spirit sphere required to cast. (Default: 0)
+#     SpiritSphereCost:       Spirit sphere required to cast. (Default: 0)
 #       - Level               Skill level.
 #         Amount              Spirit sphere required at specific skill level.
 #     ItemCost:               Item required to cast. (Default: 0)

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -115,7 +115,7 @@
 #         Amount              Ammo amount required at specific skill level.
 #     State                   Special state required to cast. (Default: None)
 #     Status:                 Status change required to cast. (Default: nullptr)
-#     SphereCost:             Spirit sphere required to cast. (Default: 0)
+#     SpiritSphereCost:       Spirit sphere required to cast. (Default: 0)
 #       - Level               Skill level.
 #         Amount              Spirit sphere required at specific skill level.
 #     ItemCost:               Item required to cast. (Default: 0)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
  * Corrected property name on skill_db.yml header doc.
  * Written as `SphereCost` which must be `SpiritSphereCost`

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
