### PR TITLE
Removed renewal exp and drop penalty in Illusions dungeons

### DIFF
--- a/npc/re/mapflag/norenewalpenalty.txt
+++ b/npc/re/mapflag/norenewalpenalty.txt
@@ -1,0 +1,65 @@
+//===== rAthena Script =======================================
+//= Mapflag: Disable renewal level penalty.
+//===== Description: ========================================= 
+//= The file groups the 'norenewalexppenalty' and 'norenewaldroppenalty' mapflags.
+//===== Additional Comments: ================================= 
+//= 1.0 Added illusions dungeons maps. [Capuche]
+//============================================================
+
+//============================================================
+// Illusion of Moonlight
+//============================================================
+pay_d03_i	mapflag	norenewalexppenalty
+pay_d03_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Vampire
+//============================================================
+gef_d01_i	mapflag	norenewalexppenalty
+gef_d01_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Frozen
+//============================================================
+ice_d03_i	mapflag	norenewalexppenalty
+ice_d03_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of old Archery
+//============================================================
+tur_d03_i	mapflag	norenewalexppenalty
+tur_d03_i	mapflag	norenewaldroppenalty
+tur_d04_i	mapflag	norenewalexppenalty
+tur_d04_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Teddy Bear
+//============================================================
+ein_d02_i	mapflag	norenewalexppenalty
+ein_d02_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Twins
+//============================================================
+ant_d02_i	mapflag	norenewalexppenalty
+ant_d02_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Luanda
+//============================================================
+com_d02_i	mapflag	norenewalexppenalty
+com_d02_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Labyrinth
+//============================================================
+prt_mz03_i	mapflag	norenewalexppenalty
+prt_mz03_i	mapflag	norenewaldroppenalty
+
+//============================================================
+// Illusion of Underwater
+//============================================================
+iz_d04_i	mapflag	norenewalexppenalty
+iz_d04_i	mapflag	norenewaldroppenalty
+iz_d05_i	mapflag	norenewalexppenalty
+iz_d05_i	mapflag	norenewaldroppenalty

--- a/npc/re/scripts_mapflags.conf
+++ b/npc/re/scripts_mapflags.conf
@@ -10,6 +10,7 @@ npc: npc/re/mapflag/noicewall.txt
 npc: npc/re/mapflag/nolockon.txt
 npc: npc/re/mapflag/nomemo.txt
 npc: npc/re/mapflag/nopenalty.txt
+npc: npc/re/mapflag/norenewalpenalty.txt
 npc: npc/re/mapflag/nosave.txt
 npc: npc/re/mapflag/noteleport.txt
 npc: npc/re/mapflag/nowarpto.txt


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Renewal exp and drop penalty should be removed in Illusions dungeons, as written for example in https://ro.gnjoy.com/news/update/View.asp?seq=248&curpage=1
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
