### PR TITLE
Allow Skill Damage Adjustments account for reflect

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8357,6 +8357,14 @@ int64 battle_calc_return_damage(struct block_list* tbl, struct block_list *src, 
 			rdamage = damage * tsc->data[SC_MAXPAIN]->val1 * 10 / 100;
 	}
 
+	// Skill damage adjustment
+	int skill_damage = battle_skill_damage(src, tbl, skill_id);
+
+	if (skill_damage != 0) {
+		rdamage += rdamage * skill_damage / 100;
+		rdamage = i64max(rdamage, 1);
+	}
+
 	if (rdamage == 0)
 		return 0; // No reflecting damage calculated.
 	else

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1808,22 +1808,8 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 	} //End of caster SC_ check
 
 	//PK damage rates
-	if (battle_config.pk_mode && sd && bl->type == BL_PC && damage && map_getmapflag(bl->m, MF_PVP)) {
-		if (flag & BF_SKILL) { //Skills get a different reduction than non-skills. [Skotlex]
-			if (flag&BF_WEAPON)
-				damage = damage * battle_config.pk_weapon_damage_rate / 100;
-			if (flag&BF_MAGIC)
-				damage = damage * battle_config.pk_magic_damage_rate / 100;
-			if (flag&BF_MISC)
-				damage = damage * battle_config.pk_misc_damage_rate / 100;
-		} else { //Normal attacks get reductions based on range.
-			if (flag & BF_SHORT)
-				damage = damage * battle_config.pk_short_damage_rate / 100;
-			if (flag & BF_LONG)
-				damage = damage * battle_config.pk_long_damage_rate / 100;
-		}
-		damage = i64max(damage,1);
-	}
+	if (map_getmapflag(bl->m, MF_PVP) > 0)
+		damage = battle_calc_pk_damage(*src, *bl, damage, skill_id, flag);
 
 	if(battle_config.skill_min_damage && damage > 0 && damage < div_) {
 		if ((flag&BF_WEAPON && battle_config.skill_min_damage&1)
@@ -2002,6 +1988,41 @@ int64 battle_calc_gvg_damage(struct block_list *src,struct block_list *bl,int64 
 	}
 	damage = i64max(damage,1);
 	return damage;
+}
+
+/**
+ * Calculates PK related damage adjustments (between players only).
+ * @param src: Source object
+ * @param bl: Target object
+ * @param damage: Damage being done
+ * @param skill_id: Skill used
+ * @param flag: Battle flag type
+ * @return Modified damage
+ */
+int64 battle_calc_pk_damage(block_list &src, block_list &bl, int64 damage, uint16 skill_id, int flag) {
+	if (damage == 0) // No reductions to make.
+		return 0;
+
+	if (battle_config.pk_mode == 0) // PK mode is disabled.
+		return damage;
+
+	if (src.type == BL_PC && bl.type == BL_PC) {
+		if (flag & BF_SKILL) { //Skills get a different reduction than non-skills. [Skotlex]
+			if (flag & BF_WEAPON)
+				damage = damage * battle_config.pk_weapon_damage_rate / 100;
+			if (flag & BF_MAGIC)
+				damage = damage * battle_config.pk_magic_damage_rate / 100;
+			if (flag & BF_MISC)
+				damage = damage * battle_config.pk_misc_damage_rate / 100;
+		} else { //Normal attacks get reductions based on range.
+			if (flag & BF_SHORT)
+				damage = damage * battle_config.pk_short_damage_rate / 100;
+			if (flag & BF_LONG)
+				damage = damage * battle_config.pk_long_damage_rate / 100;
+		}
+	}
+
+	return i64max(damage, 1);
 }
 
 /**
@@ -8356,6 +8377,16 @@ int64 battle_calc_return_damage(struct block_list* tbl, struct block_list *src, 
 		if (tsc->data[SC_MAXPAIN])
 			rdamage = damage * tsc->data[SC_MAXPAIN]->val1 * 10 / 100;
 	}
+
+	// Config damage adjustment
+	map_data *mapdata = map_getmapdata(src->m);
+
+	if (mapdata_flag_gvg2(mapdata))
+		rdamage = battle_calc_gvg_damage(src, tbl, rdamage, skill_id, flag);
+	else if (mapdata->flag[MF_BATTLEGROUND])
+		rdamage = battle_calc_bg_damage(src, tbl, rdamage, skill_id, flag);
+	else if (mapdata->flag[MF_PVP])
+		rdamage = battle_calc_pk_damage(*src, *tbl, rdamage, skill_id, flag);
 
 	// Skill damage adjustment
 	int skill_damage = battle_skill_damage(src, tbl, skill_id);

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -102,6 +102,7 @@ int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_li
 int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Damage *d,int64 damage,uint16 skill_id,uint16 skill_lv);
 int64 battle_calc_gvg_damage(struct block_list *src,struct block_list *bl,int64 damage,uint16 skill_id,int flag);
 int64 battle_calc_bg_damage(struct block_list *src,struct block_list *bl,int64 damage,uint16 skill_id,int flag);
+int64 battle_calc_pk_damage(block_list &src, block_list &bl, int64 damage, uint16 skill_id, int flag);
 
 void battle_damage(struct block_list *src, struct block_list *target, int64 damage, t_tick delay, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, unsigned short attack_type, bool additional_effects, t_tick tick, bool spdamage);
 int battle_delay_damage (t_tick tick, int amotion, struct block_list *src, struct block_list *target, int attack_type, uint16 skill_id, uint16 skill_lv, int64 damage, enum damage_lv dmg_lv, t_tick ddelay, bool additional_effects, bool spdamage);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4455 and fixes #6274

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Reflected damage will now take into account if a skill has a modified damage ratio from skill_damage_db.
  * Includes the GvG, Battlegrounds, and PK damage config adjustments as well.
Thanks to @imaqtdan!