### PR TITLE
randomoptgroup script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10627,6 +10627,25 @@ Param - Parameter of random option
 
 ---------------------------------------
 
+*randomoptgroup <random option group ID>;
+
+This command fill the following arrays with the result of a random option group.
+The random option group IDs are specified in 'db/(pre-)re/item_randomopt_group.yml'.
+
+Arrays - from index 0 to MAX_ITEM_RDM_OPT-1 :
+.@opt_id[]                - array of random option ID.
+.@opt_value[]             - array of value.
+.@opt_param[]             - array of param.
+
+Example:
+	// Fill the arrays using the random option group ID 5 (group used for Crimson weapon).
+	randomoptgroup(5);
+
+	// Create a +9 Crimson Dagger [2] with the Group 5 applied
+	getitem3 28705,1,1,9,0,0,0,0,0,.@opt_id,.@opt_value,.@opt_param;
+
+---------------------------------------
+
 *clan_join(<clan id>{,<char id>});
 
 The attached player joins the clan with the <clan id>. On a successful join,

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -25823,6 +25823,32 @@ BUILDIN_FUNC( laphine_upgrade ){
 	return SCRIPT_CMD_SUCCESS;
 }
 
+BUILDIN_FUNC(randomoptgroup)
+{
+	const char* command = script_getfuncname(st);
+	int id = script_getnum(st,2);
+
+	auto group = random_option_group.find(id);
+
+	if (group == nullptr) {
+		ShowError("buildin_%s: Invalid random option group id (%d)!\n", command, id);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	struct item item_tmp;
+	memset(&item_tmp, 0, sizeof(item_tmp));
+
+	group->apply( item_tmp );
+
+	for ( int i = 0; i < MAX_ITEM_RDM_OPT; ++i ) {
+		setd_sub_num(st, nullptr, ".@opt_id", i, item_tmp.option[i].id, nullptr);
+		setd_sub_num(st, nullptr, ".@opt_value", i, item_tmp.option[i].value, nullptr);
+		setd_sub_num(st, nullptr, ".@opt_param", i, item_tmp.option[i].param, nullptr);
+	}
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include "../custom/script.inc"
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -26534,6 +26560,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getitempos,""),
 	BUILDIN_DEF(laphine_synthesis, ""),
 	BUILDIN_DEF(laphine_upgrade, ""),
+	BUILDIN_DEF(randomoptgroup,"i"),
 #include "../custom/script_def.inc"
 
 	{NULL,NULL,NULL},


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

This is a suggestion of a new command to get the random value of the random option ID, value and param of a random option group ID. This allow to easily give an item with random option applied via script command.

Example
```
	// Fill the arrays using the random option group ID 5 (group used for Crimson weapon).
	randomoptgroup(5);

	// Create a +9 Crimson Dagger [2] with the Group 5 applied
	getitem3 28705,1,1,9,0,0,0,0,0,.@opt_id,.@opt_value,.@opt_param;
```




<!-- Describe how this pull request will resolve the issue(s) listed above. -->
