### PR TITLE
Corrects Doram healing skill effects

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -12070,7 +12070,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		else if (status_get_hp(bl) != status_get_max_hp(bl))
 			heal = ((2 * skill_lv - 1) * 10) * status_get_max_hp(bl) / 100;
 		clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
-		status_heal(bl, heal, 0, 1|2|4);
+		status_heal(bl, heal, 0, 0);
 	}
 		break;
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13926,7 +13926,7 @@ TIMER_FUNC(status_change_timer){
 		break;
 	case SC_FRESHSHRIMP:
 		if (--(sce->val4) >= 0) {
-			status_heal(bl, sce->val2, 0, 3);
+			status_heal(bl, sce->val2, 0, 0);
 			sc_timer_next((10000 - ((sce->val1 - 1) * 1000)) + tick);
 			return 0;
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6962

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Tuna Belly and Fresh Shrimp don't apply normal green heal effects.
  * Resolves an issue with the HP bars not properly updating for party members as well.
Thanks to @KrokusPokus!