### PR TITLE
Fixes for consumeitem script command

### DIFF
--- a/npc/re/merchants/enchan_illusion_17_1.txt
+++ b/npc/re/merchants/enchan_illusion_17_1.txt
@@ -210,6 +210,7 @@ sp_cor,108,130,5	script	Rebellion#rm171_7	4_F_REBELLION3,{
 			Zeny -= 1000000;
 		}
 		consumeitem .@item_id;
+		questinfo_refresh();
 		mes "[Rebellion]";
 		mes "I gave you the best I had left.";
 		mes "If you want to refine it, the <NAVI>[Tin Can]<INFO>sp_cor,106,136,0,101,0</INFO></NAVI> next to me can take good care of you.";
@@ -246,6 +247,7 @@ sp_cor,108,130,5	script	Rebellion#rm171_7	4_F_REBELLION3,{
 		delitem 25669,30;	// EP17_1_EVT02
 		delitem 25723,5;	// EP17_1_EVT39
 		consumeitem 23775;	// EP17_1_SPC04
+		questinfo_refresh();
 		close;
 	}
 	end;
@@ -331,6 +333,7 @@ sp_cor,111,130,3	script	Elyumina#rm171_4	4_EP17_ELYUMINA,{
 		delitem 25668,1;	// EP17_1_EVT01
 		delitem 25669,50;	// EP17_1_EVT02
 		consumeitem 23772;	// EP17_1_SPC01
+		questinfo_refresh();
 		close3;
 	case 2:
 		cutin "ep171_elyumina04",0;

--- a/npc/re/merchants/enchan_illusion_17_1.txt
+++ b/npc/re/merchants/enchan_illusion_17_1.txt
@@ -169,10 +169,12 @@ sp_cor,108,130,5	script	Rebellion#rm171_7	4_F_REBELLION3,{
 		mes "If you want a weapon, you can talk to Elyumina.";
 		next;
 		if (select("Request Weapon Modification Device (Physical).", "Request Weapon Modification Device (Magic).") == 1) {
-			.@item_id = 23773;	// EP17_1_SPC02
+			// .@item_id = 23773;	// EP17_1_SPC02
+			.@group = IG_EP17_1_SPC02;
 			setarray .@ids[0],23776,23777,23778;
 		} else {
-			.@item_id = 23774;	// EP17_1_SPC03
+			// .@item_id = 23774;	// EP17_1_SPC03
+			.@group = IG_EP17_1_SPC03;	// EP17_1_SPC03
 			setarray .@ids[0],23779,23780,23781;
 		}
 		mes "[Rebellion]";
@@ -209,8 +211,8 @@ sp_cor,108,130,5	script	Rebellion#rm171_7	4_F_REBELLION3,{
 			}
 			Zeny -= 1000000;
 		}
-		consumeitem .@item_id;
-		questinfo_refresh();
+		// consumeitem .@item_id;
+		getgroupitem(.@group);
 		mes "[Rebellion]";
 		mes "I gave you the best I had left.";
 		mes "If you want to refine it, the <NAVI>[Tin Can]<INFO>sp_cor,106,136,0,101,0</INFO></NAVI> next to me can take good care of you.";
@@ -246,8 +248,8 @@ sp_cor,108,130,5	script	Rebellion#rm171_7	4_F_REBELLION3,{
 		mes "If you want to refine it, the <NAVI>[Tin Can]<INFO>sp_cor,106,136,0,101,0</INFO></NAVI> next to me can take good care of you.";
 		delitem 25669,30;	// EP17_1_EVT02
 		delitem 25723,5;	// EP17_1_EVT39
-		consumeitem 23775;	// EP17_1_SPC04
-		questinfo_refresh();
+		// consumeitem 23775;	// EP17_1_SPC04
+		getgroupitem(IG_EP17_1_SPC04);
 		close;
 	}
 	end;
@@ -332,8 +334,8 @@ sp_cor,111,130,3	script	Elyumina#rm171_4	4_EP17_ELYUMINA,{
 		mes "I'm locked up in here, fixing toys, because of you. You can deal with this, right?";
 		delitem 25668,1;	// EP17_1_EVT01
 		delitem 25669,50;	// EP17_1_EVT02
-		consumeitem 23772;	// EP17_1_SPC01
-		questinfo_refresh();
+		// consumeitem 23772;	// EP17_1_SPC01
+		getgroupitem(IG_EP17_1_SPC01);
 		close3;
 	case 2:
 		cutin "ep171_elyumina04",0;

--- a/src/map/achievement.cpp
+++ b/src/map/achievement.cpp
@@ -876,6 +876,9 @@ bool achievement_check_condition( struct script_code* condition, struct map_sess
 
 	// Only if there was an old script
 	if( previous_st != nullptr ){
+		if (previous_st->bk_st) // fails when a backup exists
+			return 0;
+
 		// Detach the player from the current script
 		script_detach_rid(previous_st);
 	}

--- a/src/map/achievement.cpp
+++ b/src/map/achievement.cpp
@@ -876,9 +876,6 @@ bool achievement_check_condition( struct script_code* condition, struct map_sess
 
 	// Only if there was an old script
 	if( previous_st != nullptr ){
-		if (previous_st->bk_st) // fails when a backup exists
-			return 0;
-
 		// Detach the player from the current script
 		script_detach_rid(previous_st);
 	}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/6838
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The command consumeitem could crash the server when the item script used a command calling pc_show_questinfo (getitem/getgroupitem etc..).
consumeitem is replaced by getgroupitem in quest 17.1 for now. consumeitem will be fixed differently in another pull request


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
