### PR TITLE
Fixes skill ranges of NPC and HOM skills

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -19,39 +19,44 @@ monster_hp_rate: 100
 monster_max_aspd: 199
 
 // Defines various mob AI related settings. (Note 3)
-// 0x001: When enabled mobs will update their target cell every few iterations
-//        (normally they never update their target cell until they reach it while
-//        chasing)
-// 0x002: Makes mob use their "rude attack" skill (usually warping away) if they
-//        are attacked and they can't attack back regardless of how they were
-//        attacked (eg: GrimTooth), otherwise, their rude attack" is only activated
-//        if they can't melee reach the target (eg: sniping)
-// 0x004: If not set, mobs that can change target only do so when attacked within a
-//        distance of [attack range+1], otherwise mobs may change target and chase 
-//        ranged attackers. This flag also overrides the 'provoke' target.
-// 0x008: When set, mobs scatter as soon as they lose their target. Use this mode
-//        to make it much harder to mob-train by hiding and collecting them on a
-//        single spot (ie: GrimTooth training)
-// 0x010: If set, mob skills defined for friends will also trigger on themselves.
-// 0x020: When set, the monster ai is executed for all monsters in maps that 
-//        have players on them, instead of only for mobs who are in the vicinity
-//        of players.
-// 0x040: When set, when the mob's target changes map, the mob will walk towards
-//        any npc-warps in it's sight of view (use with mob_warp below)
-// 0x080: If not set, mobs on attack state will only change targets when attacked
-//        by normal attacks. Set this if you want mobs to also switch targets when
-//        hit by skills.
-// 0x100: When set, a mob will pick a random skill from it's list and start from
-//        that instead of checking skills in orders (when unset, if a mob has too
-//        many skills, the ones near the end will rarely get selected)
-// 0x200: When set, a mob's skill re-use delay will not be applied to all entries of
-//        the same skill, instead, only to that particular entry (eg: Mob has heal
-//        on six lines in the mob_skill_db, only the entry that is actually used
-//        will receive the delay). This will make monsters harder, especially MvPs.
-// 0x400: Set this to make mobs have a range of 9 for all skills. Otherwise, they 
-//        will obey the normal skill range rules.
-// 0x800: When set, monsters that are provoked will always change target to the
-//        provoking person, even if they would usually not change target on attack.
+// 0x0001: When enabled mobs will update their target cell every few iterations
+//         (normally they never update their target cell until they reach it while
+//         chasing)
+// 0x0002: Makes mob use their "rude attack" skill (usually warping away) if they
+//         are attacked and they can't attack back regardless of how they were
+//         attacked (eg: GrimTooth), otherwise, their "rude attack" is only activated
+//         if they can't melee reach the target (eg: sniping)
+// 0x0004: If not set, mobs that can change target only do so when attacked within a
+//         distance of [attack range+1], otherwise mobs may change target and chase 
+//         ranged attackers. This flag also overrides the 'provoke' target.
+// 0x0008: When set, mobs scatter as soon as they lose their target. Use this mode
+//         to make it much harder to mob-train by hiding and collecting them on a
+//         single spot (ie: GrimTooth training)
+// 0x0010: If set, mob skills defined for friends will also trigger on themselves.
+// 0x0020: When set, the monster ai is executed for all monsters in maps that 
+//         have players on them, instead of only for mobs who are in the vicinity
+//         of players.
+// 0x0040: When set, when the mob's target changes map, the mob will walk towards
+//         any npc-warps in it's sight of view (use with mob_warp below)
+// 0x0080: If not set, mobs on attack state will only change targets when attacked
+//         by normal attacks. Set this if you want mobs to also switch targets when
+//         hit by skills.
+// 0x0100: When set, a mob will pick a random skill from it's list and start from
+//         that instead of checking skills in orders (when unset, if a mob has too
+//         many skills, the ones near the end will rarely get selected)
+// 0x0200: When set, a mob's skill re-use delay will not be applied to all entries of
+//         the same skill, instead, only to that particular entry (eg: Mob has heal
+//         on six lines in the mob_skill_db, only the entry that is actually used
+//         will receive the delay). This will make monsters harder, especially MvPs.
+// 0x0400: Set this to make mobs have a range of 9 for all skills. Otherwise, they 
+//         will obey the normal skill range rules.
+// 0x0800: When set, monsters that are provoked will always change target to the
+//         provoking person, even if they would usually not change target on attack.
+// 0x1000: When set, when a monster picks a skill but can't use it because there is
+//         no valid target in range, it will look for another skill it can use.
+//         This makes e.g. Greatest General use "Earth Spike" at range 8-9 whereas
+//         officially it would only use it after already having used "Blind Attack"
+//         at range 0-7.
 // Example: 0x140 -> Chase players through warps + use skills in random order.
 monster_ai: 0
 

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -5332,7 +5332,7 @@ Body:
       IgnoreDefense: true
     Flags:
       IsNpc: true
-    Range: 3
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5346,7 +5346,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: -1
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5358,7 +5358,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -7
     Hit: Single
     HitCount: 1
   - Id: 161
@@ -5496,7 +5496,7 @@ Body:
       IgnoreDefense: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5508,7 +5508,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Multi_Hit
     HitCount:
       - Level: 1
@@ -5542,7 +5542,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5560,7 +5560,6 @@ Body:
     Flags:
       IsNpc: true
       TargetTrap: true
-    Range: 5
     Hit: Single
     HitCount: 1
     Element: Fire
@@ -5603,7 +5602,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5617,7 +5616,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5631,7 +5630,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5645,7 +5644,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5659,7 +5658,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5674,7 +5673,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -5688,7 +5687,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5702,7 +5701,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Random
@@ -5714,7 +5713,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Water
@@ -5727,7 +5726,7 @@ Body:
     Flags:
       IsNpc: true
       TargetHidden: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Earth
@@ -5739,7 +5738,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Fire
@@ -5751,7 +5750,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Wind
@@ -5763,7 +5762,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Poison
@@ -5776,7 +5775,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Holy
@@ -5788,7 +5787,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -5800,7 +5799,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Ghost
@@ -5812,7 +5811,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5894,7 +5893,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -9193,7 +9192,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -1
+    Range: -2
     Hit: Multi_Hit
     HitCount: -2
     Element: Dark
@@ -9211,7 +9210,6 @@ Body:
     Flags:
       IsNpc: true
       TargetSelf: true
-    Range: 5
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -9319,7 +9317,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     Duration1: 15000
     Status: Stop
@@ -9344,7 +9342,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9357,7 +9355,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9369,7 +9367,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9381,7 +9379,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Undead
@@ -9461,7 +9459,6 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 2
   - Id: 353
     Name: NPC_INVISIBLE
     Description: Invisible
@@ -9482,7 +9479,6 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 2
     Hit: Single
     AfterCastActDelay:
       - Level: 2
@@ -16120,7 +16116,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16135,7 +16131,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16352,7 +16348,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -2
     HitCount: 1
     Duration2: 180000
     Status: HellPower
@@ -30959,7 +30955,7 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Attack
-    Range: 1
+    Range: 15
     Hit: Multi_Hit
     HitCount:
       - Level: 1
@@ -31079,7 +31075,7 @@ Body:
     MaxLevel: 3
     Type: Weapon
     TargetType: Attack
-    Range: 1
+    Range: 15
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 1000
@@ -31091,7 +31087,7 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
-    Range: 9
+    Range: 15
     Hit: Single
     HitCount:
       - Level: 1
@@ -31156,7 +31152,6 @@ Body:
       IgnoreElement: true
       IgnoreFlee: true
       IgnoreDefCard: true
-    Range: 4
     Hit: Single
     HitCount: 1
     Element: Weapon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5601,7 +5601,7 @@ Body:
       IgnoreDefense: true
     Flags:
       IsNpc: true
-    Range: 3
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5615,7 +5615,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: -1
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5627,7 +5627,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -7
     Hit: Single
     HitCount: 1
   - Id: 161
@@ -5766,7 +5766,7 @@ Body:
       Critical: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5778,7 +5778,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Multi_Hit
     HitCount:
       - Level: 1
@@ -5812,7 +5812,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5830,7 +5830,6 @@ Body:
     Flags:
       IsNpc: true
       TargetTrap: true
-    Range: 5
     Hit: Single
     HitCount: 1
     Element: Fire
@@ -5873,7 +5872,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5887,7 +5886,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5901,7 +5900,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5915,7 +5914,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5929,7 +5928,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5944,7 +5943,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -5958,7 +5957,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -5972,7 +5971,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Random
@@ -5984,7 +5983,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Water
@@ -5997,7 +5996,7 @@ Body:
     Flags:
       IsNpc: true
       TargetHidden: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Earth
@@ -6009,7 +6008,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Fire
@@ -6021,7 +6020,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Wind
@@ -6033,7 +6032,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Poison
@@ -6046,7 +6045,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Holy
@@ -6058,7 +6057,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -6070,7 +6069,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Ghost
@@ -6082,7 +6081,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -6164,7 +6163,7 @@ Body:
       IgnoreFlee: true
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -9513,7 +9512,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -1
+    Range: -2
     Hit: Multi_Hit
     HitCount: -2
     Element: Dark
@@ -9531,7 +9530,6 @@ Body:
     Flags:
       IsNpc: true
       TargetSelf: true
-    Range: 5
     Hit: Single
     HitCount: 1
     Element: Dark
@@ -9639,7 +9637,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     Duration1: 15000
     Status: Stop
@@ -9664,7 +9662,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9677,7 +9675,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9689,7 +9687,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: 9
+    Range: -2
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -9701,7 +9699,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Undead
@@ -9781,7 +9779,6 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 2
   - Id: 353
     Name: NPC_INVISIBLE
     Description: Invisible
@@ -9802,7 +9799,6 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: 2
     Hit: Single
   - Id: 355
     Name: LK_AURABLADE
@@ -16519,7 +16515,7 @@ Body:
     TargetType: Attack
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16534,7 +16530,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -7
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -16751,7 +16747,7 @@ Body:
       NoDamage: true
     Flags:
       IsNpc: true
-    Range: -9
+    Range: -2
     HitCount: 1
     Duration2: 180000
     Status: HellPower
@@ -40721,7 +40717,7 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Attack
-    Range: 1
+    Range: 15
     Hit: Multi_Hit
     HitCount:
       - Level: 1
@@ -40841,7 +40837,7 @@ Body:
     MaxLevel: 3
     Type: Weapon
     TargetType: Attack
-    Range: 1
+    Range: 15
     Hit: Single
     HitCount: 1
     AfterCastActDelay: 1000
@@ -40853,7 +40849,7 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
-    Range: 9
+    Range: 15
     Hit: Single
     HitCount:
       - Level: 1
@@ -40918,7 +40914,6 @@ Body:
       IgnoreElement: true
       IgnoreFlee: true
       IgnoreDefCard: true
-    Range: 4
     Hit: Single
     HitCount: 1
     Element: Weapon

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9848,7 +9848,7 @@ static const struct _battle_data {
 	{ "display_hallucination",              &battle_config.display_hallucination,           1,      0,      1,              },
 	{ "use_statpoint_table",                &battle_config.use_statpoint_table,             1,      0,      1,              },
 	{ "debuff_on_logout",                   &battle_config.debuff_on_logout,                0,      0,      1|2,            },
-	{ "monster_ai",                         &battle_config.mob_ai,                          0x000,  0x000,  0xFFF,          },
+	{ "monster_ai",                         &battle_config.mob_ai,                          0x0000, 0x0000, 0x1FFF,         },
 	{ "hom_setting",                        &battle_config.hom_setting,                     0xFFFF, 0x0000, 0xFFFF,         },
 	{ "dynamic_mobs",                       &battle_config.dynamic_mobs,                    1,      0,      1,              },
 	{ "mob_remove_damaged",                 &battle_config.mob_remove_damaged,              1,      0,      1,              },

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3797,7 +3797,12 @@ int mobskill_use(struct mob_data *md, t_tick tick, int event)
 					bl = &md->bl;
 					break;
 			}
-			if (!bl) continue;
+			if (!bl) {
+				if (battle_config.mob_ai & 0x1000)
+					continue;
+				else
+					break;
+			}
 
 			x = bl->x;
 		  	y = bl->y;
@@ -3814,7 +3819,10 @@ int mobskill_use(struct mob_data *md, t_tick tick, int event)
 				!unit_skilluse_pos2(&md->bl, x, y, ms[i]->skill_id, ms[i]->skill_lv, ms[i]->casttime, ms[i]->cancel))
 			{
 				map_freeblock_unlock();
-				continue;
+				if (battle_config.mob_ai & 0x1000)
+					continue;
+				else
+					break;
 			}
 		} else {
 			//Targetted skill
@@ -3844,7 +3852,12 @@ int mobskill_use(struct mob_data *md, t_tick tick, int event)
 					bl = &md->bl;
 					break;
 			}
-			if (!bl) continue;
+			if (!bl) {
+				if (battle_config.mob_ai & 0x1000)
+					continue;
+				else
+					break;
+			}
 
 			md->skill_idx = i;
 			map_freeblock_lock();
@@ -3852,7 +3865,10 @@ int mobskill_use(struct mob_data *md, t_tick tick, int event)
 				!unit_skilluse_id2(&md->bl, bl->id, ms[i]->skill_id, ms[i]->skill_lv, ms[i]->casttime, ms[i]->cancel))
 			{
 				map_freeblock_unlock();
-				continue;
+				if (battle_config.mob_ai & 0x1000)
+					continue;
+				else
+					break;
 			}
 		}
 		//Skill used. Post-setups...


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #6884 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Updated skill ranges of NPC and Homunculus skills to their official values
- Implemented the official skill selection mechanic where when a mob picks a skill but can't cast it due to range, it will not check for any skills below
- Added a configuration to reset this to the previous behavior
<!-- Describe how this pull request will resolve the issue(s) listed above. -->