### PR TITLE
Updates stacking for common statuses

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -214,7 +214,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      RemoveOnDamaged: true
       OverlapFail: true
     Fail:
       Refresh: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -70,7 +70,6 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     End:
       Aeterna: true
     EndReturn:
@@ -89,7 +88,6 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     EndReturn:
       StoneWait: true
       Stone: true
@@ -121,9 +119,7 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     End:
-      Dancing: true
       Aeterna: true
   - Status: Stun
     DurationLookup: NPC_STUNATTACK
@@ -142,14 +138,13 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Stun: true
+      Stun: true
     End:
-      Dancing: true
       Stone: true
       StoneWait: true
       Freeze: true
       Sleep: true
       Burning: true
-      #Undead: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -168,6 +163,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Sleep: true
+      Sleep: true
     End:
       Dancing: true
       Stone: true
@@ -175,7 +171,6 @@ Body:
       Freeze: true
       Stun: true
       Burning: true
-      #Undead: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -2896,7 +2891,6 @@ Body:
       Freeze: true
       Stun: true
       Sleep: true
-      #Undead: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY
@@ -3112,11 +3106,12 @@ Body:
       StopAttacking: true
       OverlapFail: true
     End:
-      Dancing: true
       Burning: true
       Freezing: true
       Freeze: true
       Stone: true
+      StoneWait: true
+      Sleep: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS
     DurationLookup: WL_MARSHOFABYSS

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -165,7 +165,6 @@ Body:
       Gvg_Sleep: true
       Sleep: true
     End:
-      Dancing: true
       Stone: true
       StoneWait: true
       Freeze: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -115,6 +115,13 @@ Body:
       Inspiration: true
       Warmer: true
       Gvg_Freez: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      #Undead: true
     End:
       Dancing: true
       Aeterna: true
@@ -137,6 +144,12 @@ Body:
       Gvg_Stun: true
     End:
       Dancing: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Sleep: true
+      Burning: true
+      #Undead: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -157,6 +170,12 @@ Body:
       Gvg_Sleep: true
     End:
       Dancing: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Burning: true
+      #Undead: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -172,6 +191,8 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
+      Poison: true
+      Dpoison: true
   - Status: Curse
     DurationLookup: NPC_CURSEATTACK
     CalcFlags:
@@ -189,6 +210,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Curse: true
+      Curse: true
   - Status: Silence
     DurationLookup: NPC_SILENCEATTACK
     States:
@@ -204,6 +226,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Silence: true
+      Silence: true
   - Status: Confusion
     DurationLookup: NPC_WIDECONFUSE
     Flags:
@@ -214,6 +237,7 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
+    EndReturn:
       Confusion: true
   - Status: Blind
     DurationLookup: NPC_BLINDATTACK
@@ -231,6 +255,7 @@ Body:
       Inspiration: true
       Fear: true
       Gvg_Blind: true
+      Blind: true
   - Status: Bleeding
     Icon: EFST_BLOODING
     DurationLookup: NPC_BLEEDING
@@ -415,6 +440,8 @@ Body:
     Flags:
       BossResist: true
       TaekwonAngel: true
+    EndReturn:
+      Curse: true
   - Status: Signumcrucis
     Icon: EFST_CRUCIS
     DurationLookup: AL_CRUCIS
@@ -2849,6 +2876,8 @@ Body:
   - Status: Burning
     Icon: EFST_BURNT
     DurationLookup: RK_DRAGONBREATH
+    CalcFlags:
+      Mdef: true
     Opt1: Burning
     Flags:
       SendOption: true
@@ -2861,8 +2890,13 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
-    CalcFlags:
-      Mdef: true
+    End:
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      #Undead: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -214,7 +214,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      OverlapFail: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -249,7 +248,6 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
-      OverlapFail: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -263,7 +261,6 @@ Body:
     Flags:
       SendOption: true
       BossResist: true
-      OverlapFail: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -2848,7 +2845,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      OverlapFail: true
       Debuff: true
     Fail:
       Inspiration: true
@@ -3084,7 +3080,6 @@ Body:
       SetStand: true
       StopWalking: true
       StopAttacking: true
-      OverlapFail: true
     End:
       Freezing: true
   - Status: Marshofabyss

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -139,12 +139,6 @@ Body:
       Inspiration: true
       Gvg_Stun: true
       Stun: true
-    End:
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Sleep: true
-      Burning: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -164,12 +158,6 @@ Body:
       Inspiration: true
       Gvg_Sleep: true
       Sleep: true
-    End:
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Stun: true
-      Burning: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -2884,12 +2872,6 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
-    End:
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Stun: true
-      Sleep: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY
@@ -3105,12 +3087,7 @@ Body:
       StopAttacking: true
       OverlapFail: true
     End:
-      Burning: true
       Freezing: true
-      Freeze: true
-      Stone: true
-      StoneWait: true
-      Sleep: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS
     DurationLookup: WL_MARSHOFABYSS

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -117,6 +117,14 @@ Body:
       Inspiration: true
       Warmer: true
       Gvg_Freez: true
+      Whiteimprison: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      Burning: true
+      #Undead: true
     End:
       Dancing: true
       Aeterna: true
@@ -137,8 +145,16 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Stun: true
+      Stun: true
     End:
       Dancing: true
+      Whiteimprison: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Sleep: true
+      Burning: true
+      #Undead: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -159,6 +175,13 @@ Body:
       Gvg_Sleep: true
     End:
       Dancing: true
+      Whiteimprison: true
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Burning: true
+      #Undead: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -175,6 +198,8 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
+      Poison: true
+      Dpoison: true
   - Status: Curse
     DurationLookup: NPC_WIDECURSE
     CalcFlags:
@@ -193,6 +218,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Curse: true
+      Curse: true
   - Status: Silence
     DurationLookup: NPC_SILENCEATTACK
     States:
@@ -209,6 +235,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Silence: true
+      Silence: true
   - Status: Confusion
     DurationLookup: NPC_WIDECONFUSE
     Flags:
@@ -220,6 +247,7 @@ Body:
     Fail:
       Refresh: true
       Inspiration: true
+    EndReturn:
       Confusion: true
   - Status: Blind
     DurationLookup: NPC_BLINDATTACK
@@ -238,6 +266,7 @@ Body:
       Inspiration: true
       Fear: true
       Gvg_Blind: true
+      Blind: true
   - Status: Bleeding
     Icon: EFST_BLOODING
     DurationLookup: NPC_BLEEDING
@@ -426,6 +455,8 @@ Body:
     Flags:
       BossResist: true
       TaekwonAngel: true
+    EndReturn:
+      Curse: true
   - Status: Signumcrucis
     Icon: EFST_CRUCIS
     DurationLookup: AL_CRUCIS
@@ -2976,6 +3007,13 @@ Body:
       Refresh: true
       Inspiration: true
       Whiteimprison: true
+    End:
+      Stone: true
+      StoneWait: true
+      Freeze: true
+      Stun: true
+      Sleep: true
+      #Undead: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -220,7 +220,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      OverlapFail: true
       SpreadEffect: true
     Fail:
       Refresh: true
@@ -257,7 +256,6 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
-      OverlapFail: true
       SpreadEffect: true
     Fail:
       Refresh: true
@@ -272,7 +270,6 @@ Body:
     Flags:
       SendOption: true
       BossResist: true
-      OverlapFail: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -2958,7 +2955,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      OverlapFail: true
       Debuff: true
     Fail:
       Inspiration: true
@@ -3195,7 +3191,6 @@ Body:
       StopWalking: true
       StopAttacking: true
       StopCasting: true
-      OverlapFail: true
     End:
       Freezing: true
   - Status: Marshofabyss

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -142,13 +142,6 @@ Body:
       Inspiration: true
       Gvg_Stun: true
       Stun: true
-    End:
-      Whiteimprison: true
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Sleep: true
-      Burning: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -168,13 +161,6 @@ Body:
       Inspiration: true
       Gvg_Sleep: true
       Sleep: true
-    End:
-      Whiteimprison: true
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Stun: true
-      Burning: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -2998,12 +2984,6 @@ Body:
       Refresh: true
       Inspiration: true
       Whiteimprison: true
-    End:
-      Stone: true
-      StoneWait: true
-      Freeze: true
-      Stun: true
-      Sleep: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY
@@ -3218,13 +3198,7 @@ Body:
       StopCasting: true
       OverlapFail: true
     End:
-      Burning: true
       Freezing: true
-      Freeze: true
-      Stone: true
-      StoneWait: true
-      Sleep: true
-      Stun: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS
     DurationLookup: WL_MARSHOFABYSS

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -220,7 +220,6 @@ Body:
     Flags:
       BossResist: true
       StopWalking: true
-      RemoveOnDamaged: true
       OverlapFail: true
       SpreadEffect: true
     Fail:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -71,7 +71,6 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     End:
       Aeterna: true
     EndReturn:
@@ -91,7 +90,6 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     EndReturn:
       StoneWait: true
       Stone: true
@@ -124,9 +122,7 @@ Body:
       Stun: true
       Sleep: true
       Burning: true
-      #Undead: true
     End:
-      Dancing: true
       Aeterna: true
   - Status: Stun
     DurationLookup: NPC_STUNATTACK
@@ -147,14 +143,12 @@ Body:
       Gvg_Stun: true
       Stun: true
     End:
-      Dancing: true
       Whiteimprison: true
       Stone: true
       StoneWait: true
       Freeze: true
       Sleep: true
       Burning: true
-      #Undead: true
   - Status: Sleep
     DurationLookup: NPC_SLEEPATTACK
     States:
@@ -173,6 +167,7 @@ Body:
       Refresh: true
       Inspiration: true
       Gvg_Sleep: true
+      Sleep: true
     End:
       Dancing: true
       Whiteimprison: true
@@ -181,7 +176,6 @@ Body:
       Freeze: true
       Stun: true
       Burning: true
-      #Undead: true
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
@@ -3013,7 +3007,6 @@ Body:
       Freeze: true
       Stun: true
       Sleep: true
-      #Undead: true
   - Status: Freezing
     Icon: EFST_FROSTMISTY
     DurationLookup: WL_FROSTMISTY
@@ -3232,6 +3225,8 @@ Body:
       Freezing: true
       Freeze: true
       Stone: true
+      StoneWait: true
+      Sleep: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS
     DurationLookup: WL_MARSHOFABYSS

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -3225,7 +3225,6 @@ Body:
       StoneWait: true
       Sleep: true
       Stun: true
-      Sleep: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS
     DurationLookup: WL_MARSHOFABYSS

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -169,7 +169,6 @@ Body:
       Gvg_Sleep: true
       Sleep: true
     End:
-      Dancing: true
       Whiteimprison: true
       Stone: true
       StoneWait: true
@@ -449,8 +448,6 @@ Body:
     Flags:
       BossResist: true
       TaekwonAngel: true
-    EndReturn:
-      Curse: true
   - Status: Signumcrucis
     Icon: EFST_CRUCIS
     DurationLookup: AL_CRUCIS
@@ -3226,6 +3223,8 @@ Body:
       Freeze: true
       Stone: true
       StoneWait: true
+      Sleep: true
+      Stun: true
       Sleep: true
   - Status: Marshofabyss
     Icon: EFST_MARSHOFABYSS

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20220406
+//= 20220414
 //===== Description: =========================================
 //= Explanation of the status.yml file and structure.
 //============================================================
@@ -113,6 +113,7 @@ Opt1: Special effect when status is active (Aegis: BODYSTATE_*). This option is 
 
 	None         - No effect (Default)
 	Stone        - Stone curse effect
+	StoneWait    - Stone curse incubation effect
 	Freeze       - Freeze effect
 	Stun         - Stun effect
 	Sleep        - Sleep effect

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1302,11 +1302,24 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 				type = it.sc;
 				time = it.duration;
 
+				int32 val1 = 7, val2, val3;
+
+				if (type == SC_STONEWAIT) {
+					val2 = src->id;
+					val3 = skill_get_time(status_db.getSkill(type), 7);
+				} else {
+					val2 = 0;
+					if (type == SC_BURNING)
+						val3 = src->id;
+					else
+						val3 = 0;
+				}
+
 				if (it.flag&ATF_TARGET)
-					status_change_start(src,bl,type,rate,7,0,(type == SC_BURNING)?src->id:0,0,time,SCSTART_NONE);
+					status_change_start(src,bl,type,rate,val1,val2,val3,0,time,SCSTART_NONE);
 
 				if (it.flag&ATF_SELF)
-					status_change_start(src,src,type,rate,7,0,(type == SC_BURNING)?src->id:0,0,time,SCSTART_NONE);
+					status_change_start(src,src,type,rate,val1,val2,val3,0,time,SCSTART_NONE);
 			}
 		}
 
@@ -1321,10 +1334,23 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 				type = it.sc;
 				time = it.duration;
 
+				int32 val1 = 7, val2, val3;
+
+				if (type == SC_STONEWAIT) {
+					val2 = src->id;
+					val3 = skill_get_time(status_db.getSkill(type), 7);
+				} else {
+					val2 = 0;
+					if (type == SC_BURNING)
+						val3 = src->id;
+					else
+						val3 = 0;
+				}
+
 				if (it.target&ATF_TARGET)
-					status_change_start(src,bl,type,it.rate,7,0,0,0,time,SCSTART_NONE);
+					status_change_start(src,bl,type,it.rate,val1,val2,val3,0,time,SCSTART_NONE);
 				if (it.target&ATF_SELF)
-					status_change_start(src,src,type,it.rate,7,0,0,0,time,SCSTART_NONE);
+					status_change_start(src,src,type,it.rate,val1,val2,val3,0,time,SCSTART_NONE);
 			}
 			//"While the damage can be blocked by Pneuma, the chance to break armor remains", irowiki. [Cydh]
 			if (dmg_lv == ATK_BLOCK && skill_id == AM_ACIDTERROR) {
@@ -2516,11 +2542,24 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 			type = it.sc;
 			time = it.duration;
 
+			int32 val1 = 7, val2, val3;
+
+			if (type == SC_STONEWAIT) {
+				val2 = src->id;
+				val3 = skill_get_time(status_db.getSkill(type), 7);
+			} else {
+				val2 = 0;
+				if (type == SC_BURNING)
+					val3 = src->id;
+				else
+					val3 = 0;
+			}
+
 			if (it.flag&ATF_TARGET && src != bl)
-				status_change_start(src,src,type,rate,7,0,0,0,time,SCSTART_NONE);
+				status_change_start(src,src,type,rate,val1,val2,val3,0,time,SCSTART_NONE);
 
 			if (it.flag&ATF_SELF && !status_isdead(bl))
-				status_change_start(src,bl,type,rate,7,0,0,0,time,SCSTART_NONE);
+				status_change_start(src,bl,type,rate,val1,val2,val3,0,time,SCSTART_NONE);
 		}
 	}
 
@@ -4845,10 +4884,14 @@ static int skill_tarotcard(struct block_list* src, struct block_list *target, ui
 	}
 	case 8: // THE HANGED MAN - stop, freeze or stoned
 	{
-		enum sc_type sc[] = { SC_STOP, SC_FREEZE, SC_STONE };
+		enum sc_type sc[] = { SC_STOP, SC_FREEZE, SC_STONEWAIT };
 		uint8 rand_eff = rnd() % 3;
 		int time = ((rand_eff == 0) ? skill_get_time2(skill_id, skill_lv) : skill_get_time2(status_db.getSkill(sc[rand_eff]), 1));
-		sc_start(src, target, sc[rand_eff], 100, skill_lv, time);
+
+		if (sc[rand_eff] == SC_STONEWAIT)
+			sc_start4(src, target, SC_STONEWAIT, 100, skill_lv, src->id, skill_get_time(status_db.getSkill(SC_STONEWAIT), 1), 0, time);
+		else
+			sc_start(src, target, sc[rand_eff], 100, skill_lv, time);
 		break;
 	}
 	case 9: // DEATH - curse, coma and poison

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9659,14 +9659,6 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 
 	// List of hardcoded status cured.
 	switch (type) {
-		case SC_STONE:
-		case SC_FREEZE:
-		case SC_STUN:
-			if (sc->data[SC_DANCING]) {
-				unit_stop_walking(bl, 1);
-				status_change_end(bl, SC_DANCING, INVALID_TIMER);
-			}
-			break;
 		case SC_BLESSING:
 			// !TODO: Blessing and Agi up should do 1 damage against players on Undead Status, even on PvM
 			// !but cannot be plagiarized (this requires aegis investigation on packets and official behavior) [Brainstorm]
@@ -12018,14 +12010,16 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 					unit_stop_attack(bl);
 				}
 				break;
-			case SC_WHITEIMPRISON:
 			case SC_DEEPSLEEP:
 			case SC_CRYSTALIZE:
 			case SC_FREEZE:
 			case SC_STUN:
 			case SC_GRAVITYCONTROL:
-				if (sc->data[SC_DANCING])
+			case SC_STONE:
+				if (sc->data[SC_DANCING]) {
 					unit_stop_walking(bl, 1);
+					status_change_end(bl, SC_DANCING, INVALID_TIMER);
+				}
 				break;
 			default:
 				if (!unit_blown_immune(bl,0x1))
@@ -12389,26 +12383,6 @@ int status_change_end_(struct block_list* bl, enum sc_type type, int tid, const 
 		}
 		if (sce->timer != INVALID_TIMER) // Could be a SC with infinite duration
 			delete_timer(sce->timer,status_change_timer);
-		if (sc->opt1)
-			switch (type) {
-				// "Ugly workaround"  [Skotlex]
-				// delays status change ending so that a skill that sets opt1 fails to
-				// trigger when it also removed one
-				case SC_STONE:
-				case SC_STONEWAIT:
-					sce->val4 = -1; // Petrify time
-				case SC_FREEZE:
-				case SC_STUN:
-				case SC_SLEEP:
-					if (sce->val1) {
-						// Removing the 'level' shouldn't affect anything in the code
-						// since these SC are not affected by it, and it lets us know
-						// if we have already delayed this attack or not.
-						sce->val1 = 0;
-						sce->timer = add_timer(gettick()+10, status_change_timer, bl->id, type);
-						return 1;
-					}
-			}
 	}
 
 	(sc->count)--;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12020,11 +12020,8 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 					unit_stop_attack(bl);
 				}
 				break;
-			case SC_DEEPSLEEP:
-			case SC_CRYSTALIZE:
 			case SC_FREEZE:
 			case SC_STUN:
-			case SC_GRAVITYCONTROL:
 			case SC_STONE:
 				if (sc->data[SC_DANCING]) {
 					unit_stop_walking(bl, 1);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14496,7 +14496,7 @@ static TIMER_FUNC(status_natural_heal_timer){
  * @param data: data pushed through timer function
  * @return 0
  */
-static TIMER_FUNC(status_clear_lastEffect_timer) {
+TIMER_FUNC(status_clear_lastEffect_timer) {
 	block_list *bl = map_id2bl(id);
 
 	if (bl != nullptr) {

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9621,6 +9621,16 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 	}
 
+	// Check for OPT1 stacking
+	if (sc->opt1 > OPT1_NONE && scdb->opt1 > OPT1_NONE) {
+		for (const auto &status_it : status_db) {
+			sc_type opt1_type = status_it.second->type;
+
+			if (sc->data[opt1_type] && status_it.second->opt1 > OPT1_NONE)
+				status_change_end(bl, opt1_type, INVALID_TIMER);
+		}
+	}
+
 	// Before overlapping fail, one must check for status cured.
 	std::vector<sc_type> endlist;
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9650,6 +9650,8 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	// List of hardcoded status cured.
 	switch (type) {
 		case SC_STONE:
+		case SC_FREEZE:
+		case SC_STUN:
 			if (sc->data[SC_DANCING]) {
 				unit_stop_walking(bl, 1);
 				status_change_end(bl, SC_DANCING, INVALID_TIMER);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9695,9 +9695,6 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				pc_bonus_script_clear(sd, BSF_REM_ON_MADOGEAR);
 			break;
 		default:
-			// If new SC has OPT1 while unit has OPT1, fail it!
-			if (sc->opt1 && scdb->opt1)
-				return 0;
 			break;
 	}
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3056,6 +3056,7 @@ struct status_change {
 	unsigned short opt2;// health state (bitfield)
 	unsigned char count;
 	sc_type lastEffect; // Used to check for stacking damageable SC on the same attack
+	int32 lastEffectTimer; // Timer for lastEffect
 	//! TODO: See if it is possible to implement the following SC's without requiring extra parameters while the SC is inactive.
 	struct {
 		uint8 move;
@@ -3230,6 +3231,7 @@ int status_change_timer_sub(struct block_list* bl, va_list ap);
 int status_change_clear(struct block_list* bl, int type);
 void status_change_clear_buffs(struct block_list* bl, uint8 type);
 void status_change_clear_onChangeMap(struct block_list *bl, struct status_change *sc);
+TIMER_FUNC(status_clear_lastEffect_timer);
 
 #define status_calc_mob(md, opt) status_calc_bl_(&(md)->bl, status_db.getSCB_ALL(), opt)
 #define status_calc_pet(pd, opt) status_calc_bl_(&(pd)->bl, status_db.getSCB_ALL(), opt)

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3055,6 +3055,7 @@ struct status_change {
 	unsigned short opt1;// body state
 	unsigned short opt2;// health state (bitfield)
 	unsigned char count;
+	sc_type lastEffect; // Used to check for stacking damageable SC on the same attack
 	//! TODO: See if it is possible to implement the following SC's without requiring extra parameters while the SC is inactive.
 	struct {
 		uint8 move;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -62,7 +62,6 @@ struct unit_data {
 	char walk_done_event[EVENT_NAME_LENGTH];
 	char title[NAME_LENGTH];
 	int32 group_id;
-	sc_type lastEffect;
 };
 
 struct view_data {

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -62,6 +62,7 @@ struct unit_data {
 	char walk_done_event[EVENT_NAME_LENGTH];
 	char title[NAME_LENGTH];
 	int32 group_id;
+	sc_type lastEffect;
 };
 
 struct view_data {


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6798

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Updates the Fail, End, and EndReturn lists for OPT1 and OPT2 statuses.
  * Removes the hardcoded OPT1 overwrite prevention check.
Thanks to @Playtester!