### PR TITLE
Update 4th Job's  cast time, skill delay, cooldown match to official

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34357,6 +34357,7 @@ Body:
       - Level: 5
         Amount: 30
     CastCancel: true
+    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 30000
@@ -34462,7 +34463,7 @@ Body:
     CastCancel: true
     AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 2000
+    Cooldown: 3000
     FixedCastTime: 500
     Requires:
       SpCost: 40
@@ -34508,6 +34509,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
+    CastTime: 800
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -34532,6 +34534,7 @@ Body:
         Time: 180000
     Duration2: 5000
     Cooldown: 60000
+    FixedCastTime: 400
     Requires:
       SpCost:
         - Level: 1
@@ -34574,8 +34577,10 @@ Body:
     HitCount: 1
     Element: Weapon
     CastCancel: true
+    CastTime: 400
     AfterCastActDelay: 500
     Cooldown: 350
+    FixedCastTime: 400
     Requires:
       SpCost:
         - Level: 1
@@ -34647,9 +34652,11 @@ Body:
     HitCount: 1
     Element: Weapon
     CastCancel: true
-    AfterCastActDelay: 1000
+    CastTime: 2000
+    AfterCastActDelay: 500
     Duration1: 300000
-    Cooldown: 60000
+    Cooldown: 120000
+    FixedCastTime: 500
     Requires:
       SpCost: 100
       ApCost: 150
@@ -34679,9 +34686,10 @@ Body:
         Area: 3
     GiveAp: 2
     CastCancel: true
+    CastTime: 400
     AfterCastActDelay: 500
     Cooldown: 350
-    FixedCastTime: 500
+    FixedCastTime: 400
     Requires:
       SpCost:
         - Level: 1
@@ -34787,7 +34795,7 @@ Body:
     HitCount: 1
     Element: Undead
     CastCancel: true
-    CastTime: 4000
+    CastTime: 3000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -34838,7 +34846,7 @@ Body:
       - Level: 5
         Area: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 3000
     AfterCastActDelay: 1000
     Duration2: 900000
     Cooldown: 6000
@@ -35101,7 +35109,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 4000
-    Cooldown: 5000
+    Cooldown: 4000
     FixedCastTime: 1500
     Requires:
       SpCost:
@@ -35436,11 +35444,11 @@ Body:
       - Level: 10
         Area: 5
     CastCancel: true
-    CastTime: 8000
+    CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 15000
     Cooldown: 60000
-    FixedCastTime: 2000
+    FixedCastTime: 1500
     Requires:
       SpCost: 150
       ApCost: 150
@@ -35494,10 +35502,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 300
+    CastTime: 2000
+    AfterCastActDelay: 500
     Duration1: 300000
     Cooldown: 300000
-    FixedCastTime: 4000
+    FixedCastTime: 2500
     Requires:
       SpCost: 60
       ApCost: 150
@@ -35678,8 +35687,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1500
     Duration1:
       - Level: 1
         Time: 120000
@@ -35692,7 +35700,7 @@ Body:
       - Level: 5
         Time: 240000
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -35716,8 +35724,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1500
     Duration1:
       - Level: 1
         Time: 120000
@@ -35730,7 +35737,7 @@ Body:
       - Level: 5
         Time: 240000
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -35812,8 +35819,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1500
     Duration1:
       - Level: 1
         Time: 120000
@@ -35826,7 +35832,7 @@ Body:
       - Level: 5
         Time: 240000
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -35855,7 +35861,7 @@ Body:
     Element: Weapon
     SplashArea: 4
     CastCancel: true
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 300000
     Cooldown: 60000
     Requires:
@@ -35888,7 +35894,7 @@ Body:
         Area: 4
     GiveAp: 4
     CastCancel: true
-    Cooldown: 4000
+    Cooldown: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -35960,7 +35966,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -35973,8 +35978,18 @@ Body:
         Time: 240000
       - Level: 5
         Time: 300000
-    Cooldown: 150000
-    FixedCastTime: 1000
+    Cooldown:
+      - Level: 1
+        Time: 60000
+      - Level: 2
+        Time: 120000
+      - Level: 3
+        Time: 180000
+      - Level: 4
+        Time: 240000
+      - Level: 5
+        Time: 300000
+    FixedCastTime: 2000
     Requires:
       SpCost: 60
     Status: First_Faith_Power
@@ -35988,7 +36003,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -36001,8 +36015,18 @@ Body:
         Time: 240000
       - Level: 5
         Time: 300000
-    Cooldown: 150000
-    FixedCastTime: 1000
+    Cooldown:
+      - Level: 1
+        Time: 60000
+      - Level: 2
+        Time: 120000
+      - Level: 3
+        Time: 180000
+      - Level: 4
+        Time: 240000
+      - Level: 5
+        Time: 300000
+    FixedCastTime: 2000
     Requires:
       SpCost: 60
       ApCost: 50
@@ -36252,7 +36276,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -36265,8 +36288,18 @@ Body:
         Time: 120000
       - Level: 5
         Time: 150000
-    Cooldown: 150000
-    FixedCastTime: 1000
+    Cooldown:
+      - Level: 1
+        Time: 60000
+      - Level: 2
+        Time: 120000
+      - Level: 3
+        Time: 180000
+      - Level: 4
+        Time: 240000
+      - Level: 5
+        Time: 300000
+    FixedCastTime: 2000
     Requires:
       SpCost: 60
       ApCost: 100
@@ -36285,7 +36318,8 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    FixedCastTime: 500
+    CastTime: 1000
+    FixedCastTime: 1000
     Requires:
       SpCost: 50
       State: Shield
@@ -36306,7 +36340,7 @@ Body:
     GiveAp: 15
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 60000
     Cooldown: 15000
     FixedCastTime: 1000
@@ -36326,7 +36360,7 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 60000
     Cooldown: 15000
     FixedCastTime: 1000
@@ -36353,7 +36387,8 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    FixedCastTime: 500
+    CastTime: 1000
+    FixedCastTime: 1000
     Requires:
       SpCost: 50
     Status: Attack_Stance
@@ -36378,8 +36413,7 @@ Body:
       - Level: 5
         Area: 3
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 300000
     Cooldown:
       - Level: 1
@@ -36392,7 +36426,11 @@ Body:
         Time: 80000
       - Level: 5
         Time: 100000
-    FixedCastTime: 1000
+    FixedCastTime: 2000
+    CastTimeFlags:
+      IgnoreDex: true
+      IgnoreStatus: true
+      IgnoreItemBonus: true
     Requires:
       SpCost: 120
       Status:
@@ -36408,10 +36446,10 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 2500
+    AfterCastActDelay: 1000
     Duration1: 180000
-    Cooldown: 120000
+    Cooldown: 40000
     FixedCastTime: 1000
     Requires:
       SpCost: 60
@@ -36476,10 +36514,10 @@ Body:
     HitCount: -10
     Element: Holy
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 1000
+    CastTime: 4000
+    AfterCastActDelay: 1500
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost: 150
       ApCost: 150
@@ -36571,7 +36609,7 @@ Body:
     Element: Holy
     GiveAp: 5
     CastCancel: true
-    CastTime: 1000
+    CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 4500
     Cooldown: 5000
@@ -36637,8 +36675,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
     Cooldown:
       - Level: 1
         Time: 150000
@@ -36650,7 +36686,7 @@ Body:
         Time: 30000
       - Level: 5
         Time: 10000
-    FixedCastTime: 1000
+    FixedCastTime: 2000
     Requires:
       SpCost: 120
   - Id: 5269
@@ -36669,7 +36705,6 @@ Body:
     SplashArea: 4
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 40000
@@ -36682,7 +36717,7 @@ Body:
       - Level: 5
         Time: 120000
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36714,7 +36749,7 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 120000
@@ -36726,8 +36761,7 @@ Body:
         Time: 210000
       - Level: 5
         Time: 240000
-    Cooldown: 1000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36755,7 +36789,7 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 120000
@@ -36767,8 +36801,7 @@ Body:
         Time: 210000
       - Level: 5
         Time: 240000
-    Cooldown: 1000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36793,11 +36826,11 @@ Body:
     HitCount: 1
     Element: Holy
     CastCancel: true
-    CastTime: 2000
+    CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 20000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36870,7 +36903,7 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 120000
@@ -36882,8 +36915,7 @@ Body:
         Time: 210000
       - Level: 5
         Time: 240000
-    Cooldown: 1000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36912,8 +36944,7 @@ Body:
     HitCount: -7
     Element: Weapon
     CastCancel: true
-    AfterCastActDelay: 500
-    Cooldown: 60000
+    Cooldown: 2000
     Requires:
       SpCost: 60
       ApCost: 100
@@ -36933,7 +36964,6 @@ Body:
     HitCount: 1
     SplashArea: 10
     CastCancel: true
-    CastTime: 8000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -36947,7 +36977,7 @@ Body:
       - Level: 5
         Time: 240000
     Cooldown: 60000
-    FixedCastTime: 2000
+    FixedCastTime: 4000
     Requires:
       SpCost: 60
       ApCost: 200
@@ -36963,11 +36993,11 @@ Body:
     HitCount: -10
     Element: Holy
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 4000
+    AfterCastActDelay: 1500
     Duration1: 12000
     Cooldown: 60000
-    FixedCastTime: 2000
+    FixedCastTime: 1500
     Requires:
       SpCost: 150
       ApCost: 150
@@ -37025,9 +37055,9 @@ Body:
         Area: 3
     GiveAp: 1
     CastCancel: true
-    CastTime: 2000
     AfterCastActDelay: 500
-    FixedCastTime: 1000
+    Cooldown: 300
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -37052,8 +37082,7 @@ Body:
     HitCount: 1
     GiveAp: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1:
       - Level: 1
         Time: 120000
@@ -37065,6 +37094,7 @@ Body:
         Time: 210000
       - Level: 5
         Time: 240000
+    Cooldown: 250
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -37091,8 +37121,7 @@ Body:
     HitCount: 1
     GiveAp: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1:
       - Level: 1
         Time: 120000
@@ -37104,6 +37133,7 @@ Body:
         Time: 210000
       - Level: 5
         Time: 240000
+    Cooldown: 250
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -37154,7 +37184,6 @@ Body:
         Area: 4
     GiveAp: 2
     CastCancel: true
-    AfterCastActDelay: 500
     Cooldown: 1000
     Requires:
       SpCost:
@@ -37207,10 +37236,10 @@ Body:
         Area: 3
     GiveAp: 1
     CastCancel: true
-    CastTime: 2000
+    CastTime: 5000
     AfterCastActDelay: 500
     Cooldown: 300
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -37233,8 +37262,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 1000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 60000
@@ -37276,7 +37304,7 @@ Body:
     SplashArea: 2
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 120000
     Cooldown: 30000
     FixedCastTime: 1000
@@ -37371,7 +37399,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 30000
@@ -37504,11 +37531,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 180000
     Duration2: 30000
-    Cooldown: 150000
-    FixedCastTime: 2000
+    Cooldown: 30000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -37536,9 +37563,11 @@ Body:
     Element: Weapon
     SplashArea: 3
     CastCancel: true
+    CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 20000
     Cooldown: 60000
+    FixedCastTime: 1500
     Requires:
       SpCost: 150
       ApCost: 150
@@ -37664,7 +37693,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
     Requires:
       SpCost:
         - Level: 1
@@ -37707,7 +37735,6 @@ Body:
       - Level: 5
         Area: 3
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 80000
@@ -37749,7 +37776,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 80000
@@ -37800,7 +37826,6 @@ Body:
     GiveAp: 20
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -37841,7 +37866,6 @@ Body:
     GiveAp: 20
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -37882,7 +37906,6 @@ Body:
     GiveAp: 20
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -37922,7 +37945,6 @@ Body:
     ActiveInstance: 1
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -38044,6 +38066,8 @@ Body:
         Time: 90000
       - Level: 5
         Time: 100000
+    Cooldown: 2000
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38082,7 +38106,17 @@ Body:
         Time: 12000
       - Level: 5
         Time: 15000
-    Cooldown: 300
+    Cooldown:
+      - Level: 1
+        Time: 1500
+      - Level: 2
+        Time: 1200
+      - Level: 3
+        Time: 900
+      - Level: 4
+        Time: 600
+      - Level: 5
+        Time: 300
     Requires:
       SpCost:
         - Level: 1
@@ -38112,7 +38146,17 @@ Body:
     CastCancel: true
     AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 250
+    Cooldown:
+      - Level: 1
+        Time: 1250
+      - Level: 2
+        Time: 1000
+      - Level: 3
+        Time: 750
+      - Level: 4
+        Time: 500
+      - Level: 5
+        Time: 250
     Requires:
       SpCost:
         - Level: 1
@@ -38228,8 +38272,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 300000
     Cooldown: 60000
     FixedCastTime: 1000
@@ -38247,11 +38290,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
+    CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 100
     Cooldown: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost: 150
       ApCost: 150
@@ -38332,11 +38375,11 @@ Body:
     HitCount: 1
     GiveAp: 4
     CastCancel: true
-    CastTime: 2000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 3000
     Cooldown: 3000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -38415,6 +38458,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
+    AfterCastActDelay: 150
     Duration1:
       - Level: 1
         Time: 20000
@@ -38456,6 +38500,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -2
     CastCancel: true
+    Cooldown: 150
     Requires:
       SpCost:
         - Level: 1
@@ -38497,10 +38542,10 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
+    AfterCastActDelay: 150
     Duration1: 60000
     Cooldown: 300000
-    FixedCastTime: 1000
+    FixedCastTime: 1750
     Requires:
       SpCost: 300
       ApCost: 200
@@ -38517,9 +38562,9 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 800
+    CastTime: 3000
     AfterCastActDelay: 500
-    FixedCastTime: 200
+    FixedCastTime: 1000
     Requires:
       SpCost: 120
       ApCost: 15
@@ -38561,8 +38606,8 @@ Body:
       - Level: 10
         Area: 5
     CastCancel: true
-    CastTime: 3500
-    AfterCastActDelay: 500
+    CastTime: 1000
+    AfterCastActDelay: 150
     Cooldown: 2000
     FixedCastTime: 500
     Requires:
@@ -38620,7 +38665,8 @@ Body:
       - Level: 5
         Time: 60000
     Duration2: 20000
-    Cooldown: 30000
+    Cooldown: 20000
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38673,7 +38719,8 @@ Body:
       - Level: 5
         Time: 60000
     Duration2: 10000
-    Cooldown: 30000
+    Cooldown: 20000
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38726,7 +38773,8 @@ Body:
       - Level: 5
         Time: 60000
     Duration2: 10000
-    Cooldown: 30000
+    Cooldown: 20000
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38765,10 +38813,11 @@ Body:
     Element: Weapon
     GiveAp: 1
     CastCancel: true
-    CastTime: 800
+    CastTime: 1000
     AfterCastActDelay: 500
     Duration1: 10000
-    FixedCastTime: 200
+    Cooldown: 150
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38825,7 +38874,8 @@ Body:
       - Level: 5
         Time: 60000
     Duration2: 20000
-    Cooldown: 30000
+    Cooldown: 20000
+    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -38860,7 +38910,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
     Requires:
       SpCost: 30
   - Id: 5337
@@ -38890,7 +38939,7 @@ Body:
         Area: 15
     GiveAp: 20
     CastCancel: true
-    CastTime: 2000
+    CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -38904,7 +38953,7 @@ Body:
       - Level: 5
         Time: 180000
     Cooldown: 10000
-    FixedCastTime: 1000
+    FixedCastTime: 500
     Requires:
       SpCost:
         - Level: 1
@@ -38940,7 +38989,7 @@ Body:
       - Level: 4
         Amount: 3
     CastCancel: true
-    CastTime: 2000
+    CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
@@ -38951,7 +39000,7 @@ Body:
         Time: 50000
       - Level: 4
         Time: 60000
-    FixedCastTime: 1000
+    FixedCastTime: 500
     Requires:
       SpCost:
         - Level: 1
@@ -39001,7 +39050,7 @@ Body:
       - Level: 5
         Amount: 5
     CastCancel: true
-    CastTime: 1000
+    CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 10000
     Cooldown: 1000
@@ -39063,7 +39112,7 @@ Body:
       - Level: 5
         Amount: 5
     CastCancel: true
-    CastTime: 1000
+    CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 10000
     Cooldown: 1000
@@ -39125,7 +39174,7 @@ Body:
       - Level: 5
         Amount: 5
     CastCancel: true
-    CastTime: 1000
+    CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 10000
     Cooldown: 1000
@@ -39187,7 +39236,7 @@ Body:
       - Level: 5
         Amount: 5
     CastCancel: true
-    CastTime: 1000
+    CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 10000
     Cooldown: 1000
@@ -39227,7 +39276,6 @@ Body:
     GiveAp: 20
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -39239,7 +39287,7 @@ Body:
         Time: 300000
       - Level: 5
         Time: 360000
-    Cooldown: 30000
+    Cooldown: 15000
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -39270,7 +39318,6 @@ Body:
     GiveAp: 20
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -39282,7 +39329,7 @@ Body:
         Time: 300000
       - Level: 5
         Time: 360000
-    Cooldown: 30000
+    Cooldown: 15000
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -39313,7 +39360,6 @@ Body:
     GiveAp: 10
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 120000
@@ -39325,7 +39371,7 @@ Body:
         Time: 300000
       - Level: 5
         Time: 360000
-    Cooldown: 30000
+    Cooldown: 15000
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -39374,7 +39420,6 @@ Body:
     ActiveInstance: 1
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 60000
@@ -39410,6 +39455,8 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
+    AfterCastActDelay: 500
+    Cooldown: 5000
     Requires:
       SpCost: 1
   - Id: 5351
@@ -39422,11 +39469,9 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 150000
     Cooldown: 60000
-    FixedCastTime: 1000
     Requires:
       SpCost: 250
       ApCost: 125
@@ -39446,10 +39491,9 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 150
     Duration1: 60000
     Cooldown: 120000
-    FixedCastTime: 1000
     Requires:
       SpCost: 300
       ApCost: 100
@@ -39470,11 +39514,10 @@ Body:
     Element: Weapon
     GiveAp: 3
     CastCancel: true
-    CastTime: 1000
-    AfterCastActDelay: 500
+    CastTime: 2000
+    AfterCastActDelay: 150
     Duration1: 500
     Cooldown: 500
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39542,10 +39585,8 @@ Body:
       - Level: 5
         Amount: 2
     CastCancel: true
-    CastTime: 1000
-    AfterCastActDelay: 500
-    Cooldown: 1000
-    FixedCastTime: 1000
+    CastTime: 2000
+    AfterCastActDelay: 150
     Requires:
       SpCost:
         - Level: 1
@@ -39600,6 +39641,7 @@ Body:
       - Level: 5
         Amount: 3
     CastCancel: true
+    AfterCastActDelay: 300
     Cooldown: 500
     Requires:
       SpCost:
@@ -39644,6 +39686,7 @@ Body:
         Amount: 2
     CastCancel: true
     CastTime: 1000
+    AfterCastActDelay: 150
     Duration1:
       - Level: 1
         Time: 10000
@@ -39655,7 +39698,6 @@ Body:
         Time: 15000
       - Level: 5
         Time: 20000
-    Cooldown: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39695,11 +39737,9 @@ Body:
         Area: 11
     GiveAp: 20
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 30000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39742,12 +39782,10 @@ Body:
         Area: 11
     GiveAp: 20
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 20000
     Duration2: 20000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39789,11 +39827,9 @@ Body:
         Area: 11
     GiveAp: 20
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 30000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39836,11 +39872,9 @@ Body:
         Area: 11
     GiveAp: 10
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 180000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39883,11 +39917,9 @@ Body:
         Area: 11
     GiveAp: 10
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 180000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39930,12 +39962,10 @@ Body:
         Area: 11
     GiveAp: 20
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 20000
     Duration2: 20000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -39977,11 +40007,9 @@ Body:
         Area: 11
     GiveAp: 10
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 1000
     Duration1: 180000
     Cooldown: 10000
-    FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
@@ -40018,7 +40046,6 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 80000
@@ -40055,9 +40082,9 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
-    Cooldown: 60000
-    FixedCastTime: 1000
+    AfterCastActDelay: 1000
+    Cooldown: 8000
+    FixedCastTime: 2000
     Requires:
       SpCost:
         - Level: 1
@@ -40084,10 +40111,9 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
     AfterCastActDelay: 500
     Cooldown: 2500
-    FixedCastTime: 1000
+    FixedCastTime: 3000
     Requires:
       SpCost:
         - Level: 1
@@ -40113,12 +40139,12 @@ Body:
     Element: Water
     GiveAp: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 100
     Duration2: 10000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -40151,12 +40177,12 @@ Body:
     Element: Wind
     GiveAp: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 3000
     Duration2: 10000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -40190,12 +40216,12 @@ Body:
     Element: Poison
     GiveAp: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -40229,12 +40255,12 @@ Body:
     Element: Fire
     GiveAp: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -40268,12 +40294,12 @@ Body:
     Element: Earth
     GiveAp: 5
     CastCancel: true
-    CastTime: 4000
+    CastTime: 5000
     AfterCastActDelay: 500
     Duration1: 100
     Duration2: 10000
     Cooldown: 2000
-    FixedCastTime: 1000
+    FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -40308,11 +40334,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 5000
+    AfterCastActDelay: 1000
     Duration1: 1500000
     Cooldown: 900000
-    FixedCastTime: 2000
+    FixedCastTime: 3000
     Requires:
       SpCost: 100
       ItemCost:
@@ -40329,11 +40355,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 5000
+    AfterCastActDelay: 1000
     Duration1: 1500000
     Cooldown: 900000
-    FixedCastTime: 2000
+    FixedCastTime: 3000
     Requires:
       SpCost: 100
       ItemCost:
@@ -40350,11 +40376,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 5000
+    AfterCastActDelay: 1000
     Duration1: 1500000
     Cooldown: 900000
-    FixedCastTime: 2000
+    FixedCastTime: 3000
     Requires:
       SpCost: 100
       ItemCost:
@@ -40371,11 +40397,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 5000
+    AfterCastActDelay: 1000
     Duration1: 1500000
     Cooldown: 900000
-    FixedCastTime: 2000
+    FixedCastTime: 3000
     Requires:
       SpCost: 100
       ItemCost:
@@ -40392,11 +40418,11 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 3000
-    AfterCastActDelay: 500
+    CastTime: 5000
+    AfterCastActDelay: 1000
     Duration1: 1500000
     Cooldown: 900000
-    FixedCastTime: 2000
+    FixedCastTime: 3000
     Requires:
       SpCost: 100
       ItemCost:
@@ -40412,8 +40438,8 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 8000
-    AfterCastActDelay: 500
+    CastTime: 4000
+    AfterCastActDelay: 1500
     Cooldown: 60000
     FixedCastTime: 2000
     Requires:
@@ -40429,8 +40455,8 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 2000
-    AfterCastActDelay: 500
+    CastTime: 4000
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 120000
@@ -40443,7 +40469,7 @@ Body:
       - Level: 5
         Time: 240000
     Cooldown: 10000
-    FixedCastTime: 1000
+    FixedCastTime: 2000
     Requires:
       SpCost:
         - Level: 1


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
- cooldown is direct gathering from replay parser in divine-pride
- Fixcast is get by -100% var reduction build
- Variable cast is got after know exactly fixcast , then equip -1.5sec fixcast gear then reverse-calculate to player's int+dex.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
