### PR TITLE
Fixes Slim Potion Pitcher item lookup

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13536,7 +13536,7 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 					skill_castend_nodamage_id);
 			}
 		} else {
-			struct item_data *item = itemdb_search(skill_db.find(skill_id)->require.itemid[skill_lv]);
+			struct item_data *item = itemdb_search(skill_db.find(skill_id)->require.itemid[skill_lv - 1]);
 			int id = skill_get_max(CR_SLIMPITCHER) * 10;
 
 			potion_flag = 1;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6646

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes the item requirement check for Slim Potion Pitcher being offset by one.
Thanks to @Indigo000!