### PR TITLE
Fixed atcommand jail

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3052,9 +3052,6 @@ int unit_remove_map_(struct block_list *bl, clr_type clrtype, const char* file, 
 	ud->attackabletime = ud->canmove_tick /*= ud->canact_tick*/ = gettick();
 
 	if(sc && sc->count ) { // map-change/warp dispells.
-		if (sc->cant.warp)
-			return 0;
-
 		status_db.removeByStatusFlag(bl, { SCF_REMOVEONCHANGEMAP });
 
 		// Ensure the bl is a PC; if so, we'll handle the removal of cloaking and cloaking exceed later


### PR DESCRIPTION
* **Addressed Issue(s)**: #6677

* **Server Mode**: Both

* **Description of Pull Request**:
Due to a newly added early return the block free lock was not unlocked correctly.
Additionally this check was not there before the latest update.
 
Thanks to @gen1x8
