### PR TITLE
Implements petautobonus script commands

### DIFF
--- a/db/re/pet_db.yml
+++ b/db/re/pet_db.yml
@@ -877,9 +877,9 @@ Body:
       .@i = getpetinfo(PETINFO_INTIMATE);
       
       if (.@i >= PET_INTIMATE_LOYAL) {
-        autobonus "{ bonus2 bSubEle,Ele_Neutral,2; heal 100,0; }",100,5000,BF_SHORT|BF_NORMAL;
+        petautobonus "{ bonus2 bSubEle,Ele_Neutral,2; heal 100,0; }",100,5000,BF_SHORT|BF_NORMAL;
       } else if (.@i >= PET_INTIMATE_CORDIAL) {
-        autobonus "{ bonus2 bSubEle,Ele_Neutral,2; heal 100,0; }",100,3000,BF_SHORT|BF_NORMAL;
+        petautobonus "{ bonus2 bSubEle,Ele_Neutral,2; heal 100,0; }",100,3000,BF_SHORT|BF_NORMAL;
       }
   - Mob: MEDUSA
     TameItem: Splendid_Mirror
@@ -1511,15 +1511,15 @@ Body:
       if (.@i >= PET_INTIMATE_LOYAL) {
         bonus bCritical,6;
         bonus bHit,6;
-        autobonus "{ bonus2 bHPRegenRate,500,1000; bonus2 bSPRegenRate,20,1000; }",30,5000,BF_WEAPON|BF_SHORT;
+        petautobonus "{ bonus2 bHPRegenRate,500,1000; bonus2 bSPRegenRate,20,1000; }",30,5000,BF_WEAPON|BF_SHORT;
       } else if (.@i >= PET_INTIMATE_CORDIAL) {
         bonus bCritical,5;
         bonus bHit,5;
-        autobonus "{ bonus2 bHPRegenRate,400,1000; bonus2 bSPRegenRate,10,1000; }",30,5000,BF_WEAPON|BF_SHORT;
+        petautobonus "{ bonus2 bHPRegenRate,400,1000; bonus2 bSPRegenRate,10,1000; }",30,5000,BF_WEAPON|BF_SHORT;
       } else if (.@i >= PET_INTIMATE_NEUTRAL) {
         bonus bCritical,4;
         bonus bHit,4;
-        autobonus "{ bonus2 bHPRegenRate,300,1000; }",20,5000,BF_WEAPON|BF_SHORT;
+        petautobonus "{ bonus2 bHPRegenRate,300,1000; }",20,5000,BF_WEAPON|BF_SHORT;
       } else {
         bonus bCritical,3;
         bonus bHit,3;
@@ -1667,11 +1667,11 @@ Body:
       if (.@i >= PET_INTIMATE_LOYAL) {
         bonus bCritical,5;
         bonus bHit,5;
-        autobonus "{ bonus2 bHPRegenRate,400,1000; }",20,5000,BF_WEAPON|BF_SHORT;
+        petautobonus "{ bonus2 bHPRegenRate,400,1000; }",20,5000,BF_WEAPON|BF_SHORT;
       } else if (.@i >= PET_INTIMATE_CORDIAL) {
         bonus bCritical,4;
         bonus bHit,4;
-        autobonus "{ bonus2 bHPRegenRate,300,1000; }",20,5000,BF_WEAPON|BF_SHORT;
+        petautobonus "{ bonus2 bHPRegenRate,300,1000; }",20,5000,BF_WEAPON|BF_SHORT;
       } else if (.@i >= PET_INTIMATE_NEUTRAL) {
         bonus bCritical,3;
         bonus bHit,3;
@@ -1780,10 +1780,10 @@ Body:
       
       if (.@i >= PET_INTIMATE_LOYAL) {
         bonus bMaxSP,150;
-        autobonus "{ bonus2 bSPRegenRate,40,1000; }",30,5000,BF_MAGIC;
+        petautobonus "{ bonus2 bSPRegenRate,40,1000; }",30,5000,BF_MAGIC;
       } else if (.@i >= PET_INTIMATE_CORDIAL) {
         bonus bMaxSP,150;
-        autobonus "{ bonus2 bSPRegenRate,30,1000; }",30,5000,BF_MAGIC;
+        petautobonus "{ bonus2 bSPRegenRate,30,1000; }",30,5000,BF_MAGIC;
       } else if (.@i >= PET_INTIMATE_NEUTRAL) {
         bonus bMaxSP,100;
       } else {

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6117,9 +6117,7 @@ kind in 'doc/item_bonus.txt'.
 *autobonus3 <bonus script>,<rate>,<duration>,<skill id>,{<other script>};
 *autobonus3 <bonus script>,<rate>,<duration>,"<skill name>",{<other script>};
 
-These commands are meant to be used in item scripts. They will probably work
-outside item scripts, but the bonus will not persist for long. They, as
-expected, refer only to an invoking character.
+These commands are meant to be used in item scripts only! See 'petautobonus' for pet usage.
 
 What these commands do is 'attach' a script to the player which will get
 executed on attack (or when attacked in the case of autobonus2).
@@ -10199,6 +10197,17 @@ owner is currently fighting. Skill IDs and levels are as per 'petskillsupport'.
 inflicted and the specified number of attacks.
 
 Value of 'rate' is between 1 and 100. 100 = 100%
+
+---------------------------------------
+
+*petautobonus <bonus script>,<rate>,<duration>{,<flag>,{<other script>}};
+*petautobonus2 <bonus script>,<rate>,<duration>{,<flag>,{<other script>}};
+*petautobonus3 <bonus script>,<rate>,<duration>,<skill id>,{<other script>};
+*petautobonus3 <bonus script>,<rate>,<duration>,"<skill name>",{<other script>};
+
+Only one of each autobonus can be active on a pet at once.
+
+See 'autobonus' for more details.
 
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -10205,8 +10205,6 @@ Value of 'rate' is between 1 and 100. 100 = 100%
 *petautobonus3 <bonus script>,<rate>,<duration>,<skill id>,{<other script>};
 *petautobonus3 <bonus script>,<rate>,<duration>,"<skill name>",{<other script>};
 
-Only one of each autobonus can be active on a pet at once.
-
 See 'autobonus' for more details.
 
 ---------------------------------------

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -2374,8 +2374,7 @@ bool pet_addautobonus(std::vector<std::shared_ptr<s_petautobonus>> &bonus, const
 	entry->timer = INVALID_TIMER;
 	entry->atk_type = flag;
 	entry->bonus_script = script;
-	if (!other_script.empty())
-		entry->other_script = other_script;
+	entry->other_script = other_script;
 
 	bonus.push_back(entry);
 

--- a/src/map/pet.hpp
+++ b/src/map/pet.hpp
@@ -144,6 +144,42 @@ public:
 
 extern PetDatabase pet_db;
 
+TIMER_FUNC(pet_endautobonus);
+
+/// Pet AutoBonus bonus struct
+struct s_petautobonus {
+	int16 rate;
+	uint16 atk_type;
+	std::string bonus_script, other_script;
+	t_tick duration;
+	int32 timer;
+
+	~s_petautobonus() {
+		if (this->timer != INVALID_TIMER) {
+			delete_timer(this->timer, pet_endautobonus);
+			this->timer = INVALID_TIMER;
+		}
+
+		this->bonus_script.clear();
+		this->other_script.clear();
+	}
+
+};
+
+/// Pet Autobonus database wrapper
+struct s_pet_autobonus_wrapper {
+	script_code *script;
+
+	~s_pet_autobonus_wrapper() {
+		if (this->script != nullptr) {
+			script_free_code(this->script);
+			this->script = nullptr;
+		}
+	}
+};
+
+extern std::unordered_map<std::string, std::shared_ptr<s_pet_autobonus_wrapper>> pet_autobonuses;
+
 struct pet_data {
 	struct block_list bl;
 	struct unit_data ud;
@@ -165,6 +201,7 @@ struct pet_data {
 	struct pet_skill_attack* a_skill;
 	struct pet_skill_support* s_skill;
 	struct pet_loot* loot;
+	std::shared_ptr<s_petautobonus> autobonus, autobonus2, autobonus3;
 
 	int masterteleport_timer;
 	struct map_session_data *master;
@@ -219,6 +256,10 @@ void pet_clear_support_bonuses(struct map_session_data *sd);
 
 #define pet_stop_walking(pd, type) unit_stop_walking(&(pd)->bl, type)
 #define pet_stop_attack(pd) unit_stop_attack(&(pd)->bl)
+
+bool pet_addautobonus(std::shared_ptr<s_petautobonus> &bonus, const std::string &script, int16 rate, uint32 dur, uint16 atk_type, const std::string &other_script, bool onskill);
+void pet_exeautobonus(map_session_data &sd, std::shared_ptr<s_petautobonus> &bonus);
+void pet_delautobonus(map_session_data &sd, std::shared_ptr<s_petautobonus> &bonus, bool restore);
 
 void do_init_pet(void);
 void do_final_pet(void);

--- a/src/map/pet.hpp
+++ b/src/map/pet.hpp
@@ -201,7 +201,7 @@ struct pet_data {
 	struct pet_skill_attack* a_skill;
 	struct pet_skill_support* s_skill;
 	struct pet_loot* loot;
-	std::shared_ptr<s_petautobonus> autobonus, autobonus2, autobonus3;
+	std::vector<std::shared_ptr<s_petautobonus>> autobonus, autobonus2, autobonus3;
 
 	int masterteleport_timer;
 	struct map_session_data *master;
@@ -257,9 +257,9 @@ void pet_clear_support_bonuses(struct map_session_data *sd);
 #define pet_stop_walking(pd, type) unit_stop_walking(&(pd)->bl, type)
 #define pet_stop_attack(pd) unit_stop_attack(&(pd)->bl)
 
-bool pet_addautobonus(std::shared_ptr<s_petautobonus> &bonus, const std::string &script, int16 rate, uint32 dur, uint16 atk_type, const std::string &other_script, bool onskill);
-void pet_exeautobonus(map_session_data &sd, std::shared_ptr<s_petautobonus> &bonus);
-void pet_delautobonus(map_session_data &sd, std::shared_ptr<s_petautobonus> &bonus, bool restore);
+bool pet_addautobonus(std::vector<std::shared_ptr<s_petautobonus>> &bonus, const std::string &script, int16 rate, uint32 dur, uint16 atk_type, const std::string &other_script, bool onskill);
+void pet_exeautobonus(map_session_data &sd, std::vector<std::shared_ptr<s_petautobonus>> *bonus, std::shared_ptr<s_petautobonus> &autobonus);
+void pet_delautobonus(map_session_data &sd, std::vector<std::shared_ptr<s_petautobonus>> &bonus, bool restore);
 
 void do_init_pet(void);
 void do_final_pet(void);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4612,6 +4612,27 @@ void script_add_autobonus(const char *autobonus)
 	}
 }
 
+void script_run_petautobonus(const std::string &autobonus, map_session_data &sd) {
+	std::shared_ptr<s_pet_autobonus_wrapper> script = util::umap_find(pet_autobonuses, autobonus);
+
+	if (script != nullptr) {
+		run_script(script->script, 0, sd.bl.id, 0);
+	}
+}
+
+void script_add_petautobonus(const std::string &autobonus) {
+	if (util::umap_find(pet_autobonuses, autobonus) == nullptr) {
+		script_code *script = parse_script(autobonus.c_str(), "petautobonus", 0, 0);
+
+		if (script != nullptr) {
+			std::shared_ptr<s_pet_autobonus_wrapper> bonus = std::make_shared<s_pet_autobonus_wrapper>();
+
+			bonus->script = script;
+
+			pet_autobonuses.emplace(autobonus, bonus);
+		}
+	}
+}
 
 /// resets a temporary character array variable to given value
 void script_cleararray_pc( struct map_session_data* sd, const char* varname ){
@@ -9952,6 +9973,97 @@ BUILDIN_FUNC(autobonus3)
 		script_add_autobonus(bonus_script);
 		if( other_script )
 			script_add_autobonus(other_script);
+	}
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+BUILDIN_FUNC(petautobonus) {
+	map_session_data *sd;
+
+	if (!script_rid2sd(sd))
+		return SCRIPT_CMD_SUCCESS; // No player attached
+
+	const char *command = script_getfuncname(st);
+
+	if (sd->pd == nullptr) {
+		ShowError("buildin_%s: Requires an active pet.\n", command);
+		return SCRIPT_CMD_FAILURE; // No pet attached to player
+	}
+
+	std::string bonus_script = script_getstr(st, 2);
+	int16 rate = script_getnum(st, 3);
+	uint32 dur = script_getnum(st, 4);
+
+	if (!rate || !dur || bonus_script.empty())
+		return SCRIPT_CMD_SUCCESS;
+
+	uint16 atk_type = 0;
+	std::string other_script = {};
+	bool bonus2 = false;
+
+	if (strcmpi(command, "petautobonus2") == 0)
+		bonus2 = true;
+
+	if (script_hasdata(st, 5))
+		atk_type = script_getnum(st, 5);
+	if (script_hasdata(st, 6))
+		other_script = script_getstr(st, 6);
+
+	if (pet_addautobonus(bonus2 ? sd->pd->autobonus2 : sd->pd->autobonus, bonus_script, rate, dur, atk_type, other_script, false)) {
+		script_add_petautobonus(bonus_script);
+		if (!other_script.empty())
+			script_add_petautobonus(other_script);
+	}
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+BUILDIN_FUNC(petautobonus3) {
+	map_session_data *sd;
+
+	if (!script_rid2sd(sd))
+		return SCRIPT_CMD_SUCCESS; // No player attached
+
+	if (sd->pd == nullptr) {
+		ShowError("buildin_petautobonus3: Requires an active pet.\n");
+		return SCRIPT_CMD_FAILURE; // No pet attached to player
+	}
+
+	std::string bonus_script = script_getstr(st, 2);
+	int16 rate = script_getnum(st, 3);
+	uint32 dur = script_getnum(st, 4);
+
+	if (!rate || !dur || bonus_script.empty())
+		return SCRIPT_CMD_SUCCESS;
+
+	uint16 skill_id = 0;
+	std::string other_script = {};
+	std::shared_ptr<s_petautobonus> petbonus = sd->pd->autobonus3;
+
+	if (script_isstring(st, 5)) {
+		const char *name = script_getstr(st, 5);
+
+		if (!(skill_id = skill_name2id(name))) {
+			ShowError("buildin_petautobonus3: Invalid skill name %s passed to item bonus. Skipping.\n", name);
+			return SCRIPT_CMD_FAILURE;
+		}
+	} else {
+		skill_id = script_getnum(st, 5);
+
+		if (!skill_get_index(skill_id)) {
+			ShowError("buildin_petautobonus3: Invalid skill ID %d passed to item bonus. Skipping.\n", skill_id);
+			return SCRIPT_CMD_FAILURE;
+		}
+	}
+
+	if (script_hasdata(st, 6))
+		other_script = script_getstr(st, 6);
+
+	if (pet_addautobonus(petbonus, bonus_script, rate, dur, skill_id, other_script, true)) {
+		script_add_petautobonus(bonus_script);
+		if (!other_script.empty())
+			script_add_petautobonus(other_script);
 	}
 
 	return SCRIPT_CMD_SUCCESS;
@@ -26201,6 +26313,9 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(autobonus,"sii??"),
 	BUILDIN_DEF(autobonus2,"sii??"),
 	BUILDIN_DEF(autobonus3,"siiv?"),
+	BUILDIN_DEF(petautobonus,"sii??"),
+	BUILDIN_DEF2(petautobonus,"petautobonus2","sii??"),
+	BUILDIN_DEF(petautobonus3,"siiv?"),
 	BUILDIN_DEF(skill,"vi?"),
 	BUILDIN_DEF2(skill,"addtoskill","vi?"), // [Valaris]
 	BUILDIN_DEF(guildskill,"vi"),

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -9982,7 +9982,7 @@ BUILDIN_FUNC(petautobonus) {
 	map_session_data *sd;
 
 	if (!script_rid2sd(sd))
-		return SCRIPT_CMD_SUCCESS; // No player attached
+		return SCRIPT_CMD_FAILURE; // No player attached
 
 	const char *command = script_getfuncname(st);
 
@@ -9996,7 +9996,7 @@ BUILDIN_FUNC(petautobonus) {
 	uint32 dur = script_getnum(st, 4);
 
 	if (!rate || !dur || bonus_script.empty())
-		return SCRIPT_CMD_SUCCESS;
+		return SCRIPT_CMD_FAILURE;
 
 	uint16 atk_type = 0;
 	std::string other_script = {};
@@ -10039,7 +10039,6 @@ BUILDIN_FUNC(petautobonus3) {
 
 	uint16 skill_id = 0;
 	std::string other_script = {};
-	std::shared_ptr<s_petautobonus> petbonus = sd->pd->autobonus3;
 
 	if (script_isstring(st, 5)) {
 		const char *name = script_getstr(st, 5);
@@ -10060,7 +10059,7 @@ BUILDIN_FUNC(petautobonus3) {
 	if (script_hasdata(st, 6))
 		other_script = script_getstr(st, 6);
 
-	if (pet_addautobonus(petbonus, bonus_script, rate, dur, skill_id, other_script, true)) {
+	if (pet_addautobonus(sd->pd->autobonus3, bonus_script, rate, dur, skill_id, other_script, true)) {
 		script_add_petautobonus(bonus_script);
 		if (!other_script.empty())
 			script_add_petautobonus(other_script);

--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -2165,6 +2165,7 @@ void script_free_state(struct script_state* st);
 struct DBMap* script_get_label_db(void);
 struct DBMap* script_get_userfunc_db(void);
 void script_run_autobonus(const char *autobonus, struct map_session_data *sd, unsigned int pos);
+void script_run_petautobonus(const std::string &autobonus, map_session_data &sd);
 
 const char* script_get_constant_str(const char* prefix, int64 value);
 bool script_get_parameter(const char* name, int64* value);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2374,6 +2374,15 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		}
 	}
 
+	// Pet Autobonus when attacking
+	if (sd != nullptr && sd->pd != nullptr && sd->pd->autobonus != nullptr) {
+		auto petbonus = sd->pd->autobonus;
+
+		if (rnd() % 1000 < petbonus->rate && (((petbonus->atk_type) & attack_type) & BF_WEAPONMASK || ((petbonus->atk_type) & attack_type) & BF_RANGEMASK || ((petbonus->atk_type) & attack_type) & BF_SKILLMASK)) {
+			pet_exeautobonus(*sd, petbonus);
+		}
+	}
+
 	//Polymorph
 	if(sd && sd->bonus.classchange && attack_type&BF_WEAPON &&
 		dstmd && !status_has_mode(tstatus,MD_STATUSIMMUNE) &&
@@ -2460,6 +2469,15 @@ int skill_onskillusage(struct map_session_data *sd, struct block_list *bl, uint1
 			if (it->atk_type != skill_id)
 				continue;
 			pc_exeautobonus(*sd, &sd->autobonus3, it);
+		}
+	}
+
+	// Pet Autobonus when being attacked by skill_id
+	if (sd != nullptr && sd->pd != nullptr && sd->pd->autobonus3 != nullptr) {
+		auto petbonus = sd->pd->autobonus3;
+
+		if (rnd() % 1000 < petbonus->rate && petbonus->atk_type == skill_id) {
+			pet_exeautobonus(*sd, petbonus);
 		}
 	}
 
@@ -2684,6 +2702,15 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 				  ((it->atk_type)&attack_type)&BF_SKILLMASK))
 				continue; // one or more trigger conditions were not fulfilled
 			pc_exeautobonus(*dstsd, &dstsd->autobonus2, it);
+		}
+	}
+
+	// Pet Autobonus when attacked
+	if (dstsd != nullptr && dstsd->pd != nullptr && dstsd->pd->autobonus2 != nullptr && !status_isdead(bl) && !(skill_id && skill_get_nk(skill_id, NK_NODAMAGE))) {
+		auto petbonus = dstsd->pd->autobonus2;
+
+		if (rnd() % 1000 < petbonus->rate && (((petbonus->atk_type) & attack_type) & BF_WEAPONMASK || ((petbonus->atk_type) & attack_type) & BF_RANGEMASK || ((petbonus->atk_type) & attack_type) & BF_SKILLMASK)) {
+			pet_exeautobonus(*dstsd, petbonus);
 		}
 	}
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2356,30 +2356,38 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		}
 	}
 
-	//Autobonus when attacking
-	if( sd && !sd->autobonus.empty() )
-	{
-		for(auto &it : sd->autobonus) {
-			if( it == nullptr ){
-				continue;
+	// Check for player and pet autobonuses when attacking
+	if (sd != nullptr) {
+		// Player
+		if (!sd->autobonus.empty()) {
+			for (auto &it : sd->autobonus) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (!(((it->atk_type) & attack_type) & BF_WEAPONMASK &&
+					  ((it->atk_type) & attack_type) & BF_RANGEMASK &&
+					  ((it->atk_type) & attack_type) & BF_SKILLMASK))
+					continue; // one or more trigger conditions were not fulfilled
+
+				pc_exeautobonus(*sd, &sd->autobonus, it);
 			}
-
-			if (rnd()%1000 >= it->rate)
-				continue;
-			if (!(((it->atk_type)&attack_type)&BF_WEAPONMASK &&
-				  ((it->atk_type)&attack_type)&BF_RANGEMASK &&
-				  ((it->atk_type)&attack_type)&BF_SKILLMASK))
-				continue; // one or more trigger conditions were not fulfilled
-			pc_exeautobonus(*sd, &sd->autobonus, it);
 		}
-	}
 
-	// Pet Autobonus when attacking
-	if (sd != nullptr && sd->pd != nullptr && sd->pd->autobonus != nullptr) {
-		auto petbonus = sd->pd->autobonus;
+		// Pet
+		if (sd->pd != nullptr && !sd->pd->autobonus.empty()) {
+			for (auto &it : sd->pd->autobonus) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (!(((it->atk_type) & attack_type) & BF_WEAPONMASK &&
+					  ((it->atk_type) & attack_type) & BF_RANGEMASK &&
+					  ((it->atk_type) & attack_type) & BF_SKILLMASK))
+					continue; // one or more trigger conditions were not fulfilled
 
-		if (rnd() % 1000 < petbonus->rate && (((petbonus->atk_type) & attack_type) & BF_WEAPONMASK || ((petbonus->atk_type) & attack_type) & BF_RANGEMASK || ((petbonus->atk_type) & attack_type) & BF_SKILLMASK)) {
-			pet_exeautobonus(*sd, petbonus);
+				pet_exeautobonus(*sd, &sd->pd->autobonus, it);
+			}
 		}
 	}
 
@@ -2460,24 +2468,34 @@ int skill_onskillusage(struct map_session_data *sd, struct block_list *bl, uint1
 		sd->state.autocast = 0;
 	}
 
-	if( sd && !sd->autobonus3.empty() ) {
-		for (auto &it : sd->autobonus3) {
-			if (it == nullptr)
-				continue;
-			if (rnd()%1000 >= it->rate)
-				continue;
-			if (it->atk_type != skill_id)
-				continue;
-			pc_exeautobonus(*sd, &sd->autobonus3, it);
+	// Check for player and pet autobonuses when being attacked by skill_id
+	if (sd != nullptr) {
+		// Player
+		if (!sd->autobonus3.empty()) {
+			for (auto &it : sd->autobonus3) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (it->atk_type != skill_id)
+					continue;
+
+				pc_exeautobonus(*sd, &sd->autobonus3, it);
+			}
 		}
-	}
 
-	// Pet Autobonus when being attacked by skill_id
-	if (sd != nullptr && sd->pd != nullptr && sd->pd->autobonus3 != nullptr) {
-		auto petbonus = sd->pd->autobonus3;
+		// Pet
+		if (sd->pd != nullptr && !sd->pd->autobonus3.empty()) {
+			for (auto &it : sd->pd->autobonus3) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (it->atk_type != skill_id)
+					continue;
 
-		if (rnd() % 1000 < petbonus->rate && petbonus->atk_type == skill_id) {
-			pet_exeautobonus(*sd, petbonus);
+				pet_exeautobonus(*sd, &sd->pd->autobonus3, it);
+			}
 		}
 	}
 
@@ -2688,29 +2706,38 @@ int skill_counter_additional_effect (struct block_list* src, struct block_list *
 		}
 	}
 
-	//Autobonus when attacked
-	if( dstsd && !status_isdead(bl) && !dstsd->autobonus2.empty() && !(skill_id && skill_get_nk(skill_id, NK_NODAMAGE)) ) {
-		for (auto &it : dstsd->autobonus2) {
-			if( it == nullptr ){
-				continue;
+	// Check for player and pet autobonuses when attacked
+	if (dstsd != nullptr && !status_isdead(bl) && !(skill_id && skill_get_nk(skill_id, NK_NODAMAGE))) {
+		// Player
+		if (!dstsd->autobonus2.empty()) {
+			for (auto &it : dstsd->autobonus2) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (!(((it->atk_type) & attack_type) & BF_WEAPONMASK &&
+					  ((it->atk_type) & attack_type) & BF_RANGEMASK &&
+					  ((it->atk_type) & attack_type) & BF_SKILLMASK))
+					continue; // one or more trigger conditions were not fulfilled
+
+				pc_exeautobonus(*dstsd, &dstsd->autobonus2, it);
 			}
-
-			if (rnd()%1000 >= it->rate)
-				continue;
-			if (!(((it->atk_type)&attack_type)&BF_WEAPONMASK &&
-				  ((it->atk_type)&attack_type)&BF_RANGEMASK &&
-				  ((it->atk_type)&attack_type)&BF_SKILLMASK))
-				continue; // one or more trigger conditions were not fulfilled
-			pc_exeautobonus(*dstsd, &dstsd->autobonus2, it);
 		}
-	}
 
-	// Pet Autobonus when attacked
-	if (dstsd != nullptr && dstsd->pd != nullptr && dstsd->pd->autobonus2 != nullptr && !status_isdead(bl) && !(skill_id && skill_get_nk(skill_id, NK_NODAMAGE))) {
-		auto petbonus = dstsd->pd->autobonus2;
+		// Pet
+		if (dstsd->pd != nullptr && !dstsd->pd->autobonus2.empty()) {
+			for (auto &it : dstsd->pd->autobonus2) {
+				if (it == nullptr)
+					continue;
+				if (rnd_value(0, 1000) >= it->rate)
+					continue;
+				if (!(((it->atk_type) & attack_type) & BF_WEAPONMASK &&
+					  ((it->atk_type) & attack_type) & BF_RANGEMASK &&
+					  ((it->atk_type) & attack_type) & BF_SKILLMASK))
+					continue; // one or more trigger conditions were not fulfilled
 
-		if (rnd() % 1000 < petbonus->rate && (((petbonus->atk_type) & attack_type) & BF_WEAPONMASK || ((petbonus->atk_type) & attack_type) & BF_RANGEMASK || ((petbonus->atk_type) & attack_type) & BF_SKILLMASK)) {
-			pet_exeautobonus(*dstsd, petbonus);
+				pet_exeautobonus(*dstsd, &dstsd->pd->autobonus2, it);
+			}
 		}
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3621,6 +3621,12 @@ int status_calc_pc_sub(struct map_session_data* sd, uint8 opt)
 	pc_delautobonus(*sd, sd->autobonus2, true);
 	pc_delautobonus(*sd, sd->autobonus3, true);
 
+	if (sd->pd != nullptr) {
+		pet_delautobonus(*sd, sd->pd->autobonus, true);
+		pet_delautobonus(*sd, sd->pd->autobonus2, true);
+		pet_delautobonus(*sd, sd->pd->autobonus3, true);
+	}
+
 	// Parse equipment
 	for (i = 0; i < EQI_MAX; i++) {
 		current_equip_item_index = index = sd->equip_index[i]; // We pass INDEX to current_equip_item_index - for EQUIP_SCRIPT (new cards solution) [Lupus]

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3453,6 +3453,10 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 			struct pet_data *pd = (struct pet_data*)bl;
 			struct map_session_data *sd = pd->master;
 
+			pet_delautobonus(*sd, pd->autobonus, false);
+			pet_delautobonus(*sd, pd->autobonus2, false);
+			pet_delautobonus(*sd, pd->autobonus3, false);
+
 			pet_hungry_timer_delete(pd);
 			pet_clear_support_bonuses(sd);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7038

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Implements script commands: petautobonus, petautobonus2, and petautobonus3.
  * This allows pets to utilize the same autobonus features that players can use without having to check for the equipped item position.