### PR TITLE
Fixed Pre-Re SoftDEF Formula

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5668,13 +5668,13 @@ static void battle_calc_defense_reduction(struct Damage* wd, struct block_list *
 			def2 = 1;
 	}
 
-	//Vitality reduction from rodatazone: http://rodatazone.simgaming.net/mechanics/substats.php#def
+	//Damage reduction based on vitality
 	if (tsd) {	//Sd vit-eq
 		int skill;
 #ifndef RENEWAL
-		//[VIT*0.5] + rnd([VIT*0.3], max([VIT*0.3],[VIT^2/150]-1))
-		vit_def = def2*(def2-15)/150;
-		vit_def = def2/2 + (vit_def>0?rnd()%vit_def:0);
+		//Damage reduction: [VIT*0.3] + RND(0; [VIT^2/150] - [VIT*0.3]) + [VIT*0.5]
+		vit_def = max(1, (def2 * def2 / 150) - ((3 * def2) / 10)); //Random bonus part
+		vit_def = ((3 * def2) / 10) + (rnd() % vit_def) + (def2 / 2);
 #else
 		vit_def = def2;
 #endif

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5672,9 +5672,10 @@ static void battle_calc_defense_reduction(struct Damage* wd, struct block_list *
 	if (tsd) {	//Sd vit-eq
 		int skill;
 #ifndef RENEWAL
-		//Damage reduction: [VIT*0.3] + RND(0; [VIT^2/150] - [VIT*0.3]) + [VIT*0.5]
-		vit_def = max(1, (def2 * def2 / 150) - ((3 * def2) / 10)); //Random bonus part
-		vit_def = ((3 * def2) / 10) + (rnd() % vit_def) + (def2 / 2);
+		//Damage reduction: [VIT*0.3] + RND(0, [VIT^2/150] - [VIT*0.3] - 1) + [VIT*0.5]
+		vit_def = ((3 * def2) / 10);
+		vit_def += rnd_value(0, (def2 * def2) / 150 - ((3 * def2) / 10) - 1);
+		vit_def += (def2 / 2);
 #else
 		vit_def = def2;
 #endif


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Fixes #6648

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Damage reduction from VIT was a bit lower than it should be for players, see linked issue.

Note: This does not fix the order of processing, which is also wrong. But at least the damage is official now in 1vs1 combat if no item bonuses or status changes are involved that directly impact DEF.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->