### PR TITLE
Official client range distance offset

### DIFF
--- a/src/map/path.cpp
+++ b/src/map/path.cpp
@@ -504,7 +504,7 @@ int distance_client(int dx, int dy)
 
 	//Bonus factor used by client
 	//This affects even horizontal/vertical lines so they are one cell longer than expected
-	temp_dist -= 0.0625;
+	temp_dist -= 0.1;
 
 	if(temp_dist < 0) temp_dist = 0;
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Partially related to #6949

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed the client range distance offset which is really 1.1 and not 1.0625
- This fixes the issue that when you sometimes tried to use a skill, nothing happened -> the client didn't make you move closer but the server said you are not in range yet
- I originally got an incorrect value through testing, because I didn't know that the client calculates range in a 3D room rather than in a 2D room, now I retested on a completely flat map; fully confirmed and official now

<!-- Describe how this pull request will resolve the issue(s) listed above. -->