### PR TITLE
Removed NoRemoveOnDead flags on S_Lifepotion and L_Lifepotion

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -2778,7 +2778,6 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       OverlapFail: true
-      NoRemoveOnDead: true
   - Status: L_Lifepotion
     Icon: EFST_L_LIFEPOTION
     Flags:
@@ -2786,7 +2785,6 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       OverlapFail: true
-      NoRemoveOnDead: true
   - Status: Jexpboost
     Icon: EFST_CASH_PLUSONLYJOBEXP
     Flags:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The status S_Lifepotion and L_Lifepotion are actually removed on dead
```
EFST_L_LIFEPOTION={
	ResetDead = true;
...
EFST_S_LIFEPOTION={
	ResetDead = true;
```
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
