### PR TITLE
Resolves duplicate status calculation on players

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12129,7 +12129,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		sce->timer = INVALID_TIMER; // Infinite duration
 
 	if (calc_flag.any()) {
-		if (sd) {
+		if (sd != nullptr) {
 			switch(type) {
 				// Statuses that adjust HP/SP and heal after starting
 				case SC_BERSERK:
@@ -12138,7 +12138,8 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 					status_calc_bl_(bl, calc_flag, SCO_FORCE);
 					break;
 				default:
-					status_calc_bl_(bl, calc_flag);
+					if (!sd->state.connect_new)
+						status_calc_bl_(bl, calc_flag);
 					break;
 			}
 		} else
@@ -12149,21 +12150,8 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 	if (sc_isnew && scdb->state.any())
 		status_calc_state(bl, sc, scdb->state, true);
 
-	if (sd) {
-		if (sd->pd)
-			pet_sc_check(sd, type); // Skotlex: Pet Status Effect Healing
-		switch (type) {
-			case SC_BERSERK:
-			case SC_MERC_HPUP:
-			case SC_MERC_SPUP:
-				status_calc_pc(sd, SCO_FORCE);
-				break;
-			default:
-				if (!sd->state.connect_new)
-					status_calc_pc(sd, SCO_NONE);
-				break;
-		}
-	}
+	if (sd != nullptr && sd->pd != nullptr)
+		pet_sc_check(sd, type); // Skotlex: Pet Status Effect Healing
 
 	// 1st thing to execute when loading status
 	switch (type) {


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6930

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Follow up to a7ee51d.
  * Resolves an issue on sc_start where players are doubly calculated on their items and stats.
  * Resolves an edge case where AutoSpell3 bonuses can cause a crash if success rate is high or delay is low.
Thanks to @CairoLee!