### PR TITLE
Fixes a potential crash with database reloading

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -156,6 +156,7 @@ public:
 	void clear() override{
 		TypesafeYamlDatabase<keytype, datatype>::clear();
 		cache.clear();
+		cache.shrink_to_fit();
 	}
 
 	std::shared_ptr<datatype> find( keytype key ) override{


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7060

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * The cached YAML content will now properly reallocate the memory when the clear command is called.
Thanks to @eppc0330!