### PR TITLE
Removes the 100% rate cap for SC defense

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2762,8 +2762,8 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, i
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.flag == flag) {
-			it.rate = util::safe_addition_cap(it.rate, rate, SHRT_MAX);
-			it.arrow_rate += arrow_rate;
+			it.rate = util::safe_addition_cap(it.rate, rate, INT_MAX);
+			it.arrow_rate = util::safe_addition_cap(it.arrow_rate, arrow_rate, (short)SHRT_MAX);
 			it.duration = umax(it.duration, duration);
 			return;
 		}
@@ -2771,11 +2771,8 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, i
 
 	struct s_addeffect entry = {};
 
-	if (rate < SHRT_MIN || rate > SHRT_MAX)
-		ShowWarning("pc_bonus_addeff: Item bonus rate %d exceeds -%d~%d range, capping.\n", rate, SHRT_MIN, SHRT_MAX);
-
 	entry.sc = sc;
-	entry.rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
+	entry.rate = rate;
 	entry.arrow_rate = arrow_rate;
 	entry.flag = flag;
 	entry.duration = duration;
@@ -2804,7 +2801,7 @@ static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enu
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.skill_id == skill_id && it.target == target) {
-			it.rate = util::safe_addition_cap(it.rate, rate, SHRT_MAX);
+			it.rate = util::safe_addition_cap(it.rate, rate, INT_MAX);
 			it.duration = umax(it.duration, duration);
 			return;
 		}
@@ -2812,11 +2809,8 @@ static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enu
 
 	struct s_addeffectonskill entry = {};
 
-	if (rate < SHRT_MIN || rate > SHRT_MAX)
-		ShowWarning("pc_bonus_addeff_onskill: Item bonus rate %d exceeds -%d~%d range, capping.\n", rate, SHRT_MIN, SHRT_MAX);
-
 	entry.sc = sc;
-	entry.rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
+	entry.rate = rate;
 	entry.skill_id = skill_id;
 	entry.target = target;
 	entry.duration = duration;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2677,7 +2677,7 @@ static void pc_bonus_autospell(std::vector<s_autospell> &spell, uint16 id, uint1
 		if ((it.card_id == card_id || it.rate < 0 || rate < 0) && it.id == id && it.lv == lv && it.battle_flag == battle_flag && it.flag == flag) {
 			if (!battle_config.autospell_stacking && it.rate > 0 && rate > 0) // Stacking disabled
 				return;
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (short)10000);
 			return;
 		}
 	}
@@ -2762,7 +2762,7 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, i
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, SHRT_MIN, SHRT_MAX);
+			it.rate = util::safe_addition_cap(it.rate, rate, SHRT_MAX);
 			it.arrow_rate += arrow_rate;
 			it.duration = umax(it.duration, duration);
 			return;
@@ -2804,7 +2804,7 @@ static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enu
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.skill_id == skill_id && it.target == target) {
-			it.rate = cap_value(it.rate + rate, SHRT_MIN, SHRT_MAX);
+			it.rate = util::safe_addition_cap(it.rate, rate, SHRT_MAX);
 			it.duration = umax(it.duration, duration);
 			return;
 		}
@@ -2871,7 +2871,7 @@ static void pc_bonus_item_drop(std::vector<s_add_drop> &drop, t_itemid nameid, u
 	for (auto &it : drop) {
 		if (it.nameid == nameid && it.group == group && it.race == race && it.class_ == class_) {
 			if ((rate < 0 && it.rate < 0) || (rate > 0 && it.rate > 0)) //Adjust the rate if it has same classification
-				it.rate = cap_value(it.rate + rate, -10000, 10000);
+				it.rate = util::safe_addition_cap(it.rate, rate, 10000);
 			return;
 		}
 	}
@@ -3081,7 +3081,7 @@ static void pc_bonus_addele(struct map_session_data* sd, unsigned char ele, shor
 
 	for (auto &it : wd->addele2) {
 		if (it.ele == ele && it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (short)10000);
 			return;
 		}
 	}
@@ -3127,7 +3127,7 @@ static void pc_bonus_subele(struct map_session_data* sd, unsigned char ele, shor
 
 	for (auto &it : sd->subele2) {
 		if (it.ele == ele && it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (short)10000);
 			return;
 		}
 	}
@@ -3171,7 +3171,7 @@ static void pc_bonus_subrace(struct map_session_data* sd, unsigned char race, sh
 
 	for (auto &it : sd->subrace3) {
 		if (it.race == race && it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (short)10000);
 			return;
 		}
 	}
@@ -3199,7 +3199,7 @@ static void pc_bonus_itembonus(std::vector<s_item_bonus> &bonus, uint16 id, int 
 	for (auto &it : bonus) {
 		if (it.id == id) {
 			if (cap_rate)
-				it.val = cap_value(it.val + val, -10000, 10000);
+				it.val = util::safe_addition_cap(it.val, val, 10000);
 			else
 				it.val += val;
 			return;
@@ -3245,7 +3245,7 @@ static void pc_bonus_addvanish(std::vector<s_vanish_bonus> &bonus, int16 rate, i
 
 	for (auto &it : bonus) {
 		if (it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (int16)10000);
 			it.per += per;
 			return;
 		}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2743,7 +2743,7 @@ static void pc_bonus_autospell_onskill(std::vector<s_autospell> &spell, uint16 s
  * @param flag: Target flag
  * @param duration: Duration. If 0 use default duration lookup for associated skill with level 7
  */
-static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, short rate, short arrow_rate, unsigned char flag, unsigned int duration)
+static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, int rate, short arrow_rate, unsigned char flag, unsigned int duration)
 {
 	if (effect.size() == MAX_PC_BONUS) {
 		ShowWarning("pc_bonus_addeff: Reached max (%d) number of add effects per character!\n", MAX_PC_BONUS);
@@ -2762,7 +2762,7 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, s
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.flag == flag) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = cap_value(it.rate + rate, SHRT_MIN, SHRT_MAX);
 			it.arrow_rate += arrow_rate;
 			it.duration = umax(it.duration, duration);
 			return;
@@ -2771,11 +2771,11 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, s
 
 	struct s_addeffect entry = {};
 
-	if (rate < -10000 || rate > 10000)
-		ShowWarning("pc_bonus_addeff: Item bonus rate %d exceeds -10000~10000 range, capping.\n", rate);
+	if (rate < SHRT_MIN || rate > SHRT_MAX)
+		ShowWarning("pc_bonus_addeff: Item bonus rate %d exceeds -%d~%d range, capping.\n", rate, SHRT_MIN, SHRT_MAX);
 
 	entry.sc = sc;
-	entry.rate = cap_value(rate, -10000, 10000);
+	entry.rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
 	entry.arrow_rate = arrow_rate;
 	entry.flag = flag;
 	entry.duration = duration;
@@ -2792,7 +2792,7 @@ static void pc_bonus_addeff(std::vector<s_addeffect> &effect, enum sc_type sc, s
  * @param target: Target type
  * @param duration: Duration. If 0 use default duration lookup for associated skill with level 7
  */
-static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enum sc_type sc, short rate, short skill_id, unsigned char target, unsigned int duration)
+static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enum sc_type sc, int rate, short skill_id, unsigned char target, unsigned int duration)
 {
 	if (effect.size() == MAX_PC_BONUS) {
 		ShowWarning("pc_bonus_addeff_onskill: Reached max (%d) number of add effects per character!\n", MAX_PC_BONUS);
@@ -2804,7 +2804,7 @@ static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enu
 
 	for (auto &it : effect) {
 		if (it.sc == sc && it.skill_id == skill_id && it.target == target) {
-			it.rate = cap_value(it.rate + rate, -10000, 10000);
+			it.rate = cap_value(it.rate + rate, SHRT_MIN, SHRT_MAX);
 			it.duration = umax(it.duration, duration);
 			return;
 		}
@@ -2812,11 +2812,11 @@ static void pc_bonus_addeff_onskill(std::vector<s_addeffectonskill> &effect, enu
 
 	struct s_addeffectonskill entry = {};
 
-	if (rate < -10000 || rate > 10000)
-		ShowWarning("pc_bonus_addeff_onskill: Item bonus rate %d exceeds -10000~10000 range, capping.\n", rate);
+	if (rate < SHRT_MIN || rate > SHRT_MAX)
+		ShowWarning("pc_bonus_addeff_onskill: Item bonus rate %d exceeds -%d~%d range, capping.\n", rate, SHRT_MIN, SHRT_MAX);
 
 	entry.sc = sc;
-	entry.rate = cap_value(rate, -10000, 10000);
+	entry.rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
 	entry.skill_id = skill_id;
 	entry.target = target;
 	entry.duration = duration;
@@ -3333,7 +3333,7 @@ void pc_bonus(struct map_session_data *sd,int type,int val)
 				bonus = status->def + val;
 #ifdef RENEWAL
 				status->def = cap_value(bonus, SHRT_MIN, SHRT_MAX);
-#else
+#elsef
 				status->def = cap_value(bonus, CHAR_MIN, CHAR_MAX);
 #endif
 			}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3333,7 +3333,7 @@ void pc_bonus(struct map_session_data *sd,int type,int val)
 				bonus = status->def + val;
 #ifdef RENEWAL
 				status->def = cap_value(bonus, SHRT_MIN, SHRT_MAX);
-#elsef
+#else
 				status->def = cap_value(bonus, CHAR_MIN, CHAR_MAX);
 #endif
 			}

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -245,8 +245,8 @@ struct s_autospell {
 /// AddEff and AddEff2 bonus struct
 struct s_addeffect {
 	enum sc_type sc; /// SC type/effect
-	short rate, /// Rate
-		arrow_rate; /// Arrow rate
+	int rate; /// Rate
+	short arrow_rate; /// Arrow rate
 	unsigned char flag; /// Flag
 	unsigned int duration; /// Duration the effect applied
 };
@@ -254,8 +254,8 @@ struct s_addeffect {
 /// AddEffOnSkill bonus struct
 struct s_addeffectonskill {
 	enum sc_type sc; /// SC type/effect
-	short rate, /// Rate
-		skill_id; /// Skill ID
+	int rate; /// Rate
+	short skill_id; /// Skill ID
 	unsigned char target; /// Target
 	unsigned int duration; /// Duration the effect applied
 };

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8733,7 +8733,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			return 0;
 	}
 
-	rate = max(0, rate);
+	rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
 	sd = BL_CAST(BL_PC,bl);
 	status = status_get_status_data(bl);
 	status_src = status_get_status_data(src);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8733,7 +8733,6 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			return 0;
 	}
 
-	rate = cap_value(rate, SHRT_MIN, SHRT_MAX);
 	sd = BL_CAST(BL_PC,bl);
 	status = status_get_status_data(bl);
 	status_src = status_get_status_data(src);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8733,7 +8733,7 @@ t_tick status_get_sc_def(struct block_list *src, struct block_list *bl, enum sc_
 			return 0;
 	}
 
-	rate = cap_value(rate, 0, 10000);
+	rate = max(0, rate);
 	sd = BL_CAST(BL_PC,bl);
 	status = status_get_status_data(bl);
 	status_src = status_get_status_data(src);


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Status changes are simply not capped to 100%.
Thanks to @Playtester!