### PR TITLE
Player skills no longer proc equip break on mobs

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -167,3 +167,8 @@ warg_can_falcon: no
 // Should the target be able of dodging damage by snapping away to the edge of the screen?
 // Official behavior is "no"
 snap_dodge: no
+
+// Grant player skills/items the ability to "break" non-player equipment. (Note 1)
+// This will effectively apply the strip equip effect to the non-player target.
+// Official: no
+break_mob_equip: no

--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -170,5 +170,6 @@ snap_dodge: no
 
 // Grant player skills/items the ability to "break" non-player equipment. (Note 1)
 // This will effectively apply the strip equip effect to the non-player target.
+// NOTE: WS_MELTDOWN is exempt from this check when disabled.
 // Official: no
 break_mob_equip: no

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10126,6 +10126,7 @@ static const struct _battle_data {
 
 	{ "feature.barter",                     &battle_config.feature_barter,                  1,      0,      1,              },
 	{ "feature.barter_extended",            &battle_config.feature_barter_extended,         1,      0,      1,              },
+	{ "break_mob_equip",                    &battle_config.break_mob_equip,                 0,      0,      1,              },
 
 #include "../custom/battle_config_init.inc"
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -710,6 +710,7 @@ struct Battle_Config
 
 	int feature_barter;
 	int feature_barter_extended;
+	int break_mob_equip;
 
 #include "../custom/battle_config_struct.inc"
 };

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2218,29 +2218,23 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		}
 		if( battle_config.equip_skill_break_rate && skill_id != WS_CARTTERMINATION && skill_id != ITM_TOMAHAWK )
 		{	// Cart Termination/Tomahawk won't trigger breaking data. Why? No idea, go ask Gravity.
-			int break_flag = BCT_ENEMY;
-
 			// Target weapon breaking
 			rate = 0;
 			if( sd )
 				rate += sd->bonus.break_weapon_rate;
-			if( sc && sc->data[SC_MELTDOWN] ) {
+			if( sc && sc->data[SC_MELTDOWN] )
 				rate += sc->data[SC_MELTDOWN]->val2;
-				break_flag |= 1;
-			}
 			if( rate )
-				skill_break_equip(src,bl, EQP_WEAPON, rate, break_flag);
+				skill_break_equip(src,bl, EQP_WEAPON, rate, BCT_ENEMY);
 
 			// Target armor breaking
 			rate = 0;
 			if( sd )
 				rate += sd->bonus.break_armor_rate;
-			if( sc && sc->data[SC_MELTDOWN] ) {
+			if( sc && sc->data[SC_MELTDOWN] )
 				rate += sc->data[SC_MELTDOWN]->val3;
-				break_flag |= 1;
-			}
 			if( rate )
-				skill_break_equip(src,bl, EQP_ARMOR, rate, break_flag);
+				skill_break_equip(src,bl, EQP_ARMOR, rate, BCT_ENEMY);
 		}
 		if (sd && !skill_id && bl->type == BL_PC) { // This effect does not work with skills.
 			if (sd->def_set_race[tstatus->race].rate)
@@ -2700,12 +2694,14 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
  - rate goes from 0 to 10000 (100.00%)
  - flag is a BCT_ flag to indicate which type of adjustment should be used
    (BCT_ENEMY/BCT_PARTY/BCT_SELF) are the valid values.
-   &1 - flag is used for WS_MELTDOWN which bypasses non-player check.
 --------------------------------------------------------------------------*/
 int skill_break_equip(struct block_list *src, struct block_list *bl, unsigned short where, int rate, int flag)
 {
+	status_change *src_sc = status_get_sc(src);
+
 	// Grant player skills/items the ability to "break" non-player equipment.
-	if (!battle_config.break_mob_equip && bl->type != BL_PC && !(flag & 1))
+	// WS_MELTDOWN is exempt from this check.
+	if (!battle_config.break_mob_equip && bl->type != BL_PC && !(src_sc && src_sc->data[SC_MELTDOWN]))
 		return 0;
 
 	const int where_list[6]     = { EQP_WEAPON, EQP_ARMOR, EQP_SHIELD, EQP_HELM, EQP_ACC, EQP_SHADOW_GEAR };

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2697,6 +2697,10 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 --------------------------------------------------------------------------*/
 int skill_break_equip(struct block_list *src, struct block_list *bl, unsigned short where, int rate, int flag)
 {
+	// Grant player skills/items the ability to "break" non-player equipment.
+	if (!battle_config.break_mob_equip)
+		return 0;
+
 	const int where_list[6]     = { EQP_WEAPON, EQP_ARMOR, EQP_SHIELD, EQP_HELM, EQP_ACC, EQP_SHADOW_GEAR };
 	const enum sc_type scatk[6] = { SC_STRIPWEAPON, SC_STRIPARMOR, SC_STRIPSHIELD, SC_STRIPHELM, SC__STRIPACCESSORY, SC_SHADOW_STRIP };
 	const enum sc_type scdef[6] = { SC_CP_WEAPON, SC_CP_ARMOR, SC_CP_SHIELD, SC_CP_HELM, SC_NONE, SC_PROTECTSHADOWEQUIP };

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2218,23 +2218,29 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		}
 		if( battle_config.equip_skill_break_rate && skill_id != WS_CARTTERMINATION && skill_id != ITM_TOMAHAWK )
 		{	// Cart Termination/Tomahawk won't trigger breaking data. Why? No idea, go ask Gravity.
+			int break_flag = BCT_ENEMY;
+
 			// Target weapon breaking
 			rate = 0;
 			if( sd )
 				rate += sd->bonus.break_weapon_rate;
-			if( sc && sc->data[SC_MELTDOWN] )
+			if( sc && sc->data[SC_MELTDOWN] ) {
 				rate += sc->data[SC_MELTDOWN]->val2;
+				break_flag |= 1;
+			}
 			if( rate )
-				skill_break_equip(src,bl, EQP_WEAPON, rate, BCT_ENEMY);
+				skill_break_equip(src,bl, EQP_WEAPON, rate, break_flag);
 
 			// Target armor breaking
 			rate = 0;
 			if( sd )
 				rate += sd->bonus.break_armor_rate;
-			if( sc && sc->data[SC_MELTDOWN] )
+			if( sc && sc->data[SC_MELTDOWN] ) {
 				rate += sc->data[SC_MELTDOWN]->val3;
+				break_flag |= 1;
+			}
 			if( rate )
-				skill_break_equip(src,bl, EQP_ARMOR, rate, BCT_ENEMY);
+				skill_break_equip(src,bl, EQP_ARMOR, rate, break_flag);
 		}
 		if (sd && !skill_id && bl->type == BL_PC) { // This effect does not work with skills.
 			if (sd->def_set_race[tstatus->race].rate)
@@ -2694,11 +2700,12 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
  - rate goes from 0 to 10000 (100.00%)
  - flag is a BCT_ flag to indicate which type of adjustment should be used
    (BCT_ENEMY/BCT_PARTY/BCT_SELF) are the valid values.
+   &1 - flag is used for WS_MELTDOWN which bypasses non-player check.
 --------------------------------------------------------------------------*/
 int skill_break_equip(struct block_list *src, struct block_list *bl, unsigned short where, int rate, int flag)
 {
 	// Grant player skills/items the ability to "break" non-player equipment.
-	if (!battle_config.break_mob_equip)
+	if (!battle_config.break_mob_equip && bl->type != BL_PC && !(flag & 1))
 		return 0;
 
 	const int where_list[6]     = { EQP_WEAPON, EQP_ARMOR, EQP_SHIELD, EQP_HELM, EQP_ACC, EQP_SHADOW_GEAR };


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #5906

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Player skills (except for WS_MELTDOWN) and items that have the ability to break a target's equipment will no longer "break" a non-player's equipment.
  * Adds a battle config to toggle the behavior.
Thanks to @Tydus1 and @Xelliekins!