### PR TITLE
Fixes an item comparison check when loading chars

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -629,9 +629,8 @@ int char_memitemdata_to_sql(const struct item items[], int max, int id, enum sto
 				continue;
 
 			if( items[i].nameid == item.nameid
-			&&  items[i].card[0] == item.card[0]
-			&&  items[i].card[2] == item.card[2]
-			&&  items[i].card[3] == item.card[3]
+			&& (memcmp(items[i].card, item.card, sizeof(int) * MAX_SLOTS) == 0)
+			&& (memcmp(items[i].option, item.option, 5 * MAX_ITEM_RDM_OPT) == 0)
 			&&  items[i].unique_id == item.unique_id
 			) {	//They are the same item.
 				int k;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #4933

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds a missing card slot check when validating items during character loading.
  * Also adds the random options to the check.
Thanks to @lukasrmattos!