### PR TITLE
Added speed bonus to Serenade of Jawaii

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7862,6 +7862,7 @@ Body:
     DurationLookup: TR_JAWAII_SERENADE
     CalcFlags:
       Smatk: true
+      Speed: true
   - Status: Pron_March
     Icon: EFST_PRON_MARCH
     DurationLookup: TR_PRON_MARCH

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7351,6 +7351,9 @@ static unsigned short status_calc_speed(struct block_list *bl, struct status_cha
 			val = max(val, 25); // !TODO: Confirm bonus movement speed
 		if (sc->data[SC_EMERGENCY_MOVE])
 			val = max(val, sc->data[SC_EMERGENCY_MOVE]->val2);
+		if( sc->data[SC_JAWAII_SERENADE] ){
+			val = max( val, 25 );
+		}
 
 		// !FIXME: official items use a single bonus for this [ultramage]
 		if( sc->data[SC_SPEEDUP0] ) // Temporary item-based speedup


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Renewal

* **Description of Pull Request**: 
Adds the missing walk speed bonus to Serenade of Jawaii.

Thanks to @limitro
