### PR TITLE
Added missing export for bWeaponSubSize

### DIFF
--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -845,6 +845,7 @@
 	export_constant2("bReduceDamageReturn",SP_REDUCE_DAMAGE_RETURN);
 	export_constant2("bAddItemSPHealRate", SP_ADD_ITEM_SPHEAL_RATE);
 	export_constant2("bAddItemGroupSPHealRate", SP_ADD_ITEMGROUP_SPHEAL_RATE);
+	export_constant2("bWeaponSubSize", SP_WEAPON_SUBSIZE);
 
 	/* equip indices */
 	export_constant(EQI_COMPOUND_ON);


### PR DESCRIPTION
* **Addressed Issue(s)**: #6650

* **Server Mode**: Both

* **Description of Pull Request**: 
Added a missing export for bWeaponSubSize to the script engine.