### PR TITLE
Expands the SC start check

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -815,6 +815,8 @@ Body:
     Flags:
       NoSave: true
   - Status: Spellbreaker
+    Flags:
+      NoWarning: true
   - Status: Autospell
     Icon: EFST_AUTOSPELL
     DurationLookup: SA_AUTOSPELL
@@ -824,6 +826,8 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
   - Status: Sighttrasher
+    Flags:
+      NoWarning: true
   - Status: Autoberserk
     Icon: EFST_AUTOBERSERK
     DurationLookup: SM_AUTOBERSERK
@@ -1074,6 +1078,8 @@ Body:
       Saturdaynightfever: true
       _Bloodylust: true
   - Status: Fury
+    Flags:
+      NoWarning: true
   - Status: Gospel
     Icon: EFST_GOSPEL
     DurationLookup: PA_GOSPEL
@@ -2209,6 +2215,8 @@ Body:
       NoSave: true
       NoClearance: true
   - Status: Kaensin
+    Flags:
+      NoWarning: true
   - Status: Suiton
     Icon: EFST_NJ_SUITON
     DurationLookup: NJ_SUITON
@@ -2444,6 +2452,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
   - Status: Ksprotected
+    Flags:
+      NoWarning: true
   - Status: Armor_Resist
     CalcFlags:
       All: true
@@ -3033,6 +3043,8 @@ Body:
       DisplayPc: true
       NoClearance: true
   - Status: Reading_Sb
+    Flags:
+      NoWarning: true
   - Status: Freeze_Sp
     Icon: EFST_FREEZE_SP
     Flags:
@@ -6389,6 +6401,8 @@ Body:
     CalcFlags:
       Flee2: true
   - Status: Doram_Svsp
+    Flags:
+      NoWarning: true
   - Status: Fallen_Angel
     DurationLookup: RL_FALLEN_ANGEL
   - Status: Cheerup
@@ -6499,6 +6513,8 @@ Body:
     CalcFlags:
       Regen: true
   - Status: Earthshaker
+    Flags:
+      NoWarning: true
   - Status: Weaponblock_On
     Icon: EFST_WEAPONBLOCK_ON
     Flags:
@@ -6629,7 +6645,11 @@ Body:
     Flags:
       NoClearance: true
   - Status: Dimension1
+    Flags:
+      NoWarning: true
   - Status: Dimension2
+    Flags:
+      NoWarning: true
   - Status: Creatingstar
     Icon: EFST_CREATINGSTAR
     DurationLookup: SJ_BOOKOFCREATINGSTAR

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -828,6 +828,8 @@ Body:
     Flags:
       NoSave: true
   - Status: Spellbreaker
+    Flags:
+      NoWarning: true
   - Status: Autospell
     Icon: EFST_AUTOSPELL
     DurationLookup: SA_AUTOSPELL
@@ -837,6 +839,8 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
   - Status: Sighttrasher
+    Flags:
+      NoWarning: true
   - Status: Autoberserk
     Icon: EFST_AUTOBERSERK
     DurationLookup: SM_AUTOBERSERK
@@ -1085,6 +1089,8 @@ Body:
       Saturdaynightfever: true
       _Bloodylust: true
   - Status: Fury
+    Flags:
+      NoWarning: true
   - Status: Gospel
     Icon: EFST_GOSPEL
     DurationLookup: PA_GOSPEL
@@ -2317,6 +2323,8 @@ Body:
       NoSave: true
       NoClearance: true
   - Status: Kaensin
+    Flags:
+      NoWarning: true
   - Status: Suiton
     Icon: EFST_NJ_SUITON
     DurationLookup: NJ_SUITON
@@ -2552,6 +2560,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
   - Status: Ksprotected
+    Flags:
+      NoWarning: true
   - Status: Armor_Resist
     CalcFlags:
       All: true
@@ -3145,6 +3155,8 @@ Body:
       NoClearance: true
       SendVal1: true
   - Status: Reading_Sb
+    Flags:
+      NoWarning: true
   - Status: Freeze_Sp
     Icon: EFST_FREEZE_SP
     Flags:
@@ -6646,6 +6658,8 @@ Body:
     CalcFlags:
       Flee2: true
   - Status: Doram_Svsp
+    Flags:
+      NoWarning: true
   - Status: Fallen_Angel
     DurationLookup: RL_FALLEN_ANGEL
   - Status: Cheerup
@@ -6761,6 +6775,8 @@ Body:
     CalcFlags:
       Regen: true
   - Status: Earthshaker
+    Flags:
+      NoWarning: true
   - Status: Weaponblock_On
     Icon: EFST_WEAPONBLOCK_ON
     DurationLookup: SHC_IMPACT_CRATER
@@ -6897,7 +6913,11 @@ Body:
     Flags:
       NoClearance: true
   - Status: Dimension1
+    Flags:
+      NoWarning: true
   - Status: Dimension2
+    Flags:
+      NoWarning: true
   - Status: Creatingstar
     Icon: EFST_CREATINGSTAR
     DurationLookup: SJ_BOOKOFCREATINGSTAR
@@ -7358,6 +7378,7 @@ Body:
       DisplayPc: true
       RemoveOnDamaged: true
   - Status: Handicapstate_Swooning
+    Icon: EFST_HANDICAPSTATE_SWOONING
     States:
       #NoMove: true
       #NoCast: true
@@ -7415,9 +7436,11 @@ Body:
       BlEffect: true
       DisplayPc: true
   - Status: Handicapstate_Depression
+    Icon: EFST_HANDICAPSTATE_DEPRESSION
     Flags:
       DisplayPc: true
   - Status: Handicapstate_Holyflame
+    Icon: EFST_HANDICAPSTATE_HOLYFLAME
     Flags:
       DisplayPc: true
   - Status: Servantweapon

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7084,6 +7084,7 @@ Body:
       NoClearance: true
       NoClearbuff: true
   - Status: Reuse_Limit_Luxanima
+    Icon: EFST_REUSE_LIMIT_LUXANIMA
     Flags:
       NoBanishingBuster: true
       NoDispell: true

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -220,6 +220,7 @@ Flags: Various status flags for specific status change events.
 	NoBanishingBuster     - Cannot be removed by RL_BANISHING_BUSTER.
 	NoSave                - Won't be saved when player logs out.
 	NoSaveInfinite        - Infinite duration status won't be saved when player logs out.
+	NoWarning             - Ignores the status_change_start check for statuses that have no defining features associated to them in the status database.
 
 	RemoveOnDamaged       - Removed when receiving damage.
 	RemoveOnRefresh       - Removed by RK_REFRESH.

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8902,6 +8902,7 @@
 	export_constant(SCF_SENDVAL2);
 	export_constant(SCF_SENDVAL3);
 	export_constant(SCF_NOFORCEDEND);
+	export_constant(SCF_NOWARNING);
 
 	#undef export_constant
 	#undef export_constant2

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -11738,9 +11738,9 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 
 		default:
-			if (calc_flag == SCB_NONE && scdb->skill_id == 0 && scdb->icon == EFST_BLANK) {
+			if (calc_flag == SCB_NONE && scdb->skill_id == 0 && scdb->icon == EFST_BLANK && scdb->opt1 == OPT1_NONE && scdb->opt2 == OPT2_NONE && scdb->state.none() && scdb->flag.none() && scdb->end.empty() && scdb->fail.empty()) {
 				// Status change with no calc, no icon, and no skill associated...?
-				ShowError("status_change_start: Unknown SC %d\n", type);
+				ShowWarning("status_change_start: Status %s (%d) is bare. Add the NoWarning flag to suppress this message.\n", script_get_constant_str("SC_", type), type);
 				return 0;
 			}
 	} else // Special considerations when loading SC data.

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -2853,6 +2853,7 @@ enum e_status_change_flag : uint16 {
 	SCF_SENDVAL2,
 	SCF_SENDVAL3,
 	SCF_NOFORCEDEND,
+	SCF_NOWARNING,
 	SCF_MAX
 };
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6685

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds the EFST value for SC_REUSE_LIMIT_LUXANIMA so the status is properly applied after consuming the Lux Anima Runestone.
  * Adds the EFST value for the Handicap State statuses.
  * Adds the NoWarning flag for any status that do not have any association to skills, EFST, or other settings and is purely used for specific checks in source.
  * Expanded the 'blank' status checks for checking other fields as well.
Thanks to @idk-whoami and @eppc0330!