### PR TITLE
Corrects every attack returning at least 1 damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8342,12 +8342,14 @@ int64 battle_calc_return_damage(struct block_list* tbl, struct block_list *src, 
 	}
 
 	if (sc) {
-		if (status_reflect && sc->data[SC_REFLECTDAMAGE])
+		if (status_reflect && sc->data[SC_REFLECTDAMAGE]) {
 			rdamage -= damage * sc->data[SC_REFLECTDAMAGE]->val2 / 100;
-		if (sc->data[SC_VENOMBLEED] && sc->data[SC_VENOMBLEED]->val3 == 0)
+			rdamage = i64max(rdamage, 1);
+		}
+		if (sc->data[SC_VENOMBLEED] && sc->data[SC_VENOMBLEED]->val3 == 0) {
 			rdamage -= damage * sc->data[SC_VENOMBLEED]->val2 / 100;
-
-		rdamage = i64max(rdamage, 1);
+			rdamage = i64max(rdamage, 1);
+		}
 	}
 
 	if (tsc) {

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8355,7 +8355,10 @@ int64 battle_calc_return_damage(struct block_list* tbl, struct block_list *src, 
 			rdamage = damage * tsc->data[SC_MAXPAIN]->val1 * 10 / 100;
 	}
 
-	return cap_value(rdamage, 1, status_get_max_hp(tbl));
+	if (rdamage == 0)
+		return 0; // No reflecting damage calculated.
+	else
+		return cap_value(rdamage, 1, status_get_max_hp(tbl));
 }
 
 /**


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to 33a99b5.
  * Resolves an issue where normal attacks which have no reflect damage were being capped to at least 1.
Thanks to @XanKriegor1!