### PR TITLE
Fixed EFST initialization

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14881,6 +14881,8 @@ uint64 StatusDatabase::parseBodyNode(const YAML::Node &node) {
 }
 
 void StatusDatabase::loadingFinished(){
+	std::fill( std::begin( this->StatusRelevantBLTypes ), std::end( this->StatusRelevantBLTypes ), BL_PC );
+
 	for( auto& entry : *this ){
 		auto& status = entry.second;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #6675

* **Server Mode**: Both

* **Description of Pull Request**: 
We forgot to initialize the array to BL_PC due to a wrong assumption that we can optimize it based on per status initialization.

Thanks to @jofvgaming, @Singe-Horizontal, @secretdataz and @aleos89.