### PR TITLE
Fixed memory consumption of caches

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -194,10 +194,10 @@ public:
 			this->cache[key] = pair.second;
 		}
 
-		for( size_t index = this->cache.size() - 1; index >= 0; index-- ){
-			if( this->cache[index] != nullptr ){
+		for( auto it = this->cache.rbegin(); it != this->cache.rend(); it++ ){
+			if( *it != nullptr ){
 				// Resize to only fit all existing non null entries
-				this->cache.resize( index + 1 );
+				this->cache.resize( this->cache.rend() - it );
 
 				// Free the memory that was allocated too much
 				this->cache.shrink_to_fit();

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -194,8 +194,16 @@ public:
 			this->cache[key] = pair.second;
 		}
 
-		// Free the memory that was allocated too much
-		this->cache.shrink_to_fit();
+		for( size_t index = this->cache.size() - 1; index >= 0; index-- ){
+			if( this->cache[index] != nullptr ){
+				// Resize to only fit all existing non null entries
+				this->cache.resize( index + 1 );
+
+				// Free the memory that was allocated too much
+				this->cache.shrink_to_fit();
+				break;
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Because all elements were initialized to nullptr they were valid entries inside the cache vectors.
Therefore shrink_to_fit was not working.

Here is some debug output showing the change in vector element usage:
```
[Status]: Done reading '3900' entries in 'db/re/item_db_usable.yml'
[Status]: Done reading '8826' entries in 'db/re/item_db_equip.yml'
[Status]: Done reading '6153' entries in 'db/re/item_db_etc.yml'
[Debug]: Entries: 2000554 Capacity: 2000554
[Debug]: Entries: 1220005 Capacity: 1220005
[Status]: Done reading '2183' entries in 'db/re/mob_db.yml'
[Debug]: Entries: 40702 Capacity: 40702
[Debug]: Entries: 23858 Capacity: 23858
[Status]: Done reading '145' entries in 'db/re/job_stats.yml'
[Status]: Done reading '19' entries in 'db/re/job_exp.yml'
[Status]: Done reading '128' entries in 'db/re/job_basepoints.yml'
[Debug]: Entries: 8042 Capacity: 8042
[Debug]: Entries: 4317 Capacity: 4317
[Status]: Done reading '250' entries in 'db/re/statpoint.yml'
[Debug]: Entries: 256 Capacity: 256
[Debug]: Entries: 251 Capacity: 251
```

Thanks to @aleos89
