### PR TITLE
Updates the status resistances for renewal

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -32628,17 +32628,7 @@ Body:
         Time: 60000
       - Level: 5
         Time: 30000
-    Duration2:
-      - Level: 1
-        Time: 12000
-      - Level: 2
-        Time: 14000
-      - Level: 3
-        Time: 16000
-      - Level: 4
-        Time: 18000
-      - Level: 5
-        Time: 20000
+    Duration2: 30000
     Requires:
       SpCost: 12
     Unit:

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -175,6 +175,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
+    Duration2: 4500
     Requires:
       SpCost:
         - Level: 1
@@ -5101,7 +5102,6 @@ Body:
     Type: Weapon
     Flags:
       IsQuest: true
-    Duration2: 5000
   - Id: 146
     Name: SM_AUTOBERSERK
     Description: Auto Berserk

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -175,7 +175,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2: 4500
+    Duration2: 5000
     Requires:
       SpCost:
         - Level: 1

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -2779,7 +2779,7 @@ Body:
       NoBanishingBuster: true
       Debuff: true
       OverlapFail: true
-    MinDuration: 10000
+    MinDuration: 6000
     Fail:
       Refresh: true
       Inspiration: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -2779,7 +2779,7 @@ Body:
       NoBanishingBuster: true
       Debuff: true
       OverlapFail: true
-    MinDuration: 6000
+    MinDuration: 10000
     Fail:
       Refresh: true
       Inspiration: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -18657,7 +18657,7 @@ Body:
       - Level: 10
         Time: 2000
     AfterCastActDelay: 2000
-    Duration1: 8000
+    Duration1: 18000
     FixedCastTime: 500
     Requires:
       SpCost:
@@ -18704,7 +18704,7 @@ Body:
         Area: 6
       - Level: 5
         Area: 7
-    Duration1: 18000
+    Duration1: 15000
     Cooldown: 10000
     Requires:
       SpCost: 30
@@ -19421,7 +19421,6 @@ Body:
     CastCancel: true
     CastTime: 3000
     AfterCastActDelay: 500
-    Duration1: 13000
     Cooldown: 3000
     FixedCastTime: 1000
     Requires:
@@ -19436,7 +19435,6 @@ Body:
           Amount: 82
         - Level: 5
           Amount: 88
-    Status: Burning
   - Id: 2213
     Name: WL_COMET
     Description: Comet
@@ -23715,11 +23713,11 @@ Body:
         Time: 15000
     Duration2:
       - Level: 1
-        Time: 2000
+        Time: 4000
       - Level: 2
-        Time: 6000
+        Time: 8000
       - Level: 3
-        Time: 10000
+        Time: 12000
     Requires:
       SpCost:
         - Level: 1
@@ -27264,7 +27262,7 @@ Body:
       - Level: 5
         Time: 6000
     AfterCastActDelay: 1000
-    Duration: 18000
+    Duration1: 18000
     Cooldown: 2000
     FixedCastTime:
       - Level: 1
@@ -42854,15 +42852,15 @@ Body:
         Time: 30000
     Duration2:
       - Level: 1
-        Time: 3500
+        Time: 3000
       - Level: 2
-        Time: 5500
+        Time: 6000
       - Level: 3
-        Time: 8500
+        Time: 9000
       - Level: 4
-        Time: 11500
+        Time: 12000
       - Level: 5
-        Time: 14500
+        Time: 15000
     Requires:
       SpCost: 10
     Unit:
@@ -43507,25 +43505,25 @@ Body:
     AfterCastActDelay: 3000
     Duration2:
       - Level: 1
-        Time: 28000
+        Time: 30000
       - Level: 2
-        Time: 33000
+        Time: 35000
       - Level: 3
-        Time: 38000
+        Time: 40000
       - Level: 4
-        Time: 43000
+        Time: 45000
       - Level: 5
-        Time: 48000
+        Time: 50000
       - Level: 6
-        Time: 58000
+        Time: 60000
       - Level: 7
-        Time: 58000
+        Time: 60000
       - Level: 8
-        Time: 58000
+        Time: 60000
       - Level: 9
-        Time: 58000
+        Time: 60000
       - Level: 10
-        Time: 58000
+        Time: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -741,7 +741,7 @@ Body:
       - Level: 10
         Time: 30000
       - Level: 11
-        Time: 33000
+        Time: 30000
     FixedCastTime: 160
     Requires:
       SpCost:
@@ -5947,7 +5947,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Dark
-    Duration2: 18000
+    Duration2: 28000
     Status: Curse
   - Id: 182
     Name: NPC_SLEEPATTACK
@@ -15596,7 +15596,7 @@ Body:
       - Level: 1
         Time: 5000
       - Level: 2
-        Time: 1000
+        Time: 10000
       - Level: 3
         Time: 15000
       - Level: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -175,6 +175,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
+    Duration2: 4500
     Requires:
       SpCost:
         - Level: 1
@@ -720,25 +721,25 @@ Body:
     AfterCastActDelay: 500
     Duration2:
       - Level: 1
-        Time: 5500
+        Time: 2500
       - Level: 2
-        Time: 8500
+        Time: 5500
       - Level: 3
-        Time: 11500
+        Time: 8500
       - Level: 4
-        Time: 14500
+        Time: 11500
       - Level: 5
-        Time: 17500
+        Time: 14500
       - Level: 6
-        Time: 20500
+        Time: 17500
       - Level: 7
-        Time: 23500
+        Time: 20500
       - Level: 8
-        Time: 26500
+        Time: 23500
       - Level: 9
-        Time: 29500
+        Time: 26500
       - Level: 10
-        Time: 32500
+        Time: 29500
       - Level: 11
         Time: 32500
     FixedCastTime: 160
@@ -780,7 +781,7 @@ Body:
     CastCancel: true
     CastTime: 800
     Duration1: 5000
-    Duration2: 20000
+    Duration2: 17000
     FixedCastTime: 200
     Requires:
       SpCost:
@@ -2022,7 +2023,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 12
     Status: Poison
@@ -2617,7 +2618,7 @@ Body:
     HitCount: 1
     CastCancel: true
     AfterCastActDelay: 2000
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 5
     Status: Blind
@@ -2732,25 +2733,25 @@ Body:
     AfterCastActDelay: 3000
     Duration2:
       - Level: 1
-        Time: 30000
+        Time: 28000
       - Level: 2
-        Time: 35000
+        Time: 33000
       - Level: 3
-        Time: 40000
+        Time: 38000
       - Level: 4
-        Time: 45000
+        Time: 43000
       - Level: 5
-        Time: 50000
+        Time: 48000
       - Level: 6
-        Time: 60000
+        Time: 58000
       - Level: 7
-        Time: 60000
+        Time: 58000
       - Level: 8
-        Time: 60000
+        Time: 58000
       - Level: 9
-        Time: 60000
+        Time: 58000
       - Level: 10
-        Time: 60000
+        Time: 58000
     Requires:
       SpCost:
         - Level: 1
@@ -3217,7 +3218,7 @@ Body:
         Time: 6000
       - Level: 10
         Time: 7000
-    Duration2: 5000
+    Duration2: 4500
     Cooldown: 7000
     FixedCastTime:
       - Level: 1
@@ -3432,7 +3433,7 @@ Body:
         Time: 4500
     AfterCastActDelay: 1000
     Duration1: 1000
-    Duration2: 20000
+    Duration2: 18000
     Cooldown: 5000
     FixedCastTime:
       - Level: 1
@@ -3664,25 +3665,25 @@ Body:
     AfterCastActDelay: 200
     Duration2:
       - Level: 1
-        Time: 4000
+        Time: 1000
       - Level: 2
-        Time: 5500
+        Time: 2500
       - Level: 3
-        Time: 7000
+        Time: 4000
       - Level: 4
-        Time: 8500
+        Time: 5500
       - Level: 5
-        Time: 10000
+        Time: 7000
       - Level: 6
-        Time: 11500
+        Time: 8500
       - Level: 7
-        Time: 13000
+        Time: 10000
       - Level: 8
-        Time: 14500
+        Time: 11500
       - Level: 9
-        Time: 16000
+        Time: 13000
       - Level: 10
-        Time: 17500
+        Time: 14500
     FixedCastTime:
       - Level: 1
         Time: 160
@@ -3768,7 +3769,7 @@ Body:
         Time: 6300
     AfterCastActDelay: 1000
     Duration1: 4500
-    Duration2: 30000
+    Duration2: 27000
     Cooldown: 6000
     FixedCastTime:
       - Level: 1
@@ -4161,7 +4162,7 @@ Body:
         Area: 2
       - Level: 6
         Area: 12
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       SpCost: 10
       Weapon:
@@ -4428,7 +4429,7 @@ Body:
         Time: 80000
       - Level: 5
         Time: 40000
-    Duration2: 5000
+    Duration2: 4500
     FixedCastTime: 300
     Requires:
       SpCost: 10
@@ -4571,7 +4572,7 @@ Body:
         Time: 60000
       - Level: 5
         Time: 30000
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 12
       ItemCost:
@@ -4616,7 +4617,7 @@ Body:
         Time: 60000
       - Level: 5
         Time: 30000
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 12
       ItemCost:
@@ -4669,15 +4670,15 @@ Body:
         Time: 30000
     Duration2:
       - Level: 1
-        Time: 5500
+        Time: 2500
       - Level: 2
-        Time: 8500
+        Time: 5500
       - Level: 3
-        Time: 11500
+        Time: 8500
       - Level: 4
-        Time: 14500
+        Time: 11500
       - Level: 5
-        Time: 17500
+        Time: 14500
     Requires:
       SpCost: 10
       ItemCost:
@@ -5013,7 +5014,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -8
     Element: Weapon
-    Duration2: 5000
+    Duration2: 4500
     Cooldown: 1000
     CastDelayFlags:
       IgnoreStatus: true
@@ -5219,7 +5220,7 @@ Body:
         Time: 45000
       - Level: 10
         Time: 50000
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 20
       ItemCost:
@@ -5364,7 +5365,6 @@ Body:
     Type: Weapon
     Flags:
       IsQuest: true
-    Duration2: 5000
   - Id: 146
     Name: SM_AUTOBERSERK
     Description: Auto Berserk
@@ -5433,7 +5433,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Earth
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost: 9
     Status: Blind
@@ -5468,7 +5468,6 @@ Body:
     Requires:
       SpCost: 2
       State: Recover_Weight_Rate
-    Status: Stun
   - Id: 152
     Name: TF_THROWSTONE
     Description: Stone Fling
@@ -5487,7 +5486,7 @@ Body:
         Plagiarism: true
         Reproduce: true
     AfterCastActDelay: 100
-    Duration1: 5000
+    Duration1: 4500
     Duration2: 20000
     Requires:
       SpCost: 2
@@ -5878,7 +5877,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
+    Duration2: 18000
     Status: Poison
   - Id: 177
     Name: NPC_BLINDATTACK
@@ -5892,7 +5891,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
+    Duration2: 18000
     Status: Blind
   - Id: 178
     Name: NPC_SILENCEATTACK
@@ -5906,7 +5905,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
+    Duration2: 18000
     Status: Silence
   - Id: 179
     Name: NPC_STUNATTACK
@@ -5920,7 +5919,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 5000
+    Duration2: 4500
     Status: Stun
   - Id: 180
     Name: NPC_PETRIFYATTACK
@@ -5934,7 +5933,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
+    Duration2: 17000
     Status: Stone
   - Id: 181
     Name: NPC_CURSEATTACK
@@ -5948,7 +5947,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Dark
-    Duration2: 30000
+    Duration2: 18000
     Status: Curse
   - Id: 182
     Name: NPC_SLEEPATTACK
@@ -5962,7 +5961,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 30000
+    Duration2: 18000
     Status: Sleep
   - Id: 183
     Name: NPC_RANDOMATTACK
@@ -6320,7 +6319,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 5000
+    Duration2: 4500
     Status: Stun
   - Id: 207
     Name: NPC_HALLUCINATION
@@ -6393,7 +6392,7 @@ Body:
         Plagiarism: true
         Reproduce: true
     AfterCastActDelay: 500
-    Duration1: 5000
+    Duration1: 4500
     Cooldown: 500
     Requires:
       SpCost: 16
@@ -6841,7 +6840,7 @@ Body:
         Time: 12
       - Level: 5
         Time: 13
-    Duration2: 120000
+    Duration2: 108000
     FixedCastTime: 500
     Requires:
       SpCost: 15
@@ -7184,7 +7183,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       SpCost: 10
       State: Shield
@@ -7267,7 +7266,7 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2: 20000
+    Duration2: 18000
     Requires:
       SpCost:
         - Level: 1
@@ -7313,7 +7312,7 @@ Body:
     AfterCastActDelay: 500
     AfterCastWalkDelay: 1000
     Duration1: 950
-    Duration2: 20000
+    Duration2: 18000
     Cooldown: 1000
     FixedCastTime: 500
     Requires:
@@ -8953,7 +8952,7 @@ Body:
     HitCount: 1
     SplashArea: -1
     AfterCastActDelay: 300
-    Duration2: 30000
+    Duration2: 27000
     Cooldown: 4000
     Requires:
       SpCost:
@@ -9210,7 +9209,7 @@ Body:
     HitCount: 1
     SplashArea: -1
     AfterCastActDelay: 300
-    Duration2: 5000
+    Duration2: 4500
     Cooldown: 4000
     Requires:
       SpCost:
@@ -9517,7 +9516,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -2
     Element: Dark
-    Duration2: 20000
+    Duration2: 18000
     Status: Blind
   - Id: 339
     Name: NPC_GRANDDARKNESS
@@ -9536,7 +9535,7 @@ Body:
     HitCount: 1
     Element: Dark
     AfterCastWalkDelay: 1000
-    Duration1: 20000
+    Duration1: 18000
     Unit:
       Id: Dummyskill
       Layout: -1
@@ -10511,15 +10510,15 @@ Body:
         Time: 120000
     Duration2:
       - Level: 1
-        Time: 20000
+        Time: 18000
       - Level: 2
-        Time: 30000
+        Time: 28000
       - Level: 3
-        Time: 40000
+        Time: 46000
       - Level: 4
-        Time: 50000
+        Time: 48000
       - Level: 5
-        Time: 60000
+        Time: 58000
     Cooldown: 2000
     Requires:
       SpCost:
@@ -11187,7 +11186,7 @@ Body:
     HitCount: 1
     Element: Weapon
     AfterCastActDelay: 500
-    Duration2: 120000
+    Duration2: 108000
     Requires:
       SpCost: 23
     Status: Bleeding
@@ -11267,7 +11266,7 @@ Body:
     CastCancel: true
     CastTime: 800
     AfterCastActDelay: 500
-    Duration2: 20000
+    Duration2: 18000
     Cooldown: 1000
     FixedCastTime: 200
     Requires:
@@ -11680,7 +11679,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -3
     Element: Weapon
-    Duration2: 3000
+    Duration2: 2500
     Requires:
       SpCost:
         - Level: 1
@@ -13051,7 +13050,7 @@ Body:
     Element: Endowed
     CastTime: 80
     AfterCastActDelay: 500
-    Duration1: 2000
+    Duration1: 1500
     FixedCastTime: 20
     Requires:
       SpCost:
@@ -13573,7 +13572,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       SpCost: 15
       ZenyCost:
@@ -14153,7 +14152,7 @@ Body:
     HitCount: 1
     Element: Weapon
     AfterCastActDelay: 1000
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       SpCost: 10
       Ammo:
@@ -14301,7 +14300,7 @@ Body:
     Element: Weapon
     CastTime: 1200
     AfterCastActDelay: 500
-    Duration2: 120000
+    Duration2: 108000
     FixedCastTime: 300
     Requires:
       SpCost:
@@ -15595,15 +15594,15 @@ Body:
     Duration1: 100
     Duration2:
       - Level: 1
-        Time: 7500
+        Time: 4500
       - Level: 2
-        Time: 12500
+        Time: 9500
       - Level: 3
-        Time: 17500
+        Time: 14500
       - Level: 4
-        Time: 22500
+        Time: 19500
       - Level: 5
-        Time: 27500
+        Time: 24500
     Cooldown: 300
     FixedCastTime: 800
     Requires:
@@ -16083,7 +16082,7 @@ Body:
     Element: Water
     SplashArea: 3
     ActiveInstance: 14
-    Duration2: 30000
+    Duration2: 27000
     Status: Freeze
   - Id: 656
     Name: NPC_THUNDERBREATH
@@ -16113,7 +16112,7 @@ Body:
     Element: Poison
     SplashArea: 3
     ActiveInstance: 14
-    Duration2: 20000
+    Duration2: 18000
     Status: Poison
   - Id: 658
     Name: NPC_DARKNESSBREATH
@@ -16174,7 +16173,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 120000
+    Duration2: 108000
     Status: Bleeding
   - Id: 661
     Name: NPC_PULSESTRIKE
@@ -16192,7 +16191,6 @@ Body:
     HitCount: 1
     SplashArea: 7
     Knockback: 7
-    Status: Bleeding
   - Id: 662
     Name: NPC_HELLJUDGEMENT
     Description: Hell's Judgement
@@ -16208,7 +16206,7 @@ Body:
     Hit: Single
     HitCount: 1
     SplashArea: 14
-    Duration2: 20000
+    Duration2: 18000
     Status: Curse
   - Id: 663
     Name: NPC_WIDESILENCE
@@ -16234,7 +16232,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 20000
+    Duration2: 18000
     Status: Silence
   - Id: 664
     Name: NPC_WIDEFREEZE
@@ -16260,7 +16258,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 30000
+    Duration2: 27000
     Status: Freeze
   - Id: 665
     Name: NPC_WIDEBLEEDING
@@ -16286,7 +16284,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 120000
+    Duration2: 108000
     Status: Bleeding
   - Id: 666
     Name: NPC_WIDESTONE
@@ -16312,7 +16310,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 20000
+    Duration2: 17000
     Status: Stone
   - Id: 667
     Name: NPC_WIDECONFUSE
@@ -16338,7 +16336,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 30000
+    Duration2: 28000
     Status: Confusion
   - Id: 668
     Name: NPC_WIDESLEEP
@@ -16364,7 +16362,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 30000
+    Duration2: 18000
     Status: Sleep
   - Id: 669
     Name: NPC_WIDESIGHT
@@ -16423,7 +16421,7 @@ Body:
         Time: 11900
       - Level: 10
         Time: 12900
-    Duration2: 20000
+    Duration2: 18000
     Unit:
       Id: Evilland
       Layout: 1
@@ -16631,7 +16629,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 20000
+    Duration2: 18000
     Status: Curse
   - Id: 678
     Name: NPC_WIDESTUN
@@ -16657,7 +16655,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 5000
+    Duration2: 4500
     Status: Stun
   - Id: 679
     Name: NPC_VAMPIRE_GIFT
@@ -17039,6 +17037,7 @@ Body:
     Range: 11
     Hit: Multi_Hit
     HitCount: -20
+    Duration1: 18000
     SplashArea: 9
     Knockback: 2
     CastCancel: true
@@ -17251,15 +17250,15 @@ Body:
         Area: 9
     Duration1:
       - Level: 1
-        Time: 12500
+        Time: 9500
       - Level: 2
-        Time: 17500
+        Time: 14500
       - Level: 3
-        Time: 22500
+        Time: 19500
       - Level: 4
-        Time: 27500
+        Time: 24500
       - Level: 5
-        Time: 32500
+        Time: 29500
     Status: Freeze
   - Id: 721
     Name: NPC_WIDEWEB
@@ -17308,7 +17307,7 @@ Body:
     HitCount: 1
     Element: Water
     Duration1: 4500
-    Duration2: 30000
+    Duration2: 27000
     Unit:
       Id: Dummyskill
       Layout: 5
@@ -17575,7 +17574,7 @@ Body:
     Element: Fire
     SplashArea: 3
     ActiveInstance: 3
-    Duration1: 3000
+    Duration1: 2500
     Unit:
       Id: Magma_Eruption
       Range: 3
@@ -18240,7 +18239,7 @@ Body:
     SplashArea: 1
     Knockback: 5
     AfterCastActDelay: 2000
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       HpCost: 200
       SpCost: 40
@@ -18566,7 +18565,6 @@ Body:
         2hSword: true
         1hSpear: true
         2hSpear: true
-    Status: Fear
   - Id: 2006
     Name: RK_IGNITIONBREAK
     Description: Ignition Break
@@ -18659,7 +18657,7 @@ Body:
       - Level: 10
         Time: 2000
     AfterCastActDelay: 2000
-    Duration1: 10000
+    Duration1: 8000
     FixedCastTime: 500
     Requires:
       SpCost:
@@ -18706,7 +18704,7 @@ Body:
         Area: 6
       - Level: 5
         Area: 7
-    Duration1: 15000
+    Duration1: 18000
     Cooldown: 10000
     Requires:
       SpCost: 30
@@ -18933,7 +18931,7 @@ Body:
         Time: 12000
       - Level: 5
         Time: 14000
-    Duration2: 15000
+    Duration2: 18000
     Cooldown: 4000
     Requires:
       SpCost:
@@ -19234,15 +19232,15 @@ Body:
     AfterCastActDelay: 2000
     Duration1:
       - Level: 1
-        Time: 10000
+        Time: 7000
       - Level: 2
-        Time: 12000
+        Time: 9000
       - Level: 3
-        Time: 14000
+        Time: 11000
       - Level: 4
-        Time: 16000
+        Time: 13000
       - Level: 5
-        Time: 18000
+        Time: 15000
     Requires:
       SpCost:
         - Level: 1
@@ -19376,7 +19374,7 @@ Body:
     CastCancel: true
     CastTime: 5000
     AfterCastActDelay: 500
-    Duration1: 5000
+    Duration1: 4500
     Cooldown: 5000
     FixedCastTime: 1000
     Requires:
@@ -19423,7 +19421,7 @@ Body:
     CastCancel: true
     CastTime: 3000
     AfterCastActDelay: 500
-    Duration1: 15000
+    Duration1: 13000
     Cooldown: 3000
     FixedCastTime: 1000
     Requires:
@@ -21913,7 +21911,7 @@ Body:
       Skill:
         Reproduce: true
     Duration1: 15000
-    Duration2: 15000
+    Duration2: 13000
     Requires:
       SpCost: 10
       ItemCost:
@@ -23717,11 +23715,11 @@ Body:
         Time: 15000
     Duration2:
       - Level: 1
-        Time: 4000
+        Time: 2000
       - Level: 2
-        Time: 8000
+        Time: 6000
       - Level: 3
-        Time: 12000
+        Time: 10000
     Requires:
       SpCost:
         - Level: 1
@@ -24640,7 +24638,7 @@ Body:
     CopyFlags:
       Skill:
         Reproduce: true
-    Duration1: 5000
+    Duration1: 4500
     Requires:
       SpCost:
         - Level: 1
@@ -24734,7 +24732,7 @@ Body:
         Time: 3000
       - Level: 5
         Time: 3000
-    Duration2: 5000
+    Duration2: 4500
     Cooldown: 3000
     Requires:
       SpCost:
@@ -27266,6 +27264,7 @@ Body:
       - Level: 5
         Time: 6000
     AfterCastActDelay: 1000
+    Duration: 18000
     Cooldown: 2000
     FixedCastTime:
       - Level: 1
@@ -29227,7 +29226,7 @@ Body:
     Element: Weapon
     CastTime: 1000
     AfterCastActDelay: 1000
-    Duration1: 120000
+    Duration1: 108000
     Cooldown: 2000
     FixedCastTime: 2000
     Requires:
@@ -29971,7 +29970,7 @@ Body:
       - Level: 5
         Time: 9000
     AfterCastActDelay: 1000
-    Duration2: 2000
+    Duration2: 1500
     Cooldown: 5000
     FixedCastTime: 1000
     Requires:
@@ -30051,7 +30050,6 @@ Body:
       Weapon:
         Rifle: true
       SpiritSphereCost: -1
-    Status: Stun
   - Id: 2572
     Name: RL_R_TRIP_PLUSATK
     Description: Round Trip Plus Attack
@@ -30118,7 +30116,7 @@ Body:
     Element: Weapon
     SplashArea: 3
     CastCancel: true
-    Duration1: 20000
+    Duration1: 18000
     Cooldown: 1000
     Requires:
       SpCost:
@@ -30276,7 +30274,7 @@ Body:
     SplashArea: 3
     CastCancel: true
     AfterCastActDelay: 1000
-    Duration1: 7000
+    Duration1: 5000
     Cooldown: 10000
     FixedCastTime: 1000
     Requires:
@@ -31900,15 +31898,15 @@ Body:
     AfterCastActDelay: 1000
     Duration1:
       - Level: 1
-        Time: 8000
+        Time: 6000
       - Level: 2
-        Time: 10000
+        Time: 8000
       - Level: 3
-        Time: 12000
+        Time: 10000
       - Level: 4
-        Time: 14000
+        Time: 12000
       - Level: 5
-        Time: 16000
+        Time: 14000
     Cooldown: 10000
     Requires:
       SpCost:
@@ -32690,7 +32688,7 @@ Body:
     CastTime: 1000
     AfterCastActDelay: 500
     Duration1: 5000
-    Duration2: 5000
+    Duration2: 4500
     Cooldown:
       - Level: 1
         Time: 10000
@@ -33021,7 +33019,7 @@ Body:
     Range: 1
     Hit: Single
     HitCount: 1
-    Duration2: 20000
+    Duration2: 18000
     Status: Burning
   - Id: 5018
     Name: SU_BASIC_SKILL
@@ -33073,7 +33071,7 @@ Body:
     SplashArea: 1
     CastCancel: true
     AfterCastActDelay: 1000
-    Duration2: 120000
+    Duration2: 108000
     Cooldown:
       - Level: 1
         Time: 3000
@@ -33165,7 +33163,7 @@ Body:
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 1000
-    Duration2: 120000
+    Duration2: 108000
     Requires:
       SpCost: 40
     Status: Bleeding
@@ -33264,7 +33262,7 @@ Body:
         Time: 3000
       - Level: 5
         Time: 3500
-    Duration2: 20000
+    Duration2: 18000
     Cooldown: 5000
     FixedCastTime: 3000
     Requires:
@@ -33484,7 +33482,7 @@ Body:
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 1000
-    Duration2: 5000
+    Duration2: 4500
     Cooldown: 6000
     Requires:
       SpCost:
@@ -41723,7 +41721,7 @@ Body:
         Size: 9
     Hit: Single
     HitCount: 1
-    Duration1: 5000
+    Duration1: 4500
     FixedCastTime: 500
     Requires:
       SpCost:
@@ -42761,7 +42759,7 @@ Body:
         Time: 80000
       - Level: 5
         Time: 40000
-    Duration2: 5000
+    Duration2: 4500
     Requires:
       SpCost: 10
     Unit:
@@ -42803,15 +42801,15 @@ Body:
         Time: 30000
     Duration2:
       - Level: 1
-        Time: 12000
+        Time: 10000
       - Level: 2
-        Time: 14000
+        Time: 12000
       - Level: 3
-        Time: 16000
+        Time: 14000
       - Level: 4
-        Time: 18000
+        Time: 16000
       - Level: 5
-        Time: 20000
+        Time: 18000
     Requires:
       SpCost: 12
     Unit:
@@ -42856,15 +42854,15 @@ Body:
         Time: 30000
     Duration2:
       - Level: 1
-        Time: 5500
+        Time: 3500
       - Level: 2
-        Time: 8500
+        Time: 5500
       - Level: 3
-        Time: 11500
+        Time: 8500
       - Level: 4
-        Time: 14500
+        Time: 11500
       - Level: 5
-        Time: 17500
+        Time: 14500
     Requires:
       SpCost: 10
     Unit:
@@ -43264,7 +43262,7 @@ Body:
     Element: Weapon
     CastTime: 1000
     AfterCastActDelay: 2000
-    Duration2: 5000
+    Duration2: 4500
     CastTimeFlags:
       IgnoreDex: true
       IgnoreStatus: true
@@ -43509,25 +43507,25 @@ Body:
     AfterCastActDelay: 3000
     Duration2:
       - Level: 1
-        Time: 30000
+        Time: 28000
       - Level: 2
-        Time: 35000
+        Time: 33000
       - Level: 3
-        Time: 40000
+        Time: 38000
       - Level: 4
-        Time: 45000
+        Time: 43000
       - Level: 5
-        Time: 50000
+        Time: 48000
       - Level: 6
-        Time: 60000
+        Time: 58000
       - Level: 7
-        Time: 60000
+        Time: 58000
       - Level: 8
-        Time: 60000
+        Time: 58000
       - Level: 9
-        Time: 60000
+        Time: 58000
       - Level: 10
-        Time: 60000
+        Time: 58000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -42797,17 +42797,7 @@ Body:
         Time: 60000
       - Level: 5
         Time: 30000
-    Duration2:
-      - Level: 1
-        Time: 10000
-      - Level: 2
-        Time: 12000
-      - Level: 3
-        Time: 14000
-      - Level: 4
-        Time: 16000
-      - Level: 5
-        Time: 18000
+    Duration2: 18000
     Requires:
       SpCost: 12
     Unit:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -721,27 +721,27 @@ Body:
     AfterCastActDelay: 500
     Duration2:
       - Level: 1
-        Time: 2500
+        Time: 3000
       - Level: 2
-        Time: 5500
+        Time: 6000
       - Level: 3
-        Time: 8500
+        Time: 9000
       - Level: 4
-        Time: 11500
+        Time: 12000
       - Level: 5
-        Time: 14500
+        Time: 15000
       - Level: 6
-        Time: 17500
+        Time: 18000
       - Level: 7
-        Time: 20500
+        Time: 21000
       - Level: 8
-        Time: 23500
+        Time: 24000
       - Level: 9
-        Time: 26500
+        Time: 27000
       - Level: 10
-        Time: 29500
+        Time: 30000
       - Level: 11
-        Time: 32500
+        Time: 33000
     FixedCastTime: 160
     Requires:
       SpCost:
@@ -2733,25 +2733,25 @@ Body:
     AfterCastActDelay: 3000
     Duration2:
       - Level: 1
-        Time: 28000
+        Time: 30000
       - Level: 2
-        Time: 33000
+        Time: 35000
       - Level: 3
-        Time: 38000
+        Time: 40000
       - Level: 4
-        Time: 43000
+        Time: 45000
       - Level: 5
-        Time: 48000
+        Time: 50000
       - Level: 6
-        Time: 58000
+        Time: 60000
       - Level: 7
-        Time: 58000
+        Time: 60000
       - Level: 8
-        Time: 58000
+        Time: 60000
       - Level: 9
-        Time: 58000
+        Time: 60000
       - Level: 10
-        Time: 58000
+        Time: 60000
     Requires:
       SpCost:
         - Level: 1
@@ -3665,25 +3665,25 @@ Body:
     AfterCastActDelay: 200
     Duration2:
       - Level: 1
-        Time: 1000
+        Time: 1500
       - Level: 2
-        Time: 2500
+        Time: 3000
       - Level: 3
-        Time: 4000
+        Time: 4500
       - Level: 4
-        Time: 5500
+        Time: 6000
       - Level: 5
-        Time: 7000
+        Time: 7500
       - Level: 6
-        Time: 8500
+        Time: 9000
       - Level: 7
-        Time: 10000
+        Time: 10500
       - Level: 8
-        Time: 11500
+        Time: 12000
       - Level: 9
-        Time: 13000
+        Time: 13500
       - Level: 10
-        Time: 14500
+        Time: 15000
     FixedCastTime:
       - Level: 1
         Time: 160
@@ -4670,15 +4670,15 @@ Body:
         Time: 30000
     Duration2:
       - Level: 1
-        Time: 2500
+        Time: 3000
       - Level: 2
-        Time: 5500
+        Time: 6000
       - Level: 3
-        Time: 8500
+        Time: 9000
       - Level: 4
-        Time: 11500
+        Time: 12000
       - Level: 5
-        Time: 14500
+        Time: 15000
     Requires:
       SpCost: 10
       ItemCost:
@@ -10510,15 +10510,15 @@ Body:
         Time: 120000
     Duration2:
       - Level: 1
-        Time: 18000
+        Time: 20000
       - Level: 2
-        Time: 28000
+        Time: 30000
       - Level: 3
-        Time: 46000
+        Time: 40000
       - Level: 4
-        Time: 48000
+        Time: 50000
       - Level: 5
-        Time: 58000
+        Time: 60000
     Cooldown: 2000
     Requires:
       SpCost:
@@ -15594,15 +15594,15 @@ Body:
     Duration1: 100
     Duration2:
       - Level: 1
-        Time: 4500
+        Time: 5000
       - Level: 2
-        Time: 9500
+        Time: 1000
       - Level: 3
-        Time: 14500
+        Time: 15000
       - Level: 4
-        Time: 19500
+        Time: 20000
       - Level: 5
-        Time: 24500
+        Time: 25000
     Cooldown: 300
     FixedCastTime: 800
     Requires:
@@ -16336,7 +16336,7 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 28000
+    Duration2: 18000
     Status: Confusion
   - Id: 668
     Name: NPC_WIDESLEEP
@@ -17250,15 +17250,15 @@ Body:
         Area: 9
     Duration1:
       - Level: 1
-        Time: 9500
+        Time: 10000
       - Level: 2
-        Time: 14500
+        Time: 15000
       - Level: 3
-        Time: 19500
+        Time: 20000
       - Level: 4
-        Time: 24500
+        Time: 25000
       - Level: 5
-        Time: 29500
+        Time: 30000
     Status: Freeze
   - Id: 721
     Name: NPC_WIDEWEB

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -2889,7 +2889,7 @@ Body:
       Debuff: true
       OverlapFail: true
       SpreadEffect: true
-    MinDuration: 6000
+    MinDuration: 10000
     Fail:
       Refresh: true
       Inspiration: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -2871,6 +2871,7 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
+      Imprison: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -2871,7 +2871,7 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
-      Imprison: true
+      Whiteimprison: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -148,7 +148,7 @@ Body:
       Refresh: true
       Inspiration: true
   - Status: Curse
-    DurationLookup: NPC_CURSEATTACK
+    DurationLookup: NPC_WIDECURSE
     CalcFlags:
       Luk: true
       Batk: true

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1399,7 +1399,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		if( sd && skill_lv > 5 && pc_checkskill(sd,SM_FATALBLOW)>0 ){
 			//BaseChance gets multiplied with BaseLevel/50.0; 500/50 simplifies to 10 [Playtester]
 			status_change_start(src,bl,SC_STUN,(skill_lv-5)*sd->status.base_level*10,
-				skill_lv,0,0,0,skill_get_time2(SM_FATALBLOW,skill_lv),SCSTART_NONE);
+				skill_lv,0,0,0,skill_get_time2(skill_id,skill_lv),SCSTART_NONE);
 		}
 		break;
 
@@ -14979,7 +14979,7 @@ static int skill_unit_onplace(struct skill_unit *unit, struct block_list *bl, t_
 			break;
 
 		case UNT_CHAOSPANIC:
-			status_change_start(ss, bl, type, 3500 + (sg->skill_lv * 1500), sg->skill_lv, 0, 0, 1, sg->skill_lv * 4000, SCSTART_NOAVOID|SCSTART_NORATEDEF|SCSTART_NOTICKDEF);
+			status_change_start(ss, bl, type, 3500 + (sg->skill_lv * 1500), sg->skill_lv, 0, 0, 1, skill_get_time2(sg->skill_id, sg->skill_lv), SCSTART_NOAVOID|SCSTART_NORATEDEF|SCSTART_NOTICKDEF);
 			break;
 
 		case UNT_WARP_WAITING: {
@@ -15924,7 +15924,7 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 		case UNT_CHAOSPANIC:
 			if (tsc && tsc->data[type])
 				break;
-			status_change_start(ss, bl, type, 3500 + (sg->skill_lv * 1500), sg->skill_lv, 0, 0, 1, sg->skill_lv * 4000, SCSTART_NOAVOID|SCSTART_NORATEDEF|SCSTART_NOTICKDEF);
+			status_change_start(ss, bl, type, 3500 + (sg->skill_lv * 1500), sg->skill_lv, 0, 0, 1, skill_get_time2(sg->skill_id, sg->skill_lv), SCSTART_NOAVOID|SCSTART_NORATEDEF|SCSTART_NOTICKDEF);
 			break;
 
 		case UNT_B_TRAP:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8726,7 +8726,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	sc = status_get_sc(bl);
 	if( sc && !sc->count )
 		sc = NULL;
-levelDiff
+
 #ifdef RENEWAL
 	uint16 levelDiff = max(0, status_get_lv(src) - status_get_lv(bl));
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8726,12 +8726,18 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	sc = status_get_sc(bl);
 	if( sc && !sc->count )
 		sc = NULL;
+levelDiff
+#ifdef RENEWAL
+	uint16 levelDiff = max(0, status_get_lv(src) - status_get_lv(bl));
+
+	levelDiff = (levelDiff * levelDiff / 5) * 100;
+#endif
 
 	switch (type) {
 		case SC_POISON:
 		case SC_DPOISON:
-			sc_def = status->vit*100;
 #ifndef RENEWAL
+			sc_def = status->vit*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			if (sd) {
 				// For players: 60000 - 450*vit - 100*luk
@@ -8742,54 +8748,73 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 				tick>>=1;
 				tick_def = (status->vit*200)/3;
 			}
+#else
+			sc_def = status->vit * 100 - levelDiff;
+			tick_def2 = -2000;
 #endif
 			break;
 		case SC_STUN:
+#ifndef RENEWAL
 			sc_def = status->vit*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->vit * 100 - levelDiff;
+			tick_def2 = -500;
+#endif
 			break;
 		case SC_SILENCE:
 #ifndef RENEWAL
 			sc_def = status->vit*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#else
-			sc_def = status->int_*100;
-			sc_def2 = (status->vit + status->luk) * 5 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#endif
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->int_ * 100 - levelDiff;
+			tick_def2 = -2000;
+#endif
 			break;
 		case SC_BLEEDING:
 #ifndef RENEWAL
 			sc_def = status->vit*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#else
-			sc_def = status->agi*100;
-			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#endif
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->agi * 100 - levelDiff;
+			tick_def2 = -12000;
+#endif
 			break;
 		case SC_SLEEP:
 #ifndef RENEWAL
 			sc_def = status->int_*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#else
-			sc_def = status->agi*100;
-			sc_def2 = (status->int_ + status->luk) * 5 + status_get_lv(bl)*10 - status_get_lv(src)*10;
-#endif
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->agi * 100 - levelDiff;
+			tick_def2 = -2000;
+#endif
 			break;
 		case SC_STONE:
+#ifndef RENEWAL
 			sc_def = status->mdef*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
+#else
+			sc_def = status->mdef * 100 - levelDiff;
+			tick_def2 = -3000;
+#endif
 			tick_def = 0; // No duration reduction
 			break;
 		case SC_FREEZE:
+#ifndef RENEWAL
 			sc_def = status->mdef*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status_src->luk*-10; // Caster can increase final duration with luk
+#else
+			sc_def = status->mdef * 100 - levelDiff;
+			tick_def2 = -3000;
+#endif
 			break;
 		case SC_CURSE:
+#ifndef RENEWAL
 			// Special property: immunity when luk is zero
 			if (status->luk == 0)
 				return 0;
@@ -8797,16 +8822,31 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 - status_get_lv(src)*10; // Curse only has a level penalty and no resistance
 			tick_def = status->vit*100;
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->luk * 100 - levelDiff;
+			tick_def2 = -2000;
+#endif
 			break;
 		case SC_BLIND:
+#ifndef RENEWAL
 			sc_def = (status->vit + status->int_)*50;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->int_ * 100 - levelDiff;
+			tick_def2 = -2000;
+#endif
 			break;
 		case SC_CONFUSION:
+#ifndef RENEWAL
 			sc_def = (status->str + status->int_)*50;
 			sc_def2 = status_get_lv(src)*10 - status_get_lv(bl)*10 - status->luk*10; // Reversed sc_def2
 			tick_def2 = status->luk*10;
+#else
+			sc_def = status->luk * 100 - levelDiff;
+			tick_def2 = -2000;
+
+#endif
 			break;
 		case SC_DECREASEAGI:
 			if (sd)
@@ -8823,7 +8863,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def2 = (status->luk * 50 + status->agi * 200) / 2; // (50 * LUK / 100 + 20 * AGI / 100) / 2
 			break;
 		case SC_DEEPSLEEP:
-			tick_def2 = status_get_base_status(bl)->int_ * 25 + status_get_lv(bl) * 50;
+			tick_def2 = max(0, status_get_base_status(bl)->int_ * 25 + status_get_lv(bl) * 50);
 			break;
 		case SC_NETHERWORLD:
 			// Resistance: {(Target's Base Level / 50) + (Target's Job Level / 10)} seconds
@@ -8838,17 +8878,20 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def2 = (status->vit + status->dex) * 50;
 			break;
 		case SC_WHITEIMPRISON:
-			if( tick == 5000 ) // 100% on caster
+			if( src == bl ) // 100% on caster
 				break;
-			if( bl->type == BL_PC )
-				tick_def2 = status_get_lv(bl)*20 + status->vit*25 + status->agi*10;
-			else
-				tick_def2 = (status->vit + status->luk)*50;
+			sc_def = status->str * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			tick_def2 = -2000;
+			break;
+		case SC_FEAR:
+			sc_def = status->int_ * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			tick_def2 = -2000;
 			break;
 		case SC_BURNING:
-			tick_def2 = 75*status->luk + 125*status->agi;
+			sc_def = status->agi * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			tick_def2 = -2000;
 			break;
-		case SC_FREEZING:
+		case SC_FREEZING: // TODO: Confirm
 			tick_def2 = (status->vit + status->dex)*50;
 			break;
 		case SC_OBLIVIONCURSE: // 100% - (100 - 0.8 x INT)
@@ -8873,7 +8916,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def2 = (status->vit + status->agi) * 70;
 			break;
 		case SC_CRYSTALIZE:
-			tick_def2 = (sd ? sd->status.vit : status_get_base_status(bl)->vit) * 100;
+			tick_def = 0;
+			tick_def2 = status_get_base_status(bl)->vit * 100;
 			break;
 		case SC_VACUUM_EXTREME:
 			tick_def2 = (sd ? sd->status.str : status_get_base_status(bl)->str) * 50;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8812,10 +8812,10 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 #endif
 			break;
 		case SC_CURSE:
-#ifndef RENEWAL
 			// Special property: immunity when luk is zero
 			if (status->luk == 0)
 				return 0;
+#ifndef RENEWAL
 			sc_def = status->luk*100;
 			sc_def2 = status->luk*10 - status_get_lv(src)*10; // Curse only has a level penalty and no resistance
 			tick_def = status->vit*100;
@@ -8877,7 +8877,10 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		case SC_WHITEIMPRISON:
 			if( src == bl ) // 100% on caster
 				break;
-			sc_def = status->str * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			if (bl->type == BL_PC)
+				sc_def = status->str * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			else
+				tick_def2 = (status->vit + status->luk) * 50;
 			tick_def2 = -2000;
 			break;
 		case SC_FEAR:
@@ -9258,6 +9261,11 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_FREEZE:
 			// Undead are immune to Freeze/Stone
 			if (undead_flag && !(flag&SCSTART_NOAVOID))
+				return 0;
+			break;
+		case SC_BURNING:
+			// Level 2 Fire Element is immune
+			if (status->def_ele == ELE_FIRE && status->ele_lv == 2)
 				return 0;
 			break;
 		case SC_ALL_RIDING:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8877,18 +8877,15 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		case SC_WHITEIMPRISON:
 			if( src == bl ) // 100% on caster
 				break;
-			if (bl->type == BL_PC)
-				sc_def = status->str * 10 + status_get_lv(bl) * 10 + status->luk * 10;
-			else
-				tick_def2 = (status->vit + status->luk) * 50;
+			sc_def = status->str * 20 + status_get_lv(bl) * 20 + status->luk * 10;
 			tick_def2 = -2000;
 			break;
 		case SC_FEAR:
-			sc_def = status->int_ * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			sc_def = status->int_ * 20 + status_get_lv(bl) * 20 + status->luk * 10;
 			tick_def2 = -4000; // 2 seconds is applied twice on Aegis
 			break;
 		case SC_BURNING:
-			sc_def = status->agi * 10 + status_get_lv(bl) * 10 + status->luk * 10;
+			sc_def = status->agi * 20 + status_get_lv(bl) * 20 + status->luk * 10;
 			tick_def2 = -2000;
 			break;
 		case SC_FREEZING:
@@ -9033,6 +9030,19 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		return i64max(tick, scdb->min_duration);
 
 	tick -= tick*tick_def/10000;
+
+#ifdef RENEWAL
+	// Renewal applies item resistance also to duration
+	if (sd) {
+		for (const auto &it : sd->reseff) {
+			if (it.id == type)
+				tick -= tick * it.val / 10000;
+		}
+		if (sd->sc.data[SC_COMMONSC_RESIST] && SC_COMMON_MIN <= type && type <= SC_COMMON_MAX)
+			tick -= tick * sd->sc.data[SC_COMMONSC_RESIST]->val1 / 100;
+	}
+#endif
+
 	tick -= tick_def2;
 
 	return i64max(tick, scdb->min_duration);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8728,9 +8728,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		sc = NULL;
 
 #ifdef RENEWAL
-	uint16 levelDiff = max(0, status_get_lv(src) - status_get_lv(bl));
-
-	levelDiff = (levelDiff * levelDiff / 5) * 100;
+	uint16 levelAdv = (pow(max(0, status_get_lv(src) - status_get_lv(bl)), 2) / 5) * 100;
 #endif
 
 	switch (type) {
@@ -8749,7 +8747,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 				tick_def = (status->vit*200)/3;
 			}
 #else
-			sc_def = status->vit * 100 - levelDiff;
+			sc_def = status->vit * 100 - levelAdv;
 			tick_def2 = -2000;
 #endif
 			break;
@@ -8759,7 +8757,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->vit * 100 - levelDiff;
+			sc_def = status->vit * 100 - levelAdv;
 			tick_def2 = -500;
 #endif
 			break;
@@ -8769,7 +8767,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->int_ * 100 - levelDiff;
+			sc_def = status->int_ * 100 - levelAdv;
 			tick_def2 = -2000;
 #endif
 			break;
@@ -8779,7 +8777,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->agi * 100 - levelDiff;
+			sc_def = status->agi * 100 - levelAdv;
 			tick_def2 = -12000;
 #endif
 			break;
@@ -8789,7 +8787,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->agi * 100 - levelDiff;
+			sc_def = status->agi * 100 - levelAdv;
 			tick_def2 = -2000;
 #endif
 			break;
@@ -8797,11 +8795,11 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 #ifndef RENEWAL
 			sc_def = status->mdef*100;
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
+			tick_def = 0; // No duration reduction
 #else
-			sc_def = status->mdef * 100 - levelDiff;
+			sc_def = status->mdef * 100 - levelAdv;
 			tick_def2 = -3000;
 #endif
-			tick_def = 0; // No duration reduction
 			break;
 		case SC_FREEZE:
 #ifndef RENEWAL
@@ -8809,7 +8807,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status_src->luk*-10; // Caster can increase final duration with luk
 #else
-			sc_def = status->mdef * 100 - levelDiff;
+			sc_def = status->mdef * 100 - levelAdv;
 			tick_def2 = -3000;
 #endif
 			break;
@@ -8823,7 +8821,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def = status->vit*100;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->luk * 100 - levelDiff;
+			sc_def = status->luk * 100 - levelAdv;
 			tick_def2 = -2000;
 #endif
 			break;
@@ -8833,7 +8831,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status->luk*10 + status_get_lv(bl)*10 - status_get_lv(src)*10;
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->int_ * 100 - levelDiff;
+			sc_def = status->int_ * 100 - levelAdv;
 			tick_def2 = -2000;
 #endif
 			break;
@@ -8843,9 +8841,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = status_get_lv(src)*10 - status_get_lv(bl)*10 - status->luk*10; // Reversed sc_def2
 			tick_def2 = status->luk*10;
 #else
-			sc_def = status->luk * 100 - levelDiff;
+			sc_def = status->luk * 100 - levelAdv;
 			tick_def2 = -2000;
-
 #endif
 			break;
 		case SC_DECREASEAGI:
@@ -8863,7 +8860,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def2 = (status->luk * 50 + status->agi * 200) / 2; // (50 * LUK / 100 + 20 * AGI / 100) / 2
 			break;
 		case SC_DEEPSLEEP:
-			tick_def2 = max(0, status_get_base_status(bl)->int_ * 25 + status_get_lv(bl) * 50);
+			tick_def2 = status_get_base_status(bl)->int_ * 25 + status_get_lv(bl) * 50;
 			break;
 		case SC_NETHERWORLD:
 			// Resistance: {(Target's Base Level / 50) + (Target's Job Level / 10)} seconds
@@ -8885,14 +8882,14 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			break;
 		case SC_FEAR:
 			sc_def = status->int_ * 10 + status_get_lv(bl) * 10 + status->luk * 10;
-			tick_def2 = -2000;
+			tick_def2 = -4000; // 2 seconds is applied twice on Aegis
 			break;
 		case SC_BURNING:
 			sc_def = status->agi * 10 + status_get_lv(bl) * 10 + status->luk * 10;
 			tick_def2 = -2000;
 			break;
-		case SC_FREEZING: // TODO: Confirm
-			tick_def2 = (status->vit + status->dex)*50;
+		case SC_FREEZING:
+			tick_def2 = (status->vit + status->dex) * 50;
 			break;
 		case SC_OBLIVIONCURSE: // 100% - (100 - 0.8 x INT)
 			sc_def = status->int_ * 80;
@@ -8916,7 +8913,6 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			tick_def2 = (status->vit + status->agi) * 70;
 			break;
 		case SC_CRYSTALIZE:
-			tick_def = 0;
 			tick_def2 = status_get_base_status(bl)->vit * 100;
 			break;
 		case SC_VACUUM_EXTREME:
@@ -8951,8 +8947,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = sc_def2*battle_config.pc_sc_def_rate/100;
 		}
 
-		sc_def = min(sc_def, battle_config.pc_max_sc_def*100);
-		sc_def2 = min(sc_def2, battle_config.pc_max_sc_def*100);
+		sc_def = cap_value(sc_def, 0, battle_config.pc_max_sc_def*100);
+		sc_def2 = cap_value(sc_def2, 0, battle_config.pc_max_sc_def*100);
 
 		if (battle_config.pc_sc_def_rate != 100) {
 			tick_def = tick_def*battle_config.pc_sc_def_rate/100;
@@ -8964,8 +8960,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			sc_def2 = sc_def2*battle_config.mob_sc_def_rate/100;
 		}
 
-		sc_def = min(sc_def, battle_config.mob_max_sc_def*100);
-		sc_def2 = min(sc_def2, battle_config.mob_max_sc_def*100);
+		sc_def = cap_value(sc_def, 0, battle_config.mob_max_sc_def*100);
+		sc_def2 = cap_value(sc_def2, 0, battle_config.mob_max_sc_def*100);
 
 		if (battle_config.mob_sc_def_rate != 100) {
 			tick_def = tick_def*battle_config.mob_sc_def_rate/100;
@@ -9025,8 +9021,6 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 
 	// Cap minimum rate
 	rate = max(rate, scdb->min_rate);
-	// Cap minimum duration
-	tick = i64max(tick, scdb->min_duration);
 
 	if (rate < 10000 && (rate <= 0 || !(rnd()%10000 < rate)))
 		return 0;
@@ -9038,26 +9032,8 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 	tick -= tick*tick_def/10000;
 	tick -= tick_def2;
 
-	// Minimum durations
-	switch (type) {
-		case SC_ANKLE:
-		case SC_MARSHOFABYSS:
-			tick = i64max(tick, 5000); // Minimum duration 5s
-			break;
-		case SC_FREEZING:
-			tick = i64max(tick, 6000); // Minimum duration 6s
-			// NEED AEGIS CHECK: might need to be 10s (http://ro.gnjoy.com/news/notice/View.asp?seq=5352)
-			break;
-		case SC_BURNING:
-		case SC_STASIS:
-		case SC_VOICEOFSIREN:
-			tick = i64max(tick, 10000); // Minimum duration 10s
-			break;
-		default:
-			// Skills need to trigger even if the duration is reduced below 1ms
-			tick = i64max(tick, 1);
-			break;
-	}
+	// Cap minimum duration
+	tick = i64max(tick, scdb->min_duration);
 
 	return tick;
 }

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9027,15 +9027,12 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 
 	// Duration cannot be reduced
 	if (flag&SCSTART_NOTICKDEF)
-		return i64max(tick, 1);
+		return i64max(tick, scdb->min_duration);
 
 	tick -= tick*tick_def/10000;
 	tick -= tick_def2;
 
-	// Cap minimum duration
-	tick = i64max(tick, scdb->min_duration);
-
-	return tick;
+	return i64max(tick, scdb->min_duration);
 }
 
 /**


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4694

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Updates the status resistance formulas for several of the common statuses.
  * Renewal only protects against a single base stat.
  * When the caster is a higher base level, some statuses now take this difference into effect.
Thanks to @Playtester!