### PR TITLE
Fixed PLAGIARIZED skill would cause skill data loss

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -433,7 +433,7 @@ int char_mmo_char_tosql(uint32 char_id, struct mmo_charstatus* p){
 
 				if( p->skill[i].lv == 0 && ( p->skill[i].flag == SKILL_FLAG_PERM_GRANTED || p->skill[i].flag == SKILL_FLAG_PERMANENT ) )
 					continue;
-				if( p->skill[i].flag != SKILL_FLAG_PERMANENT && p->skill[i].flag != SKILL_FLAG_PERM_GRANTED && (p->skill[i].flag - SKILL_FLAG_REPLACED_LV_0) == 0 )
+				if( p->skill[i].flag != SKILL_FLAG_PERMANENT && p->skill[i].flag != SKILL_FLAG_PERM_GRANTED && (p->skill[i].flag - SKILL_FLAG_REPLACED_LV_0) <= 0 )
 					continue;
 				if( count )
 					StringBuf_AppendStr(&buf, ",");


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6681

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

  - This problem is caused by shadowcaster's PLAGIARIZED skill.
  - The flag of the copied skill is SKILL_FLAG_PLAGIARIZED with a value of 2, but before it is written to the database rAthena calculates the skill level by taking the flag - SKILL_FLAG_REPLACED_LV_0 (with a value of 10)
This makes the copied skill level -8, and the field in the database can't hold negative numbers, so it thinks it's out of range and reports an error.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

* **中文说明 (Description of Chinese)**: 

  - 这应该是一个非常久远的问题
  - 流氓系列职业使用抄袭技能，抄袭到一个技能后的处理存在问题（技能等级变成 -8）
  - 数据库中的字段定义是无符号的，因此技能等级不能是也不应该是负数
  - 在这种情况下，角色的技能数据写入将会因为 -8 而导致 SQL 报错，最终导致全部技能数据丢失