### PR TITLE
Defaulting dropeffect client

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -889,27 +889,31 @@ void clif_dropflooritem( struct flooritem_data* fitem, bool canShowEffect ){
 
 		if( dropEffect > 0 ){
 			p.showdropeffect = 1;
-			p.dropeffectmode = dropEffect - 1;
-		}else if (battle_config.rndopt_drop_pillar != 0){
-			uint8 optionCount = 0;
+			if (dropEffect == 1) {
+				if (battle_config.rndopt_drop_pillar != 0) {
+					uint8 optionCount = 0;
 
-			for (uint8 i = 0; i < MAX_ITEM_RDM_OPT; i++) {
-				if (fitem->item.option[i].id != 0) {
-					optionCount++;
+					for (uint8 i = 0; i < MAX_ITEM_RDM_OPT; i++) {
+						if (fitem->item.option[i].id != 0) {
+							optionCount++;
+						}
+					}
+
+					if (optionCount > 0) {
+						if (optionCount == 1)
+							p.dropeffectmode = DROPEFFECT_BLUE_PILLAR - 1;
+						else if (optionCount == 2)
+							p.dropeffectmode = DROPEFFECT_YELLOW_PILLAR - 1;
+						else
+							p.dropeffectmode = DROPEFFECT_PURPLE_PILLAR - 1;
+					} else {
+						p.dropeffectmode = DROPEFFECT_CLIENT - 1;
+					}
+				} else {
+					p.dropeffectmode = DROPEFFECT_CLIENT - 1;
 				}
-			}
-
-			if (optionCount > 0) {
-				p.showdropeffect = 1;
-				if (optionCount == 1)
-					p.dropeffectmode = DROPEFFECT_BLUE_PILLAR - 1;
-				else if (optionCount == 2)
-					p.dropeffectmode = DROPEFFECT_YELLOW_PILLAR - 1;
-				else
-					p.dropeffectmode = DROPEFFECT_PURPLE_PILLAR - 1;
 			} else {
-				p.showdropeffect = 0;
-				p.dropeffectmode = DROPEFFECT_NONE;
+				p.dropeffectmode = dropEffect - 1;
 			}
 		} else {
 			p.showdropeffect = 0;

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -714,14 +714,14 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			int64 constant;
 
 			if (!script_get_constant(effect_constant.c_str(), &constant) || constant < DROPEFFECT_NONE || constant > DROPEFFECT_MAX) {
-				this->invalidWarning(flagNode["DropEffect"], "Invalid item drop effect %s, defaulting to DROPEFFECT_NONE.\n", effect.c_str());
-				constant = DROPEFFECT_NONE;
+				this->invalidWarning(flagNode["DropEffect"], "Invalid item drop effect %s, defaulting to DROPEFFECT_CLIENT.\n", effect.c_str());
+				constant = DROPEFFECT_CLIENT;
 			}
 
 			item->flag.dropEffect = static_cast<e_item_drop_effect>(constant);
 		} else {
 			if (!exists)
-				item->flag.dropEffect = DROPEFFECT_NONE;
+				item->flag.dropEffect = DROPEFFECT_CLIENT;
 		}
 	} else {
 		if (!exists) {
@@ -733,7 +733,7 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			item->flag.broadcast = false;
 			if (!(item->flag.delay_consume & DELAYCONSUME_TEMP))
 				item->flag.delay_consume = DELAYCONSUME_NONE;
-			item->flag.dropEffect = DROPEFFECT_NONE;
+			item->flag.dropEffect = DROPEFFECT_CLIENT;
 		}
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6894 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

 This pull will default dropeffect to DROPEFFECT_CLIENT instead of DROPEFFECT_NONE.
 I just work this pull for suggestion but not sure about stability.
 If there is other reason not defauting dropeffect to CLIENT or better way to implement suggestion, I will close this pull.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
