### PR TITLE
Adds INF2_ISTOGGLEABLE skill flag

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -1977,6 +1977,7 @@ Body:
       IgnoreKagehumi: true
       AllowOnMado: true
       IgnoreWugBite: true
+      IsToggleable: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -4097,6 +4098,7 @@ Body:
       NoDamage: true
     Flags:
       AllowOnMado: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -4729,6 +4731,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -5078,6 +5081,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -6757,6 +6761,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000
@@ -9952,6 +9958,8 @@ Body:
     DamageFlags:
       NoDamage: true
       IgnoreFlee: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -10632,6 +10640,7 @@ Body:
       NoDamage: true
     Flags:
       IgnoreKagehumi: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastTime: 1200
@@ -11256,6 +11265,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Knockback: 4
@@ -11307,6 +11318,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11352,6 +11365,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11395,6 +11410,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11441,6 +11458,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11876,6 +11895,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 1000
@@ -14080,6 +14101,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16955,6 +16978,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
+      IsToggleable: true
     Hit: Single
     Knockback: 2
     Duration1: 300000
@@ -32850,6 +32874,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -32865,6 +32891,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -1977,7 +1977,7 @@ Body:
       IgnoreKagehumi: true
       AllowOnMado: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -4098,7 +4098,7 @@ Body:
       NoDamage: true
     Flags:
       AllowOnMado: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -4731,7 +4731,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -5081,7 +5081,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -6762,7 +6762,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000
@@ -9959,7 +9959,7 @@ Body:
       NoDamage: true
       IgnoreFlee: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -10640,7 +10640,7 @@ Body:
       NoDamage: true
     Flags:
       IgnoreKagehumi: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastTime: 1200
@@ -11266,7 +11266,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Knockback: 4
@@ -11319,7 +11319,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11366,7 +11366,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11411,7 +11411,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11459,7 +11459,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11896,7 +11896,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 1000
@@ -14102,7 +14102,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16978,7 +16978,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     Knockback: 2
     Duration1: 300000
@@ -32875,7 +32875,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -32892,7 +32892,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -1980,7 +1980,7 @@ Body:
       AllowWhenHidden: true
       IgnoreKagehumi: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -4323,7 +4323,7 @@ Body:
       NoDamage: true
     Flags:
       AllowOnMado: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -4976,7 +4976,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -5344,7 +5344,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -7132,7 +7132,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000
@@ -7415,7 +7415,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -10241,7 +10241,7 @@ Body:
       NoDamage: true
       IgnoreFlee: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -10909,7 +10909,7 @@ Body:
       NoDamage: true
     Flags:
       IgnoreKagehumi: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastTime: 500
@@ -11540,7 +11540,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Knockback: 4
@@ -11615,7 +11615,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11662,7 +11662,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11707,7 +11707,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11755,7 +11755,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -12197,7 +12197,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -14419,7 +14419,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -17954,7 +17954,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     Knockback: 2
     Duration1: 300000
@@ -20373,7 +20373,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 2000
@@ -21589,7 +21589,7 @@ Body:
     Flags:
       AllowOnWarg: true
       IncreaseDanceWithWugDamage: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -21724,7 +21724,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 10000
@@ -30096,7 +30096,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30175,7 +30175,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30332,7 +30332,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30541,7 +30541,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -31240,7 +31240,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -31328,7 +31328,7 @@ Body:
     TargetType: Self
     Flags:
       AllowWhenHidden: true
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 200000
@@ -36251,7 +36251,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -36269,7 +36269,7 @@ Body:
       NoDamage: true
       Splash: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     SplashArea: 10
@@ -43055,7 +43055,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -43073,7 +43073,7 @@ Body:
     DamageFlags:
       NoDamage: true
     Flags:
-      IsToggleable: true
+      Toggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -1980,6 +1980,7 @@ Body:
       AllowWhenHidden: true
       IgnoreKagehumi: true
       IgnoreWugBite: true
+      IsToggleable: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -4322,6 +4323,7 @@ Body:
       NoDamage: true
     Flags:
       AllowOnMado: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -4974,6 +4976,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1:
@@ -5341,6 +5344,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -7127,6 +7131,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000
@@ -7408,6 +7414,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -10232,6 +10240,8 @@ Body:
     DamageFlags:
       NoDamage: true
       IgnoreFlee: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -10899,6 +10909,7 @@ Body:
       NoDamage: true
     Flags:
       IgnoreKagehumi: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastTime: 500
@@ -11528,6 +11539,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Knockback: 4
@@ -11601,6 +11614,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11646,6 +11661,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11689,6 +11706,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -11735,6 +11754,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Requires:
@@ -12175,6 +12196,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 600000
@@ -14395,6 +14418,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -17929,6 +17954,7 @@ Body:
       NoDamage: true
     Flags:
       IsQuest: true
+      IsToggleable: true
     Hit: Single
     Knockback: 2
     Duration1: 300000
@@ -20347,6 +20373,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 2000
@@ -21562,6 +21589,7 @@ Body:
     Flags:
       AllowOnWarg: true
       IncreaseDanceWithWugDamage: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -21696,6 +21724,7 @@ Body:
     Flags:
       IgnoreKagehumi: true
       IgnoreWugBite: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 10000
@@ -30066,6 +30095,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30143,6 +30174,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30298,6 +30331,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -30505,6 +30540,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -31202,6 +31239,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -31289,6 +31328,7 @@ Body:
     TargetType: Self
     Flags:
       AllowWhenHidden: true
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 200000
@@ -36210,6 +36250,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     CastCancel: true
@@ -36226,6 +36268,8 @@ Body:
     DamageFlags:
       NoDamage: true
       Splash: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     SplashArea: 10
@@ -43010,6 +43054,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 800
@@ -43026,6 +43072,8 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
+    Flags:
+      IsToggleable: true
     Hit: Single
     HitCount: 1
     Duration1: 300000

--- a/doc/skill_db.txt
+++ b/doc/skill_db.txt
@@ -103,6 +103,7 @@ IgnoreAutoGuard				- Not blocked by SC_AUTOGUARD (When TargetType is Weapon only
 IgnoreCicada				- Not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (When TargetType is Weapon only).
 ShowScale					- Shows AoE area while casting
 IgnoreGtb					- Not blocked by Golden Thief Bug card.
+IsToggleable				- Skill is able to be toggled on and off. When toggled off the skill doesn't consume HP/SP.
 
 ---------------------------------------
 

--- a/doc/skill_db.txt
+++ b/doc/skill_db.txt
@@ -103,7 +103,7 @@ IgnoreAutoGuard				- Not blocked by SC_AUTOGUARD (When TargetType is Weapon only
 IgnoreCicada				- Not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (When TargetType is Weapon only).
 ShowScale					- Shows AoE area while casting
 IgnoreGtb					- Not blocked by Golden Thief Bug card.
-IsToggleable				- Skill is able to be toggled on and off. When toggled off the skill doesn't consume HP/SP.
+Toggleable					- Skill can be toggled on and off. When toggled off the skill doesn't consume HP/SP.
 
 ---------------------------------------
 

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8394,7 +8394,7 @@
 	export_constant(INF2_IGNORECICADA);
 	export_constant(INF2_SHOWSCALE);
 	export_constant(INF2_IGNOREGTB);
-	export_constant(INF2_ISTOGGLEABLE);
+	export_constant(INF2_TOGGLEABLE);
 
 	/* skill no near npc flags */
 	export_constant(SKILL_NONEAR_WARPPORTAL);

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -8394,6 +8394,7 @@
 	export_constant(INF2_IGNORECICADA);
 	export_constant(INF2_SHOWSCALE);
 	export_constant(INF2_IGNOREGTB);
+	export_constant(INF2_ISTOGGLEABLE);
 
 	/* skill no near npc flags */
 	export_constant(SKILL_NONEAR_WARPPORTAL);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16676,7 +16676,7 @@ bool skill_check_condition_castbegin(struct map_session_data* sd, uint16 skill_i
 		return false;
 
 	//Checks if disabling skill - in which case no SP requirements are necessary
-	if( sc && skill_disable_check(sc,skill_id))
+	if( sc && skill_disable_check(*sc,skill_id))
 		return true;
 
 	std::bitset<INF2_MAX> inf2 = skill_db.find(skill_id)->inf2;
@@ -18015,7 +18015,7 @@ struct s_skill_condition skill_get_requirement(struct map_session_data* sd, uint
 		sc = NULL;
 
 	//Checks if disabling skill - in which case no SP requirements are necessary
-	if( sc && skill_disable_check(sc,skill_id) )
+	if( sc && skill_disable_check(*sc,skill_id) )
 		return req;
 
 	skill_lv = cap_value(skill_lv, 1, MAX_SKILL_LEVEL);
@@ -22899,19 +22899,19 @@ int skill_block_check(struct block_list *bl, sc_type type , uint16 skill_id) {
  * @param skill_id: Skill to toggle
  * @return True on success or false otherwise
  */
-bool skill_disable_check(status_change *sc, uint16 skill_id) {
+bool skill_disable_check(status_change &sc, uint16 skill_id) {
 	std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id);
 
 	if (skill->sc <= SC_NONE || skill->sc >= SC_MAX)
 		return false;
 
 	if (skill->inf2[INF2_ISTOGGLEABLE]) { // HP & SP Consumption Check
-		if (sc->data[skill->sc])
+		if (sc.data[skill->sc])
 			return true;
 		// These 2 skills contain a master and are not correctly pulled using skill_get_sc
-		if (skill->nameid == NC_NEUTRALBARRIER && sc->data[SC_NEUTRALBARRIER_MASTER])
+		if (skill->nameid == NC_NEUTRALBARRIER && sc.data[SC_NEUTRALBARRIER_MASTER])
 			return true;
-		if (skill->nameid == NC_STEALTHFIELD && sc->data[SC_STEALTHFIELD_MASTER])
+		if (skill->nameid == NC_STEALTHFIELD && sc.data[SC_STEALTHFIELD_MASTER])
 			return true;
 	}
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22902,10 +22902,10 @@ int skill_block_check(struct block_list *bl, sc_type type , uint16 skill_id) {
 bool skill_disable_check(status_change &sc, uint16 skill_id) {
 	std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id);
 
-	if (skill->sc <= SC_NONE || skill->sc >= SC_MAX)
+	if (skill == nullptr || skill->sc <= SC_NONE || skill->sc >= SC_MAX)
 		return false;
 
-	if (skill->inf2[INF2_ISTOGGLEABLE]) { // HP & SP Consumption Check
+	if (skill->inf2[INF2_TOGGLEABLE]) {
 		if (sc.data[skill->sc])
 			return true;
 		// These 2 skills contain a master and are not correctly pulled using skill_get_sc

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22893,61 +22893,29 @@ int skill_block_check(struct block_list *bl, sc_type type , uint16 skill_id) {
 	return 0;
 }
 
-/* Determines whether a skill is currently active or not
- * Used for purposes of cancelling SP usage when disabling a skill
+/**
+ * Determines whether a skill is currently active or not. Used for purposes of cancelling HP/SP usage when disabling a skill.
+ * @param sc: Status changes active on target
+ * @param skill_id: Skill to toggle
+ * @return True on success or false otherwise
  */
-int skill_disable_check(struct status_change *sc, uint16 skill_id)
-{
-	enum sc_type type = skill_get_sc(skill_id);
+bool skill_disable_check(status_change *sc, uint16 skill_id) {
+	std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id);
 
-	if (type <= SC_NONE || type >= SC_MAX)
-		return 0;
-	switch( skill_id ) { //HP & SP Consumption Check
-		case BS_MAXIMIZE:
-		case NV_TRICKDEAD:
-		case TF_HIDING:
-		case AS_CLOAKING:
-		case GC_CLOAKINGEXCEED:
-		case ST_CHASEWALK:
-		case CR_DEFENDER:
-		case CR_SHRINK:
-		case CR_AUTOGUARD:
-		case ML_DEFENDER:
-		case ML_AUTOGUARD:
-		case PA_GOSPEL:
-		case GS_GATLINGFEVER:
-		case TK_READYCOUNTER:
-		case TK_READYDOWN:
-		case TK_READYSTORM:
-		case TK_READYTURN:
-		case TK_RUN:
-		case SG_FUSION:
-		case KO_YAMIKUMO:
-		case RA_WUGDASH:
-		case RA_CAMOUFLAGE:
-		case SJ_LUNARSTANCE:
-		case SJ_STARSTANCE:
-		case SJ_UNIVERSESTANCE:
-		case SJ_SUNSTANCE:
-		case SP_SOULCOLLECT:
-		case IG_GUARD_STANCE:
-		case IG_ATTACK_STANCE:
-			if( sc->data[type] )
-				return 1;
-			break;
+	if (skill->sc <= SC_NONE || skill->sc >= SC_MAX)
+		return false;
 
+	if (skill->inf2[INF2_ISTOGGLEABLE]) { // HP & SP Consumption Check
+		if (sc->data[skill->sc])
+			return true;
 		// These 2 skills contain a master and are not correctly pulled using skill_get_sc
-		case NC_NEUTRALBARRIER:
-			if( sc->data[SC_NEUTRALBARRIER_MASTER] )
-				return 1;
-			break;
-		case NC_STEALTHFIELD:
-			if( sc->data[SC_STEALTHFIELD_MASTER] )
-				return 1;
-			break;
+		if (skill->nameid == NC_NEUTRALBARRIER && sc->data[SC_NEUTRALBARRIER_MASTER])
+			return true;
+		if (skill->nameid == NC_STEALTHFIELD && sc->data[SC_STEALTHFIELD_MASTER])
+			return true;
 	}
 
-	return 0;
+	return false;
 }
 
 int skill_get_elemental_type( uint16 skill_id , uint16 skill_lv ) {

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -26,6 +26,7 @@ struct homun_data;
 struct skill_unit;
 struct s_skill_unit_group;
 struct status_change_entry;
+struct status_change;
 
 #define MAX_SKILL_PRODUCE_DB	300 /// Max Produce DB
 #define MAX_PRODUCE_RESOURCE	12 /// Max Produce requirements
@@ -613,7 +614,7 @@ bool skill_check_condition_castend(struct map_session_data *sd, uint16 skill_id,
 int skill_check_condition_char_sub (struct block_list *bl, va_list ap);
 void skill_consume_requirement(struct map_session_data *sd, uint16 skill_id, uint16 skill_lv, short type);
 struct s_skill_condition skill_get_requirement(struct map_session_data *sd, uint16 skill_id, uint16 skill_lv);
-bool skill_disable_check(status_change *sc, uint16 skill_id);
+bool skill_disable_check(status_change &sc, uint16 skill_id);
 bool skill_pos_maxcount_check(struct block_list *src, int16 x, int16 y, uint16 skill_id, uint16 skill_lv, enum bl_type type, bool display_failure);
 
 int skill_check_pc_partner(struct map_session_data *sd, uint16 skill_id, uint16 *skill_lv, int range, int cast_flag);

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -108,6 +108,7 @@ enum e_skill_inf2 : uint8 {
 	INF2_IGNORECICADA, // Skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 	INF2_SHOWSCALE, // Skill shows AoE area while casting
 	INF2_IGNOREGTB, // Skill ignores effect of GTB
+	INF2_ISTOGGLEABLE, // Skill can be toggled on and off (won't consume HP/SP when toggled off)
 	INF2_MAX,
 };
 
@@ -612,7 +613,7 @@ bool skill_check_condition_castend(struct map_session_data *sd, uint16 skill_id,
 int skill_check_condition_char_sub (struct block_list *bl, va_list ap);
 void skill_consume_requirement(struct map_session_data *sd, uint16 skill_id, uint16 skill_lv, short type);
 struct s_skill_condition skill_get_requirement(struct map_session_data *sd, uint16 skill_id, uint16 skill_lv);
-int skill_disable_check(struct status_change *sc, uint16 skill_id);
+bool skill_disable_check(status_change *sc, uint16 skill_id);
 bool skill_pos_maxcount_check(struct block_list *src, int16 x, int16 y, uint16 skill_id, uint16 skill_lv, enum bl_type type, bool display_failure);
 
 int skill_check_pc_partner(struct map_session_data *sd, uint16 skill_id, uint16 *skill_lv, int range, int cast_flag);

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -109,7 +109,7 @@ enum e_skill_inf2 : uint8 {
 	INF2_IGNORECICADA, // Skill is not blocked by SC_UTSUSEMI or SC_BUNSINJYUTSU (physical-skill only)
 	INF2_SHOWSCALE, // Skill shows AoE area while casting
 	INF2_IGNOREGTB, // Skill ignores effect of GTB
-	INF2_ISTOGGLEABLE, // Skill can be toggled on and off (won't consume HP/SP when toggled off)
+	INF2_TOGGLEABLE, // Skill can be toggled on and off (won't consume HP/SP when toggled off)
 	INF2_MAX,
 };
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds the INF2_ISTOGGLEABLE skill flag which is used to enable or disable a skill's status. When toggled off the skill doesn't consume HP/SP.