### PR TITLE
Fixed refinement success and def for pre-re

### DIFF
--- a/db/pre-re/refine.yml
+++ b/db/pre-re/refine.yml
@@ -49,7 +49,7 @@ Body:
       - Level: 1
         RefineLevels:
           - Level: 1
-            Bonus: 66
+            Bonus: 70
             Chances:
               - Type: Normal
                 Rate: 10000
@@ -60,7 +60,7 @@ Body:
                 Price: 2000
                 Material: Enriched_Elunium
           - Level: 2
-            Bonus: 132
+            Bonus: 140
             Chances:
               - Type: Normal
                 Rate: 10000
@@ -71,7 +71,7 @@ Body:
                 Price: 2000
                 Material: Enriched_Elunium
           - Level: 3
-            Bonus: 198
+            Bonus: 210
             Chances:
               - Type: Normal
                 Rate: 10000
@@ -82,7 +82,7 @@ Body:
                 Price: 2000
                 Material: Enriched_Elunium
           - Level: 4
-            Bonus: 264
+            Bonus: 280
             Chances:
               - Type: Normal
                 Rate: 10000
@@ -93,7 +93,7 @@ Body:
                 Price: 2000
                 Material: Enriched_Elunium
           - Level: 5
-            Bonus: 330
+            Bonus: 350
             Chances:
               - Type: Normal
                 Rate: 6000
@@ -106,7 +106,7 @@ Body:
                 Material: Enriched_Elunium
                 BreakingRate: 10000
           - Level: 6
-            Bonus: 396
+            Bonus: 420
             Chances:
               - Type: Normal
                 Rate: 4000
@@ -119,7 +119,7 @@ Body:
                 Material: Enriched_Elunium
                 BreakingRate: 10000
           - Level: 7
-            Bonus: 462
+            Bonus: 490
             Chances:
               - Type: Normal
                 Rate: 4000
@@ -132,7 +132,7 @@ Body:
                 Material: Enriched_Elunium
                 BreakingRate: 10000
           - Level: 8
-            Bonus: 528
+            Bonus: 560
             BlacksmithBlessingAmount: 1
             Chances:
               - Type: Normal
@@ -146,7 +146,7 @@ Body:
                 Material: Enriched_Elunium
                 BreakingRate: 10000
           - Level: 9
-            Bonus: 594
+            Bonus: 630
             BlacksmithBlessingAmount: 2
             Chances:
               - Type: Normal
@@ -160,11 +160,11 @@ Body:
                 Material: Enriched_Elunium
                 BreakingRate: 10000
           - Level: 10
-            Bonus: 660
+            Bonus: 700
             BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
-                Rate: 900
+                Rate: 1000
                 Price: 2000
                 Material: Elunium
                 BreakingRate: 10000
@@ -290,7 +290,7 @@ Body:
             BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
-                Rate: 1900
+                Rate: 2000
                 Price: 50
                 Material: Phracon
                 BreakingRate: 10000
@@ -417,7 +417,7 @@ Body:
             BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
-                Rate: 1900
+                Rate: 2000
                 Price: 200
                 Material: Emveretarcon
                 BreakingRate: 10000
@@ -547,7 +547,7 @@ Body:
             BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
-                Rate: 1900
+                Rate: 2000
                 Price: 5000
                 Material: Oridecon
                 BreakingRate: 10000
@@ -681,7 +681,7 @@ Body:
             BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
-                Rate: 900
+                Rate: 1000
                 Price: 20000
                 Material: Oridecon
                 BreakingRate: 10000


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Fixes #6780

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
* Fixed some refinement values for pre-re that got bugged during the YML conversion
* Officially you gain 0.7 def per armor refine and from +9 to +10 it is 10% for armor and level 4 weapons and 20% for the rest

<!-- Describe how this pull request will resolve the issue(s) listed above. -->