### PR TITLE
Fix possible crash in TypesafeCachedYamlDatabase

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -159,7 +159,7 @@ public:
 	}
 
 	std::shared_ptr<datatype> find( keytype key ) override{
-		if( this->cache.empty() || key >= this->cache.capacity() ){
+		if( this->cache.empty() || key >= this->cache.size() ){
 			return TypesafeYamlDatabase<keytype, datatype>::find( key );
 		}else{
 			return cache[this->calculateCacheKey( key )];


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Both

* **Description of Pull Request**:  We compare against capacity instead of size, this could possibly crash the server.