### PR TITLE
Spiral pierce immune fix

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1668,7 +1668,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 
 	case LK_SPIRALPIERCE:
 	case ML_SPIRALPIERCE:
-		if( dstsd || ( dstmd && status_bl_has_mode(bl,MD_STATUSIMMUNE) ) ) //Does not work on status immune
+		if( dstsd || ( dstmd && !status_bl_has_mode(bl,MD_STATUSIMMUNE) ) ) //Does not work on status immune
 			sc_start(src,bl,SC_STOP,100,0,skill_get_time2(skill_id,skill_lv));
 		break;
 


### PR DESCRIPTION
Fixes the inversion of target type being stopped by spiral pierce, ie it should stop normal monsters and not status immune

  * **Addressed Issue(s):**

https://github.com/rathena/rathena/issues/6667

   * **Server Mode:**

Both

   * **Description of Pull Request:**

Now applies root when target is not immune