### PR TITLE
Fixes Mounted characters immune to freeze/stone

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9208,6 +9208,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			// Undead are immune to Freeze/Stone
 			if (undead_flag && !(flag&SCSTART_NOAVOID))
 				return 0;
+			break;
 		case SC_ALL_RIDING:
 			if( !sd || sc->option&(OPTION_RIDING|OPTION_DRAGON|OPTION_WUG|OPTION_MADOGEAR) )
 				return 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#6688 
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Restore a missing break after SC_STONE and SC_FREEZE cases that make them enter SC_ALL_RIDING case
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
