### PR TITLE
Fixed reloadpcdb

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -183,8 +183,10 @@ public:
 
 			// Check if the key fits into the current cache size
 			if (this->cache.capacity() <= key) {
+				// Some keys compute to 0, so we allocate a minimum of 500 (250*2) entries
+				const static size_t minimum = 250;
 				// Double the current size, so we do not have to resize that often
-				size_t new_size = key * 2;
+				size_t new_size = std::max( key, minimum ) * 2;
 
 				// Very important => initialize everything to nullptr
 				this->cache.resize(new_size, nullptr);


### PR DESCRIPTION
* **Addressed Issue(s)**: #7063

* **Server Mode**: Both

* **Description of Pull Request**: 
Some keys compute to zero (like Novice = 0), which will lead to not increasing the cache size, since 0*2 is still 0.
Therefore the server would crash if it would try to add an element to the cache.
We now allocate a minimum of 500 elements initially. It will be shrunk and the unused memory will be freed after loading again.

Thanks to @kaninhot004