### PR TITLE
Minor Adjustment to Expanded Class skills

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -33239,17 +33239,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -5
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 1000
@@ -33656,17 +33646,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -5
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
     Duration1:
       - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -33251,7 +33251,7 @@ Body:
       - Level: 5
         Area: 3
     CastCancel: true
-    CastTime: 3000
+    CastTime: 2000
     AfterCastActDelay: 1000
     Duration1:
       - Level: 1
@@ -33266,7 +33266,7 @@ Body:
         Time: 3500
     Duration2: 18000
     Cooldown: 5000
-    FixedCastTime: 3000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3715,15 +3715,19 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 				if(sd->bonus.crit_atk_rate && is_attack_critical(wd, src, target, skill_id, skill_lv, false)) { // add +crit damage bonuses here in pre-renewal mode [helvetica]
 					ATK_ADDRATE(wd->damage, wd->damage2, sd->bonus.crit_atk_rate);
 				}
-#endif
 				if(sd->status.party_id && (skill=pc_checkskill(sd,TK_POWER)) > 0) {
 					if( (i = party_foreachsamemap(party_sub_count, sd, 0)) > 1 ) { // exclude the player himself [Inkfish]
 						// Reduce count by one (self) [Tydus1]
 						i -= 1; 
 						ATK_ADDRATE(wd->damage, wd->damage2, 2*skill*i);
-						RE_ALLATK_ADDRATE(wd, 2*skill*i);
 					}
 				}
+#else
+				if ((skill = pc_checkskill(sd, TK_POWER)) > 0) {
+					ATK_ADDRATE(wd->damage, wd->damage2, 10 + 15 * skill);
+					RE_ALLATK_ADDRATE(wd, 10 + 15 * skill);
+				}
+#endif
 			}
 #ifndef RENEWAL
 			if(tsd != nullptr && tsd->bonus.crit_def_rate != 0 && !skill_id && is_attack_critical(wd, src, target, skill_id, skill_lv, false)) {
@@ -5003,7 +5007,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case SU_LUNATICCARROTBEAT:
 		case SU_LUNATICCARROTBEAT2:
-			skillratio += 100 + 100 * skill_lv;
+			skillratio += 100 + 100 * skill_lv + sstatus->str / 6; // !TODO: What's the STR bonus?
+			RE_LVL_MOD(100);
 			if (sd && pc_checkskill(sd, SU_SPIRITOFLIFE))
 				skillratio += skillratio * status_get_hp(src) / status_get_max_hp(src);
 			break;
@@ -7313,7 +7318,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case SU_CN_METEOR:
 					case SU_CN_METEOR2:
-						skillratio += 100 + 100 * skill_lv;
+						skillratio += 100 + 100 * skill_lv + sstatus->int_ / 6; // !TODO: Confirm INT bonus
+						RE_LVL_MOD(100);
 						break;
 					case NPC_VENOMFOG:
 						skillratio += 600 + 100 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5007,8 +5007,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case SU_LUNATICCARROTBEAT:
 		case SU_LUNATICCARROTBEAT2:
-			skillratio += 100 + 100 * skill_lv + sstatus->str / 6; // !TODO: What's the STR bonus?
-			RE_LVL_MOD(100);
+			skillratio += 100 + 100 * skill_lv + sstatus->str * 5; // !TODO: What's the STR bonus?
+			RE_LVL_DMOD(100);
 			if (sd && pc_checkskill(sd, SU_SPIRITOFLIFE))
 				skillratio += skillratio * status_get_hp(src) / status_get_max_hp(src);
 			break;
@@ -7318,8 +7318,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case SU_CN_METEOR:
 					case SU_CN_METEOR2:
-						skillratio += 100 + 100 * skill_lv + sstatus->int_ / 6; // !TODO: Confirm INT bonus
-						RE_LVL_MOD(100);
+						skillratio += 100 + 100 * skill_lv + sstatus->int_ * 5; // !TODO: Confirm INT bonus
+						RE_LVL_DMOD(100);
 						break;
 					case NPC_VENOMFOG:
 						skillratio += 600 + 100 * skill_lv;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Kihop now applies physical damage bonus directly no longer depending on the number of party members. Physical damage bonus: (10 + (15 x skill level))%.
  * Catnip Meteor:
    - Reduces fixed casting time from 3 seconds to 1.5 seconds.
    - Reduces variable casting time from 4 seconds to 2 seconds.
    - From base level 100, deals additional damage depending on the user's base level and INT.
  * Lunatic Carrot Beat now deals additional damage (from base level 100) depending on user's base level and STR.