### PR TITLE
Add QuestInfo display for Lost Knife quest in Kunlun

### DIFF
--- a/npc/quests/quests_gonryun.txt
+++ b/npc/quests/quests_gonryun.txt
@@ -3805,6 +3805,7 @@ gon_fild01,245,257,0	script	#gonknife	111,3,3,{
 OnTouch_:
 	if (nakha == 1) {
 		set nakha,2;
+		changequest 10034,10035;
 		mes "^3355FFHm? What's this?";
 		mes " ";
 		mes "Something was hidden beneath the leaves...^000000";
@@ -3812,7 +3813,6 @@ OnTouch_:
 		mes "- You have found an old knife -";
 		close2;
 		getitem 1201,1; //Knife
-		changequest 10034,10035;
 	}
 	end;
 }

--- a/npc/quests/quests_gonryun.txt
+++ b/npc/quests/quests_gonryun.txt
@@ -3713,6 +3713,7 @@ gonryun,237,226,3	script	Han Ran Jiao#gon	776,{
 		next;
 		if (BaseLevel >= 20) {
 			set nakha,1;
+			setquest 10034;
 			mes "[Han Ran Jiao]";
 			mes "I need to go down to get it";
 			mes "but...the monsters...";
@@ -3759,6 +3760,7 @@ gonryun,237,226,3	script	Han Ran Jiao#gon	776,{
 		next;
 		if (select("Return the knife.:Refuse.") == 1) {
 			set nakha,3;
+			completequest 10035;
 			delitem 1201,1; //Knife
 			mes "[Han Ran Jiao]";
 			mes "Thank you! Thank you so much!";
@@ -3810,6 +3812,7 @@ OnTouch_:
 		mes "- You have found an old knife -";
 		close2;
 		getitem 1201,1; //Knife
+		changequest 10034,10035;
 	}
 	end;
 }


### PR DESCRIPTION
OngoingQuestInfo (both in official kro version and in the english translation) contains data for the Lost Knife quest in Kunlun at ID 10034 - 10035. This PR adds the missing setquest/changequest/completequest calls to the rAthena NPC script.