### PR TITLE
Illusion of Vampire Boss Spawn Fixes

### DIFF
--- a/npc/re/quests/quests_16_2_illusion.txt
+++ b/npc/re/quests/quests_16_2_illusion.txt
@@ -3907,9 +3907,10 @@ gef_d01_i,81,135,5	script	Wizard#ilgf01	4_F_BOMI,5,5,{
 			specialeffect EF_DEVIL;
 			mes "[Bomi]";
 			mes "Oh, no! There is too many toxins in my body. It's getting dangerous!";
-			if (mobcount("gef_d01_i", "ill_vampire_spawn_bomi::OnMobDead") < 1 && mobcount("gef_d01_i", "ill_vampire_spawn_dracula::OnMobDead") < 1)
+			if (mobcount("gef_d01_i", "ill_vampire_spawn_bomi::OnMobDead") < 1 && mobcount("gef_d01_i", "ill_vampire_spawn_dracula::OnMobDead") < 1) {
 				.bomi_count = 0;
 				donpcevent "ill_vampire_spawn_bomi::OnStart";
+			}
 			close;
 		}
 		mes "[Bomi]";

--- a/npc/re/quests/quests_16_2_illusion.txt
+++ b/npc/re/quests/quests_16_2_illusion.txt
@@ -3908,6 +3908,7 @@ gef_d01_i,81,135,5	script	Wizard#ilgf01	4_F_BOMI,5,5,{
 			mes "[Bomi]";
 			mes "Oh, no! There is too many toxins in my body. It's getting dangerous!";
 			if (mobcount("gef_d01_i", "ill_vampire_spawn_bomi::OnMobDead") < 1 && mobcount("gef_d01_i", "ill_vampire_spawn_dracula::OnMobDead") < 1)
+				.bomi_count = 0;
 				donpcevent "ill_vampire_spawn_bomi::OnStart";
 			close;
 		}

--- a/npc/re/quests/quests_16_2_illusion.txt
+++ b/npc/re/quests/quests_16_2_illusion.txt
@@ -3967,7 +3967,6 @@ OnStart:
 	mapannounce "gef_d01_i", "Oh, no...	I can feel the toxins spreading through my body...!", bc_map, 0xFF0000;
 	if (mobcount("gef_d01_i", "ill_vampire_spawn_bomi::OnMobDead") < 1 && mobcount("gef_d01_i", "ill_vampire_spawn_dracula::OnMobDead") < 1) {
 		monster "gef_d01_i",84,135,"Berserk Bomi",3756,1,"ill_vampire_spawn_bomi::OnMobDead";
-		.bomi_count = 0;
 	}
 	end;
 OnMobDead:


### PR DESCRIPTION
Fix Illusion of Vampire Boss Spawn on quests_16_2_illusion.txt

Because .bomi_count = 0 on a different NPC (ill_vampire_spawn_bomi) is not read on the main Bomi NPC (Wizard#ilgf01).

Thanks to @Everade 

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
