### PR TITLE
Auto Spell rate fix

### DIFF
--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -17195,7 +17195,7 @@ Body:
       if (.@r>9) {
          bonus2 bVariableCastrate,"MO_EXTREMITYFIST",-100;
          bonus2 bFixedCastrate,"MO_EXTREMITYFIST",-100;
-         bonus4 bAutoSpellOnSkill,"MO_EXPLOSIONSPIRITS","CH_SOULCOLLECT",1,10000;
+         bonus4 bAutoSpellOnSkill,"MO_EXPLOSIONSPIRITS","CH_SOULCOLLECT",1,1000;
          bonus2 bHPLossRate,500,3000;
       }
   - Id: 1833

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2679,19 +2679,19 @@ static void pc_bonus_autospell(std::vector<s_autospell> &spell, uint16 id, uint1
 		if ((it.card_id == card_id || it.rate < 0 || rate < 0) && it.id == id && it.lv == lv && it.battle_flag == battle_flag && it.flag == flag) {
 			if (!battle_config.autospell_stacking && it.rate > 0 && rate > 0) // Stacking disabled
 				return;
-			it.rate = util::safe_addition_cap(it.rate, rate, (short)10000);
+			it.rate = util::safe_addition_cap(it.rate, rate, (short)1000);
 			return;
 		}
 	}
 
 	struct s_autospell entry = {};
 
-	if (rate < -10000 || rate > 10000)
-		ShowWarning("pc_bonus_autospell: Item bonus rate %d exceeds -10000~10000 range, capping.\n", rate);
+	if (rate < -1000 || rate > 1000)
+		ShowWarning("pc_bonus_autospell: Item bonus rate %d exceeds -1000~1000 range, capping.\n", rate);
 
 	entry.id = id;
 	entry.lv = lv;
-	entry.rate = cap_value(rate, -10000, 10000);
+	entry.rate = cap_value(rate, -1000, 1000);
 	entry.battle_flag = battle_flag;
 	entry.card_id = card_id;
 	entry.flag = flag;
@@ -2723,13 +2723,13 @@ static void pc_bonus_autospell_onskill(std::vector<s_autospell> &spell, uint16 s
 
 	struct s_autospell entry = {};
 
-	if (rate < -10000 || rate > 10000)
-		ShowWarning("pc_bonus_onskill: Item bonus rate %d exceeds -10000~10000 range, capping.\n", rate);
+	if (rate < -1000 || rate > 1000)
+		ShowWarning("pc_bonus_onskill: Item bonus rate %d exceeds -1000~1000 range, capping.\n", rate);
 
 	entry.trigger_skill = src_skill;
 	entry.id = id;
 	entry.lv = lv;
-	entry.rate = cap_value(rate, -10000, 10000);
+	entry.rate = cap_value(rate, -1000, 1000);
 	entry.card_id = card_id;
 	entry.flag = flag;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: -
* **Server Mode**: Re
* **Description of Pull Request**: 
Fix Auto Spell rate for Vellum Claw.
> Adds a n/10% chance to autospell skill x at level y when using skill sk

* Updated check for min/max rate values, because max value is 1000 in autocast formula.
https://github.com/rathena/rathena/blob/6e58ab7d402c9a1d552c394958ced2c843b553d0/src/map/skill.cpp#L2314