### PR TITLE
Fixes Wug Rider allowing physical attacks

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2848,7 +2848,7 @@ bool unit_can_attack(struct block_list *bl, int target_id) {
 	if (bl->type == BL_PC) {
 		map_session_data *sd = ((TBL_PC *)bl);
 
-		if (sd && (sd->state.block_action & PCBLOCK_ATTACK))
+		if (sd && ((sd->state.block_action & PCBLOCK_ATTACK) || pc_isridingwug(sd)))
 			return false;
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6713

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Physical attacks are now disabled when a Ranger-type class is riding a Wug.
Thanks to @Surefirer!