### PR TITLE
Disabled random options for stolen items

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -220,6 +220,10 @@ backstab_bow_penalty: yes
 // Use 0 to disable (max allowed value is 255)
 skill_steal_max_tries: 0
 
+// Should random options be applied to stolen items? (Note 1)
+// Official: no
+skill_steal_random_options: no
+
 // Level and Strength of "MVP heal". When someone casts a heal of this level or
 // above, the heal formula is bypassed and this value is used instead.
 max_heal: 9999

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9815,6 +9815,7 @@ static const struct _battle_data {
 	{ "mobs_level_up_exp_rate",             &battle_config.mobs_level_up_exp_rate,          1,      1,      INT_MAX,        },
 	{ "pk_min_level",                       &battle_config.pk_min_level,                    55,     1,      INT_MAX,        },
 	{ "skill_steal_max_tries",              &battle_config.skill_steal_max_tries,           0,      0,      UCHAR_MAX,      },
+	{ "skill_steal_random_options",         &battle_config.skill_steal_random_options,      0,      0,      1,              },
 	{ "motd_type",                          &battle_config.motd_type,                       0,      0,      1,              },
 	{ "finding_ore_rate",                   &battle_config.finding_ore_rate,                100,    0,      INT_MAX,        },
 	{ "exp_calc_type",                      &battle_config.exp_calc_type,                   0,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -403,6 +403,7 @@ struct Battle_Config
 	int mobs_level_up_exp_rate; // [Valaris]
 	int pk_min_level; // [celest]
 	int skill_steal_max_tries; //max steal skill tries on a mob. if 0, then w/o limit [Lupus]
+	int skill_steal_random_options;
 	int motd_type; // [celest]
 	int finding_ore_rate; // orn
 	int exp_calc_type;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6108,7 +6108,6 @@ bool pc_steal_item(struct map_session_data *sd,struct block_list *bl, uint16 ski
 	unsigned char flag = 0;
 	struct status_data *sd_status, *md_status;
 	struct mob_data *md;
-	struct item tmp_item;
 
 	if(!sd || !bl || bl->type!=BL_MOB)
 		return false;
@@ -6154,11 +6153,13 @@ bool pc_steal_item(struct map_session_data *sd,struct block_list *bl, uint16 ski
 		return false;
 
 	itemid = md->db->dropitem[i].nameid;
-	memset(&tmp_item,0,sizeof(tmp_item));
+	struct item tmp_item = {};
 	tmp_item.nameid = itemid;
 	tmp_item.amount = 1;
 	tmp_item.identify = itemdb_isidentified(itemid);
-	mob_setdropitem_option(&tmp_item, &md->db->dropitem[i]);
+	if( battle_config.skill_steal_random_options ){
+		mob_setdropitem_option( &tmp_item, &md->db->dropitem[i] );
+	}
 	flag = pc_additem(sd,&tmp_item,1,LOG_TYPE_PICKDROP_PLAYER);
 
 	//TODO: Should we disable stealing when the item you stole couldn't be added to your inventory? Perhaps players will figure out a way to exploit this behaviour otherwise?


### PR DESCRIPTION
* **Addressed Issue(s)**: #6833

* **Server Mode**: Both

* **Description of Pull Request**: 
Added a battle config to enable/disable random options for stolen items.
