### PR TITLE
Implements SC_STONEWAIT

### DIFF
--- a/db/import-tmpl/status.yml
+++ b/db/import-tmpl/status.yml
@@ -36,9 +36,9 @@
 #   MinDuration               Minimum duration in milliseconds after status change reduction. (Default: 1)
 #   Fail:                     List of Status Changes that causes the status to fail to activate. (Optional)
 #   End:                      List of Status Changes that will end when the status activates. (Optional)
-#   EndReturn                 If the status has an End list and succeeds to remove these status changes, it won't give its effect. (Default: false)
+#   EndReturn:                List of Status Changes that will end when the status activates and won't give its effect. (Optional)
 ###########################################################################
 
 Header:
   Type: STATUS_DB
-  Version: 1
+  Version: 2

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -795,8 +795,8 @@ Body:
     Element: Earth
     CastCancel: true
     CastTime: 1000
-    Duration1: 5000
-    Duration2: 20000
+    Duration1: 20000
+    Duration2: 5000
     Requires:
       SpCost:
         - Level: 1
@@ -822,7 +822,7 @@ Body:
       ItemCost:
         - Item: Red_Gemstone
           Amount: 1
-    Status: Stone
+    Status: StoneWait
   - Id: 17
     Name: MG_FIREBALL
     Description: Fire Ball
@@ -5663,8 +5663,9 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
-    Status: Stone
+    Duration1: 20000
+    Duration2: 5000
+    Status: StoneWait
   - Id: 181
     Name: NPC_CURSEATTACK
     Description: Curse Attack
@@ -15911,8 +15912,9 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 20000
-    Status: Stone
+    Duration1: 20000
+    Duration2: 5000
+    Status: StoneWait
   - Id: 667
     Name: NPC_WIDECONFUSE
     Description: Wide Confusion

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -5664,7 +5664,7 @@ Body:
     HitCount: 1
     Element: Weapon
     Duration1: 20000
-    Duration2: 5000
+    Duration2: 100
     Status: StoneWait
   - Id: 181
     Name: NPC_CURSEATTACK
@@ -15913,7 +15913,7 @@ Body:
       - Level: 5
         Area: 14
     Duration1: 20000
-    Duration2: 5000
+    Duration2: 100
     Status: StoneWait
   - Id: 667
     Name: NPC_WIDECONFUSE

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -66,16 +66,28 @@ Body:
       Inspiration: true
       Power_Of_Gaia: true
       Gvg_Stone: true
+    Fail:
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      Undead: true
     End:
-      Dancing: true
+      Aeterna: true
   - Status: StoneWait
     DurationLookup: NPC_PETRIFYATTACK
+    States:
+      NoCast: true
     Opt1: StoneWait
     Flags:
       SendOption: true
       StopAttacking: true
-    End:
-      Aeterna: true
+    Fail:
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      Undead: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:
@@ -256,6 +268,11 @@ Body:
       BossResist: true
       Debuff: true
       NoSaveInfinite: true
+    End:
+      Freeze: true
+      Stone: true
+      Sleep: true
+      TrickDead: true
   - Status: Endure
     Icon: EFST_ENDURE
     DurationLookup: SM_ENDURE
@@ -1327,6 +1344,10 @@ Body:
     Flags:
       NoSave: true
       Debuff: true
+    End:
+      Freeze: true
+      Stone: true
+      Sleep: true
   - Status: Memorize
     Icon: EFST_MEMORIZE
     DurationLookup: PF_MEMORIZE

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -66,12 +66,11 @@ Body:
       Inspiration: true
       Power_Of_Gaia: true
       Gvg_Stone: true
-    Fail:
       Freeze: true
       Stun: true
       Sleep: true
       Burning: true
-      Undead: true
+      #Undead: true
     End:
       Aeterna: true
     EndReturn:
@@ -90,7 +89,7 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      Undead: true
+      #Undead: true
     EndReturn:
       StoneWait: true
       Stone: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -74,6 +74,9 @@ Body:
       Undead: true
     End:
       Aeterna: true
+    EndReturn:
+      StoneWait: true
+      Stone: true
   - Status: StoneWait
     DurationLookup: NPC_PETRIFYATTACK
     States:
@@ -88,6 +91,9 @@ Body:
       Sleep: true
       Burning: true
       Undead: true
+    EndReturn:
+      StoneWait: true
+      Stone: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -36,12 +36,12 @@
 #   MinDuration               Minimum duration in milliseconds after status change reduction. (Default: 1)
 #   Fail:                     List of Status Changes that causes the status to fail to activate. (Optional)
 #   End:                      List of Status Changes that will end when the status activates. (Optional)
-#   EndReturn                 If the status has an End list and succeeds to remove these status changes, it won't give its effect. (Default: false)
+#   EndReturn:                List of Status Changes that will end when the status activates and won't give its effect. (Optional)
 ###########################################################################
 
 Header:
   Type: STATUS_DB
-  Version: 1
+  Version: 2
 
 Body:
   - Status: Stone
@@ -1256,9 +1256,8 @@ Body:
     Fail:
       Quagmire: true
       Dontforgetme: true
-    End:
+    EndReturn:
       Decreaseagi: true
-    EndReturn: true
   - Status: Chasewalk
     Icon: EFST_CHASEWALK
     DurationLookup: ST_CHASEWALK
@@ -4210,9 +4209,8 @@ Body:
     Fail:
       Quagmire: true
       Dontforgetme: true
-    End:
+    EndReturn:
       Decreaseagi: true
-    EndReturn: true
   - Status: Thornstrap
     Icon: EFST_THORNS_TRAP
     DurationLookup: GN_THORNS_TRAP
@@ -5729,9 +5727,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
-    End:
+    EndReturn:
       All_Riding: true
-    EndReturn: true
   - Status: Teargas_Sob
     Flags:
       BossResist: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -48,18 +48,19 @@ Body:
     DurationLookup: NPC_PETRIFYATTACK
     States:
       NoMove: true
-      NoMoveCond: true
       NoCast: true
       NoAttack: true
     CalcFlags:
       Def_Ele: true
       Def: true
       Mdef: true
+    Opt1: Stone
     Flags:
       SendOption: true
       BossResist: true
       StopAttacking: true
       StopCasting: true
+      RemoveOnDamaged: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -67,6 +68,14 @@ Body:
       Gvg_Stone: true
     End:
       Dancing: true
+  - Status: StoneWait
+    DurationLookup: NPC_PETRIFYATTACK
+    Opt1: StoneWait
+    Flags:
+      SendOption: true
+      StopAttacking: true
+    End:
+      Aeterna: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:
@@ -505,6 +514,7 @@ Body:
     Flags:
       NoSave: true
     Fail:
+      Stone: true
       Freeze: true
   - Status: Adrenaline
     Icon: EFST_ADRENALINE

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5934,7 +5934,7 @@ Body:
     HitCount: 1
     Element: Weapon
     Duration1: 17000
-    Duration2: 5000
+    Duration2: 100
     Status: StoneWait
   - Id: 181
     Name: NPC_CURSEATTACK
@@ -16312,7 +16312,7 @@ Body:
       - Level: 5
         Area: 14
     Duration1: 17000
-    Duration2: 5000
+    Duration2: 100
     Status: StoneWait
   - Id: 667
     Name: NPC_WIDECONFUSE
@@ -19234,15 +19234,16 @@ Body:
     AfterCastActDelay: 2000
     Duration1:
       - Level: 1
-        Time: 7000
+        Time: 10000
       - Level: 2
-        Time: 9000
+        Time: 12000
       - Level: 3
-        Time: 11000
+        Time: 14000
       - Level: 4
-        Time: 13000
+        Time: 16000
       - Level: 5
-        Time: 15000
+        Time: 18000
+    Duration2: 100
     Requires:
       SpCost:
         - Level: 1
@@ -19258,6 +19259,7 @@ Body:
       ItemCost:
         - Item: Red_Gemstone
           Amount: 2
+    Status: StoneWait
   - Id: 2208
     Name: WL_RADIUS
     Description: Radius

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -19234,15 +19234,15 @@ Body:
     AfterCastActDelay: 2000
     Duration1:
       - Level: 1
-        Time: 10000
+        Time: 7000
       - Level: 2
-        Time: 12000
+        Time: 9000
       - Level: 3
-        Time: 14000
+        Time: 11000
       - Level: 4
-        Time: 16000
+        Time: 13000
       - Level: 5
-        Time: 18000
+        Time: 15000
     Duration2: 100
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -779,8 +779,8 @@ Body:
     Element: Earth
     CastCancel: true
     CastTime: 800
-    Duration1: 5000
-    Duration2: 20000
+    Duration1: 20000
+    Duration2: 5000
     FixedCastTime: 200
     Requires:
       SpCost:
@@ -807,7 +807,7 @@ Body:
       ItemCost:
         - Item: Red_Gemstone
           Amount: 1
-    Status: Stone
+    Status: StoneWait
   - Id: 17
     Name: MG_FIREBALL
     Description: Fire Ball
@@ -5934,8 +5934,9 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    Duration2: 20000
-    Status: Stone
+    Duration1: 20000
+    Duration2: 5000
+    Status: StoneWait
   - Id: 181
     Name: NPC_CURSEATTACK
     Description: Curse Attack
@@ -16312,8 +16313,9 @@ Body:
         Area: 11
       - Level: 5
         Area: 14
-    Duration2: 20000
-    Status: Stone
+    Duration1: 20000
+    Duration2: 5000
+    Status: StoneWait
   - Id: 667
     Name: NPC_WIDECONFUSE
     Description: Wide Confusion
@@ -19243,6 +19245,7 @@ Body:
         Time: 16000
       - Level: 5
         Time: 18000
+    Duration2: 5000
     Requires:
       SpCost:
         - Level: 1
@@ -19258,7 +19261,7 @@ Body:
       ItemCost:
         - Item: Red_Gemstone
           Amount: 2
-    Status: Stone
+    Status: StoneWait
   - Id: 2208
     Name: WL_RADIUS
     Description: Radius
@@ -32014,6 +32017,7 @@ Body:
     CastCancel: true
     AfterCastActDelay: 1000
     Duration1: 10000
+    Duration2: 5000
     Requires:
       SpCost: 30
     Unit:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -66,16 +66,29 @@ Body:
       Inspiration: true
       Power_Of_Gaia: true
       Gvg_Stone: true
+      Whiteimprison: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      Undead: true
     End:
-      Dancing: true
+      Aeterna: true
   - Status: StoneWait
     DurationLookup: NPC_PETRIFYATTACK
+    States:
+      NoCast: true
     Opt1: StoneWait
     Flags:
       SendOption: true
       StopAttacking: true
-    End:
-      Aeterna: true
+    Fail:
+      Whiteimprison: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      Undead: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:
@@ -262,6 +275,11 @@ Body:
       BossResist: true
       Debuff: true
       NoSaveInfinite: true
+    End:
+      Freeze: true
+      Stone: true
+      Sleep: true
+      TrickDead: true
   - Status: Endure
     Icon: EFST_ENDURE
     DurationLookup: SM_ENDURE
@@ -1340,6 +1358,10 @@ Body:
     Flags:
       NoSave: true
       Debuff: true
+    End:
+      Freeze: true
+      Stone: true
+      Sleep: true
   - Status: Memorize
     Icon: EFST_MEMORIZE
     DurationLookup: PF_MEMORIZE

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -36,12 +36,12 @@
 #   MinDuration               Minimum duration in milliseconds after status change reduction. (Default: 1)
 #   Fail:                     List of Status Changes that causes the status to fail to activate. (Optional)
 #   End:                      List of Status Changes that will end when the status activates. (Optional)
-#   EndReturn                 If the status has an End list and succeeds to remove these status changes, it won't give its effect. (Default: false)
+#   EndReturn:                List of Status Changes that will end when the status activates and won't give its effect. (Optional)
 ###########################################################################
 
 Header:
   Type: STATUS_DB
-  Version: 1
+  Version: 2
 
 Body:
   - Status: Stone
@@ -1270,9 +1270,8 @@ Body:
       NoDispell: true
     Fail:
       Quagmire: true
-    End:
+    EndReturn:
       Decreaseagi: true
-    EndReturn: true
   - Status: Chasewalk
     Icon: EFST_CHASEWALK
     DurationLookup: ST_CHASEWALK
@@ -4355,9 +4354,8 @@ Body:
     Fail:
       Quagmire: true
       Dontforgetme: true
-    End:
+    EndReturn:
       Decreaseagi: true
-    EndReturn: true
   - Status: Thornstrap
     Icon: EFST_THORNS_TRAP
     DurationLookup: GN_THORNS_TRAP
@@ -5963,9 +5961,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
-    End:
+    EndReturn:
       All_Riding: true
-    EndReturn: true
   - Status: Teargas_Sob
     Flags:
       BossResist: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -48,18 +48,19 @@ Body:
     DurationLookup: NPC_PETRIFYATTACK
     States:
       NoMove: true
-      NoMoveCond: true
       NoCast: true
       NoAttack: true
     CalcFlags:
       Def_Ele: true
       Def: true
       Mdef: true
+    Opt1: Stone
     Flags:
       SendOption: true
       BossResist: true
       StopAttacking: true
       StopCasting: true
+      RemoveOnDamaged: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -67,6 +68,14 @@ Body:
       Gvg_Stone: true
     End:
       Dancing: true
+  - Status: StoneWait
+    DurationLookup: NPC_PETRIFYATTACK
+    Opt1: StoneWait
+    Flags:
+      SendOption: true
+      StopAttacking: true
+    End:
+      Aeterna: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:
@@ -515,6 +524,7 @@ Body:
     Flags:
       NoSave: true
     Fail:
+      Stone: true
       Freeze: true
   - Status: Adrenaline
     Icon: EFST_ADRENALINE

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -71,7 +71,7 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      Undead: true
+      #Undead: true
     End:
       Aeterna: true
     EndReturn:
@@ -91,7 +91,7 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      Undead: true
+      #Undead: true
     EndReturn:
       StoneWait: true
       Stone: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -74,6 +74,9 @@ Body:
       Undead: true
     End:
       Aeterna: true
+    EndReturn:
+      StoneWait: true
+      Stone: true
   - Status: StoneWait
     DurationLookup: NPC_PETRIFYATTACK
     States:
@@ -89,6 +92,9 @@ Body:
       Sleep: true
       Burning: true
       Undead: true
+    EndReturn:
+      StoneWait: true
+      Stone: true
   - Status: Freeze
     DurationLookup: NPC_WIDEFREEZE
     States:

--- a/db/status.yml
+++ b/db/status.yml
@@ -36,12 +36,12 @@
 #   MinDuration               Minimum duration in milliseconds after status change reduction. (Default: 1)
 #   Fail:                     List of Status Changes that causes the status to fail to activate. (Optional)
 #   End:                      List of Status Changes that will end when the status activates. (Optional)
-#   EndReturn                 If the status has an End list and succeeds to remove these status changes, it won't give its effect. (Default: false)
+#   EndReturn:                List of Status Changes that will end when the status activates and won't give its effect. (Optional)
 ###########################################################################
 
 Header:
   Type: STATUS_DB
-  Version: 1
+  Version: 2
 
 Footer:
   Imports:

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20220222
+//= 20220406
 //===== Description: =========================================
 //= Explanation of the status.yml file and structure.
 //============================================================
@@ -270,7 +270,7 @@ End: List of status that will end if the status activates.
 
 ---------------------------------------
 
-EndReturn: If the status has any 'End' and succeeds to end other status in the list, it won't give its effect.
+EndReturn: List of status that will end if the status activates and it won't give its effect.
 
 ---------------------------------------
 

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -271,6 +271,8 @@ End: List of status that will end if the status activates.
 ---------------------------------------
 
 EndReturn: List of status that will end if the status activates and it won't give its effect.
+           The statuses checked in this list are done at the beginning of status_change_start(). If at least 1 status from this list
+		   is removed then it will return back and not check anything else.
 
 ---------------------------------------
 

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -940,7 +940,7 @@
 	export_constant2("VAR_SHOES",LOOK_SHOES);
 
 	/* status changes */
-	export_constant2("Eff_Stone",SC_STONE);
+	export_constant2("Eff_Stone",SC_STONEWAIT);
 	export_constant2("Eff_Freeze",SC_FREEZE);
 	export_constant2("Eff_Stun",SC_STUN);
 	export_constant2("Eff_Sleep",SC_SLEEP);

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -972,6 +972,7 @@
 	export_constant(SC_BLIND);
 	export_constant(SC_BLEEDING);
 	export_constant(SC_DPOISON);
+	export_constant(SC_STONEWAIT);
 	export_constant(SC_PROVOKE);
 	export_constant(SC_ENDURE);
 	export_constant(SC_TWOHANDQUICKEN);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8713,6 +8713,13 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if(status_isimmune(bl) || !tsc)
 				break;
 
+			// Temporary solution to not consume item on failure when cancelling (see EndReturn logic)
+			if (tsc && (tsc->data[type] || tsc->data[SC_STONE])) {
+				status_change_end(bl, type, INVALID_TIMER);
+				status_change_end(bl, SC_STONE, INVALID_TIMER);
+				break;
+			}
+
 			int32 brate = 0;
 
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
@@ -10768,9 +10775,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			int rate = 45 + 5 * skill_lv + ( sd? sd->status.job_level : 50 ) / 4;
 			// IroWiki says Rate should be reduced by target stats, but currently unknown
 			if( rnd()%100 < rate ) { // Success on First Target
-				rate = status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF);
-
-				if( rate ) {
+				if( status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF) ) {
 					clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 					skill_area_temp[1] = bl->id;
 					map_foreachinallrange(skill_area_sub,bl,skill_get_splash(skill_id,skill_lv),BL_CHAR,src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,skill_castend_nodamage_id);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8723,8 +8723,10 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				skill_get_time2(skill_id,skill_lv)))
 					clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			else if(sd) {
+				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				// Level 6-10 doesn't consume a red gem if it fails [celest]
-				if (skill_lv > 5) { // not to consume items
+				if (skill_lv > 5)
+				{ // not to consume items
 					map_freeblock_unlock();
 					return 0;
 				}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1622,7 +1622,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		break;
 
 	case NPC_PETRIFYATTACK:
-		sc_start4(src,bl,SC_STONE,(20*skill_lv),skill_lv,0,0,skill_get_time(skill_id,skill_lv),skill_get_time2(skill_id,skill_lv));
+		sc_start4(src,bl,SC_STONEWAIT,(20*skill_lv),skill_lv,src->id,skill_get_time(skill_id,skill_lv),0,skill_get_time2(skill_id,skill_lv));
 		break;
 	case NPC_CURSEATTACK:
 		sc_start(src,bl,SC_CURSE,(20*skill_lv),skill_lv,skill_get_time2(skill_id,skill_lv));
@@ -7948,8 +7948,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		if( tsc && tsc->count )
 		{
 			status_change_end(bl, SC_FREEZE, INVALID_TIMER);
-			if( tsc->data[SC_STONE] && tsc->opt1 == OPT1_STONE )
-				status_change_end(bl, SC_STONE, INVALID_TIMER);
+			status_change_end(bl, SC_STONE, INVALID_TIMER);
 			status_change_end(bl, SC_SLEEP, INVALID_TIMER);
 			status_change_end(bl, SC_TRICKDEAD, INVALID_TIMER);
 		}
@@ -8725,7 +8724,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
 				brate = sd->sc.data[SC_PETROLOGY_OPTION]->val3;
 
-			if (tsc && tsc->data[type]) {
+			if (tsc && tsc->data[SC_STONE]) {
 				status_change_end(bl, type, INVALID_TIMER);
 				if (sd) clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				break;
@@ -9846,8 +9845,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 			if(tsc && tsc->count){
 				status_change_end(bl, SC_FREEZE, INVALID_TIMER);
-				if(tsc->data[SC_STONE] && tsc->opt1 == OPT1_STONE)
-					status_change_end(bl, SC_STONE, INVALID_TIMER);
+				status_change_end(bl, SC_STONE, INVALID_TIMER);
 				status_change_end(bl, SC_SLEEP, INVALID_TIMER);
 			}
 
@@ -10333,8 +10331,8 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			case SC_BURNING:
 				sc_start4(src,bl,type,100,skill_lv,1000,src->id,0,skill_get_time2(skill_id,skill_lv));
 				break;
-			case SC_VOICEOFSIREN:
-				sc_start2(src,bl,type,100,skill_lv,src->id,skill_get_time2(skill_id,skill_lv));
+			case SC_STONEWAIT:
+				sc_start4(src,bl,type,100,skill_lv,src->id,skill_get_time(skill_id, skill_lv), 0, skill_get_time2(skill_id,skill_lv));
 				break;
 			default:
 				sc_start2(src,bl,type,100,skill_lv,src->id,skill_get_time2(skill_id,skill_lv));
@@ -15908,7 +15906,7 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 					case UNT_ZENKAI_LAND:
 						switch (rnd()%2 + 1) {
 							case 1:
-								sc_start2(ss, bl, SC_STONE, sg->val1*5, sg->skill_lv, ss->id, skill_get_time(sg->skill_id, sg->skill_lv));
+								sc_start4(ss, bl, SC_STONEWAIT, sg->val1*5, sg->skill_lv, ss->id, skill_get_time(sg->skill_id, sg->skill_lv), 0, skill_get_time2(sg->skill_id, sg->skill_lv));
 								break;
 							case 2:
 								sc_start2(ss, bl, SC_POISON, sg->val1*5, sg->skill_lv, ss->id, skill_get_time(sg->skill_id, sg->skill_lv));

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8717,9 +8717,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
 				brate = sd->sc.data[SC_PETROLOGY_OPTION]->val3;
-			// If the target has SC_STONEWAIT or SC_STONE, cancel at 100%
-			if (tsc->data[type] || tsc->data[SC_STONE])
-				brate = 100;
 
 			if (sc_start4(src,bl,type,(skill_lv*4+20)+brate,
 				skill_lv, src->id, skill_get_time(skill_id, skill_lv), 0,

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8713,14 +8713,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if(status_isimmune(bl) || !tsc)
 				break;
 
-			if (tsc && (tsc->data[type] || tsc->data[SC_STONE])) {
-				status_change_end(bl, type, INVALID_TIMER);
-				status_change_end(bl, SC_STONE, INVALID_TIMER);
-				if (sd)
-					clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
-				break;
-			}
-
 			int32 brate = 0;
 
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
@@ -10773,20 +10765,12 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( bl->id == skill_area_temp[1] )
 				break; // Already work on this target
 
-			if( tsc && tsc->data[type] )
-				status_change_end(bl,type,INVALID_TIMER);
-			else
-				status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF);
+			status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF);
 		} else {
 			int rate = 45 + 5 * skill_lv + ( sd? sd->status.job_level : 50 ) / 4;
 			// IroWiki says Rate should be reduced by target stats, but currently unknown
 			if( rnd()%100 < rate ) { // Success on First Target
-				if( !tsc->data[type] )
-					rate = status_change_start(src,bl,type,10000,skill_lv,src->id,0,0,skill_get_time(skill_id, skill_lv),SCSTART_NOTICKDEF);
-				else {
-					rate = 1;
-					status_change_end(bl,type,INVALID_TIMER);
-				}
+				rate = status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF);
 
 				if( rate ) {
 					clif_skill_nodamage(src,bl,skill_id,skill_lv,1);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8713,13 +8713,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if(status_isimmune(bl) || !tsc)
 				break;
 
-			// Temporary solution to not consume item on failure when cancelling (see EndReturn logic)
-			if (tsc && (tsc->data[type] || tsc->data[SC_STONE])) {
-				status_change_end(bl, type, INVALID_TIMER);
-				status_change_end(bl, SC_STONE, INVALID_TIMER);
-				break;
-			}
-
 			int32 brate = 0;
 
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8717,16 +8717,17 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
 				brate = sd->sc.data[SC_PETROLOGY_OPTION]->val3;
+			// If the target has SC_STONEWAIT or SC_STONE, cancel at 100%
+			if (tsc->data[type] || tsc->data[SC_STONE])
+				brate = 100;
 
 			if (sc_start4(src,bl,type,(skill_lv*4+20)+brate,
 				skill_lv, src->id, skill_get_time(skill_id, skill_lv), 0,
 				skill_get_time2(skill_id,skill_lv)))
 					clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			else if(sd) {
-				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				// Level 6-10 doesn't consume a red gem if it fails [celest]
-				if (skill_lv > 5)
-				{ // not to consume items
+				if (skill_lv > 5) { // not to consume items
 					map_freeblock_unlock();
 					return 0;
 				}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7945,14 +7945,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage(src, bl, skill_id == SM_SELFPROVOKE ? SM_PROVOKE : skill_id, skill_lv, i);
 		unit_skillcastcancel(bl, 2);
 
-		if( tsc && tsc->count )
-		{
-			status_change_end(bl, SC_FREEZE, INVALID_TIMER);
-			status_change_end(bl, SC_STONE, INVALID_TIMER);
-			status_change_end(bl, SC_SLEEP, INVALID_TIMER);
-			status_change_end(bl, SC_TRICKDEAD, INVALID_TIMER);
-		}
-
 		if( dstmd )
 		{
 			dstmd->state.provoke_flag = src->id;
@@ -8713,22 +8705,27 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case MG_STONECURSE:
 		{
-			int brate = 0;
 			if (status_has_mode(tstatus,MD_STATUSIMMUNE)) {
-				if (sd) clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+				if (sd)
+					clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				break;
 			}
 			if(status_isimmune(bl) || !tsc)
 				break;
 
+			if (tsc && (tsc->data[type] || tsc->data[SC_STONE])) {
+				status_change_end(bl, type, INVALID_TIMER);
+				status_change_end(bl, SC_STONE, INVALID_TIMER);
+				if (sd)
+					clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+				break;
+			}
+
+			int32 brate = 0;
+
 			if (sd && sd->sc.data[SC_PETROLOGY_OPTION])
 				brate = sd->sc.data[SC_PETROLOGY_OPTION]->val3;
 
-			if (tsc && tsc->data[SC_STONE]) {
-				status_change_end(bl, type, INVALID_TIMER);
-				if (sd) clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
-				break;
-			}
 			if (sc_start4(src,bl,type,(skill_lv*4+20)+brate,
 				skill_lv, src->id, skill_get_time(skill_id, skill_lv), 0,
 				skill_get_time2(skill_id,skill_lv)))
@@ -9843,12 +9840,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 			unit_skillcastcancel(bl,0);
 
-			if(tsc && tsc->count){
-				status_change_end(bl, SC_FREEZE, INVALID_TIMER);
-				status_change_end(bl, SC_STONE, INVALID_TIMER);
-				status_change_end(bl, SC_SLEEP, INVALID_TIMER);
-			}
-
 			if (dstmd)
 				mob_target(dstmd, src, skill_get_range2(src, skill_id, skill_lv, true));
 		}
@@ -10785,7 +10776,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( tsc && tsc->data[type] )
 				status_change_end(bl,type,INVALID_TIMER);
 			else
-				status_change_start(src,bl,type,10000,skill_lv,src->id,0,0,skill_get_time(skill_id, skill_lv),SCSTART_NOTICKDEF);
+				status_change_start(src,bl,type,10000,skill_lv,src->id,skill_get_time(skill_id, skill_lv),0,skill_get_time2(skill_id,skill_lv), SCSTART_NOTICKDEF);
 		} else {
 			int rate = 45 + 5 * skill_lv + ( sd? sd->status.job_level : 50 ) / 4;
 			// IroWiki says Rate should be reduced by target stats, but currently unknown

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8727,7 +8727,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		sc = NULL;
 
 #ifdef RENEWAL
-	uint16 levelAdv = ((uint16)pow(max(0, status_get_lv(src) - status_get_lv(bl)), 2) / 5) * 100;
+	uint16 levelAdv = (static_cast<uint16>(pow(max(0, status_get_lv(src) - status_get_lv(bl)), 2)) / 5) * 100;
 #endif
 
 	switch (type) {
@@ -12384,6 +12384,7 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 				// "Ugly workaround"  [Skotlex]
 				// delays status change ending so that a skill that sets opt1 fails to
 				// trigger when it also removed one
+				case SC_STONE:
 				case SC_STONEWAIT:
 				case SC_FREEZE:
 				case SC_STUN:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9618,9 +9618,6 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				pc_bonus_script_clear(sd, BSF_REM_ON_MADOGEAR);
 			break;
 		default:
-			// Allow Stone to overwrite StoneWait
-			if (sc->opt1 == OPT1_STONEWAIT && scdb->opt1 == OPT1_STONE)
-				break;
 			// If new SC has OPT1 while unit has OPT1, fail it!
 			if (sc->opt1 && scdb->opt1)
 				return 0;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10110,7 +10110,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 
 		case SC_STONEWAIT:
-			val3 -= status_get_sc_interval(SC_STONE); // Petrify time
+			val3 -= tick; // Petrify time - Incubation time
 			break;
 
 		case SC_DPOISON:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9685,14 +9685,19 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 
 	// End the SCs from the list and immediately return
 	if (!scdb->endreturn.empty()) {
+		bool isRemoved = false;
+
 		for (const auto &it : scdb->endreturn) {
 			sc_type rem_sc = it;
 
-			if (sc->data[rem_sc])
+			if (sc->data[rem_sc]) {
 				status_change_end(bl, rem_sc, INVALID_TIMER);
+				isRemoved = true;
+			}
 		}
 
-		return 0; // Don't give the status
+		if (isRemoved) // Something was removed, don't give the status
+			return 0;
 	}
 
 	// Check for overlapping fails

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8658,7 +8658,6 @@ static int status_get_sc_interval(enum sc_type type)
 		case SC_MAGICMUSHROOM:
 			return 4000;
 		case SC_STONE:
-		case SC_STONEWAIT:
 			return 5000;
 		case SC_BLEEDING:
 		case SC_TOXIN:
@@ -8728,7 +8727,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 		sc = NULL;
 
 #ifdef RENEWAL
-	uint16 levelAdv = (pow(max(0, status_get_lv(src) - status_get_lv(bl)), 2) / 5) * 100;
+	uint16 levelAdv = ((uint16)pow(max(0, status_get_lv(src) - status_get_lv(bl)), 2) / 5) * 100;
 #endif
 
 	switch (type) {
@@ -9607,7 +9606,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 
 	// Before overlapping fail, one must check for status cured.
 	switch (type) {
-		case SC_STONEWAIT:
+		case SC_STONE:
 			if (sc->data[SC_DANCING]) {
 				unit_stop_walking(bl, 1);
 				status_change_end(bl, SC_DANCING, INVALID_TIMER);
@@ -10099,7 +10098,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 
 		case SC_STONEWAIT:
-			val3 -= status_get_sc_interval(type); // Petrify time
+			val3 -= status_get_sc_interval(SC_STONE); // Petrify time
 			break;
 
 		case SC_DPOISON:
@@ -13129,10 +13128,8 @@ TIMER_FUNC(status_change_timer){
 		break;
 
 	case SC_STONE:
-		if (sce->val4 >= 0) {
-			if (status->hp > status->max_hp / 4)
-				status_percent_damage(nullptr, bl, 1, 0, false);
-		}
+		if (sce->val4 >= 0 && status->hp > status->max_hp / 4)
+			status_percent_damage(nullptr, bl, 1, 0, false);
 		break;
 
 	case SC_POISON:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9239,6 +9239,24 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	if(status->mode&MD_MVP && !(flag&SCSTART_NOAVOID) && scdb->flag[SCF_MVPRESIST])
 		return 0;
 
+	// End the SCs from the list and immediately return
+	// If anything in this list is removed, the rest is ignored.
+	if (!scdb->endreturn.empty()) {
+		bool isRemoved = false;
+
+		for (const auto &it : scdb->endreturn) {
+			sc_type rem_sc = it;
+
+			if (sc->data[rem_sc]) {
+				status_change_end(bl, rem_sc, INVALID_TIMER);
+				isRemoved = true;
+			}
+		}
+
+		if (isRemoved) // Something was removed, don't give the status
+			return 0;
+	}
+
 	// Check failing SCs from list
 	if (!scdb->fail.empty()) {
 		for (const auto &it : scdb->fail) {
@@ -9628,23 +9646,6 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				}
 			}
 		}
-	}
-
-	// End the SCs from the list and immediately return
-	if (!scdb->endreturn.empty()) {
-		bool isRemoved = false;
-
-		for (const auto &it : scdb->endreturn) {
-			sc_type rem_sc = it;
-
-			if (sc->data[rem_sc]) {
-				status_change_end(bl, rem_sc, INVALID_TIMER);
-				isRemoved = true;
-			}
-		}
-
-		if (isRemoved) // Something was removed, don't give the status
-			return 0;
 	}
 
 	// List of hardcoded status cured.

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9254,7 +9254,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		}
 
 		if (isRemoved) // Something was removed, don't give the status
-			return 0;
+			return 1; // Return 1 so that sc_start can be checked as success
 	}
 
 	// Check failing SCs from list

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -11898,7 +11898,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 
 		default:
-			if (calc_flag.none() && scdb->skill_id == 0 && scdb->icon == EFST_BLANK && scdb->opt1 == OPT1_NONE && scdb->opt2 == OPT2_NONE && scdb->state.none() && scdb->flag.none() && scdb->end.empty() && scdb->fail.empty()) {
+			if (calc_flag.none() && scdb->skill_id == 0 && scdb->icon == EFST_BLANK && scdb->opt1 == OPT1_NONE && scdb->opt2 == OPT2_NONE && scdb->state.none() && scdb->flag.none() && scdb->end.empty() && scdb->endreturn.empty() && scdb->fail.empty()) {
 				// Status change with no calc, no icon, and no skill associated...?
 				ShowWarning("status_change_start: Status %s (%d) is bare. Add the NoWarning flag to suppress this message.\n", script_get_constant_str("SC_", type), type);
 				return 0;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13145,7 +13145,7 @@ TIMER_FUNC(status_change_timer){
 
 	case SC_STONE:
 		if (sce->val4 >= 0 && status->hp > status->max_hp / 4)
-			status_percent_damage(nullptr, bl, 1, 0, false);
+			status_percent_damage(nullptr, bl, -1, 0, false);
 		break;
 
 	case SC_POISON:

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -2878,7 +2878,7 @@ struct s_status_change_db {
 
 class StatusDatabase : public TypesafeCachedYamlDatabase<uint16, s_status_change_db> {
 public:
-	StatusDatabase() : TypesafeCachedYamlDatabase("STATUS_DB", 2, 1) {
+	StatusDatabase() : TypesafeCachedYamlDatabase("STATUS_DB", 2) {
 		// All except BASE and extra flags.
 		SCB_BATTLE.set();
 		SCB_BATTLE.reset(SCB_BASE);

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -161,6 +161,7 @@ enum sc_type : int16 {
 	SC_BLIND,
 	SC_BLEEDING,
 	SC_DPOISON, //10
+	SC_STONEWAIT,
 	SC_COMMON_MAX = 10, // end
 
 	//Next up, we continue on 20, to leave enough room for additional "common" ailments in the future.

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -162,7 +162,7 @@ enum sc_type : int16 {
 	SC_BLEEDING,
 	SC_DPOISON, //10
 	SC_STONEWAIT,
-	SC_COMMON_MAX = 10, // end
+	SC_COMMON_MAX = 11, // end
 
 	//Next up, we continue on 20, to leave enough room for additional "common" ailments in the future.
 	SC_PROVOKE = 20,

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -2871,14 +2871,14 @@ struct s_status_change_db {
 	uint16 skill_id;				///< Associated skill for (addeff) duration lookups
 	std::vector<sc_type> end;		///< List of SC that will be ended when this SC is activated
 	std::vector<sc_type> fail;		///< List of SC that causing this SC cannot be activated
-	bool end_return;				///< After SC ends the SC from end list, it does nothing
+	std::vector<sc_type> endreturn;	///< List of SC that will be ended when this SC is activated and then immediately return
 	t_tick min_duration;			///< Minimum duration effect (after all status reduction)
 	uint16 min_rate;				///< Minimum rate to be applied (after all status reduction)
 };
 
 class StatusDatabase : public TypesafeCachedYamlDatabase<uint16, s_status_change_db> {
 public:
-	StatusDatabase() : TypesafeCachedYamlDatabase("STATUS_DB", 1) {
+	StatusDatabase() : TypesafeCachedYamlDatabase("STATUS_DB", 2, 1) {
 		// All except BASE and extra flags.
 		SCB_BATTLE.set();
 		SCB_BATTLE.reset(SCB_BASE);

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -150,7 +150,7 @@ enum sc_type : int16 {
 
 	//First we enumerate common status ailments which are often used around.
 	SC_STONE = 0,
-	SC_COMMON_MIN = 0, // begin
+	SC_COMMON_MIN = SC_STONE, // begin
 	SC_FREEZE,
 	SC_STUN,
 	SC_SLEEP,
@@ -162,7 +162,7 @@ enum sc_type : int16 {
 	SC_BLEEDING,
 	SC_DPOISON, //10
 	SC_STONEWAIT,
-	SC_COMMON_MAX = 11, // end
+	SC_COMMON_MAX = SC_STONEWAIT, // end
 
 	//Next up, we continue on 20, to leave enough room for additional "common" ailments in the future.
 	SC_PROVOKE = 20,


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6748

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Implements SC_STONEWAIT to be used with OPT1_STONEWAIT.
  * Removes a lot of hard coded OPT1_STONE checks now that the two states are split to their own statuses.
  * Fixes SC_STONE not ending when the target receives damage.
  * Fixes SC_STONE getting overwritten by other statuses that have OPT1 states.
Thanks to @Singe-Horizontal and @Lemongrass3110!