### PR TITLE
Renewal Physical damage cleanup

### DIFF
--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -156,7 +156,7 @@ Body:
          bonus2 bSkillAtk,"NC_AXEBOOMERANG",15;
       }
       if ((.@eq + .@weapon) >= 18) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          if ((.@eq + .@weapon) >= 22) {
             bonus bLongAtkRate,10;
          }
@@ -2062,7 +2062,7 @@ Body:
           - S_Shadowchaser_Shield
     Script: |
       bonus2 bSkillAtk,"SC_TRIANGLESHOT",20;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bMatkRate,2;
       bonus bLongAtkRate,2;
   - Combos:
@@ -2483,7 +2483,7 @@ Body:
       bonus2 bIgnoreDefRaceRate,RC_Demon,15;
       bonus2 bIgnoreDefRaceRate,RC_Undead,15;
       bonus bMaxHPrate,10+.@r;
-      bonus2 bAddClass,Class_All,2+.@r;
+      bonus bAtkRate,2+.@r;
   - Combos:
       - Combo:
           - Valkyrie_Manteau
@@ -2845,13 +2845,13 @@ Body:
           - Gh_md_dex
           - Hawkeye
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Combos:
       - Combo:
           - Contaminated_Raydric_Card
           - Daydric_Card
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus2 bSubEle,Ele_Neutral,10;
   - Combos:
       - Combo:
@@ -4052,6 +4052,22 @@ Body:
       bonus bMatkRate,10;
   - Combos:
       - Combo:
+          - Min_Toad_Card
+          - Min_Chimera_Card
+      - Combo:
+          - Min_Vagabond_Wolf_Card
+          - Min_Chimera_Card
+      - Combo:
+          - Min_Vocal_Card
+          - Min_Chimera_Card
+      - Combo:
+          - Min_Eclipse_Card
+          - Min_Chimera_Card
+    Script: |
+      bonus bAtkRate,10;
+      bonus bMatkRate,10;
+  - Combos:
+      - Combo:
           - Old_DetachmentsRing_J
           - Old_Rune_Circlet
     Script: |
@@ -4226,7 +4242,7 @@ Body:
           - Mantis_Card
           - Chaotic_Mantis_Card
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bHit,12;
   - Combos:
       - Combo:
@@ -5171,11 +5187,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RA_AIMEDBOLT",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RA_AIMEDBOLT",10;
       }
   - Combos:
@@ -5187,11 +5203,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",10;
       }
   - Combos:
@@ -5203,11 +5219,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"AB_DUPLELIGHT",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"AB_DUPLELIGHT",10;
       }
   - Combos:
@@ -5251,11 +5267,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bVariableCastRate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CARTCANNON",10;
       if (.@r >= 27) {
          bonus bVariableCastRate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CARTCANNON",10;
       }
   - Combos:
@@ -5267,11 +5283,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CART_TORNADO",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CART_TORNADO",10;
       }
   - Combos:
@@ -5283,11 +5299,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GC_ROLLINGCUTTER",10;
       }
   - Combos:
@@ -5309,11 +5325,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bCritAtkRate,5;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus bCritAtkRate,5;
       }
   - Combos:
@@ -5325,11 +5341,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SC_FATALMENACE",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SC_FATALMENACE",10;
       }
   - Combos:
@@ -5341,11 +5357,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SU_PICKYPECK",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SU_PICKYPECK",10;
       }
   - Combos:
@@ -5357,11 +5373,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_R_TRIP",10;
       if (.@r >= 27) {
          bonus bLongAtkRate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_R_TRIP",10;
       }
   - Combos:
@@ -5373,11 +5389,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_FIRE_RAIN",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_FIRE_RAIN",10;
       }
   - Combos:
@@ -5389,11 +5405,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_SOLARBURST",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_SOLARBURST",10;
       }
   - Combos:
@@ -5405,11 +5421,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus2 bAddSize,Size_All,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_FULLMOONKICK",10;
       if (.@r >= 27) {
          bonus2 bAddSize,Size_All,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_FULLMOONKICK",10;
       }
   - Combos:
@@ -5421,11 +5437,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"KO_HAPPOKUNAI",10;
       if (.@r >= 27) {
          bonus bLongAtkRate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"KO_HAPPOKUNAI",10;
       }
   - Combos:
@@ -5437,11 +5453,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_KNUCKLEARROW",10;
       }
   - Combos:
@@ -5453,11 +5469,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bMaxHPrate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_TIGERCANNON",10;
       if (.@r >= 27) {
          bonus bMaxHPrate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_TIGERCANNON",10;
       }
   - Combos:
@@ -5479,11 +5495,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bMaxHPrate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bCritAtkRate,5;
       if (.@r >= 27) {
          bonus bMaxHPrate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus bCritAtkRate,5;
       }
   - Combos:
@@ -5773,11 +5789,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RA_AIMEDBOLT",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
       }
   - Combos:
@@ -5789,11 +5805,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",10;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
       }
   - Combos:
@@ -5805,11 +5821,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"AB_DUPLELIGHT",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"AB_DUPLELIGHT",15;
       }
   - Combos:
@@ -5821,11 +5837,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_KNUCKLEARROW",15;
       }
   - Combos:
@@ -5837,11 +5853,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bMaxHPrate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_TIGERCANNON",10;
       if (.@r >= 27) {
          bonus bMaxHPrate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_TIGERCANNON",15;
       }
   - Combos:
@@ -5885,11 +5901,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bVariableCastRate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CARTCANNON",10;
       if (.@r >= 27) {
          bonus bVariableCastRate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CARTCANNON",15;
       }
   - Combos:
@@ -5901,11 +5917,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CART_TORNADO",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CART_TORNADO",15;
       }
   - Combos:
@@ -5917,11 +5933,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GC_ROLLINGCUTTER",15;
       }
   - Combos:
@@ -5933,11 +5949,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SC_FATALMENACE",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SC_FATALMENACE",15;
       }
   - Combos:
@@ -5949,11 +5965,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SU_PICKYPECK",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SU_PICKYPECK",15;
       }
   - Combos:
@@ -5965,11 +5981,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_R_TRIP",10;
       if (.@r >= 27) {
          bonus bLongAtkRate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_R_TRIP",15;
       }
   - Combos:
@@ -5981,11 +5997,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_FIRE_RAIN",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_FIRE_RAIN",15;
       }
   - Combos:
@@ -5997,11 +6013,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_SOLARBURST",10;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_SOLARBURST",15;
       }
   - Combos:
@@ -6013,11 +6029,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus2 bAddSize,Size_All,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_FULLMOONKICK",10;
       if (.@r >= 27) {
          bonus2 bAddSize,Size_All,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
       }
   - Combos:
@@ -6029,11 +6045,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"KO_HAPPOKUNAI",10;
       if (.@r >= 27) {
          bonus bLongAtkRate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"KO_HAPPOKUNAI",15;
       }
   - Combos:
@@ -6323,11 +6339,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-10;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
       }
   - Combos:
@@ -6339,11 +6355,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
       if (.@r >= 27) {
          bonus bDelayrate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
       }
   - Combos:
@@ -6355,11 +6371,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"AB_DUPLELIGHT",15;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"AB_DUPLELIGHT",15;
       }
   - Combos:
@@ -6371,11 +6387,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-10;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",15;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_KNUCKLEARROW",15;
       }
   - Combos:
@@ -6387,11 +6403,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bMaxHPrate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SR_TIGERCANNON",15;
       if (.@r >= 27) {
          bonus bMaxHPrate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SR_TIGERCANNON",15;
       }
   - Combos:
@@ -6435,11 +6451,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bVariableCastRate,-5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CARTCANNON",15;
       if (.@r >= 27) {
          bonus bVariableCastRate,-5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CARTCANNON",15;
       }
   - Combos:
@@ -6451,11 +6467,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GN_CART_TORNADO",15;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GN_CART_TORNADO",15;
       }
   - Combos:
@@ -6467,11 +6483,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-10;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",15;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"GC_ROLLINGCUTTER",15;
       }
   - Combos:
@@ -6483,11 +6499,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-10;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SC_FATALMENACE",10;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SC_FATALMENACE",15;
       }
   - Combos:
@@ -6499,11 +6515,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bDelayrate,-10;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SU_PICKYPECK",15;
       if (.@r >= 27) {
          bonus bDelayrate,-10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SU_PICKYPECK",15;
       }
   - Combos:
@@ -6515,11 +6531,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_R_TRIP",15;
       if (.@r >= 27) {
          bonus bLongAtkRate,10;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_R_TRIP",15;
       }
   - Combos:
@@ -6531,11 +6547,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"RL_FIRE_RAIN",15;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"RL_FIRE_RAIN",15;
       }
   - Combos:
@@ -6547,11 +6563,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_SOLARBURST",15;
       if (.@r >= 27) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_SOLARBURST",15;
       }
   - Combos:
@@ -6563,11 +6579,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus2 bAddSize,Size_All,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
       if (.@r >= 27) {
          bonus2 bAddSize,Size_All,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
       }
   - Combos:
@@ -6579,11 +6595,11 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT)+getequiprefinerycnt(EQI_ARMOR);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bSkillAtk,"KO_HAPPOKUNAI",15;
       if (.@r >= 27) {
          bonus bLongAtkRate,5;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"KO_HAPPOKUNAI",15;
       }
   - Combos:
@@ -7972,7 +7988,7 @@ Body:
           - Overwhelm_Str_Armor
           - Modify_Str_Boots_
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       .@r = getequiprefinerycnt(EQI_ARMOR) + getequiprefinerycnt(EQI_SHOES);
       if (.@r >= 21) {
          bonus2 bIgnoreDefRaceRate,RC_Brute,20;
@@ -8090,7 +8106,7 @@ Body:
           - E_Illusion_Leg_A
           - E_Illusion_Armor_A
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Combos:
       - Combo:
           - Illusion_Armor_A
@@ -8273,7 +8289,7 @@ Body:
          .@val = 20;
       }
       if ((.@weapon + .@eq) >= 18) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       }
       if ((.@weapon + .@eq) >= 22) {
          .@val += 30;
@@ -8288,7 +8304,7 @@ Body:
     Script: |
       .@weapon = getequiprefinerycnt(EQI_HAND_R);
       .@eq = getequiprefinerycnt(EQI_SHOES);
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       if (.@weapon >= 7 && .@eq >= 7) {
          bonus bAspd,2;
       }
@@ -9249,7 +9265,7 @@ Body:
     Script: |
       .@weapon = getequiprefinerycnt(EQI_HAND_R);
       .@eq = getequiprefinerycnt(EQI_HEAD_TOP);
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       if (.@weapon >= 7 && .@eq >= 7) {
          bonus bAspd,2;
       }
@@ -9268,7 +9284,7 @@ Body:
       .@eq = getequiprefinerycnt(EQI_HEAD_TOP);
       .@weapon = getequiprefinerycnt(EQI_HAND_R);
       if (.@eq >= 7 && .@weapon >= 7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if ((.@eq + .@weapon) >= 18) {
          bonus2 bSubSize,Size_Small,20;
@@ -10046,12 +10062,12 @@ Body:
           - Lava_Leather_Boots
           - Lava_Leather_Armor
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       .@a = getequiprefinerycnt(EQI_GARMENT);
       .@b = getequiprefinerycnt(EQI_SHOES);
       .@c = getequiprefinerycnt(EQI_ARMOR);
       if (.@a >= 7 && .@b >= 7 && .@c >= 7)
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@a+.@b+.@c >= 27)
             bonus bDelayrate,-20;
   - Combos:
@@ -10060,12 +10076,12 @@ Body:
           - Lava_Leather_Shoes
           - Lava_Leather_Suit
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       .@a = getequiprefinerycnt(EQI_GARMENT);
       .@b = getequiprefinerycnt(EQI_SHOES);
       .@c = getequiprefinerycnt(EQI_ARMOR);
       if (.@a >= 7 && .@b >= 7 && .@c >= 7)
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@a+.@b+.@c >= 27)
             bonus bCritAtkRate,20;
   - Combos:
@@ -10223,10 +10239,10 @@ Body:
       bonus bMaxSPRate,5;
       .@r = getequiprefinerycnt(EQI_SHOES);
       if (.@r >= 7) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
       }
       if (.@r >= 9) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
       }
       if (.@r >= 12) {
          bonus bDelayrate,-5;
@@ -10558,7 +10574,7 @@ Body:
          .@val = 20;
       }
       if ((.@eq + .@weapon) >= 18) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          if ((.@eq + .@weapon) >= 22) {
             .@val += 20;
          }
@@ -10668,7 +10684,7 @@ Body:
           - Ancient_Hero_Boots
           - Meteor_Striker
     Script: |
-      autobonus "{ bonus bStr,20; bonus2 bAddClass,Class_All,15; }",30,7000;
+      autobonus "{ bonus bStr,20; bonus bAtkRate,15; }",30,7000;
   - Combos:
       - Combo:
           - Ancient_Hero_Boots
@@ -10704,7 +10720,7 @@ Body:
           - Ancient_Hero_Boots
           - MeawFoxtail
     Script: |
-      autobonus "{ bonus bLuk,20; bonus bMatkRate,15; bonus2 bAddClass,Class_All,15; }",20,7000,BF_MAGIC|BF_WEAPON; /* unknown rate */
+      autobonus "{ bonus bLuk,20; bonus bMatkRate,15; bonus bAtkRate,15; }",20,7000,BF_MAGIC|BF_WEAPON; /* unknown rate */
   - Combos:
       - Combo:
           - Ancient_Hero_Boots
@@ -10738,7 +10754,7 @@ Body:
           - Sharp_Wind_Sword
           - Fog_Dew_Sword
     Script: |
-      autobonus "{ bonus bStr,20; bonus2 bAddClass,Class_All,10; }",20,7000,BF_WEAPON; /* unknown rate */
+      autobonus "{ bonus bStr,20; bonus bAtkRate,10; }",20,7000,BF_WEAPON; /* unknown rate */
   - Combos:
       - Combo:
           - Ancient_Hero_Boots
@@ -10796,7 +10812,7 @@ Body:
           - Illusion_Boots
           - Illusion_Butcher
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       .@eq = getequiprefinerycnt(EQI_SHOES);
       .@weapon = getequiprefinerycnt(EQI_HAND_R);
       if (.@eq >= 7 && .@weapon >= 7) {
@@ -10826,7 +10842,7 @@ Body:
           - S_Physical_Pendant
     Script: |
       if (getequiprefinerycnt(EQI_SHADOW_ACC_R) + getequiprefinerycnt(EQI_SHADOW_ACC_L) + getequiprefinerycnt(EQI_SHADOW_WEAPON) >= 23) {
-         bonus2 bAddClass,Class_All,1;
+         bonus bAtkRate,1;
       }
   - Combos:
       - Combo:
@@ -11261,7 +11277,7 @@ Body:
           - S_Infinity_Earring
           - S_Infinity_Pendant
     Script: |
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
       if (getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L) >= 15)
          bonus bNoSizeFix;
   - Combos:
@@ -11807,7 +11823,7 @@ Body:
       if ((getequiprefinerycnt(EQI_SHADOW_ACC_L)+getequiprefinerycnt(EQI_SHADOW_ACC_R)) >= 10) {
          .@val += 2;
       }
-      bonus2 bAddClass,Class_All,.@val;
+      bonus bAtkRate,.@val;
       bonus bMaxHPrate,.@val;
   - Combos:
       - Combo:
@@ -12132,10 +12148,10 @@ Body:
       .@r = getequiprefinerycnt(EQI_SHADOW_ARMOR) + getequiprefinerycnt(EQI_SHADOW_SHIELD) + getequiprefinerycnt(EQI_SHADOW_SHOES);
       bonus bBaseAtk,.@r*2;
       if (.@r >= 25) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       else if (.@r >= 23) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
       }
   - Combos:
       - Combo:
@@ -12545,7 +12561,7 @@ Body:
           - LivingDead_Card
           - Vampire's_Servant
     Script: |
-      bonus2 bAddClass,Class_All,(getrefine()/3);
+      bonus bAtkRate,(getrefine()/3);
   - Combos:
       - Combo:
           - Ill_Dracula_Card
@@ -12647,7 +12663,7 @@ Body:
           - Cowraiders2_Card
     Script: |
       bonus bStr,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Combos:
       - Combo:
           - Cowraiders1_Card
@@ -13059,7 +13075,7 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_HAND_R) + getequiprefinerycnt(EQI_HAND_L);
       bonus bBaseAtk,10*(.@r/3);
-      bonus2 bAddClass,Class_All,2*(.@r/5);
+      bonus bAtkRate,2*(.@r/5);
       if (.@r >= 14) {
          .@val = 25;
          if (.@r >= 16) {
@@ -13087,7 +13103,7 @@ Body:
          bonus2 bSkillAtk,"GC_COUNTERSLASH",20;
       }
       if (.@a+.@b >= 18)
-         bonus2 bAddClass,Class_All,12;
+         bonus bAtkRate,12;
          if (.@a+.@b >= 20) .@val = 20;
             bonus2 bSkillAtk,"ASC_BREAKER",40+.@val;
             bonus2 bSkillAtk,"ASC_METEORASSAULT",40+.@val;
@@ -13494,7 +13510,7 @@ Body:
           - King_Schmidt_Manteau
     Script: |
       bonus bCritAtkRate,7;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Combos:
       - Combo:
           - Schmidt_Insignia_Rigid_Body
@@ -13657,7 +13673,7 @@ Body:
           - Ancient_Hero_Boots
           - Ray_Knuckle
     Script: |
-      autobonus "{ bonus bStr,20; bonus2 bAddClass,Class_All,15; }",30,7000,BF_WEAPON;
+      autobonus "{ bonus bStr,20; bonus bAtkRate,15; }",30,7000,BF_WEAPON;
   - Combos:
       - Combo:
           - Great_Hero_Boots
@@ -13682,7 +13698,7 @@ Body:
           - Up_Thousand_Sun
     Script: |
       bonus bStr,10;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - Great_Hero_Boots
@@ -13786,21 +13802,21 @@ Body:
           - Up_Crimson_Rose
     Script: |
       bonus bDex,10;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - Great_Hero_Boots
           - Up_Ray_Knuckle
     Script: |
       bonus bVit,10;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - Great_Hero_Boots
           - Up_MeawFoxtail
     Script: |
       bonus bLuk,10;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bMatkRate,7;
   - Combos:
       - Combo:
@@ -13816,7 +13832,7 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_HAND_R) + getequiprefinerycnt(EQI_HAND_L);
       bonus bBaseAtk,15*(.@r/3);
-      bonus2 bAddClass,Class_All,3*(.@r/5);
+      bonus bAtkRate,3*(.@r/5);
       if (.@r >= 14) {
          bonus2 bSkillAtk,"KO_JYUMONJIKIRI",30;
          bonus2 bSkillCooldown,"KO_JYUMONJIKIRI",-2000;
@@ -13863,11 +13879,11 @@ Body:
           - Dragon_Boots
     Script: |
       .@sum = getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMdef,8;
       bonus bDef,50;
       bonus bBaseAtk,15*(readparam(bStr)/15);
-      autobonus2 "{ bonus2 bAddClass,Class_All,10; if (readparam(bStr) >= 120) { bonus2 bAddClass,Class_All,15; } }",1+(readparam(bStr) >= 120),10000,BF_MAGIC|BF_WEAPON;
+      autobonus2 "{ bonus bAtkRate,10; if (readparam(bStr) >= 120) { bonus bAtkRate,15; } }",1+(readparam(bStr) >= 120),10000,BF_MAGIC|BF_WEAPON;
       if (.@sum >= 33) {
          bonus bAspdRate,20;
          bonus bDelayrate,-25;
@@ -14049,7 +14065,7 @@ Body:
           - King_Schmidt_Manteau
     Script: |
       .@sum = getequiprefinerycnt(EQI_HAND_R)+getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_GARMENT);
-      autobonus "{ bonus2 bAddClass,Class_All,10; }",1,10000,BF_WEAPON;
+      autobonus "{ bonus bAtkRate,10; }",1,10000,BF_WEAPON;
       bonus bBaseAtk,30;
       if (.@sum >= 40) {
          bonus2 bAddEle,Ele_Undead,20;
@@ -14090,7 +14106,7 @@ Body:
           - King_Schmidt_Manteau
     Script: |
       .@sum = getequiprefinerycnt(EQI_HAND_R)+getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_GARMENT);
-      autobonus "{ bonus bMatkRate,7; bonus2 bAddClass,Class_All,7; }",1,10000,BF_MAGIC;
+      autobonus "{ bonus bMatkRate,7; bonus bAtkRate,7; }",1,10000,BF_MAGIC;
       if (.@sum >= 30) {
          bonus2 bMagicAddEle,Ele_Undead,20;
          bonus2 bAddEle,Ele_Undead,20;
@@ -14119,7 +14135,7 @@ Body:
       bonus2 bAddSize,Size_Medium,5;
       bonus2 bMagicAddSize,Size_Medium,5;
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Combos:
       - Combo:
           - ILL_Obeaune_Card
@@ -14175,7 +14191,7 @@ Body:
     Script: |
       bonus2 bAddSize,Size_Small,20;
       bonus bCritical,5;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bMaxHPrate,10;
       bonus bMaxSPrate,10;
       bonus bStr,5;
@@ -14224,7 +14240,7 @@ Body:
       .@weapon = getequiprefinerycnt(EQI_HAND_R);
       bonus bBaseAtk,30;
       if (.@eq >= 7 && .@weapon >= 7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if ((.@eq + .@weapon) >= 18) {
          bonus2 bSkillAtk,"SR_SKYNETBLOW",20;
@@ -14238,7 +14254,7 @@ Body:
           - KatarOfCold_Icicle_IL
     Script: |
       .@sum = getequiprefinerycnt(EQI_HAND_R)+getequiprefinerycnt(EQI_ARMOR);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@sum >= 7) {
          bonus bCritical,5;
       }
@@ -14255,7 +14271,7 @@ Body:
           - Morrigane's_Pendant_IL
     Script: |
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Combos:
       - Combo:
           - Electronic_Guitar_IL
@@ -14316,7 +14332,7 @@ Body:
           - KatarOfCold_Icicle_IL
           - Ring_IL
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (getequiprefinerycnt(EQI_HAND_R) >= 9) {
          bonus bCritAtkRate,20;
       }
@@ -14329,7 +14345,7 @@ Body:
           - Water_Sprits_Armor_IL
     Script: |
       .@sum = getequiprefinerycnt(EQI_HAND_R)+getequiprefinerycnt(EQI_ARMOR);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@sum >= 7) {
          bonus bDelayrate,-5;
       }
@@ -14399,7 +14415,7 @@ Body:
     Script: |
       .@sum = getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT);
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMdef,8;
       bonus bDef,50;
       bonus bAspdRate,3*(readparam(bDex)/15);
@@ -14434,12 +14450,12 @@ Body:
           - Dragon_Boots
     Script: |
       .@sum = getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_SHOES)+getequiprefinerycnt(EQI_GARMENT);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMdef,8;
       bonus bDef,50;
       bonus bCritAtkRate,3*(readparam(bLuk)/15);
       bonus bCritical,2*(readparam(bLuk)/15);
-      autobonus2 "{ bonus bCritAtkRate,10; bonus2 bAddClass,Class_All,7; if (readparam(bLuk) >= 120) { bonus bCritAtkRate,10; bonus2 bAddClass,Class_All,7; } }",1+(readparam(bLuk) >= 120),10000,BF_MAGIC|BF_WEAPON;
+      autobonus2 "{ bonus bCritAtkRate,10; bonus bAtkRate,7; if (readparam(bLuk) >= 120) { bonus bCritAtkRate,10; bonus bAtkRate,7; } }",1+(readparam(bLuk) >= 120),10000,BF_MAGIC|BF_WEAPON;
       if (.@sum >= 33) {
          bonus bAspdRate,20;
          bonus bDelayrate,-25;
@@ -14457,7 +14473,7 @@ Body:
       bonus2 bSubRace,RC_Angel,15;
       bonus2 bSubRace,RC_Demon,15;
       if (.@sum >= 27) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          bonus bDelayrate,-20;
          bonus bFixedCastrate,-20;
       }
@@ -14492,7 +14508,7 @@ Body:
       bonus2 bSubRace,RC_Demon,20;
       if (.@sum >= 27) {
          bonus bMatkRate,4;
-         bonus2 bAddClass,Class_All,4;
+         bonus bAtkRate,4;
          bonus bDelayrate,-20;
          bonus bFixedCastrate,-20;
       }
@@ -14510,7 +14526,7 @@ Body:
       bonus2 bSubRace,RC_Demon,15;
       if (.@sum >= 27) {
          bonus bMatkRate,7;
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
          bonus bDelayrate,-20;
          bonus bFixedCastrate,-20;
       }
@@ -14542,7 +14558,7 @@ Body:
       bonus bDef,30;
       bonus bLuk,8;
       if (.@sum >= 27) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          bonus bDelayrate,-20;
          bonus bFixedCastrate,-20;
       }
@@ -14618,14 +14634,14 @@ Body:
           - Reginleif_Card
           - Randgris_Card
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bMaxHPrate,5;
   - Combos:
       - Combo:
           - Ingrid_Card
           - Randgris_Card
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMaxHPrate,10;
   - Combos:
       - Combo:
@@ -14666,7 +14682,7 @@ Body:
           - CassockA_STR
     Script: |
       bonus2 bAddRace,RC_All,12;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Combos:
       - Combo:
           - Cassock_Agi
@@ -15021,7 +15037,7 @@ Body:
           - GuillotineCross_Robe2
           - GuillotineCross_Bottom2
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bCritAtkRate,15;
   - Combos:
       - Combo:
@@ -15128,7 +15144,7 @@ Body:
           - Attacker_Booster_Manteau_
           - Attacker_Booster_Ring
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bDelayrate,-15;
       bonus2 bSkillAtk,"SC_FATALMENACE",min(BaseLevel,180)/15;
       autobonus3 "{ bonus2 bSkillAtk,\"SC_FATALMENACE\",35; }",1000,60000,"ST_PRESERVE";
@@ -15442,7 +15458,7 @@ Body:
           - Ranger_Booster_Manteau_
           - Range_Booster_Brooch
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bDelayrate,-15;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",min(BaseLevel,180)/15;
       autobonus3 "{ bonus2 bSkillAtk,\"GC_ROLLINGCUTTER\",20; }",1000,60000,"ASC_EDP";
@@ -15545,13 +15561,16 @@ Body:
       bonus2 bSkillAtk,"SU_CN_METEOR",4*(.@r/2);
   - Combos:
       - Combo:
-          - Auto_Leg_A
-          - Auto_Armor_A
-      - Combo:
           - Gray_W_Boots
           - Gray_W_Suits
     Script: |
       bonus2 bAddClass,Class_All,7;
+  - Combos:
+      - Combo:
+          - Auto_Leg_A
+          - Auto_Armor_A
+    Script: |
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - Auto_Leg_A
@@ -16606,7 +16625,7 @@ Body:
           - S_FullPene_Pendant
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L);
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@sum >= 18) {
          bonus bIgnoreDefRace,RC_All;
          bonus2 bIgnoreDefRaceRate,RC_Player_Human,-100;
@@ -16618,7 +16637,7 @@ Body:
           - S_FullPene_Shoes
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_ARMOR)+getequiprefinerycnt(EQI_SHADOW_SHOES);
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@sum >= 18) {
          bonus bIgnoreDefRace,RC_All;
          bonus2 bIgnoreDefRaceRate,RC_Player_Human,-100;
@@ -16709,7 +16728,7 @@ Body:
           - Blue_Rear_Ribbon
           - Bag_Of_Antonio_S
     Script: |
-      bonus2 bAddClass,Class_All,4;
+      bonus bAtkRate,4;
       if (getequiprefinerycnt(EQI_GARMENT) >= 12) {
          bonus bAllStats,1;
       }
@@ -16982,7 +17001,7 @@ Body:
     Script: |
       bonus bLongAtkRate,10;
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       if (getequiprefinerycnt(EQI_GARMENT) >= 10) {
          bonus bCritAtkRate,15;
          bonus bHit,15;
@@ -17155,7 +17174,7 @@ Body:
           - Time_Overload_Robe
     Script: |
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Combos:
       - Combo:
           - Regia_Hunting_Boots
@@ -17682,7 +17701,7 @@ Body:
           - Temporal_M_Str
     Script: |
       .@sum = getequiprefinerycnt(EQI_HEAD_MID)+getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_GARMENT);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@sum >= 14) {
          bonus bBaseAtk,80;
       }
@@ -17706,7 +17725,7 @@ Body:
       }
       if (.@sum >= 18) {
          bonus2 bAddSize,Size_All,7;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@sum >= 22) {
          bonus bLongAtkRate,10;
@@ -17759,7 +17778,7 @@ Body:
          bonus bBaseAtk,80;
       }
       if (.@sum >= 18) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          bonus bMaxSPrate,7;
       }
       if (.@sum >= 22) {
@@ -18086,7 +18105,7 @@ Body:
       }
       if (.@r >= 9) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@r >= 11) {
          bonus bFixedCast,-500;
@@ -18104,7 +18123,7 @@ Body:
       }
       if (.@r >= 9) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r >= 11) {
             bonus bFixedCast,-500;
          }
@@ -18122,7 +18141,7 @@ Body:
       }
       if (.@r >= 9) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r >= 11) {
             bonus bFixedCast,-500;
          }
@@ -18281,7 +18300,7 @@ Body:
           - Beginner's_Ring
     Script: |
       bonus bBaseAtk,3*(min(BaseLevel,150)/10);
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bAspd,1;
   - Combos:
       - Combo:
@@ -18314,7 +18333,7 @@ Body:
       bonus bBaseAtk,3*(min(BaseLevel,150)/10);
       bonus bVariableCastrate,-10;
       bonus bMatkRate,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Combos:
       - Combo:
           - Rebeginer_N2_Mace
@@ -18338,7 +18357,7 @@ Body:
     Script: |
       bonus bBaseAtk,3*(min(BaseLevel,150)/10);
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
   - Combos:
       - Combo:
           - Rebeginer_WM_Bow
@@ -18639,7 +18658,7 @@ Body:
           - S_Mammoth_Weapon
           - S_Mammoth_Shield
     Script: |
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
       if (getequiprefinerycnt(EQI_SHADOW_ARMOR)+getequiprefinerycnt(EQI_SHADOW_SHIELD)+getequiprefinerycnt(EQI_SHADOW_SHOES)+getequiprefinerycnt(EQI_SHADOW_WEAPON)+getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L) >= 45) {
          bonus bNoKnockback;
       }
@@ -18677,7 +18696,7 @@ Body:
           - S_M_Mammoth_Shoes
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_ARMOR)+getequiprefinerycnt(EQI_SHADOW_SHOES);
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@sum >= 18) {
          bonus bNoKnockback;
          if (.@sum >= 20) {
@@ -18690,7 +18709,7 @@ Body:
           - S_M_Mammoth_Pendant
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L);
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@sum >= 18) {
          bonus bNoKnockback;
          if (.@sum >= 20) {
@@ -19328,7 +19347,7 @@ Body:
             bonus2 bAddRace,RC_All,20;
             if (.@sum >= 22) {
                bonus bVariableCastrate,-10;
-               bonus2 bAddClass,Class_All,15;
+               bonus bAtkRate,15;
             }
          }
       }
@@ -19338,7 +19357,7 @@ Body:
           - Sprint_Shoes_IL
     Script: |
       .@sum = getequiprefinerycnt(EQI_ARMOR)+getequiprefinerycnt(EQI_SHOES);
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       if (getequiprefinerycnt(EQI_ARMOR) >= 7 && getequiprefinerycnt(EQI_SHOES) >= 7) {
          bonus bBaseAtk,70;
          if (.@sum >= 18) {
@@ -19916,13 +19935,13 @@ Body:
     Script: |
       bonus bFixedCast,-200;
       if (BaseLevel >= 30) {
-         bonus2 bAddClass,Class_All,1;
+         bonus bAtkRate,1;
          bonus bAspdRate,2;
          if (BaseLevel >= 45) {
-            bonus2 bAddClass,Class_All,1;
+            bonus bAtkRate,1;
             bonus bAspdRate,3;
             if (BaseLevel >= 85) {
-               bonus2 bAddClass,Class_All,1;
+               bonus bAtkRate,1;
                bonus bAspdRate,5;
             }
          }
@@ -19953,7 +19972,7 @@ Body:
       bonus bFixedCast,-200;
       bonus bAspdRate,10;
       if (BaseLevel >= 105) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          if (BaseLevel >= 110) {
             bonus bShortAtkRate,5;
             bonus bLongAtkRate,5;
@@ -20765,7 +20784,7 @@ Body:
           - HeroBoots_AGI
     Script: |
       bonus bCritical,15;
-      bonus2 bAddClass,Class_All,15;
+      bonus bAtkRate,15;
   - Combos:
       - Combo:
           - WanderMins_Top3
@@ -21090,7 +21109,7 @@ Body:
           - S_AutoSpell_Earring
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_WEAPON)+getequiprefinerycnt(EQI_SHADOW_ACC_L)+getequiprefinerycnt(EQI_SHADOW_ACC_R);
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
       if (.@sum >= 27) {
          bonus3 bAutoSpell,"AS_SONICBLOW",10,80;
       }
@@ -21116,7 +21135,7 @@ Body:
           - S_M_AutoSpell_Pendant
     Script: |
       .@sum = getequiprefinerycnt(EQI_SHADOW_ACC_R)+getequiprefinerycnt(EQI_SHADOW_ACC_L);
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@sum >= 20) {
          bonus5 bAutoSpell,"NC_POWERSWING",max(getskilllv("NC_POWERSWING"),8),80,BF_SHORT|BF_NORMAL,1;
       }
@@ -21319,7 +21338,7 @@ Body:
           - Thanos_Bow_AD     # 700029
     Script: |
       .@r_weapon = getequiprefinerycnt(EQI_HAND_R);
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"SN_SHARPSHOOTING",10*(.@r_weapon/2);
   - Combos:
       - Combo:
@@ -21851,7 +21870,7 @@ Body:
       bonus bBaseAtk,50;
       if (getequiprefinerycnt(EQI_ARMOR) >= 11) {
          bonus bAspdRate,10;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Combos:
       - Combo:
@@ -21859,7 +21878,7 @@ Body:
           - Victory_Wing_Ear
     Script: |
       bonus bDelayrate,-15;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - aegis_480124
@@ -21870,14 +21889,14 @@ Body:
     Script: |
       bonus bLongAtkRate,5;
       bonus bShortAtkRate,5;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - aegis_480124
           - aegis_410079
     Script: |
       bonus bVariableCastrate,-15;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
       - Combo:
           - aegis_480125
@@ -21957,7 +21976,7 @@ Body:
           - Signet_Of_Pow_Star
           - Star_Armor_Of_Pow
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bPAtk,2;
   - Combos:
       - Combo:
@@ -22475,7 +22494,7 @@ Body:
           - Hero_Boots_LT   # 470094
     Script: |
       bonus bPAtk,2;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Combos:
       - Combo:
           - Solid_Dagger
@@ -23546,14 +23565,14 @@ Body:
          }
       }
       bonus bBaseAtk,15*(.@sum/3);
-      bonus2 bAddClass,Class_All,4*(.@sum/5);
+      bonus bAtkRate,4*(.@sum/5);
   - Combos:
       - Combo:
           - MeawFoxtail_LT   # 550067
           - Hero_Boots_LT   # 470094
     Script: |
       bonus bSmatk,2;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bMatkRate,10;
   - Combos:
       - Combo:
@@ -23995,7 +24014,7 @@ Body:
           - aegis_300362  # 300362 Unfrost Flower Card
           - aegis_300360  # 300360 Shining Seaweed Card
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Combos:
      - Combo:
           - aegis_300367  # 300367 Lesser Rgan Card
@@ -24029,7 +24048,7 @@ Body:
           - aegis_300381  # 300381 Hearthunter AT Card
           - aegis_300363  # 300363 Limacina Card
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Combos:
      - Combo:
           - Snowflower_Armor  # 450206
@@ -24059,7 +24078,7 @@ Body:
           - Snowflower_Boots  # 470115
           - Snowflower_Armor  # 450206
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Combos:
      - Combo:
           - Snowflower_Boots  # 470115
@@ -24707,7 +24726,7 @@ Body:
           - Royal_Guardian_Ring     # 28483
           - Lich_Lord_Card     # 27025
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMatkRate,5;
   - Combos:
       - Combo:

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -6097,7 +6097,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_all,5;
+      bonus bAtkRate,5;
       bonus bBaseAtk,4*.@r;
       if (.@r>=11)
          .@val = 35;
@@ -6163,7 +6163,7 @@ Body:
     Refineable: true
     Script: |
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       .@r = getrefine();
       bonus bLongAtkRate,.@r;
       if (.@r >= 9) {
@@ -17644,7 +17644,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bAspdRate,7;
          if (.@r >= 9) {
@@ -17770,7 +17770,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"SR_KNUCKLEARROW",10;
       if (.@r>=7) {
          bonus bAspdRate,15;
@@ -31874,7 +31874,7 @@ Body:
       NoAuction: true
     Script: |
       bonus2 bAddClass,Class_All,5;
-      bonus2 bMagicAddClass,Class_All,5;
+      bonus bMatkRate,5;
   - Id: 2645
     AegisName: Moonlight_Ring
     Name: Moonlight Ring
@@ -58577,8 +58577,8 @@ Body:
       }
       if (.@r>=6) {
          .@rate = 5*(.@i+1);
-         bonus2 bAddClass,Class_All,.@rate;
-         bonus2 bMagicAddClass,Class_All,.@rate;
+         bonus2 bAddRace,RC_All,.@rate;
+         bonus2 bMagicAddRace,RC_All,.@rate;
       }
   - Id: 13093
     AegisName: Thanos_Dagger
@@ -58662,7 +58662,7 @@ Body:
          if (.@r>=12) {
             .@dmg += 7;
          }
-         bonus2 bAddClass,Class_All,.@dmg;
+         bonus bAtkRate,.@dmg;
       }
   - Id: 13096
     AegisName: Half_BF_Dagger2
@@ -61733,7 +61733,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,15;
+      bonus bAtkRate,15;
       bonus bUnbreakableWeapon;
       bonus2 bSkillAtk,"KO_HUUMARANKA",15;
       if (.@r>=7) {
@@ -67752,7 +67752,7 @@ Body:
          .@val += .@r;
       }
       if (.@val) {
-         bonus2 bAddClass,Class_All,.@val;
+         bonus bAtkRate,.@val;
       }
   - Id: 15215
     AegisName: Tatenasi_Armor_TW
@@ -67862,7 +67862,7 @@ Body:
       bonus bAllStats,1;
       bonus bMaxHP,400;
       bonus bMaxSP,100;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus2 bMagicAddClass,Class_All,2;
   - Id: 15278
     AegisName: Overwhelm_Str_Armor
@@ -67880,7 +67880,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,50;
       if (.@r > 2)
-         bonus2 bAddClass,Class_All,.@r/3*2;
+         bonus bAtkRate,.@r/3*2;
       if (.@r > 6) {
          bonus2 bIgnoreDefRaceRate,RC_Brute,30;
          bonus2 bIgnoreDefRaceRate,RC_Demon,30;
@@ -68645,7 +68645,7 @@ Body:
       bonus bMaxHPrate,15;
       bonus bMaxSPrate,10;
       bonus bStr,12;
-      bonus2 bAddClass,Class_All,2*(.@r/2);
+      bonus bAtkRate,2*(.@r/2);
       bonus2 bAddRace,RC_Dragon,7*(.@r/3);
       if (.@r>=11) {
          bonus bFixedCast,-200;
@@ -68799,7 +68799,7 @@ Body:
       bonus bMaxHPrate,10;
       bonus bMaxSPrate,10;
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,3*(.@r/2);
+      bonus bAtkRate,3*(.@r/2);
       bonus bStr,5*(.@r/3);
       bonus2 bAddRace,RC_Angel,8*(.@r/4);
       bonus2 bAddRace,RC_Demon,8*(.@r/4);
@@ -68867,7 +68867,7 @@ Body:
       bonus bAspdRate,10;
       bonus bVariableCastrate,-10;
       bonus bMatkRate,(.@r/2);
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       bonus bDex,5*(.@r/3);
       bonus2 bAddRace,RC_Angel,6*(.@r/4);
       bonus2 bMagicAddRace,RC_Angel,6*(.@r/4);
@@ -70045,11 +70045,11 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,(.@r/3)*30;
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus2 bAddRace,RC_All,5;
          bonus3 bAutoSpell,"BS_WEAPONPERFECT",1,10;
       }
       if (.@r>=6) {
-         bonus2 bAddClass,Class_All,5;
+         bonus2 bAddRace,RC_All,5;
       }
   - Id: 16027
     AegisName: Hammer_Of_Evil_Slayer
@@ -70082,7 +70082,7 @@ Body:
       bonus2 bAddRace,RC_Demon,10;
       bonus2 bAddRace,RC_Undead,10;
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,(.@r>=12?12:(.@r>=9?5:0));
+      bonus bAtkRate,(.@r>=12?12:(.@r>=9?5:0));
   - Id: 16028
     AegisName: Thanos_Hammer
     Name: Thanos Hammer
@@ -71019,7 +71019,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bVariableCastrate,-7;
          if (.@r >= 9) {
@@ -71116,7 +71116,7 @@ Body:
       .@r = getrefine();
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,10;
-      bonus2 bAddClass,Class_All,.@r;
+      bonus bAtkRate,.@r;
       if (.@r>=9)
          bonus2 bSkillAtk,"GN_CARTCANNON",25;
       if (.@r>=11)
@@ -71209,7 +71209,7 @@ Body:
          bonus2 bSkillAtk,"MO_INVESTIGATE",50;
       }
       if (.@r>=11)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
   - Id: 16099
     AegisName: Ein_1HHAMMER
     Name: Rubber Hammer
@@ -71786,7 +71786,7 @@ Body:
       bonus2 bAddRace,RC_Demon,10;
       bonus2 bAddRace,RC_Undead,10;
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,(.@r>=12?12:(.@r>=9?5:0));
+      bonus bAtkRate,(.@r>=12?12:(.@r>=9?5:0));
   - Id: 18121
     AegisName: Sinister_Bow
     Name: Bow of Vicious Mind
@@ -72631,7 +72631,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bLongAtkRate,7;
          if (.@r >= 9) {
@@ -72664,7 +72664,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bLongAtkRate,7;
          if (.@r >= 9) {
@@ -72947,7 +72947,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"RA_AIMEDBOLT",10;
       if (.@r>=7) {
          bonus bVariableCastrate,-10;
@@ -83833,7 +83833,7 @@ Body:
     Refineable: true
     View: 14
     Script: |
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
       bonus bBaseAtk,(2*getrefine());
   - Id: 19238
     AegisName: PoringTownOnion
@@ -84050,7 +84050,7 @@ Body:
       }
       if (.@r>8) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@r>10) {
          bonus bCritAtkRate,15;
@@ -84431,7 +84431,7 @@ Body:
          bonus bLongAtkRate,7;
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bAspd,1;
       }
       if (.@r>=11) {
@@ -84492,7 +84492,7 @@ Body:
          bonus bBaseAtk,30;
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bAspd,1;
       }
       if (.@r>=11) {
@@ -84540,7 +84540,7 @@ Body:
       }
       if (.@r>=11) {
          bonus bMatkRate,3;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@r>=10) {
          bonus bFixedCast,-100*(min((.@r-10),15)/1);
@@ -84885,7 +84885,7 @@ Body:
       }
       if (.@r>=11) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus2 bAddRace,RC_Formless,min(.@r-10,15);
          bonus2 bMagicAddRace,RC_Formless,min(.@r-10,15);
       }
@@ -85716,7 +85716,7 @@ Body:
       bonus2 bSkillAtk,"LG_CANNONSPEAR",15*(.@r/3);
       bonus bLongAtkRate,5*(.@r/4);
       if (.@r>=11) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Id: 19476
     AegisName: S_Circlet_Of_Time_NC
@@ -85816,7 +85816,7 @@ Body:
       bonus bAspdRate,2*(.@r/3);
       bonus2 bSkillAtk,"GC_COUNTERSLASH",20*(.@r/3);
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",20*(.@r/3);
-      bonus2 bAddClass,Class_All,2*(.@r/4);
+      bonus bAtkRate,2*(.@r/4);
       if (.@r>=11) {
          bonus bDelayrate,-5;
       }
@@ -85850,7 +85850,7 @@ Body:
       bonus bAspdRate,2*(.@r/3);
       bonus2 bSkillAtk,"SC_FATALMENACE",30*(.@r/3);
       bonus2 bSkillAtk,"SC_FEINTBOMB",30*(.@r/3);
-      bonus2 bAddClass,Class_All,2*(.@r/4);
+      bonus bAtkRate,2*(.@r/4);
       if (.@r>=11) {
          bonus bDelayrate,-5;
       }
@@ -85919,7 +85919,7 @@ Body:
       bonus2 bSkillAtk,"SR_TIGERCANNON",10*(.@r/3);
       bonus bLongAtkRate,5*(.@r/4);
       if (.@r>=11) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Id: 19482
     AegisName: S_Circlet_Of_Time_WL
@@ -86089,7 +86089,7 @@ Body:
       bonus2 bSkillAtk,"SJ_FALLINGSTAR_ATK",30*(.@r/3);
       bonus2 bAddSize,Size_All,2*(.@r/4);
       if (.@r>=11) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Id: 19487
     AegisName: S_Circlet_Of_Time_SP
@@ -86217,7 +86217,7 @@ Body:
       bonus2 bSkillAtk,"KO_JYUMONJIKIRI",20*(.@r/3);
       bonus2 bAddSize,Size_All,2*(.@r/4);
       if (.@r>=11) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Id: 19491
     AegisName: S_Circlet_Of_Time_NV
@@ -98788,7 +98788,7 @@ Body:
     Script: |
       .@r = getrefine();
       if (.@r >= 2)
-         bonus2 bAddClass,Class_All,.@r/2;
+         bonus bAtkRate,.@r/2;
       if (.@r >= 9)
          bonus bAspdRate,10;
       if (.@r >= 12)
@@ -99517,7 +99517,7 @@ Body:
       if (.@r>=9)
          bonus bCritAtkRate,5;
       if (.@r>=11)
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
   - Id: 20937
     AegisName: Lava_Leather_Hood
     Name: Lava Leather Hood
@@ -99674,7 +99674,7 @@ Body:
       bonus bMaxHP,(300+(100*(.@r/2)));
       bonus bMaxHPRate,(2*(.@r/3));
       if (.@r >= 7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r >= 9) {
          bonus bVariableCastrate,-10;
@@ -99881,7 +99881,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMatkRate,(.@r/2);
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       if (.@r>=9) {
          bonus bMatk,30;
          bonus bBaseAtk,30;
@@ -99938,11 +99938,11 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       bonus bBaseAtk,10*(.@r/2);
       bonus2 bAddSize,Size_All,5*(.@r/4);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r>=9) {
          bonus2 bIgnoreDefRaceRate,RC_Demon,20;
@@ -99974,7 +99974,7 @@ Body:
       bonus bBaseAtk,10*(.@r/2);
       bonus2 bAddSize,Size_All,5*(.@r/4);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r>=9) {
          bonus2 bIgnoreDefRaceRate,RC_Demon,20;
@@ -100006,7 +100006,7 @@ Body:
       bonus bMaxHP,400*(.@r/2);
       bonus bMaxHPrate,3*(.@r/4);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r>=9) {
          bonus2 bIgnoreDefRaceRate,RC_Demon,20;
@@ -100070,7 +100070,7 @@ Body:
       bonus bBaseAtk,10*(.@r/2);
       bonus bCritAtkRate,3*(.@r/4);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r>=9) {
          bonus2 bIgnoreDefRaceRate,RC_Demon,20;
@@ -100102,7 +100102,7 @@ Body:
       bonus bCritical,3*(.@r/2);
       bonus bAspdRate,5*(.@r/4);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
       if (.@r>=9) {
          bonus2 bIgnoreDefRaceRate,RC_Demon,20;
@@ -101194,7 +101194,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bLongAtkRate,.@r;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@r>=9) {
          bonus2 bSkillAtk,"LK_SPIRALPIERCE",30;
          bonus2 bSkillAtk,"RK_SONICWAVE",30;
@@ -101246,7 +101246,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bCritical,5;
-      bonus2 bAddClass,Class_All,15;
+      bonus bAtkRate,15;
       if (.@r>=7) {
          bonus bCritAtkRate,25;
          bonus bAspdRate,10;
@@ -101279,7 +101279,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bBaseAtk,4*.@r;
       if (.@r>=9) {
          bonus bCritAtkRate,25;
@@ -103655,7 +103655,7 @@ Body:
       bonus bMdef,10;
       skill "BS_MAXIMIZE",1;
       bonus2 bSkillUseSP,"ASC_METEORASSAULT",8;
-      bonus2 bAddClass,Class_All,4*.@a;
+      bonus bAtkRate,4*.@a;
       bonus2 bSkillCooldown,"GC_HALLUCINATIONWALK",-5000*.@b;
       bonus2 bIgnoreDefRaceRate,RC_All,20*.@c;
       bonus2 bVariableCastrate,"ASC_METEORASSAULT",-7*(.@a+.@b+.@c);
@@ -103761,7 +103761,7 @@ Body:
       bonus2 bVariableCastrate,"MO_STEELBODY",-.@c*10;
       bonus2 bFixedCastrate,"CH_SOULCOLLECT",-.@c*10;
       bonus bAspdRate,2*getskilllv("SR_GENTLETOUCH_CHANGE");
-      bonus2 bAddClass,Class_All,4*getskilllv("SR_GENTLETOUCH_QUIET");
+      bonus bAtkRate,4*getskilllv("SR_GENTLETOUCH_QUIET");
   - Id: 22167
     AegisName: Astraea_Shoes
     Name: Asteria's Boots
@@ -104250,7 +104250,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@r>=7)
          bonus bBaseAtk,25;
       if (.@r>=9)
@@ -104584,7 +104584,7 @@ Body:
       bonus bMaxHPrate,.@r/3;
       bonus bMaxSPrate,.@r/3;
       if (.@r >= 7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bMatkRate,5;
       }
       if (.@r >= 9) {
@@ -108702,7 +108702,7 @@ Body:
       bonus bBaseAtk,.@r;
       bonus bMatk,.@r;
       bonus bAspd,1;
-      bonus2 bAddClass,Class_All,.@r;
+      bonus bAtkRate,.@r;
       bonus bMatkRate,.@r;
       if (.@r>=7) {
          bonus bMaxHP,1000;
@@ -109325,7 +109325,7 @@ Body:
       }
       bonus2 bIgnoreDefClassRate,Class_Normal,(3*(getskilllv("TK_HPTIME")+.@r));
       bonus2 bIgnoreMdefClassRate,Class_Normal,(3*(getskilllv("TK_SPTIME")+.@r));
-      bonus2 bAddClass,Class_All,.@val;
+      bonus bAtkRate,.@val;
       bonus bMatkRate,.@val;
   - Id: 24316
     AegisName: S_DoramPhysical_Shield
@@ -109341,7 +109341,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMaxHP,.@r*10;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       autobonus3 "{ bonus bAspd,1; }",1000,50000,"SU_ARCLOUSEDASH";
       bonus2 bSkillCooldown,"SU_LUNATICCARROTBEAT",-(.@r*200);
       if (.@r>=7)
@@ -109389,11 +109389,11 @@ Body:
       bonus bAspdRate,(2*getskilllv("TF_DOUBLE")+.@r);
       bonus bVariableCastrate,-(2*getskilllv("AC_OWL")+.@r);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus bMatkRate,2;
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus bMatkRate,3;
       }
   - Id: 24319
@@ -109433,7 +109433,7 @@ Body:
          .@val += 1;
       }
       bonus bFlee,5;
-      bonus2 bAddClass,Class_All,.@val;
+      bonus bAtkRate,.@val;
       bonus bMatkRate,.@val;
   - Id: 24321
     AegisName: S_Bearer's_Pendant_II
@@ -109499,7 +109499,7 @@ Body:
       bonus bBaseAtk,.@r;
       bonus bMatk,.@r;
       bonus bSPrecovRate,5;
-      bonus2 bAddClass,Class_All,1 + (.@r >= 7);
+      bonus bAtkRate,1 + (.@r >= 7);
   - Id: 24325
     AegisName: S_Malicious_Armor_II
     Name: Malicious Shadow Armor II
@@ -109511,7 +109511,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMaxHP,100+.@r*10;
-      bonus2 bAddClass,Class_All,1 + (.@r >= 7);
+      bonus bAtkRate,1 + (.@r >= 7);
   - Id: 24326
     AegisName: S_Sigrun_Armor
     Name: Sigrun Shadow Armor
@@ -110622,9 +110622,9 @@ Body:
       bonus bMaxHP,.@r*10;
       bonus bBaseAtk,20;
       if (.@r >= 9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       } else if (.@r >= 7) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
       }
   - Id: 24396
     AegisName: S_Magical_Shoes
@@ -111305,7 +111305,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,.@r;
       bonus bMatk,.@r;
-      bonus2 bAddClass,Class_All,1+.@r/2;
+      bonus bAtkRate,1+.@r/2;
       bonus bMatkRate,1+.@r/2;
       if (.@r >= 7) {
          bonus bDef,15;
@@ -112038,7 +112038,7 @@ Body:
     EquipLevelMin: 99
     Refineable: true
     Script: |
-      bonus2 bAddClass,Class_All,2+(getrefine()/3);
+      bonus bAtkRate,2+(getrefine()/3);
   - Id: 24482
     AegisName: S_Knucklearrow_Armor
     Name: Knuckle Shadow Armor
@@ -115382,7 +115382,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,10+(.@r/2);
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
       }
   - Id: 24672
     AegisName: S_Mammoth_Earring
@@ -115489,7 +115489,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bLongAtkRate,(.@r/2);
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=10) {
@@ -115504,7 +115504,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bLongAtkRate,(.@r/2);
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=10) {
@@ -115519,7 +115519,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bLongAtkRate,(.@r/2);
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=10) {
@@ -115534,7 +115534,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bLongAtkRate,(.@r/2);
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=10) {
@@ -115568,7 +115568,7 @@ Body:
       .@r = getrefine();
       bonus bMaxHPrate,3;
       bonus bMaxSPrate,3;
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
       if (.@r>=7) {
          bonus bVariableCastrate,-3;
          if (.@r>=10) {
@@ -115587,7 +115587,7 @@ Body:
       .@r = getrefine();
       bonus bMaxHPrate,3;
       bonus bMaxSPrate,3;
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
       if (.@r>=7) {
          bonus bVariableCastrate,-3;
          if (.@r>=10) {
@@ -116343,7 +116343,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=9) {
          bonus bAspd,1;
@@ -116360,7 +116360,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bShortAtkRate,(.@r/2);
       if (.@r>=10) {
          bonus bAspdRate,3;
@@ -116375,7 +116375,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMatkRate,1+(.@r/2);
-      bonus2 bAddClass,Class_All,1+(.@r/2);
+      bonus bAtkRate,1+(.@r/2);
       if (.@r>=7) {
          bonus bDef,15;
          bonus bFlee,15;
@@ -116410,7 +116410,7 @@ Body:
       .@r = getrefine();
       bonus bLongAtkRate,2;
       bonus bShortAtkRate,2;
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       if (.@r>=9) {
          bonus bAspd,1;
          if (.@r>=10) {
@@ -116430,7 +116430,7 @@ Body:
       .@r = getrefine();
       bonus bLongAtkRate,2;
       bonus bShortAtkRate,2;
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       if (.@r>=9) {
          bonus bAspd,1;
          if (.@r>=10) {
@@ -116597,7 +116597,7 @@ Body:
       bonus bAspdRate,3*(.@r/2);
       if (.@r>=9) {
          bonus bMatkRate,3;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
       }
   - Id: 24747
     AegisName: S_SpellCaster_Armor
@@ -116610,7 +116610,7 @@ Body:
       .@r = getrefine();
       bonus bVariableCastrate,-.@r;
       bonus bMatkRate,(.@r/3);
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
   - Id: 24748
     AegisName: S_SpellCaster_Shoes
     Name: Spell Caster Shoes Shadow    # !todo check english name
@@ -116622,7 +116622,7 @@ Body:
       .@r = getrefine();
       bonus bVariableCastrate,-.@r;
       bonus bMatkRate,(.@r/3);
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
   - Id: 24749
     AegisName: S_SpellCaster_Earring
     Name: Spell Caster Earring Shadow    # !todo check english name
@@ -116634,7 +116634,7 @@ Body:
       .@r = getrefine();
       bonus bVariableCastrate,-.@r;
       bonus bMatkRate,(.@r/3);
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
   - Id: 24750
     AegisName: S_SpellCaster_Pendant
     Name: Spell Caster Pendant Shadow    # !todo check english name
@@ -116646,7 +116646,7 @@ Body:
       .@r = getrefine();
       bonus bVariableCastrate,-.@r;
       bonus bMatkRate,(.@r/3);
-      bonus2 bAddClass,Class_All,(.@r/3);
+      bonus bAtkRate,(.@r/3);
   - Id: 24751
     AegisName: S_P_Power_Weapon
     Name: Physical Power Weapon Shadow    # !todo check english name
@@ -117142,7 +117142,7 @@ Body:
       .@r = getrefine();
       bonus bLongAtkRate,3*(.@r/2);
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       if (.@r>=9)
          bonus2 bAddRace,RC_All,15;
   - Id: 26021
@@ -117899,7 +117899,7 @@ Body:
       .@r = getrefine();
       bonus bMatk,10*(.@r/2);
       bonus bBaseAtk,10*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/3);
+      bonus bAtkRate,2*(.@r/3);
       bonus bMatkRate,2*(.@r/3);
       if (.@r >= 7) {
          bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",15;
@@ -118962,7 +118962,7 @@ Body:
       if (getrefine() >= 9) {
          .@flee += 5;
          .@flee2 += 2;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       bonus bFlee,.@flee;
       bonus bFlee2,.@flee2;
@@ -119103,7 +119103,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bAspdRate,7;
          if (.@r >= 9) {
@@ -119212,7 +119212,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,.@r;
       if (.@r>=9)
          bonus2 bSkillAtk,"GC_ROLLINGCUTTER",30;
@@ -119246,7 +119246,7 @@ Body:
          bonus2 bAddSize,Size_All,15;
       if (.@r>=11) {
          bonus bUnbreakableWeapon;
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       }
   - Id: 28045
     AegisName: Ein_BHKATAR
@@ -119269,7 +119269,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",10;
       if (.@r>=7) {
          bonus bAspdRate,10;
@@ -119303,7 +119303,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bBaseAtk,5*.@r;
       if (.@r>=9) {
          bonus2 bSkillAtk,"GC_CROSSRIPPERSLASHER",20;
@@ -120026,7 +120026,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bUnbreakableWeapon;
       bonus2 bSkillAtk,"NC_ARMSCANNON",10;
       if (.@r>=7) {
@@ -120065,7 +120065,7 @@ Body:
       bonus2 bMagicSubSize,Size_Medium,10;
       bonus2 bSubSize,Size_Large,10;
       bonus2 bMagicSubSize,Size_Large,10;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,.@r;
       if (.@r>=9) {
@@ -120726,7 +120726,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bDex,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bLongAtkRate,(.@r/2)*5 + (.@r > 11 ? 5 : 0);
       if (.@r > 6) {
          bonus2 bSkillAtk,"RL_R_TRIP",20;
@@ -120782,7 +120782,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bDex,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bLongAtkRate,(.@r/2)*5;
       if (.@r > 6) {
          bonus bAspdRate,5;
@@ -120969,7 +120969,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bLongAtkRate,7;
          if (.@r >= 9) {
@@ -122416,7 +122416,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
   - Id: 28444
     AegisName: Para_Team_Str_Necklace100
     Name: Awakened Eden Group Necklace of Strength I
@@ -122450,7 +122450,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 28446
     AegisName: Para_Team_Str_Necklace115
     Name: Awakened Eden Group Necklace of Strength II
@@ -122484,7 +122484,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,4;
+      bonus bAtkRate,4;
   - Id: 28448
     AegisName: Para_Team_Str_Necklace130
     Name: Awakened Eden Group Necklace of Strength III
@@ -122518,7 +122518,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 28450
     AegisName: Para_Team_Str_Necklace145
     Name: Awakened Eden Group Necklace of Strength IV
@@ -122552,7 +122552,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       skill "AL_HEAL",1;
   - Id: 28452
     AegisName: Para_Team_Str_Necklace160
@@ -123119,7 +123119,7 @@ Body:
       .@S = getskilllv("RL_S_STORM");
       .@D = getskilllv("RL_D_TAIL");
       .@E = getskilllv("RL_E_CHAIN");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bAspdRate,2*.@M;
       bonus bVariableCastrate,-10;
       bonus bDelayrate,-(.@F);
@@ -123227,7 +123227,7 @@ Body:
       NoAuction: true
     Script: |
       if (readparam(bStr) > 89)
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
       if (readparam(bVit) > 89)
          bonus bMaxHP,1000;
       if (readparam(bDex) > 89)
@@ -123371,7 +123371,7 @@ Body:
     Script: |
       bonus bMaxSPrate,5;
       bonus bAspdRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 28507
     AegisName: Glove_Of_Wizard
     Name: Magician's Gloves
@@ -123608,7 +123608,7 @@ Body:
       bonus bUseSPrate,-3;
       bonus bAspdRate,5;
       bonus bVariableCastrate,-5;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMatkRate,3;
       bonus2 bHPDrainRate,10,3;
       autobonus "{ bonus2 bHPRegenRate,300,1000; }",10,5000,BF_MAGIC;
@@ -124539,7 +124539,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r >= 7) {
          bonus bAspdRate,7;
          if (.@r >= 9) {
@@ -124711,7 +124711,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bCritical,3;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       if (.@r>=7) {
          bonus bAspdRate,10;
          bonus bBaseAtk,40;
@@ -125501,7 +125501,7 @@ Body:
       bonus bCritical,90;
       bonus bCritAtkRate,(3*(.@r/2));
       if (.@r >= 7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r >= 9) {
             bonus2 bAddSize,Size_All,20;
             if (.@r >= 11) {
@@ -125841,7 +125841,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"GC_CROSSIMPACT",10;
       if (.@r>=7) {
          bonus bAspdRate,10;
@@ -125911,7 +125911,7 @@ Body:
     EquipLevelMin: 170
     Refineable: true
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 28775
     AegisName: R_Gladius_L
     Name: Royal Gladius (L)
@@ -126582,7 +126582,7 @@ Body:
     View: 1
     Script: |
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMatkRate,3;
       bonus2 bSubEle,Ele_All,7;
       autobonus2 "{ bonus2 bSPRegenRate,25,1000; }",50,5000;
@@ -126612,7 +126612,7 @@ Body:
     View: 1
     Script: |
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMatkRate,3;
       bonus2 bSubEle,Ele_All,7;
       autobonus2 "{ bonus2 bSPRegenRate,25,1000; }",50,5000;
@@ -126642,7 +126642,7 @@ Body:
     View: 1
     Script: |
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMatkRate,5;
       bonus2 bSubEle,Ele_All,10;
       autobonus2 "{ bonus2 bSPRegenRate,50,1000; }",50,5000;
@@ -135681,7 +135681,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bDelayrate,-.@r;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@r>=9)
          bonus2 bSkillAtk,"LG_CANNONSPEAR",20;
       if (.@r>=11)
@@ -135707,7 +135707,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"LG_BANISHINGPOINT",10;
       if (.@r>=7) {
          bonus bAspdRate,10;
@@ -136140,7 +136140,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 32208
     AegisName: Illusion_B_L
     Name: Illusion Booster L
@@ -136153,7 +136153,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 130
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 32209
     AegisName: Illusion_BC_R
     Name: Illusion Battle chip R
@@ -136269,7 +136269,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 150
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 32229
     AegisName: Schmidt_Insignia_Divine_Power
     Name: King Schmidt's Divine Power Insignia
@@ -136474,7 +136474,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 170
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 32251
     AegisName: Ein_SAFETY_EPAULL
     Name: Safety Epaulet B
@@ -136720,7 +136720,7 @@ Body:
       bonus bAspdRate,3*(.@r/3);
       if (.@r >= 7) {
          bonus bAspd,1;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r >= 9) {
             bonus bCritAtkRate,20;
             if (.@r >= 11) {
@@ -136870,7 +136870,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"GN_CARTCANNON",10;
       if (.@r>=7) {
          bonus bVariableCastrate,-10;
@@ -136981,7 +136981,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,.@r;
       if (.@r>=9) {
@@ -137013,7 +137013,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,.@r;
       if (.@r>=9) {
@@ -137045,7 +137045,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bUnbreakableWeapon;
       bonus bBaseAtk,4*.@r;
       if (.@r>=9) {
@@ -137181,7 +137181,7 @@ Body:
     EquipLevelMin: 120
     Script: |
       bonus bMatkRate,1;
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
   - Id: 400001
     AegisName: Victory_Wing_Ear
     Name: Victory Wing Ears
@@ -137257,7 +137257,7 @@ Body:
       bonus bBaseAtk,5*(.@r/2);
       if (.@r>=7) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@r>=9) {
          bonus2 bHPDrainRate,50,5;
@@ -137356,7 +137356,7 @@ Body:
       bonus bMaxSPrate,5;
       if (.@r>=7) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
       if (.@r>=9) {
          bonus bVariableCastrate,-10;
@@ -137778,7 +137778,7 @@ Body:
       }
       if (.@r>=9) {
          bonus2 bMagicAtkEle,Ele_Holy,15;
-         bonus2 bAddClass,Class_All,15;
+         bonus bAtkRate,15;
       }
       if (.@r>=11) {
          bonus bFixedCast,-200;
@@ -137867,7 +137867,7 @@ Body:
     Script: |
       bonus bUnbreakableHelm;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       if (getrefine()>=9) {
          bonus bMatk,40;
          bonus bBaseAtk,40;
@@ -138039,7 +138039,7 @@ Body:
       }
       if (.@r>=9) {
          bonus bMatkRate,15;
-         bonus2 bAddClass,Class_All,15;
+         bonus bAtkRate,15;
       }
       if (.@r>=11) {
          bonus2 bMagicAtkEle,Ele_All,10;
@@ -138102,7 +138102,7 @@ Body:
       }
       if (.@r>=9) {
          bonus bMatkRate,15;
-         bonus2 bAddClass,Class_All,15;
+         bonus bAtkRate,15;
       }
       if (.@r>=11) {
          bonus2 bAddSize,Size_All,10;
@@ -138203,7 +138203,7 @@ Body:
     View: 511
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,4*(.@r/3);
+      bonus bAtkRate,4*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,10;
          if (.@r>=9) {
@@ -138229,7 +138229,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5*(.@r/3);
+      bonus bAtkRate,5*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,15;
          if (.@r>=9) {
@@ -138355,7 +138355,7 @@ Body:
     View: 2089
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,4*(.@r/3);
+      bonus bAtkRate,4*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,10;
          if (.@r>=9) {
@@ -138380,7 +138380,7 @@ Body:
     View: 2090
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5*(.@r/3);
+      bonus bAtkRate,5*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,15;
          if (.@r>=9) {
@@ -138482,7 +138482,7 @@ Body:
     View: 2105
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,4*(.@r/3);
+      bonus bAtkRate,4*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,10;
          if (.@r>=9) {
@@ -138507,7 +138507,7 @@ Body:
     View: 2104
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5*(.@r/3);
+      bonus bAtkRate,5*(.@r/3);
       if (.@r>=7) {
          bonus bAspdRate,15;
          if (.@r>=9) {
@@ -138953,7 +138953,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -138994,7 +138994,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139085,7 +139085,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139127,7 +139127,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139168,7 +139168,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139217,7 +139217,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139258,7 +139258,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139341,7 +139341,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139391,7 +139391,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139432,7 +139432,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139567,7 +139567,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139609,7 +139609,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139691,7 +139691,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139732,7 +139732,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139774,7 +139774,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139823,7 +139823,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139864,7 +139864,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139902,7 +139902,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139940,7 +139940,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -139978,7 +139978,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -140018,7 +140018,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -140134,7 +140134,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -140173,7 +140173,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -140211,7 +140211,7 @@ Body:
             bonus bFixedCast,-200;
             if (.@r>=11) {
                bonus bFixedCast,-300;
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
@@ -140284,14 +140284,14 @@ Body:
       if (.@r>=7) {
          bonus bShortAtkRate,15;
          if (.@r>=9) {
-            bonus2 bAddClass,Class_All,10;
+            bonus bAtkRate,10;
             if (.@r>=11) {
                bonus bShortAtkRate,10;
             }
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bPow,3;
          if (.@g>=2) {
             bonus bFixedCast,-500;
@@ -141691,7 +141691,7 @@ Body:
     Script: |
       bonus2 bAddRace,RC_Player_Human,10;
       bonus2 bAddRace,RC_Player_Doram,10;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 436002
     AegisName: aegis_436002
     Name: Thanatos's Odium Mask
@@ -141740,7 +141740,7 @@ Body:
     Script: |
       bonus2 bAddRace,RC_Player_Human,10;
       bonus2 bAddRace,RC_Player_Doram,10;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 436005
     AegisName: aegis_436005
     Name: Thanatos's Maeror Mask
@@ -141976,7 +141976,7 @@ Body:
       bonus bDelayrate,-5;
       .@r = getrefine();
       if (.@r>=2) {
-         bonus2 bAddClass,Class_All,.@r/2;
+         bonus bAtkRate,.@r/2;
       }
       if (.@r>=3) {
          bonus bCritAtkRate,.@r/3;
@@ -142731,7 +142731,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,50;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       if (.@r>=9)
          bonus bLongAtkRate,5;
   - Id: 450039
@@ -142760,7 +142760,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,50;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       if (.@r>=9)
          bonus bLongAtkRate,5;
   - Id: 450040
@@ -142922,7 +142922,7 @@ Body:
       if (.@r>=7)
          bonus bAspdRate,3;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
   - Id: 450045
     AegisName: Noblesse_Moon_Suit
     Name: Noblesse Moon Suit
@@ -142954,7 +142954,7 @@ Body:
       if (.@r>=7)
          bonus2 bAddSize,Size_All,5;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
   - Id: 450046
     AegisName: Noblesse_Ninja_Suit
     Name: Noblesse Ninja Suit
@@ -143010,7 +143010,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,50;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       if (.@r>=9)
          bonus bLongAtkRate,5;
   - Id: 450048
@@ -143865,7 +143865,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,75;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       if (.@r>=9)
          bonus bLongAtkRate,7;
   - Id: 450075
@@ -143894,7 +143894,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,75;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       if (.@r>=9)
          bonus bLongAtkRate,7;
   - Id: 450076
@@ -144056,7 +144056,7 @@ Body:
       if (.@r>=7)
          bonus bAspdRate,5;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
   - Id: 450081
     AegisName: Imperial_Moon_Suit
     Name: Imperial Moon Suit
@@ -144088,7 +144088,7 @@ Body:
       if (.@r>=7)
          bonus2 bAddSize,Size_All,7;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
   - Id: 450082
     AegisName: Imperial_Ninja_Suit
     Name: Imperial Ninja Suit
@@ -144144,7 +144144,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,75;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,7;
+         bonus bAtkRate,7;
       if (.@r>=9)
          bonus bLongAtkRate,7;
   - Id: 450084
@@ -144935,7 +144935,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,100;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       if (.@r>=9)
          bonus bLongAtkRate,10;
   - Id: 450109
@@ -144964,7 +144964,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,100;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       if (.@r>=9)
          bonus bLongAtkRate,10;
   - Id: 450110
@@ -145126,7 +145126,7 @@ Body:
       if (.@r>=7)
          bonus bAspdRate,7;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
   - Id: 450115
     AegisName: Grace_Moon_Suit
     Name: Grace Moon Suit
@@ -145158,7 +145158,7 @@ Body:
       if (.@r>=7)
          bonus2 bAddSize,Size_All,10;
       if (.@r>=9)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
   - Id: 450116
     AegisName: Grace_Ninja_Suit
     Name: Grace Ninja Suit
@@ -145214,7 +145214,7 @@ Body:
       .@r = getrefine();
       bonus bBaseAtk,100;
       if (.@r>=7)
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       if (.@r>=9)
          bonus bLongAtkRate,10;
   - Id: 450118
@@ -145620,7 +145620,7 @@ Body:
       bonus2 bAddEle,Ele_Fire,4*(.@r/3);
       bonus2 bAddEle,Ele_Water,4*(.@r/3);
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       }
       if (.@r>=11) {
          bonus bAspdRate,10;
@@ -145917,25 +145917,25 @@ Body:
       bonus bPow,1;
       bonus bBaseAtk,125+15*(.@r/2);
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=11) {
             bonus bShortAtkRate,20;
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,(.@r/2);
+         bonus bAtkRate,(.@r/2);
          bonus bBaseAtk,2*(.@r/2);
          bonus bShortAtkRate,(.@r/3);
          if (.@g>=2) {
-            bonus2 bAddClass,Class_All,(.@r/2);
+            bonus bAtkRate,(.@r/2);
             bonus bBaseAtk,3*(.@r/2);
             bonus bShortAtkRate,(.@r/3);
             if (.@g>=3) {
-               bonus2 bAddClass,Class_All,2*(.@r/2);
+               bonus bAtkRate,2*(.@r/2);
                bonus bShortAtkRate,(.@r/3);
                bonus bPAtk,(.@r/4);
                if (.@g>=4) {
-                  bonus2 bAddClass,Class_All,3*(.@r/2);
+                  bonus bAtkRate,3*(.@r/2);
                   bonus bShortAtkRate,2*(.@r/3);
                   bonus bPAtk,2*(.@r/4);
                }
@@ -146023,11 +146023,11 @@ Body:
       }
       if (.@g>=1) {
          bonus bAspdRate,(.@r/2);
-         bonus2 bAddClass,Class_All,(.@r/2);
+         bonus bAtkRate,(.@r/2);
          bonus bBaseAtk,2*(.@r/2);
          if (.@g>=2) {
             bonus bAspdRate,(.@r/2);
-            bonus2 bAddClass,Class_All,2*(.@r/2);
+            bonus bAtkRate,2*(.@r/2);
             bonus bBaseAtk,3*(.@r/2);
             if (.@g>=3) {
                bonus bAspdRate,2*(.@r/2);
@@ -146425,7 +146425,7 @@ Body:
       bonus bBaseAtk,5*(min(.@l,150)/10);
       .@l = BaseLevel;
       if (.@l>=105)
-         bonus2 bAddClass,Class_ALL,3;
+         bonus bAtkRate,3;
       if (.@l>=110)
          bonus bDelayrate,-5;
       if (.@l>=120)
@@ -146565,7 +146565,7 @@ Body:
       .@r = getrefine();
       bonus bPow,(readparam(bStr)/25);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bCritAtkRate,10;
             if (.@r>=11) {
@@ -146574,9 +146574,9 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             bonus bPow,3;
             if (.@g>=3) {
                bonus bShortAtkRate,10;
@@ -146700,7 +146700,7 @@ Body:
       .@r = getrefine();
       bonus bCon,(readparam(bDex)/25);
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bCritAtkRate,10;
             if (.@r>=11) {
@@ -146709,9 +146709,9 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             bonus bCon,3;
             if (.@g>=3) {
                bonus bLongAtkRate,10;
@@ -146855,7 +146855,7 @@ Body:
     View: 1
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMdef,10;
       if (.@r>=7) {
          bonus bCritical,3;
@@ -146864,7 +146864,7 @@ Body:
             bonus bAspdRate,5;
             if (.@r>=12) {
                bonus bCritAtkRate,10;
-               bonus2 bAddClass,Class_All,7;
+               bonus bAtkRate,7;
             }
          }
       }
@@ -146961,7 +146961,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bMatkRate,5+2*(.@r/2);
-      bonus2 bAddClass,Class_All,5+2*(.@r/2);
+      bonus bAtkRate,5+2*(.@r/2);
       bonus bAspd,3;
       if (.@r>=7) {
          bonus bAspdRate,5;
@@ -148187,7 +148187,7 @@ Body:
       if (.@l>=120)
          bonus bCritAtkRate,5;
       if (.@l>=130)
-         bonus2 bAddClass,Class_ALL,5;
+         bonus bAtkRate,5;
   - Id: 470070
     AegisName: Egirnion_Shoes
     Name: Aegirnion Shoes
@@ -148386,7 +148386,7 @@ Body:
             if (.@r>=13) {
                bonus bCritAtkRate,7;
                bonus bCritical,7;
-               bonus2 bAddClass,Class_All,7;
+               bonus bAtkRate,7;
             }
          }
       }
@@ -148815,7 +148815,7 @@ Body:
       }
       if (.@r>=7) {
          bonus bMatkRate,5;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bVariableCastrate,-5;
             bonus bPerfectHitAddRate,10;
@@ -148954,7 +148954,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bFixedCast,-300;
             bonus bVariableCastrate,-5;
@@ -148965,12 +148965,12 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          if (.@g>=2) {
             bonus bFixedCast,-300;
             if (.@g>=3) {
                bonus bPAtk,2;
-               bonus2 bAddClass,Class_All,2;
+               bonus bAtkRate,2;
                if (.@g>=4) {
                   bonus bFixedCast,-200;
                }
@@ -149046,7 +149046,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bFixedCast,-300;
             bonus bCritAtkRate,5;
@@ -149057,12 +149057,12 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          if (.@g>=2) {
             bonus bFixedCast,-300;
             if (.@g>=3) {
                bonus bPAtk,2;
-               bonus2 bAddClass,Class_All,2;
+               bonus bAtkRate,2;
                if (.@g>=4) {
                   bonus bCrate,1;
                }
@@ -150318,7 +150318,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,(.@r/2);
+      bonus bAtkRate,(.@r/2);
       bonus bBaseAtk,5*(.@r/2);
       bonus2 bAddSize,Size_All,3*(.@r/3);
       if (.@r>=7) {
@@ -150582,15 +150582,15 @@ Body:
          if (.@r>=9) {
             bonus bCritAtkRate,10;
             if (.@r>=11) {
-               bonus2 bAddClass,Class_All,5;
+               bonus bAtkRate,5;
             }
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bPAtk,2;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus bShortAtkRate,5;
                if (.@g>=4) {
@@ -150666,7 +150666,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bCritAtkRate,10;
             if (.@r>=11) {
@@ -150675,10 +150675,10 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bPAtk,2;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus bLongAtkRate,5;
                if (.@g>=4) {
@@ -151062,7 +151062,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMaxHPrate,5;
   - Id: 490025
     AegisName: Auto_B_L
@@ -151075,7 +151075,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 160
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMaxSPrate,5;
   - Id: 490026
     AegisName: Auto_BC_R
@@ -151143,7 +151143,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 30
     Script: |
-      bonus2 bAddClass,Class_All,6;
+      bonus bAtkRate,6;
       bonus bMatkRate,6;
       bonus bHit,15;
   - Id: 490035
@@ -151246,7 +151246,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490045
     AegisName: Sin_Necklace_R
     Name: Sinful Ruby Necklace
@@ -151259,7 +151259,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490046
     AegisName: Sin_Ring_E
     Name: Sinful Emerald Ring
@@ -151272,7 +151272,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490047
     AegisName: Sin_Necklace_E
     Name: Sinful Emerald Necklace
@@ -151285,7 +151285,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490048
     AegisName: Sin_Ring_T
     Name: Sinful Topaz Ring
@@ -151299,7 +151299,7 @@ Body:
     Script: |
       bonus bAspdRate,7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490049
     AegisName:  Sin_Necklace_T
     Name: Sinful Topaz Necklace
@@ -151313,7 +151313,7 @@ Body:
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490050
     AegisName: Sin_Ring_A
     Name: Sinful Amethyst Ring
@@ -151327,7 +151327,7 @@ Body:
     Script: |
       bonus bAspdRate,7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490051
     AegisName: Sin_Necklace_A
     Name: Sinful Amethyst Necklace
@@ -151341,7 +151341,7 @@ Body:
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490052
     AegisName: Sin_Ring_S
     Name: Sinful Sapphire Ring
@@ -151380,7 +151380,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490055
     AegisName: Sin_Necklace_O
     Name: Sinful Opal Necklace
@@ -151393,7 +151393,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490056
     AegisName: Shine_Ring_R
     Name: Brilliant Light Ruby Ring
@@ -151406,7 +151406,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490057
     AegisName: Shine_Necklace_R
     Name: Brilliant Light Ruby Necklace
@@ -151419,7 +151419,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490058
     AegisName: Shine_Ring_A
     Name: Brilliant Light Amethyst Ring
@@ -151433,7 +151433,7 @@ Body:
     Script: |
       bonus bAspdRate,7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490059
     AegisName: Shine_Necklace_A
     Name: Brilliant Light Amethyst Necklace
@@ -151447,7 +151447,7 @@ Body:
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490060
     AegisName: Shine_Ring_E
     Name: Brilliant Light Emerald Ring
@@ -151461,7 +151461,7 @@ Body:
     Script: |
       bonus bAspdRate,7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490061
     AegisName: Shine_Necklace_E
     Name: Brilliant Light Emerald Necklace
@@ -151475,7 +151475,7 @@ Body:
     Script: |
       bonus bVariableCastrate,-7;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490062
     AegisName: Shine_Ring_Z
     Name: Brilliant Light Zircon Ring
@@ -151488,7 +151488,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490063
     AegisName: Shine_Necklace_Z
     Name: Brilliant Light Zircon Necklace
@@ -151501,7 +151501,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490064
     AegisName: Shine_Ring_S
     Name: Brilliant Light Sapphire Ring
@@ -151540,7 +151540,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bAspdRate,7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490067
     AegisName: Shine_Necklace_AQ
     Name: Brilliant Light Aquamarine Necklace
@@ -151553,7 +151553,7 @@ Body:
     EquipLevelMin: 170
     Script: |
       bonus bVariableCastrate,-7;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 490068
     AegisName: RingofVenus
     Name: Ring of Venus
@@ -151638,7 +151638,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 490073
     AegisName: E_Illusion_B_L
     Name: Illusion Booster L(Bound)
@@ -151657,7 +151657,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 490074
     AegisName: E_Illusion_BC_R
     Name: Illusion Battle Chip R(Bound)
@@ -151724,7 +151724,7 @@ Body:
     EquipLevelMin: 230
     Script: |
       bonus bMaxHPrate,5;
-      bonus2 bAddClass,Class_All,8;
+      bonus bAtkRate,8;
   - Id: 490078
     AegisName: MD_Geffen_Ring2
     Name: Mental Condenser
@@ -151932,7 +151932,7 @@ Body:
     ArmorLevel: 1
     Script: |
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 490100
     AegisName: Blue_Mental_Pendant
     Name: Red Force Pendant
@@ -151944,7 +151944,7 @@ Body:
     ArmorLevel: 1
     Script: |
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 490101
     AegisName: Red_Force_Pendant
     Name: Blue Mental Pendant
@@ -151956,7 +151956,7 @@ Body:
     ArmorLevel: 1
     Script: |
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 490102
     AegisName: aegis_490102
     Name: Skull Ring
@@ -152031,7 +152031,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 190
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bMaxHPrate,5;
   - Id: 490107
     AegisName: Gray_W_Ring
@@ -152044,7 +152044,7 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 190
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bMaxSPrate,5;
   - Id: 490108
     AegisName: Gray_W_Earing
@@ -152214,7 +152214,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bNoCastCancel;
   - Id: 490123
     AegisName: 1Para_Acc_R_A
@@ -152290,7 +152290,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bNoCastCancel;
   - Id: 490127
     AegisName: L_60Lv_Gloves
@@ -152402,7 +152402,7 @@ Body:
       NoAuction: true
     Script: |
       bonus bPAtk,3;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 490133
     AegisName: Signet_Of_Sta_Star
     Name: Stellar Stamina Seal
@@ -152642,7 +152642,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490153
     AegisName: aegis_490153
@@ -152661,7 +152661,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490155
     AegisName: aegis_490155
@@ -152680,7 +152680,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490156
     AegisName: aegis_490156
@@ -152699,7 +152699,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490159
     AegisName: Omega_Core
@@ -152788,7 +152788,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490165
     AegisName: aegis_490165
@@ -152807,7 +152807,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490166
     AegisName: aegis_490166
@@ -152826,7 +152826,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490167
     AegisName: aegis_490167
@@ -152845,7 +152845,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490171
     AegisName: aegis_490171
@@ -152864,7 +152864,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490172
     AegisName: aegis_490172
@@ -152883,7 +152883,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490176
     AegisName: Snowflower_Pendant
@@ -152896,7 +152896,7 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 210
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bMaxHPrate,7;
   - Id: 490177
     AegisName: Snowflower_Ring
@@ -152909,7 +152909,7 @@ Body:
     ArmorLevel: 2
     EquipLevelMin: 210
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bMaxSPrate,7;
   - Id: 490178
     AegisName: Snowflower_Necklace
@@ -152954,7 +152954,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490181
     AegisName: aegis_490181
@@ -152973,7 +152973,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490182
     AegisName: aegis_490182
@@ -153006,7 +153006,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490185
     AegisName: aegis_490185
@@ -153025,7 +153025,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490186
     AegisName: aegis_490186
@@ -153044,7 +153044,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490187
     AegisName: aegis_490187
@@ -153063,7 +153063,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490188
     AegisName: aegis_490188
@@ -153082,7 +153082,7 @@ Body:
     EquipLevelMin: 205
     Script: |
       bonus bMatkRate,10;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bVariableCastrate,-10;
   - Id: 490193
     AegisName: aegis_490193
@@ -153438,7 +153438,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -153515,7 +153515,7 @@ Body:
       .@r = getrefine();
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",5*(.@r/2);
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",5*(.@r/2);
-      bonus2 bAddClass,Class_All,3*(.@r/4);
+      bonus bAtkRate,3*(.@r/4);
   - Id: 500019
     AegisName: Poenitentia_Gladius
     Name: Poenitentia Gladius
@@ -153582,7 +153582,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WATER",10;
@@ -153640,7 +153640,7 @@ Body:
       bonus bLongAtkRate,4*(.@r/3);
       if (.@r>=7) {
          bonus bVariableCastrate,-15;
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          if (.@r>=9) {
             bonus bAspdRate,10;
             bonus2 bSkillAtk,"GN_CARTCANNON",15;
@@ -153651,14 +153651,14 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",10;
          bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",10;
          bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WATER",10;
          bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_GROUND",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",10;
                bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",10;
@@ -153834,7 +153834,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"GN_CARTCANNON",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -153963,7 +153963,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bShortAtkRate,10;
       if (BaseLevel>=75)
@@ -153993,7 +153993,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bShortAtkRate,10;
       if (BaseLevel>=75)
@@ -154073,7 +154073,7 @@ Body:
       .@l = BaseLevel;
       .@a = getskilllv("GN_TRAINING_SWORD");
       bonus bShortAtkRate,2*.@a;
-      bonus2 bAddClass,Class_ALL,5*.@a;
+      bonus bAtkRate,5*.@a;
       if (.@l>=105) {
          bonus bDelayrate,-5;
          bonus2 bSkillAtk,"GN_HELLS_PLANT",25;
@@ -154164,7 +154164,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -154183,7 +154183,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -154217,7 +154217,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -154236,7 +154236,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bShortAtkRate,15;
             bonus bPAtk,1;
@@ -154390,7 +154390,7 @@ Body:
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",6*(.@r/2);
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",6*(.@r/2);
       bonus2 bSkillAtk,"GN_CART_TORNADO",7*(.@r/3);
-      bonus2 bAddClass,Class_All,5*(.@r/4);
+      bonus bAtkRate,5*(.@r/4);
       if (.@g>=1) {
          bonus bPow,2;
          if (.@g>=2) {
@@ -154422,7 +154422,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus2 bSkillAtk,"HN_DOUBLEBOWLINGBASH",10+3*(.@r/2);
       bonus2 bSkillAtk,"HN_SHIELD_CHAIN_RUSH",10+3*(.@r/2);
       if (.@r>=7) {
@@ -154507,7 +154507,7 @@ Body:
     Refineable: true
     Script: |
       bonus2 bMagicAtkEle,Ele_Fire,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       .@r = getrefine();
       if (.@r) {
          bonus bBaseAtk,.@r*2;
@@ -154543,7 +154543,7 @@ Body:
       bonus2 bMagicAtkEle,Ele_Fire,3;
       bonus2 bMagicAtkEle,Ele_Wind,3;
       bonus2 bMagicAtkEle,Ele_Water,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       .@r = getrefine();
       if (.@r) {
          bonus bBaseAtk,.@r*2;
@@ -154681,7 +154681,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -154729,7 +154729,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMatkRate,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bMatk,3*(.@r+(min(BaseLevel,195)/15));
       bonus bBaseAtk,3*(.@r+(min(BaseLevel,195)/15));
       if (.@r>=7) {
@@ -154911,7 +154911,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"SHC_SHADOW_STAB",10;
       bonus2 bSkillAtk,"GC_CROSSIMPACT",3*(.@r/2);
       if (.@r>=7) {
@@ -154955,7 +154955,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"ABC_DEFT_STAB",10;
       bonus2 bSkillAtk,"SC_FATALMENACE",3*(.@r/2);
       if (.@r>=7) {
@@ -155108,7 +155108,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SC_FATALMENACE",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -155293,7 +155293,7 @@ Body:
       bonus bMatk,180;
       bonus bMatkRate,3;
       bonus bDelayrate,-1*.@a;
-      bonus2 bAddClass,Class_ALL,3;
+      bonus bAtkRate,3;
       if (.@l>=105) {
          bonus2 bSkillAtk,"SC_FATALMENACE",25;
          bonus bAspd,1;
@@ -155333,7 +155333,7 @@ Body:
       .@l = BaseLevel;
       .@a = getskilllv("SM_SWORD");
       bonus bShortAtkRate,1*.@a;
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       if (.@l>=105) {
          bonus bAspdRate,10;
          bonus2 bSkillAtk,"RG_RAID",25;
@@ -155420,7 +155420,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -155439,7 +155439,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bShortAtkRate,15;
             bonus bPAtk,1;
@@ -155680,7 +155680,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus2 bSkillAtk,"SS_KUNAIKAITEN",7;
       bonus2 bSkillAtk,"SS_KUNAIKUSSETSU",7;
       bonus2 bSkillAtk,"KO_JYUMONJIKIRI",2*(.@r/2);
@@ -155783,7 +155783,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -155969,7 +155969,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"NC_AXEBOOMERANG",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -156029,7 +156029,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bShortAtkRate,10;
       if (BaseLevel>=75)
@@ -156065,7 +156065,7 @@ Body:
       .@a = getskilllv("NC_MADOLICENCE");
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,2*.@a;
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       if (.@l>=105) {
          bonus bVariableCastrate,-10;
          bonus2 bSkillAtk,"NC_VULCANARM",25;
@@ -156126,7 +156126,7 @@ Body:
     Refineable: true
     Script: |
       bonus bMatkRate,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus2 bMagicAtkEle,Ele_Holy,3;
       .@r = getrefine();
       if (.@r) {
@@ -156202,7 +156202,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -156301,7 +156301,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"IG_OVERSLASH",10;
       bonus2 bSkillAtk,"LG_OVERBRAND",3*(.@r/2);
       if (.@r>=7) {
@@ -156362,11 +156362,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"IG_OVERSLASH",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"IG_OVERSLASH",10;
             }
@@ -156450,7 +156450,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"LG_OVERBRAND",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -156516,7 +156516,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bAspdRate,10;
       if (BaseLevel>=75)
@@ -156551,7 +156551,7 @@ Body:
       .@l = BaseLevel;
       .@a = getskilllv("CR_SPEARQUICKEN");
       bonus bAspdRate,1*.@a;
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       if (.@l>=105) {
          bonus bAspd,1;
          bonus2 bSkillAtk,"LG_BANISHINGPOINT",25;
@@ -156590,7 +156590,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -156609,7 +156609,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus2 bAddEle,Ele_All,15;
             bonus bPAtk,1;
@@ -156730,7 +156730,7 @@ Body:
          bonus bAspdRate,getskilllv("TK_RUN");
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       }
   - Id: 540004
     AegisName: Ep172_1h_Book
@@ -157026,7 +157026,7 @@ Body:
       .@r = getrefine();
       bonus bUnbreakableWeapon;
       bonus bMatkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMatk,215;
       bonus2 bSkillAtk,"CD_PETITIO",10;
       bonus2 bSkillAtk,"AB_DUPLELIGHT",3*(.@r/2);
@@ -157372,7 +157372,7 @@ Body:
          bonus2 bSkillAtk,"AB_DUPLELIGHT",25;
          if (.@g>=3) {
             bonus bMatkRate,7;
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -157465,7 +157465,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bShortAtkRate,10;
       if (BaseLevel>=75) {
@@ -157498,7 +157498,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bShortAtkRate,10;
       if (BaseLevel>=75) {
@@ -157645,9 +157645,9 @@ Body:
       .@l = BaseLevel;
       .@a = getskilllv("TK_HPTIME");
       bonus bShortAtkRate,1*.@a;
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       if (.@l>=105) {
-         bonus2 bAddClass,Class_ALL,10;
+         bonus bAtkRate,10;
          bonus2 bSkillAtk,"SJ_PROMINENCEKICK",25;
          bonus2 bSkillAtk,"SJ_SOLARBURST",25;
          if (.@l>=110) {
@@ -157687,9 +157687,9 @@ Body:
       .@l = BaseLevel;
       .@a = getskilllv("TK_HPTIME");
       bonus bShortAtkRate,1*.@a;
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       if (.@l>=105) {
-         bonus2 bAddClass,Class_ALL,10;
+         bonus bAtkRate,10;
          bonus2 bSkillAtk,"SJ_PROMINENCEKICK",25;
          bonus2 bSkillAtk,"SJ_SOLARBURST",25;
          if (.@l>=110) {
@@ -157782,7 +157782,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -157794,7 +157794,7 @@ Body:
             bonus2 bSkillAtk,"SJ_NEWMOONKICK",25;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
-               bonus2 bAddClass,Class_All,10;
+               bonus bAtkRate,10;
                if (.@r>=13) {
                   bonus2 bSkillAtk,"SJ_FALLINGSTAR_ATK",15;
                   bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
@@ -157829,7 +157829,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -157840,7 +157840,7 @@ Body:
             bonus2 bSkillAtk,"SJ_PROMINENCEKICK",25;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
-               bonus2 bAddClass,Class_All,10;
+               bonus bAtkRate,10;
                if (.@r>=13) {
                   bonus2 bSkillAtk,"SJ_SOLARBURST",15;
                   bonus2 bSkillAtk,"SJ_PROMINENCEKICK",15;
@@ -157962,7 +157962,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"SKE_SUNSET_BLAST",10;
       bonus2 bSkillAtk,"SKE_DAWN_BREAK",10;
       bonus2 bSkillAtk,"SJ_SOLARBURST",3*(.@r/2);
@@ -158034,7 +158034,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SJ_FALLINGSTAR_ATK",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -158084,7 +158084,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SJ_FULLMOONKICK",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -158129,7 +158129,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bShortAtkRate,15;
             bonus bPAtk,1;
@@ -158248,7 +158248,7 @@ Body:
       bonus bMatk,350;
       bonus bUnbreakableWeapon;
       bonus bMatkRate,7;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus2 bSkillAtk,"SU_CN_METEOR",15;
       bonus2 bSkillAtk,"SU_PICKYPECK",15;
       if (.@r>=7) {
@@ -158563,7 +158563,7 @@ Body:
       .@r = getrefine();
       bonus bMatk,15*(.@r/2);
       bonus bBaseAtk,15*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/3);
+      bonus bAtkRate,2*(.@r/3);
       bonus bMatkRate,2*(.@r/3);
       if (.@r>=7) {
          bonus2 bSkillAtk,"SU_LUNATICCARROTBEAT",25;
@@ -159295,7 +159295,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -159434,7 +159434,7 @@ Body:
     Script: |
       .@l = BaseLevel;
       .@a = getskilllv("SU_PICKYPECK");
-      bonus2 bAddClass,Class_ALL,5;
+      bonus bAtkRate,5;
       bonus bUnbreakableWeapon;
       bonus bLongAtkRate,2*.@a;
       if (.@l>=105) {
@@ -159685,7 +159685,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -160387,7 +160387,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SU_PICKYPECK",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -160434,7 +160434,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus bMatkRate,3;
          if (.@g>=2) {
             bonus2 bMagicAtkEle,Ele_All,15;
@@ -160448,7 +160448,7 @@ Body:
       }
       bonus bMatk,15*(.@r/2);
       bonus bBaseAtk,15*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/3);
+      bonus bAtkRate,2*(.@r/3);
       bonus bMatkRate,2*(.@r/3);
   - Id: 550068
     AegisName: SoulWeight_LT
@@ -160662,7 +160662,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,(3*.@r)+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,2*getskilllv("MO_CALLSPIRITS");
@@ -160707,14 +160707,14 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2+(min(BaseLevel,195)/15);
+      bonus bAtkRate,2+(min(BaseLevel,195)/15);
       bonus bMaxHP,250*.@r;
       bonus bMaxSP,20*.@r;
       if (.@r>=7) {
          bonus bMaxHPrate,2*getskilllv("MO_CHAINCOMBO");
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus2 bSkillAtk,"SR_SKYNETBLOW",25;
          bonus2 bSkillAtk,"SR_TIGERCANNON",25;
       }
@@ -160840,7 +160840,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"IQ_SECOND_FAITH",10;
       bonus2 bSkillAtk,"SR_TIGERCANNON",3*(.@r/2);
       if (.@r>=7) {
@@ -160884,7 +160884,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"IQ_EXPOSION_BLASTER",10;
       bonus2 bSkillAtk,"SR_RAMPAGEBLASTER",3*(.@r/2);
       if (.@r>=7) {
@@ -160945,11 +160945,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"IQ_THIRD_FLAME_BOMB",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"IQ_THIRD_FLAME_BOMB",10;
             }
@@ -161068,7 +161068,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SR_TIGERCANNON",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -161118,7 +161118,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SR_RAMPAGEBLASTER",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -161147,7 +161147,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bAspdRate,10;
       if (BaseLevel>=75)
@@ -161176,7 +161176,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -161209,7 +161209,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("MO_CHAINCOMBO");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMaxHPrate,2*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"SR_TIGERCANNON",-1000;
@@ -161250,7 +161250,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("MO_CALLSPIRITS");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,2*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"SR_RAMPAGEBLASTER",-1000;
@@ -161287,7 +161287,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -161307,7 +161307,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -161341,7 +161341,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -161360,7 +161360,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bShortAtkRate,15;
@@ -161448,7 +161448,7 @@ Body:
     Refineable: true
     Script: |
       bonus2 bMagicAtkEle,Ele_Neutral,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       .@r = getrefine();
       bonus bBaseAtk,.@r*3;
       bonus bMatk,.@r*3;
@@ -161763,11 +161763,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"TR_RHYTHMSHOOTING",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"TR_RHYTHMSHOOTING",10;
             }
@@ -161890,7 +161890,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -161972,7 +161972,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -162006,7 +162006,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("BA_MUSICALLESSON");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"WM_SEVERE_RAINSTORM",-2000;
@@ -162089,7 +162089,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -162240,7 +162240,7 @@ Body:
     Refineable: true
     Script: |
       bonus2 bMagicAtkEle,Ele_Neutral,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       .@r = getrefine();
       bonus bBaseAtk,.@r*3;
       bonus bMatk,.@r*3;
@@ -162251,7 +162251,7 @@ Body:
          bonus bVariableCastrate,getskilllv("DC_DANCINGLESSON")*-1;
       }
       if (.@r>=9) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          bonus2 bMagicAddClass,Class_All,10;
       }
   - Id: 580002
@@ -162555,11 +162555,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"TR_RHYTHMSHOOTING",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"TR_RHYTHMSHOOTING",10;
             }
@@ -162682,7 +162682,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -162764,7 +162764,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
         bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -162798,7 +162798,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("DC_DANCINGLESSON");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"WM_SEVERE_RAINSTORM",-2000;
@@ -162881,7 +162881,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -163034,7 +163034,7 @@ Body:
       bonus bMatk,160;
       bonus bUnbreakableWeapon;
       bonus2 bMagicAtkEle,Ele_Holy,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMatk,2*.@r;
       bonus bBaseAtk,2*.@r;
       bonus bMatk,3*(min(BaseLevel,180)/15);
@@ -163175,7 +163175,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,2*getskilllv("NC_MADOLICENCE");
@@ -163221,7 +163221,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,2*getskilllv("AM_LEARNINGPOTION");
@@ -163268,7 +163268,7 @@ Body:
       .@r = getrefine();
       bonus bUnbreakableWeapon;
       bonus bMatkRate,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bMatk,160+(3*.@r)+3*(min(BaseLevel,195)/15);
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -163404,7 +163404,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"MT_AXE_STOMP",10;
       if (.@r>=7) {
          bonus bVariableCastrate,-10;
@@ -163446,7 +163446,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WIND",10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_FIRE",10;
       bonus2 bSkillAtk,"BO_ACIDIFIED_ZONE_WATER",10;
@@ -163510,7 +163510,7 @@ Body:
          bonus bAspdRate,10;
          if (.@r>=9) {
             bonus bMatkRate,5;
-            bonus2 bAddClass,Class_All,5;
+            bonus bAtkRate,5;
             bonus2 bSkillAtk,"AB_DUPLELIGHT",30;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
@@ -163520,7 +163520,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"CD_PETITIO",10;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
@@ -163646,7 +163646,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"NC_VULCANARM",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -163697,7 +163697,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"GN_CART_TORNADO",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -163762,7 +163762,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bVariableCastrate,-10;
       if (BaseLevel>=75)
@@ -163825,7 +163825,7 @@ Body:
     Script: |
       .@a = getskilllv("AM_LEARNINGPOTION");
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus bVariableCastrate,-10;
@@ -163962,7 +163962,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -163980,7 +163980,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -164355,7 +164355,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"DK_STORMSLASH",10;
       bonus2 bSkillAtk,"RK_IGNITIONBREAK",3*(.@r/2);
       if (.@r>=7) {
@@ -164407,7 +164407,7 @@ Body:
          bonus bAspdRate,10;
          bonus2 bSkillAtk,"RK_WINDCUTTER",20;
          if (.@r>=9) {
-            bonus2 bAddClass,Class_All,5;
+            bonus bAtkRate,5;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
                bonus bShortAtkRate,15;
@@ -164415,11 +164415,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"DK_SERVANTWEAPON_ATK",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"DK_SERVANTWEAPON_ATK",10;
             }
@@ -164503,7 +164503,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RK_WINDCUTTER",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -164603,7 +164603,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -164623,7 +164623,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bShortAtkRate,15;
@@ -164988,7 +164988,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"SHC_IMPACT_CRATER",10;
       bonus2 bSkillAtk,"GC_ROLLINGCUTTER",3*(.@r/2);
       if (.@r>=7) {
@@ -165040,7 +165040,7 @@ Body:
          bonus bDelayrate,-10;
          bonus2 bSkillAtk,"GC_COUNTERSLASH",15;
          if (.@r>=9) {
-            bonus2 bAddClass,Class_All,5;
+            bonus bAtkRate,5;
             bonus2 bSkillAtk,"GC_ROLLINGCUTTER",25;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
@@ -165049,7 +165049,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"SHC_IMPACT_CRATER",10;
          if (.@g>=2) {
             bonus bDelayrate,-5;
@@ -165172,7 +165172,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"GC_ROLLINGCUTTER",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -165222,7 +165222,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"GC_COUNTERSLASH",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -165280,7 +165280,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bHit,15;
       if (BaseLevel>=75)
@@ -165354,7 +165354,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("AS_KATAR");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bDelayrate,-1*.@a;
       if (BaseLevel>=105) {
          bonus bShortAtkRate,10;
@@ -165393,7 +165393,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -165434,7 +165434,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -165454,7 +165454,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bShortAtkRate,15;
             bonus bPAtk,1;
@@ -165488,7 +165488,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -165509,7 +165509,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bShortAtkRate,15;
@@ -165603,7 +165603,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bShortAtkRate,getskilllv("BS_WEAPONRESEARCH");
@@ -165700,7 +165700,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"MT_AXE_STOMP",10;
       bonus2 bSkillAtk,"NC_AXETORNADO",3*(.@r/2);
       if (.@r>=7) {
@@ -165762,11 +165762,11 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          bonus2 bSkillAtk,"MT_AXE_STOMP",10;
          if (.@g>=2) {
             bonus bPAtk,1;
-            bonus2 bAddClass,Class_All,3;
+            bonus bAtkRate,3;
             if (.@g>=3) {
                bonus2 bSkillAtk,"MT_AXE_STOMP",10;
             }
@@ -165860,7 +165860,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("BS_WEAPONRESEARCH");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bShortAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"NC_AXETORNADO",-1000;
@@ -165898,7 +165898,7 @@ Body:
       .@g = getenchantgrade();
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -165916,7 +165916,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bShortAtkRate,15;
@@ -166039,7 +166039,7 @@ Body:
     Refineable: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"LG_OVERBRAND",5*(.@r/2);
       if (.@r>=7) {
          bonus2 bSkillAtk,"LG_OVERBRAND",20;
@@ -166116,7 +166116,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2+(min(BaseLevel,195)/15);
+      bonus bAtkRate,2+(min(BaseLevel,195)/15);
       bonus bMaxHP,250*.@r;
       bonus bMaxSP,20*.@r;
       if (.@r>=7) {
@@ -166158,7 +166158,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"DK_MADNESS_CRUSHER",10;
       bonus2 bSkillAtk,"RK_HUNDREDSPEAR",3*(.@r/2);
       if (.@r>=7) {
@@ -166259,7 +166259,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RK_HUNDREDSPEAR",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -166288,7 +166288,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus2 bSkillAtk,"KN_PIERCE",20;
       if (BaseLevel>=75)
@@ -166321,7 +166321,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("RK_DRAGONTRAINING");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bDelayrate,-3*.@a;
       if (BaseLevel>=105) {
          bonus bVariableCastrate,-10;
@@ -167544,7 +167544,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -167618,7 +167618,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("NJ_TOBIDOUGU");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"KO_JYUMONJIKIRI",-2000;
@@ -167704,7 +167704,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bUnbreakableWeapon;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -167822,7 +167822,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"KO_JYUMONJIKIRI",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -167873,7 +167873,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"KO_HUUMARANKA",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -167920,7 +167920,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -168193,7 +168193,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bDelayrate,-1*(getskilllv("AC_VULTURE")/2);
@@ -168239,7 +168239,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,getskilllv("AC_OWL");
@@ -168283,7 +168283,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,getskilllv("AC_VULTURE");
@@ -168295,7 +168295,7 @@ Body:
       }
       if (.@r>=11) {
          bonus2 bAddSize,Size_All,15;
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
       }
       if (.@r>=13) {
          bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
@@ -168329,7 +168329,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r+3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
          bonus bLongAtkRate,2*getskilllv("BA_MUSICALLESSON");
@@ -168458,7 +168458,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"ABC_FRENZY_SHOT",10;
       bonus2 bSkillAtk,"SC_TRIANGLESHOT",3*(.@r/2);
       if (.@r>=7) {
@@ -168502,7 +168502,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"WH_CRESCIVE_BOLT",10;
       bonus2 bSkillAtk,"RA_AIMEDBOLT",3*(.@r/2);
       if (.@r>=7) {
@@ -168546,7 +168546,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"WH_GALESTORM",10;
       bonus2 bSkillAtk,"RA_ARROWSTORM",3*(.@r/2);
       if (.@r>=7) {
@@ -168590,7 +168590,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"TR_RHYTHMSHOOTING",10;
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM",3*(.@r/2);
       if (.@r>=7) {
@@ -168651,7 +168651,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          bonus2 bSkillAtk,"WH_CRESCIVE_BOLT",10;
          if (.@g>=2) {
             bonus bDelayrate,-5;
@@ -168810,7 +168810,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"SC_TRIANGLESHOT",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -168861,7 +168861,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RA_ARROWSTORM",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -168911,7 +168911,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RA_AIMEDBOLT",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bPow,(.@r/3);
@@ -168968,7 +168968,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -168997,7 +168997,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -169026,7 +169026,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bAspdRate,10;
       if (BaseLevel>=75)
@@ -169055,7 +169055,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -169088,7 +169088,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("AC_VULTURE");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus bVariableCastrate,-10;
@@ -169129,7 +169129,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("AC_OWL");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"RA_ARROWSTORM",-700;
@@ -169167,7 +169167,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("AC_VULTURE");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bAspdRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"RA_AIMEDBOLT",-1000;
@@ -169205,7 +169205,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -169224,7 +169224,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -169258,7 +169258,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -169276,7 +169276,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -169312,7 +169312,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (BaseLevel>=210) {
          bonus bPAtk,1;
          bonus bPow,2;
@@ -169331,7 +169331,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -169437,7 +169437,7 @@ Body:
       bonus bBaseAtk,.@r/2*10;
       bonus2 bSkillAtk,"RL_FIREDANCE",.@r/3*2;
       if (.@r>=7) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bLongAtkRate,10;
       }
       if (.@r>=9) {
@@ -169532,7 +169532,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bAspdRate,10;
       if (BaseLevel>=75)
@@ -169562,7 +169562,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("GS_CHAINACTION");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus bLongAtkRate,10;
@@ -169601,7 +169601,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -169696,7 +169696,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"NW_ONLY_ONE_BULLET",10;
       bonus2 bSkillAtk,"NW_MAGAZINE_FOR_ONE",10;
       bonus2 bSkillAtk,"RL_FIREDANCE",3*(.@r/2);
@@ -169767,7 +169767,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RL_FIREDANCE",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bCon,(.@r/3);
@@ -169802,7 +169802,7 @@ Body:
          bonus2 bMagicSubSize,Size_All,20;
          bonus2 bSkillAtk,"RL_FIREDANCE",25;
          if (.@r>=9) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             bonus2 bSkillAtk,"RL_FIREDANCE",35;
             if (.@r>=11) {
                bonus2 bAddSize,Size_All,15;
@@ -169811,7 +169811,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -169960,7 +169960,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (BaseLevel>=60)
          bonus bLongAtkRate,10;
       if (BaseLevel>=75)
@@ -170043,7 +170043,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"NW_SPIRAL_SHOOTING",10;
       bonus2 bSkillAtk,"NW_ONLY_ONE_BULLET",10;
       bonus2 bSkillAtk,"RL_HAMMER_OF_GOD",3*(.@r/2);
@@ -170115,7 +170115,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RL_HAMMER_OF_GOD",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bCon,(.@r/3);
@@ -170387,7 +170387,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RL_S_STORM",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bCon,(.@r/3);
@@ -170434,7 +170434,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -170609,7 +170609,7 @@ Body:
       NoAuction: true
     Script: |
       .@a = getskilllv("GS_SINGLEACTION");
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,1*.@a;
       if (BaseLevel>=105) {
          bonus2 bSkillCooldown,"RL_FIRE_RAIN",-1000;
@@ -170648,7 +170648,7 @@ Body:
       NoAuction: true
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,3*.@r;
       bonus bBaseAtk,3*(min(BaseLevel,195)/15);
       if (.@r>=7) {
@@ -170744,7 +170744,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"NW_THE_VIGILANTE_AT_NIGHT_GUN_GATLING",10;
       bonus2 bSkillAtk,"NW_MAGAZINE_FOR_ONE",10;
       bonus2 bSkillAtk,"RL_R_TRIP",3*(.@r/2);
@@ -170814,7 +170814,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RL_R_TRIP",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bCon,(.@r/3);
@@ -170858,7 +170858,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;
@@ -171059,7 +171059,7 @@ Body:
     Script: |
       .@g = getenchantgrade();
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus2 bSkillAtk,"NW_SPIRAL_SHOOTING",10;
       bonus2 bSkillAtk,"NW_WILD_FIRE",10;
       bonus2 bSkillAtk,"RL_D_TAIL",3*(.@r/2);
@@ -171130,7 +171130,7 @@ Body:
       if (.@g>=2) {
          bonus2 bSkillAtk,"RL_D_TAIL",15;
          if (.@g>=3) {
-            bonus2 bAddClass,Class_All,7;
+            bonus bAtkRate,7;
             if (.@g>=4) {
                bonus bPAtk,(.@r/3);
                bonus bCon,(.@r/3);
@@ -171174,7 +171174,7 @@ Body:
          }
       }
       if (.@g>=1) {
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@g>=2) {
             bonus bLongAtkRate,15;
             bonus bPAtk,1;

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -9715,7 +9715,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@rate = ((getrefine()>14)?15:10);
-      bonus2 bAddClass,Class_All,.@rate;
+      bonus bAtkRate,.@rate;
       bonus3 bAutoSpell,"SM_MAGNUM",10,15;
   - Id: 4495
     AegisName: Sealed_Amon_Ra_Card
@@ -37104,7 +37104,7 @@ Body:
     SubType: Enchant
     Weight: 10
     Script: |
-      autobonus "{ bonus bInt,50; bonus bMatkRate,15; bonus2 bAddClass,Class_All,-15; }",20,10000,BF_MAGIC;
+      autobonus "{ bonus bInt,50; bonus bMatkRate,15; bonus bAtkRate,-15; }",20,10000,BF_MAGIC;
       /* unknown rate */
   - Id: 25702
     AegisName: EP17_1_EVT35
@@ -37122,7 +37122,7 @@ Body:
     SubType: Enchant
     Weight: 10
     Script: |
-      autobonus "{ bonus bStr,50; bonus2 bAddClass,Class_All,15; bonus bMatkRate,-15; }",20,10000,BF_WEAPON;
+      autobonus "{ bonus bStr,50; bonus bAtkRate,15; bonus bMatkRate,-15; }",20,10000,BF_WEAPON;
       /* unknown rate */
   - Id: 25704
     AegisName: EP17_1_EVT37
@@ -38214,7 +38214,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus5 bAutoSpell,"SM_ENDURE",1,5,BF_SHORT,0;
   - Id: 27101
     AegisName: SweetNightM_Card
@@ -38928,7 +38928,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       bonus bStr,4;
-      bonus2 bAddClass,Class_All,4;
+      bonus bAtkRate,4;
   - Id: 27172
     AegisName: Cowraiders3_Card
     Name: Scimitar Buffalo Bandit Card
@@ -39620,7 +39620,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bLongAtkRate,5;
   - Id: 27257
     AegisName: Kuro_Akuma_Card
@@ -39649,7 +39649,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bAspdRate,5;
   - Id: 27259
     AegisName: Rechenier_Card
@@ -39790,7 +39790,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@val = 10;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (getrefine() >= 10) {
          .@val += 5;
       }
@@ -39967,7 +39967,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 27304
     AegisName: E_EA2S_Card
     Name: E EA2S Card
@@ -40247,7 +40247,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bMaxHPRate,-50;
       bonus2 bAddRace,RC_DemiHuman,30;
       bonus2 bAddRace,RC_Player_Human,30;
@@ -40331,7 +40331,7 @@ Body:
     Script: |
       .@r = getrefine();
       bonus3 bAutoSpellWhenHit,"NPC_WIDECURSE",3,(1+.@r);
-      autobonus2 "{ bonus2 bAddClass,Class_All,25; bonus bMatkRate,25; }",(1+.@r),10000,BF_WEAPON|BF_MAGIC;
+      autobonus2 "{ bonus bAtkRate,25; bonus bMatkRate,25; }",(1+.@r),10000,BF_WEAPON|BF_MAGIC;
       autobonus3 "{ }",1000,5000,"NV_FIRSTAID","{ active_transform 3029,5000; }";
       /* unknown rates */
   - Id: 27328
@@ -40412,7 +40412,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,25;
+      bonus bAtkRate,25;
       bonus2 bSubRace,RC_Demon,-5;
   - Id: 27335
     AegisName: Chaotic_Baphomet_Junior_Card
@@ -40670,7 +40670,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 27355
     AegisName: Contaminated_Raydric_Archer_Card
     Name: Contaminated Raydric Archer Card
@@ -41433,7 +41433,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,4;
+      bonus bAtkRate,4;
       bonus bHit,10;
   - Id: 29062
     AegisName: Mettle2
@@ -41442,7 +41442,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,8;
+      bonus bAtkRate,8;
       bonus bHit,20;
   - Id: 29063
     AegisName: Mettle3
@@ -41451,7 +41451,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,12;
+      bonus bAtkRate,12;
       bonus bHit,30;
   - Id: 29064
     AegisName: Mettle4
@@ -41460,7 +41460,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,16;
+      bonus bAtkRate,16;
       bonus bHit,40;
   - Id: 29065
     AegisName: Mettle5
@@ -41469,7 +41469,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,20;
+      bonus bAtkRate,20;
       bonus bHit,50;
   - Id: 29066
     AegisName: Mettle6
@@ -41478,7 +41478,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,24;
+      bonus bAtkRate,24;
       bonus bHit,60;
   - Id: 29067
     AegisName: Mettle7
@@ -41487,7 +41487,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,28;
+      bonus bAtkRate,28;
       bonus bHit,70;
   - Id: 29068
     AegisName: Mettle8
@@ -41496,7 +41496,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,32;
+      bonus bAtkRate,32;
       bonus bHit,80;
   - Id: 29069
     AegisName: Mettle9
@@ -41505,7 +41505,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,36;
+      bonus bAtkRate,36;
       bonus bHit,90;
   - Id: 29070
     AegisName: Mettle10
@@ -41514,7 +41514,7 @@ Body:
     SubType: Enchant
     Buy: 10
     Script: |
-      bonus2 bAddClass,Class_All,44;
+      bonus bAtkRate,44;
       bonus bHit,100;
   - Id: 29071
     AegisName: MagicEessence1
@@ -43491,7 +43491,7 @@ Body:
     SubType: Enchant
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (.@r>=7) {
          bonus bBaseAtk,25;
          if (.@r>=9) {
@@ -43655,7 +43655,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus bInt,50; bonus bMatkRate,15; bonus2 bAddClass,Class_All,-15; }",30,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
+      autobonus "{ bonus bInt,50; bonus bMatkRate,15; bonus bAtkRate,-15; }",30,10000,BF_MAGIC,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29549
     AegisName: Improve_Orb_L_DEX
     Name: Modification Orb(Firing Shot)
@@ -43669,7 +43669,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus bStr,50; bonus2 bAddClass,Class_All,15; bonus bMatkRate,-15; }",30,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
+      autobonus "{ bonus bStr,50; bonus bAtkRate,15; bonus bMatkRate,-15; }",30,10000,BF_NORMAL,"{ specialeffect2 EF_POTION_BERSERK; }";
   - Id: 29551
     AegisName: Improve_Orb_L_AGI
     Name: Modification Orb(Fatal Flash)
@@ -44085,7 +44085,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,2*(.@r/2);
       bonus bHit,3*(.@r/2);
-      bonus2 bAddClass,Class_All,(.@r/5);
+      bonus bAtkRate,(.@r/5);
   - Id: 29673
     AegisName: Time_Jewely_Str_2
     Name: Temporal Jewel (STR) Lv 2
@@ -44095,7 +44095,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,4*(.@r/2);
       bonus bHit,5*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/5);
+      bonus bAtkRate,2*(.@r/5);
   - Id: 29674
     AegisName: Time_Jewely_Str_3
     Name: Temporal Jewel (STR) Lv 3
@@ -44105,7 +44105,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bBaseAtk,7*(.@r/2);
       bonus bHit,7*(.@r/2);
-      bonus2 bAddClass,Class_All,3*(.@r/5);
+      bonus bAtkRate,3*(.@r/5);
   - Id: 29675
     AegisName: Time_Jewely_Agi_1
     Name: Temporal Jewel (AGI) Lv 1
@@ -44205,7 +44205,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,(.@r/2);
       bonus bHit,2*(.@r/2);
-      bonus2 bAddClass,Class_All,(.@r/5);
+      bonus bAtkRate,(.@r/5);
   - Id: 29685
     AegisName: Time_Jewely_Dex_2
     Name: Temporal Jewel (DEX) Lv 2
@@ -44215,7 +44215,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,2*(.@r/2);
       bonus bHit,5*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/5);
+      bonus bAtkRate,2*(.@r/5);
   - Id: 29686
     AegisName: Time_Jewely_Dex_3
     Name: Temporal Jewel (DEX) Lv 3
@@ -44225,7 +44225,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus2 bWeaponDamageRate,W_BOW,3*(.@r/2);
       bonus bHit,7*(.@r/2);
-      bonus2 bAddClass,Class_All,3*(.@r/5);
+      bonus bAtkRate,3*(.@r/5);
   - Id: 29687
     AegisName: Time_Jewely_Luk_1
     Name: Temporal Jewel (LUK) Lv 1
@@ -44235,7 +44235,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,3*(.@r/2);
       bonus bCritical,(.@r/2);
-      bonus2 bAddClass,Class_All,(.@r/5);
+      bonus bAtkRate,(.@r/5);
   - Id: 29688
     AegisName: Time_Jewely_Luk_2
     Name: Temporal Jewel (LUK) Lv 2
@@ -44245,7 +44245,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,6*(.@r/2);
       bonus bCritical,2*(.@r/2);
-      bonus2 bAddClass,Class_All,2*(.@r/5);
+      bonus bAtkRate,2*(.@r/5);
   - Id: 29689
     AegisName: Time_Jewely_Luk_3
     Name: Temporal Jewel (LUK) Lv 3
@@ -44255,7 +44255,7 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       bonus bCritAtkRate,9*(.@r/2);
       bonus bCritical,3*(.@r/2);
-      bonus2 bAddClass,Class_All,3*(.@r/5);
+      bonus bAtkRate,3*(.@r/5);
   - Id: 29706
     AegisName: Tenacity1
     Name: Tenacity Lv1
@@ -44597,7 +44597,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@r = getrefine()/2;
-      bonus2 bAddClass,Class_All,1+.@r;
+      bonus bAtkRate,1+.@r;
       bonus bMatkRate,1+.@r;
       bonus bMaxHPrate,-2*(1+.@r);
   - Id: 31018
@@ -44651,7 +44651,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       bonus bAspdRate,10;
-      bonus2 bAddClass,Class_All,-3;
+      bonus bAtkRate,-3;
   - Id: 31022
     AegisName: XM_Teddy_Bear_Card
     Name: Abandoned Teddy Bear Card
@@ -44690,7 +44690,7 @@ Body:
       BuyingStore: true
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus5 bAutoSpell,"RK_IGNITIONBREAK",5,20,BF_WEAPON,1;
   - Id: 31025
     AegisName: As_Wind_Ghost_Card
@@ -44927,7 +44927,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       bonus bUnbreakableArmor;
-      bonus2 bAddClass,Class_All,30;
+      bonus bAtkRate,30;
       bonus bMaxHPrate,-15;
   - Id: 300014
     AegisName: Ingrid_Card
@@ -44941,7 +44941,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       bonus bUnbreakableArmor;
-      bonus2 bAddClass,Class_All,-15;
+      bonus bAtkRate,-15;
       bonus bMaxHPrate,40;
       bonus2 bHPLossRate,1000,4000;
     UnEquipScript: |
@@ -44959,10 +44959,10 @@ Body:
       BuyingStore: true
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bMaxHPrate,-5;
       bonus bMaxSPrate,-5;
-      bonus2 bAddClass,Class_All,(getrefine()/4);
+      bonus bAtkRate,(getrefine()/4);
   - Id: 300016
     AegisName: Treasure_Mimic_Card
     Name: Treasure Mimic Card
@@ -45235,7 +45235,7 @@ Body:
     Script: |
       .@r = getrefine();
       if (getiteminfo(getequipid(EQI_HAND_R), ITEMINFO_VIEW) == W_BOOK) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
          bonus bHit,20;
       }
       bonus bShortAtkRate,.@r;
@@ -46034,7 +46034,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       bonus bMaxHPrate,-5;
-      bonus2 bAddClass,Class_All,(getrefine()/3);
+      bonus bAtkRate,(getrefine()/3);
   - Id: 300151
     AegisName: ILL_Kraken_Card
     Name: Deep Sea Kraken Card
@@ -46246,7 +46246,7 @@ Body:
     Flags:
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bLongAtkRate,7;
   - Id: 300185
     AegisName: MD_Geffen_Akuma_Card
@@ -46755,7 +46755,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       if (BaseJob == JOB_NOVICE) {
-         bonus2 bAddClass,Class_All,10;
+         bonus bAtkRate,10;
          bonus bMaxHP,1500;
       }
   - Id: 300243
@@ -47082,7 +47082,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (getiteminfo(getequipid(EQI_HAND_R),11) == W_1HSWORD || getiteminfo(getequipid(EQI_HAND_R),11) == W_2HSWORD || getiteminfo(getequipid(EQI_HAND_R),11) == W_DAGGER) {
          bonus bShortAtkRate,10+2*(.@r/3);
          if (BaseLevel>=200) {
@@ -47100,7 +47100,7 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       if (getiteminfo(getequipid(EQI_HAND_R),11) == W_1HSPEAR || getiteminfo(getequipid(EQI_HAND_R),11) == W_2HSPEAR) {
          bonus bLongAtkRate,10+2*(.@r/3);
          if (BaseLevel>=200) {
@@ -47237,9 +47237,9 @@ Body:
       DropEffect: CLIENT
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,-10+3*(.@r/3);
+      bonus bAtkRate,-10+3*(.@r/3);
       if (.@r>=11) {
-         bonus2 bAddClass,Class_All,5;
+         bonus bAtkRate,5;
       }
   - Id: 300275
     AegisName: aegis_300275
@@ -47773,12 +47773,12 @@ Body:
       .@r = getrefine();
       if (getrefine() < 12) {
         bonus bMaxHPrate,-30;
-        bonus2 bAddClass,Class_All,-10;
+        bonus bAtkRate,-10;
         bonus bMatkRate,-10;
       }
       else {
         bonus bMaxHPrate,30;
-        bonus2 bAddClass,Class_All,10;
+        bonus bAtkRate,10;
         bonus bMatkRate,10;
       }
       if (getequiparmorlv() == 2) {
@@ -47797,7 +47797,7 @@ Body:
       BuyingStore: true
       DropEffect: CLIENT
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bMatkRate,5;
       .@r = getrefine();
       bonus bPAtk,2*(.@r/3);
@@ -47992,7 +47992,7 @@ Body:
       bonus bStr,10;
       bonus bMdef,3;
       bonus bDef,25;
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 310077
     AegisName: Cassock_Agi
     Name: AGI Blessing
@@ -48095,7 +48095,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bStr,3;
   - Id: 310087
     AegisName: aegis_310087
@@ -48218,7 +48218,7 @@ Body:
     SubType: Enchant
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bBaseAtk,75;
       if (.@r>=9) {
          bonus bShortAtkRate,2;
@@ -48459,13 +48459,13 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMatkRate,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       if (.@r>=9) {
          bonus bMatkRate,3;
-         bonus2 bAddClass,Class_All,3;
+         bonus bAtkRate,3;
          if (.@r>=11) {
             bonus bMatkRate,4;
-            bonus2 bAddClass,Class_All,4;
+            bonus bAtkRate,4;
          }
       }
   - Id: 310118
@@ -48543,7 +48543,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus bShortAtkRate,10; bonus2 bAddClass,Class_All,15; bonus bStr,50; }",30,10000,BF_WEAPON;
+      autobonus "{ bonus bShortAtkRate,10; bonus bAtkRate,15; bonus bStr,50; }",30,10000,BF_WEAPON;
   - Id: 310125
     AegisName: aegis_310125
     Name: Automatic Orb(Fatal Flash)
@@ -49544,35 +49544,35 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
   - Id: 310198
     AegisName: aegis_310198
     Name: Anger Lv2
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 310199
     AegisName: aegis_310199
     Name: Anger Lv3
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 310200
     AegisName: aegis_310200
     Name: Anger Lv4
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 310201
     AegisName: aegis_310201
     Name: Anger Lv5
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 310202
     AegisName: aegis_310202
     Name: Horror Lv1
@@ -49689,35 +49689,35 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,1;
+      bonus bAtkRate,1;
   - Id: 310218
     AegisName: aegis_310218
     Name: Empathy Lv2
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 310219
     AegisName: aegis_310219
     Name: Empathy Lv3
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 310220
     AegisName: aegis_310220
     Name: Empathy Lv4
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
   - Id: 310221
     AegisName: aegis_310221
     Name: Empathy Lv5
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 310222
     AegisName: aegis_310222
     Name: Happiness Lv1
@@ -50566,7 +50566,7 @@ Body:
     SubType: Enchant
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bBaseAtk,25;
       if (.@r>=7) {
          bonus bShortAtkRate,3;
@@ -50619,7 +50619,7 @@ Body:
     SubType: Enchant
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,4;
+      bonus bAtkRate,4;
       bonus bBaseAtk,50;
       if (.@r>=7) {
          bonus bShortAtkRate,3;
@@ -50672,7 +50672,7 @@ Body:
     SubType: Enchant
     Script: |
       .@r = getrefine();
-      bonus2 bAddClass,Class_All,6;
+      bonus bAtkRate,6;
       bonus bBaseAtk,100;
       if (.@r>=7) {
          bonus bShortAtkRate,5;
@@ -50760,16 +50760,16 @@ Body:
     Script: |
       .@r = getrefine();
       bonus bMatkRate,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       if (.@r>=7) {
          bonus bMatkRate,2;
-         bonus2 bAddClass,Class_All,2;
+         bonus bAtkRate,2;
          if (.@r>=9) {
             bonus bMatkRate,2;
-            bonus2 bAddClass,Class_All,2;
+            bonus bAtkRate,2;
             if (.@r>=11) {
                bonus bMatkRate,4;
-               bonus2 bAddClass,Class_All,4;
+               bonus bAtkRate,4;
             }
          }
       }
@@ -52620,7 +52620,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus2 bAddClass,Class_All,25; bonus bVit,50; }",30,10000,BF_WEAPON;
+      autobonus "{ bonus bAtkRate,25; bonus bVit,50; }",30,10000,BF_WEAPON;
   - Id: 310610
     AegisName: Wolf_Orb_Sp_Int
     Name: Wolf Orb (Spell Buster)
@@ -53504,7 +53504,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
       bonus bHit,10;
   - Id: 310693
     AegisName: Star_Of_Mettle2
@@ -53512,7 +53512,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bHit,15;
   - Id: 310694
     AegisName: Star_Of_Mettle3
@@ -53520,7 +53520,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bHit,20;
       bonus bPAtk,1;
   - Id: 310695
@@ -53529,7 +53529,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
       bonus bHit,25;
       bonus bPAtk,2;
   - Id: 310696
@@ -53538,7 +53538,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,15;
+      bonus bAtkRate,15;
       bonus bHit,30;
       bonus bPAtk,4;
   - Id: 310697
@@ -53548,7 +53548,7 @@ Body:
     SubType: Enchant
     Script: |
       bonus bLongAtkRate,2;
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
   - Id: 310698
     AegisName: Star_Of_MasterArcher2
     Name: Star of Master Archer Lv2
@@ -53556,7 +53556,7 @@ Body:
     SubType: Enchant
     Script: |
       bonus bLongAtkRate,3;
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 310699
     AegisName: Star_Of_MasterArcher3
     Name: Star of Master Archer Lv3
@@ -53564,7 +53564,7 @@ Body:
     SubType: Enchant
     Script: |
       bonus bLongAtkRate,5;
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
       bonus bPAtk,1;
   - Id: 310700
     AegisName: Star_Of_MasterArcher4
@@ -53573,7 +53573,7 @@ Body:
     SubType: Enchant
     Script: |
       bonus bLongAtkRate,7;
-      bonus2 bAddClass,Class_All,6;
+      bonus bAtkRate,6;
       bonus bPAtk,2;
   - Id: 310701
     AegisName: Star_Of_MasterArcher5
@@ -53582,7 +53582,7 @@ Body:
     SubType: Enchant
     Script: |
       bonus bLongAtkRate,10;
-      bonus2 bAddClass,Class_All,7;
+      bonus bAtkRate,7;
       bonus bPAtk,4;
   - Id: 310702
     AegisName: Star_Of_Sharp1
@@ -54430,14 +54430,14 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus bAgi,100; bonus2 bAddClass,Class_All,10; }",5,10000,BF_WEAPON;
+      autobonus "{ bonus bAgi,100; bonus bAtkRate,10; }",5,10000,BF_WEAPON;
   - Id: 310914
     AegisName: HeroInsignia_STR
     Name: Strength
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,10;
+      bonus bAtkRate,10;
   - Id: 310915
     AegisName: HeroInsignia_LUK
     Name: Luck
@@ -54948,14 +54948,14 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,3;
+      bonus bAtkRate,3;
   - Id: 310987
     AegisName: ATK_2Lv
     Name: ATK 2Lv
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,5;
+      bonus bAtkRate,5;
   - Id: 310988
     AegisName: MATK_1Lv
     Name: MATK 1Lv
@@ -55159,7 +55159,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,15+5*getenchantgrade();
+      bonus bAtkRate,15+5*getenchantgrade();
   - Id: 311017
     AegisName: Gear_MATK
     Name: Clockwork (Matk)
@@ -56278,7 +56278,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,6;
+      bonus bAtkRate,6;
       bonus bBaseAtk,100;
       .@r = getrefine();
       if (.@r >= 7) {
@@ -56296,7 +56296,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,6;
+      bonus bAtkRate,6;
       bonus bBaseAtk,100;
       .@r = getrefine();
       if (.@r >= 7) {
@@ -56349,17 +56349,17 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      bonus2 bAddClass,Class_All,2;
+      bonus bAtkRate,2;
       bonus bMatkRate,2;
       .@r = getrefine();
       if (.@r >= 7) {
-        bonus2 bAddClass,Class_All,2;
+        bonus bAtkRate,2;
         bonus bMatkRate,2;
         if (.@r >= 9) {
-          bonus2 bAddClass,Class_All,2;
+          bonus bAtkRate,2;
           bonus bMatkRate,2;
           if (.@r >= 11) {
-            bonus2 bAddClass,Class_All,4;
+            bonus bAtkRate,4;
             bonus bMatkRate,4;
           }
         }
@@ -56636,7 +56636,7 @@ Body:
     Type: Card
     SubType: Enchant
     Script: |
-      autobonus "{ bonus2 bAddClass,Class_All,25; bonus bVit,50; }",30,10000,BF_WEAPON;
+      autobonus "{ bonus bAtkRate,25; bonus bVit,50; }",30,10000,BF_WEAPON;
   - Id: 311121
     AegisName: Ice_F_Orb_Sp_Int
     Name: Ice Magic Orb (Spell Buster)
@@ -59945,7 +59945,7 @@ Body:
       bonus bLongAtkRate,5*(.@r/3);
       bonus bShortAtkRate,5*(.@r/3);
       if (.@r>=9) {
-        bonus2 bAddClass,Class_All,10;
+        bonus bAtkRate,10;
         if (.@r>=11 ) {
           bonus bPAtk,5;
           .@i = getiteminfo(getequipid(EQI_HAND_R), ITEMINFO_VIEW);

--- a/db/re/item_randomopt_db.yml
+++ b/db/re/item_randomopt_db.yml
@@ -83,7 +83,7 @@ Body:
   - Id: 13
     Option: VAR_ATKPERCENT
     Script: |
-      bonus2 bAddClass,Class_All,getrandomoptinfo(ROA_VALUE);
+      bonus bAtkRate,getrandomoptinfo(ROA_VALUE);
   - Id: 14
     Option: VAR_MAGICATKPERCENT
     Script: |

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -42474,7 +42474,7 @@ Body:
         - Level: 10
           Amount: 16
       SpCost: 30
-    Status: Watk_Element
+    Status: Sub_Weaponproperty
   - Id: 8203
     Name: MS_BOWLINGBASH
     Description: Bowling_Bash

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -8131,3 +8131,12 @@ Body:
       All: true
     Flags:
       RemoveElementalOption: true
+  - Status: Sub_Weaponproperty
+    Flags:
+      NoBanishingBuster: true
+      NoDispell: true
+      NoClearance: true
+      NoRemoveOnDead: true
+      NoClearbuff: true
+    End:
+      Sub_Weaponproperty: true

--- a/doc/item_bonus.txt
+++ b/doc/item_bonus.txt
@@ -125,7 +125,7 @@ Atk/Def
 bonus bBaseAtk,n;  			Basic attack power + n
 bonus bAtk,n;      			ATK + n (unofficial)
 bonus bAtk2,n;     			ATK2 + n
-bonus bAtkRate,n;  			Attack power + n% (unofficial)
+bonus bAtkRate,n;  			ATK + n% that won't interfere with Damage modifier and SC_EDP (renewal mode only)
 bonus bWeaponAtkRate,n; 	Weapon ATK + n%
 bonus bMatk,n;     			Magical attack power + n
 bonus bMatkRate,n; 			Magical attack power + n%

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3494,10 +3494,7 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 		critical = true;
 
 	wd->weaponAtk += battle_calc_base_weapon_attack(src, tstatus, &sstatus->rhw, sd, critical);
-	wd->weaponAtk = battle_attr_fix(src, target, wd->weaponAtk, right_element, tstatus->def_ele, tstatus->ele_lv);
-
 	wd->weaponAtk2 += battle_calc_base_weapon_attack(src, tstatus, &sstatus->lhw, sd, critical);
-	wd->weaponAtk2 = battle_attr_fix(src, target, wd->weaponAtk2, left_element, tstatus->def_ele, tstatus->ele_lv);
 
 	// Weapon ATK gain bonus from SC_SUB_WEAPONPROPERTY here ( +x% pseudo element damage)
 	if (sd && sd->sc.data[SC_SUB_WEAPONPROPERTY]) {
@@ -3509,6 +3506,9 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 		wd->weaponAtk += bonus_atk;
 		wd->weaponAtk2 += bonus_atk2;
 	}
+
+	wd->weaponAtk = battle_attr_fix(src, target, wd->weaponAtk, right_element, tstatus->def_ele, tstatus->ele_lv);
+	wd->weaponAtk2 = battle_attr_fix(src, target, wd->weaponAtk2, left_element, tstatus->def_ele, tstatus->ele_lv);
 
 	wd->equipAtk += battle_calc_equip_attack(src, skill_id);
 	wd->equipAtk = battle_attr_fix(src, target, wd->equipAtk, right_element, tstatus->def_ele, tstatus->ele_lv);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6018,15 +6018,17 @@ static void battle_calc_attack_gvg_bg(struct Damage* wd, struct block_list *src,
 				wd->damage2 = battle_calc_bg_damage(src,target,wd->damage2,skill_id,wd->flag);
 		}
 		else {
-			int64 d1 = wd->damage + wd->damage2,d2 = wd->damage2;
-			wd->damage = battle_calc_damage(src,target,wd,d1,skill_id,skill_lv);
-			if( mapdata_flag_gvg2(mapdata) )
-				wd->damage = battle_calc_gvg_damage(src,target,wd->damage,skill_id,wd->flag);
-			else if( mapdata->flag[MF_BATTLEGROUND] )
-				wd->damage = battle_calc_bg_damage(src,target,wd->damage,skill_id,wd->flag);
-			wd->damage2 = (int64)d2*100/d1 * wd->damage/100;
+			wd->damage = battle_calc_damage(src, target, wd, wd->damage, skill_id, skill_lv);
+			wd->damage2 = battle_calc_damage(src, target, wd, wd->damage2, skill_id, skill_lv);
+			if (mapdata_flag_gvg2(mapdata)) {
+				wd->damage = battle_calc_gvg_damage(src, target, wd->damage, skill_id, wd->flag);
+				wd->damage2 = battle_calc_gvg_damage(src, target, wd->damage2, skill_id, wd->flag);
+			}
+			else if (mapdata->flag[MF_BATTLEGROUND]) {
+				wd->damage = battle_calc_bg_damage(src, target, wd->damage, skill_id, wd->flag);
+				wd->damage2 = battle_calc_bg_damage(src, target, wd->damage2, skill_id, wd->flag);
+			}
 			if(wd->damage > 1 && wd->damage2 < 1) wd->damage2 = 1;
-			wd->damage-=wd->damage2;
 		}
 	}
 }

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6410,21 +6410,20 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	}
 
 	std::bitset<NK_MAX> nk = battle_skill_get_damage_properties(skill_id, wd.miscflag);
-	int i = 0;
 
 	// check if we're landing a hit
 	if(!is_attack_hitting(&wd, src, target, skill_id, skill_lv, true))
 		wd.dmg_lv = ATK_FLEE;
 	else if(!(infdef = is_infinite_defense(target, wd.flag))) { //no need for math against plants
-		int64 ratio = 0;
 
 		battle_calc_skill_base_damage(&wd, src, target, skill_id, skill_lv); // base skill damage
+
+		int64 ratio = 0;
 
 #ifndef RENEWAL
 		ratio = battle_calc_attack_skill_ratio(&wd, src, target, skill_id, skill_lv); // skill level ratios
 
 		ATK_RATE(wd.damage, wd.damage2, ratio);
-		RE_ALLATK_RATE(&wd, ratio);
 #endif
 
 		int64 bonus_damage = battle_calc_skill_constant_addition(&wd, src, target, skill_id, skill_lv); // other skill bonuses
@@ -6444,6 +6443,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 #ifndef RENEWAL
 		// add any miscellaneous player ATK bonuses
+		int i = 0;
 		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
 			ATK_ADDRATE(wd.damage, wd.damage2, i);
 			RE_ALLATK_ADDRATE(&wd, i);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6441,9 +6441,10 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		}
 #endif
 
+int i = 0;
+
 #ifndef RENEWAL
 		// add any miscellaneous player ATK bonuses
-		int i = 0;
 		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
 			ATK_ADDRATE(wd.damage, wd.damage2, i);
 			RE_ALLATK_ADDRATE(&wd, i);
@@ -6568,7 +6569,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 #ifdef RENEWAL
 	// add any miscellaneous player ATK bonuses
-	int i = 0;
 	if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
 		ATK_ADDRATE(wd.damage, wd.damage2, i);
 		RE_ALLATK_ADDRATE(&wd, i);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6568,6 +6568,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 #ifdef RENEWAL
 	// add any miscellaneous player ATK bonuses
+	int i = 0;
 	if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
 		ATK_ADDRATE(wd.damage, wd.damage2, i);
 		RE_ALLATK_ADDRATE(&wd, i);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6447,11 +6447,9 @@ int i = 0;
 		// add any miscellaneous player ATK bonuses
 		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
 			ATK_ADDRATE(wd.damage, wd.damage2, i);
-			RE_ALLATK_ADDRATE(&wd, i);
 		}
 		if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id))) {
 			ATK_ADDRATE(wd.damage, wd.damage2, -i);
-			RE_ALLATK_ADDRATE(&wd, -i);
 		}
 #endif
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6444,12 +6444,10 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 #ifndef RENEWAL
 		// add any miscellaneous player ATK bonuses
-		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
+		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id)))
 			ATK_ADDRATE(wd.damage, wd.damage2, i);
-		}
-		if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id))) {
+		if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id)))
 			ATK_ADDRATE(wd.damage, wd.damage2, -i);
-		}
 #endif
 
 #ifdef RENEWAL
@@ -6516,9 +6514,8 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		// Advance Katar Mastery
 		if (sd) {
 			int skill = 0;
-			if (sd->status.weapon == W_KATAR && (skill = pc_checkskill(sd, ASC_KATAR)) > 0) { // Adv. Katar Mastery applied after calculate with skillratio.
+			if (sd->status.weapon == W_KATAR && (skill = pc_checkskill(sd, ASC_KATAR)) > 0) // Adv. Katar Mastery applied after calculate with skillratio.
 				ATK_ADDRATE(wd.damage, wd.damage2, (10 + 2 * skill));
-			}
 		}
 
 		// Res reduces physical damage by a percentage and
@@ -6585,15 +6582,13 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	if (is_attack_critical(&wd, src, target, skill_id, skill_lv, false)) {
 		if (sd) { //Check for player so we don't crash out, monsters don't have bonus crit rates [helvetica]
 			wd.damage = (int64)floor((float)((wd.damage * (1.4f + (0.01f * sstatus->crate)))));
-			if (is_attack_left_handed(src, skill_id)) {
+			if (is_attack_left_handed(src, skill_id))
 				wd.damage2 = (int64)floor((float)((wd.damage2 * (1.4f + (0.01f * sstatus->crate)))));
-			}
 		} else
 			wd.damage = (int64)floor((float)(wd.damage * 1.4f));
 
-		if (tsd && tsd->bonus.crit_def_rate != 0) {
+		if (tsd && tsd->bonus.crit_def_rate != 0)
 			ATK_ADDRATE(wd.damage, wd.damage2, -tsd->bonus.crit_def_rate);
-		}
 	}
 #endif
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6410,6 +6410,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	}
 
 	std::bitset<NK_MAX> nk = battle_skill_get_damage_properties(skill_id, wd.miscflag);
+	int i = 0;
 
 	// check if we're landing a hit
 	if(!is_attack_hitting(&wd, src, target, skill_id, skill_lv, true))
@@ -6440,8 +6441,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				ATK_ADD(wd.weaponAtk, wd.weaponAtk2, sstatus->matk_min);
 		}
 #endif
-
-int i = 0;
 
 #ifndef RENEWAL
 		// add any miscellaneous player ATK bonuses

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6410,7 +6410,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 	}
 
 	std::bitset<NK_MAX> nk = battle_skill_get_damage_properties(skill_id, wd.miscflag);
-	int i = 0;
 
 	// check if we're landing a hit
 	if(!is_attack_hitting(&wd, src, target, skill_id, skill_lv, true))
@@ -6441,6 +6440,8 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 				ATK_ADD(wd.weaponAtk, wd.weaponAtk2, sstatus->matk_min);
 		}
 #endif
+
+		int i = 0;
 
 #ifndef RENEWAL
 		// add any miscellaneous player ATK bonuses
@@ -6559,19 +6560,19 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 			battle_calc_attack_post_defense(&wd, src, target, skill_id, skill_lv);
 		}
-	}
 
 #ifdef RENEWAL
-	// add any miscellaneous player ATK bonuses
-	if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
-		ATK_ADDRATE(wd.damage, wd.damage2, i);
-		RE_ALLATK_ADDRATE(&wd, i);
-	}
-	if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id))) {
-		ATK_ADDRATE(wd.damage, wd.damage2, -i);
-		RE_ALLATK_ADDRATE(&wd, -i);
-	}
+		// add any miscellaneous player ATK bonuses
+		if( sd && skill_id && (i = pc_skillatk_bonus(sd, skill_id))) {
+			ATK_ADDRATE(wd.damage, wd.damage2, i);
+			RE_ALLATK_ADDRATE(&wd, i);
+		}
+		if (tsd && (i = pc_sub_skillatk_bonus(tsd, skill_id))) {
+			ATK_ADDRATE(wd.damage, wd.damage2, -i);
+			RE_ALLATK_ADDRATE(&wd, -i);
+		}
 #endif
+	}
 
 	battle_calc_element_damage(&wd, src, target, skill_id, skill_lv);
 

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -72,7 +72,7 @@ enum e_battle_check_target : uint32 {
 /// Damage structure
 struct Damage {
 #ifdef RENEWAL
-	int64 statusAtk, statusAtk2, weaponAtk, weaponAtk2, equipAtk, equipAtk2, masteryAtk, masteryAtk2;
+	int64 statusAtk, statusAtk2, weaponAtk, weaponAtk2, equipAtk, equipAtk2, masteryAtk, masteryAtk2, percentAtk, percentAtk2;
 #endif
 	int64 damage, /// Right hand damage
 		damage2; /// Left hand damage

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -1840,6 +1840,7 @@
 	export_constant(SC_DEEP_POISONING_OPTION);
 	export_constant(SC_POISON_SHIELD);
 	export_constant(SC_POISON_SHIELD_OPTION);
+	export_constant(SC_SUB_WEAPONPROPERTY);
 
 #ifdef RENEWAL
 	export_constant(SC_EXTREMITYFIST2);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7485,7 +7485,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			src,skill_id,skill_lv,tick, flag|BCT_ENEMY|1, skill_castend_damage_id);
 		clif_skill_nodamage (src,src,skill_id,skill_lv,1);
 		// Initiate 20% of your damage becomes fire element.
+#ifdef RENEWAL
+		sc_start4(src,src,SC_SUB_WEAPONPROPERTY,100,3,20,skill_id,0,skill_get_time2(skill_id, skill_lv));
+#else
 		sc_start4(src,src,SC_WATK_ELEMENT,100,3,20,0,0,skill_get_time2(skill_id, skill_lv));
+#endif
 		break;
 
 	case TK_JUMPKICK:
@@ -7552,7 +7556,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case HW_MAGICPOWER:
 	case PF_MEMORIZE:
 	case PA_SACRIFICE:
+#ifndef RENEWAL
 	case ASC_EDP:
+#endif
 	case PF_DOUBLECASTING:
 	case SG_SUN_COMFORT:
 	case SG_MOON_COMFORT:
@@ -7642,6 +7648,15 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,
 			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
 		break;
+
+#ifdef RENEWAL
+	// EDP also give +25% WATK poison pseudo element to user.
+	case ASC_EDP:
+		clif_skill_nodamage(src,bl,skill_id,skill_lv,
+			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
+		sc_start4(src,src,SC_SUB_WEAPONPROPERTY,100,5,25,skill_id,0,skill_get_time2(skill_id, skill_lv));
+		break;
+#endif
 
 	case LG_SHIELDSPELL:
 		if (skill_lv == 1)

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -11911,6 +11911,16 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_DEEP_POISONING_OPTION:
 			val3 = ELE_POISON;
 			break;
+		case SC_SUB_WEAPONPROPERTY:
+			if (sd && val3 == ASC_EDP) {
+				uint16 poison_level = pc_checkskill(sd, GC_RESEARCHNEWPOISON);
+
+				if (poison_level > 0) {
+					tick += 30000; // Base of 30 seconds
+					tick += poison_level * 15 * 1000; // Additional 15 seconds per level
+				}
+			}
+			break;
 
 		default:
 			if (calc_flag.none() && scdb->skill_id == 0 && scdb->icon == EFST_BLANK && scdb->opt1 == OPT1_NONE && scdb->opt2 == OPT2_NONE && scdb->state.none() && scdb->flag.none() && scdb->end.empty() && scdb->endreturn.empty() && scdb->fail.empty()) {

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -1174,6 +1174,8 @@ enum sc_type : int16 {
 	SC_POISON_SHIELD,
 	SC_POISON_SHIELD_OPTION,
 
+	SC_SUB_WEAPONPROPERTY,
+
 #ifdef RENEWAL
 	SC_EXTREMITYFIST2, //! NOTE: This SC should be right before SC_MAX, so it doesn't disturb if RENEWAL is disabled
 #endif


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: correction order and formula of calculation physical damage in renewal.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- add new itembonus ATK%  ( It's called VAR_ATKPERCENT in aegis )
- correction order of calculation of physical attack
- fix skill EDP that give 25% poison pseudo elemental bonus to user. also Magnum break that give 20% fire pseudo elemental damage.
- correction advance katar mastery bonus.
- fix critical damage to always do max-variance attack same as Maximize power buff.

- [x] Correction item-script of many items/combo from bAddClass,Class_All  to bAtkRate according to aegis.
- [ ] Test & Review.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
