### PR TITLE
Natural recovery formula and interval behavior

### DIFF
--- a/src/map/elemental.cpp
+++ b/src/map/elemental.cpp
@@ -227,6 +227,7 @@ void elemental_summon_init(s_elemental_data *ed) {
  */
 int elemental_data_received(s_elemental *ele, bool flag) {
 	map_session_data *sd;
+	t_tick tick = gettick();
 
 	if( (sd = map_charid2sd(ele->char_id)) == NULL )
 		return 0;
@@ -259,6 +260,10 @@ int elemental_data_received(s_elemental *ele, bool flag) {
 		unit_calc_pos(&ed->bl, sd->bl.x, sd->bl.y, sd->ud.dir);
 		ed->bl.x = ed->ud.to_x;
 		ed->bl.y = ed->ud.to_y;
+
+		// Ticks need to be initialized before adding bl to map_addiddb
+		ed->regen.tick.hp = tick;
+		ed->regen.tick.sp = tick;
 
 		map_addiddb(&ed->bl);
 		status_calc_elemental(ed,SCO_FIRST);

--- a/src/map/homunculus.cpp
+++ b/src/map/homunculus.cpp
@@ -1081,6 +1081,7 @@ void hom_alloc(struct map_session_data *sd, struct s_homunculus *hom)
 {
 	struct homun_data *hd;
 	int i = 0;
+	t_tick tick = gettick();
 
 	nullpo_retv(sd);
 
@@ -1114,6 +1115,10 @@ void hom_alloc(struct map_session_data *sd, struct s_homunculus *hom)
 	unit_calc_pos(&hd->bl, sd->bl.x, sd->bl.y, sd->ud.dir);
 	hd->bl.x = hd->ud.to_x;
 	hd->bl.y = hd->ud.to_y;
+
+	// Ticks need to be initialized before adding bl to map_addiddb
+	hd->regen.tick.hp = tick;
+	hd->regen.tick.sp = tick;
 
 	map_addiddb(&hd->bl);
 	status_calc_homunculus(hd, SCO_FIRST);

--- a/src/map/mercenary.cpp
+++ b/src/map/mercenary.cpp
@@ -325,6 +325,7 @@ void merc_contract_init(s_mercenary_data *md) {
 bool mercenary_recv_data(s_mercenary *merc, bool flag)
 {
 	map_session_data *sd;
+	t_tick tick = gettick();
 
 	if( (sd = map_charid2sd(merc->char_id)) == NULL )
 		return false;
@@ -358,6 +359,10 @@ bool mercenary_recv_data(s_mercenary *merc, bool flag)
 		unit_calc_pos(&md->bl, sd->bl.x, sd->bl.y, sd->ud.dir);
 		md->bl.x = md->ud.to_x;
 		md->bl.y = md->ud.to_y;
+
+		// Ticks need to be initialized before adding bl to map_addiddb
+		md->regen.tick.hp = tick;
+		md->regen.tick.sp = tick;
 
 		map_addiddb(&md->bl);
 		status_calc_mercenary(md, SCO_FIRST);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1684,6 +1684,9 @@ bool pc_authok(struct map_session_data *sd, uint32 login_id2, time_t expiration_
 	sd->cansendmail_tick = tick;
 	sd->idletime = last_tick;
 
+	sd->regen.tick.hp = tick;
+	sd->regen.tick.sp = tick;
+
 	for(int i = 0; i < MAX_SPIRITBALL; i++)
 		sd->spirit_timer[i] = INVALID_TIMER;
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14342,7 +14342,7 @@ static int status_natural_heal(struct block_list* bl, va_list args)
 		flag &= ~(RGN_SHP|RGN_SSP);
 		if (!regen->state.walk) {
 			flag &= ~RGN_HP;
-			regen->tick.hp = gettick();
+			regen->tick.hp = natural_heal_prev_tick;
 		}
 	}
 
@@ -14371,8 +14371,8 @@ static int status_natural_heal(struct block_list* bl, va_list args)
 		// Our timer system isn't 100% accurate so make sure we use the closest interval
 		rate -= NATURAL_HEAL_INTERVAL / 2;
 
-		if(regen->tick.hp + rate <= gettick()) {
-			regen->tick.hp = gettick();
+		if(regen->tick.hp + rate <= natural_heal_prev_tick) {
+			regen->tick.hp = natural_heal_prev_tick;
 			if (status_heal(bl, regen->hp, 0, 1) < regen->hp)
 				flag &= ~RGN_SHP; // Full.
 		}
@@ -14394,8 +14394,8 @@ static int status_natural_heal(struct block_list* bl, va_list args)
 		// Our timer system isn't 100% accurate so make sure we use the closest interval
 		rate -= NATURAL_HEAL_INTERVAL / 2;
 
-		if(regen->tick.sp + rate <= gettick()) {
-			regen->tick.sp = gettick();
+		if(regen->tick.sp + rate <= natural_heal_prev_tick) {
+			regen->tick.sp = natural_heal_prev_tick;
 			if (status_heal(bl, 0, regen->sp, 1) < regen->sp)
 				flag &= ~RGN_SSP; // full.
 		}
@@ -14453,8 +14453,8 @@ static int status_natural_heal(struct block_list* bl, va_list args)
  */
 static TIMER_FUNC(status_natural_heal_timer){
 	natural_heal_diff_tick = DIFF_TICK(tick,natural_heal_prev_tick);
-	map_foreachregen(status_natural_heal);
 	natural_heal_prev_tick = tick;
+	map_foreachregen(status_natural_heal);
 	return 0;
 }
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14391,7 +14391,7 @@ static int status_natural_heal(struct block_list* bl, va_list args)
 		if(bl->type==BL_HOM)
 			rate /= 2;
 #ifdef RENEWAL
-		if (bl->type == BL_PC && (((TBL_PC*)bl)->class_&MAPID_UPPERMASK) == MAPID_MONK &&
+		if (sd && (sd->class_&MAPID_UPPERMASK) == MAPID_MONK &&
 			sc && sc->data[SC_EXPLOSIONSPIRITS] && (!sc->data[SC_SPIRIT] || sc->data[SC_SPIRIT]->val2 != SL_MONK))
 			rate *= 2; // Tick is doubled in Fury state
 #endif

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3012,7 +3012,8 @@ struct regen_data {
 
 	//tick accumulation before healing.
 	struct {
-		unsigned int hp,sp,shp,ssp;
+		t_tick hp, sp; //time of last natural recovery
+		unsigned int shp,ssp;
 	} tick;
 
 	//Regen rates. n/100


### PR DESCRIPTION
* **Addressed Issue(s)**: #6754 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (fully tested locally in pre-renewal)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
* Fixed HP recovery per tick being 1 too high (after reach 200 HP)
* The interval will now work similar to official servers where it remembers the time of the last recovery and check if the interval has passed since that time
* Fixed walking not resetting the HP recovery timer
* Note: This also works with custom intervals, but you should make sure they are multiples of 4*NATURAL_HEAL_INTERVAL, otherwise it will round to the closest possible interval (you can reduce the timer interval in map.hpp when needed)