### PR TITLE
Cleans up Thief's Double Attack item bonuses

### DIFF
--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -844,7 +844,6 @@ Body:
     Refineable: true
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
       bonus2 bAddRace,RC_DemiHuman,5;
       bonus2 bAddRace,RC_Player_Human,5;
   - Id: 1131
@@ -24702,7 +24701,6 @@ Body:
     Script: |
       bonus bMaxSP,100;
       skill "TF_DOUBLE",3;
-      bonus bDoubleRate,15;
       skill "TF_STEAL",1;
       skill "TF_HIDING",1;
       skill "TF_POISON",1;
@@ -29767,7 +29765,6 @@ Body:
       bonus bMaxHP,50;
       bonus bMaxSP,50;
       skill "TF_DOUBLE",2;
-      bonus bDoubleRate,10;
       bonus2 bSubRace,RC_DemiHuman,3;
       bonus2 bSubRace,RC_Player_Human,3;
   - Id: 5284
@@ -31728,7 +31725,6 @@ Body:
       NoGuildStorage: true
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
   - Id: 5389
     AegisName: Angel_Spirit
     Name: Angel Spirit
@@ -34171,9 +34167,7 @@ Body:
     View: 525
     Script: |
       bonus bDex,2;
-      .@bonus = max(getskilllv("TF_DOUBLE"), 5);
-      skill "TF_DOUBLE",.@bonus;
-      bonus bDoubleRate,.@bonus * 5;
+      skill "TF_DOUBLE",5;
   - Id: 5532
     AegisName: Pirate_Dagger_J
     Name: Pirate Dagger
@@ -39963,7 +39957,6 @@ Body:
     WeaponLevel: 4
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
       bonus2 bAddRace,RC_DemiHuman,40;
       bonus2 bAddRace,RC_Player_Human,40;
   - Id: 13408

--- a/db/pre-re/item_db_etc.yml
+++ b/db/pre-re/item_db_etc.yml
@@ -4026,7 +4026,6 @@ Body:
       BuyingStore: true
     Script: |
       skill "TF_DOUBLE",1;
-      bonus bDoubleRate,5;
   - Id: 4118
     AegisName: Petit_Card
     Name: Earth Petite Card

--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -2518,13 +2518,10 @@ Body:
     Script: |
       .@r = getequiprefinerycnt(EQI_GARMENT);
       if (.@r >= 7) {
-         .@bonus = max(getskilllv("TF_DOUBLE"),5);
-         skill "TF_DOUBLE",.@bonus;
-         bonus bDoubleRate,.@bonus*5;
+         skill "TF_DOUBLE",5;
       }
       else if (.@r >= 5) {
          skill "TF_DOUBLE",1;
-         bonus bDoubleRate,25;
       }
   - Combos:
       - Combo:
@@ -9915,7 +9912,6 @@ Body:
          .@val += 15;
          if ((.@weapon + .@eq) >= 22) {
             skill "TF_DOUBLE",4;
-            bonus bDoubleRate,20;
          }
       }
       bonus bAspdRate,.@val;

--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -844,7 +844,6 @@ Body:
     Refineable: true
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
       bonus2 bAddRace,RC_DemiHuman,5;
       bonus2 bAddRace,RC_Player_Human,5;
   - Id: 1131
@@ -8689,7 +8688,6 @@ Body:
       bonus bAtkEle,Ele_Poison;
       bonus bCritical,10;
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
       bonus2 bAddEff,Eff_Poison,1000;
       bonus2 bAddEff2,Eff_Poison,300;
   - Id: 1448
@@ -35842,7 +35840,6 @@ Body:
     Script: |
       bonus bMaxSP,100;
       skill "TF_DOUBLE",3;
-      bonus bDoubleRate,15;
       skill "TF_STEAL",1;
       skill "TF_HIDING",1;
       skill "TF_POISON",1;
@@ -43509,7 +43506,6 @@ Body:
       bonus bMaxHP,50;
       bonus bMaxSP,50;
       skill "TF_DOUBLE",2;
-      bonus bDoubleRate,10;
       bonus2 bSubRace,RC_DemiHuman,3;
       bonus2 bSubRace,RC_Player_Human,3;
       bonus2 bSubRace,RC_Brute,3;
@@ -45480,7 +45476,6 @@ Body:
     View: 393
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
   - Id: 5389
     AegisName: Angel_Spirit
     Name: Angel Spirit
@@ -48103,9 +48098,7 @@ Body:
       NoDrop: true
     Script: |
       bonus bDex,2;
-      .@bonus = max(getskilllv("TF_DOUBLE"), 5);
-      skill "TF_DOUBLE",.@bonus;
-      bonus bDoubleRate,.@bonus * 5;
+      skill "TF_DOUBLE",5;
   - Id: 5532
     AegisName: Pirate_Dagger_J
     Name: Pirate Dagger
@@ -49893,7 +49886,6 @@ Body:
       bonus2 bSubRace,RC_Brute,3;
       bonus2 bSubRace,RC_Player_Doram,3;
       skill "TF_DOUBLE",2;
-      bonus bDoubleRate,10;
       bonus bMaxHP,50;
       bonus bMaxSP,50;
   - Id: 5626
@@ -62443,7 +62435,6 @@ Body:
       NoAuction: true
     Script: |
       skill "TF_DOUBLE",5;
-      bonus bDoubleRate,25;
       bonus2 bAddRace,RC_DemiHuman,40;
       bonus2 bAddRace,RC_Player_Human,40;
   - Id: 13408
@@ -82624,7 +82615,6 @@ Body:
       bonus bMaxHP,50;
       bonus bMaxSP,50;
       skill "TF_DOUBLE",2;
-      bonus bDoubleRate,10;
       bonus2 bSubRace,RC_DemiHuman,3;
       bonus2 bSubRace,RC_Player_Human,3;
   - Id: 19130
@@ -83583,7 +83573,6 @@ Body:
          bonus bCritAtkRate,5*getskilllv("BS_OVERTHRUST");
       if (.@r>=11) {
          skill "TF_DOUBLE",5;
-         bonus bDoubleRate,25;
       }
   - Id: 19190
     AegisName: Racing_Cap_GN
@@ -83797,7 +83786,6 @@ Body:
       if (.@r>=11) {
          bonus bUnbreakableWeapon;
          skill "TF_DOUBLE",5;
-         bonus bDoubleRate,25;
       }
   - Id: 19196
     AegisName: Racing_Cap_RG
@@ -99654,21 +99642,18 @@ Body:
          bonus bFlee,30;
          skill "TF_DOUBLE",10;
          skill "MO_TRIPLEATTACK",10;
-         bonus bDoubleRate,50;
       }
       else if (.@r>=7) {
          bonus bAspdRate,6;
          bonus bFlee,20;
          skill "TF_DOUBLE",5;
          skill "MO_TRIPLEATTACK",5;
-         bonus bDoubleRate,25;
       }
       else {
          bonus bAspdRate,3;
          bonus bFlee,10;
          skill "TF_DOUBLE",3;
          skill "MO_TRIPLEATTACK",3;
-         bonus bDoubleRate,15;
       }
   - Id: 20863
     AegisName: MenblattWing
@@ -118546,7 +118531,6 @@ Body:
       }
       if (.@r>=10) {
          skill "TF_DOUBLE",3;
-         bonus bDoubleRate,15;
       }
   - Id: 26154
     AegisName: SoulWeight

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -4213,7 +4213,6 @@ Body:
       DropEffect: CLIENT
     Script: |
       skill "TF_DOUBLE",1;
-      bonus bDoubleRate,5;
   - Id: 4118
     AegisName: Petit_Card
     Name: Earth Petite Card
@@ -42880,7 +42879,6 @@ Body:
     SubType: Enchant
     Script: |
       skill "TF_DOUBLE",3;
-      bonus bDoubleRate,15;
   - Id: 29366
     AegisName: Strong_Blow1
     Name: Hard Blow 1
@@ -49587,7 +49585,6 @@ Body:
       bonus bCritAtkRate,15;
       if (getskilllv("AS_KATAR") >= 10) {
          skill "TF_DOUBLE",3;
-         bonus bDoubleRate,15;
       }
   - Id: 310189
     AegisName: GuillotineCross_Bottom2

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -363,8 +363,9 @@ struct startitem {
 	uint32 pos;
 };
 
-enum e_skill_flag
+enum e_skill_flag : int8
 {
+	SKILL_FLAG_NONE = -1,
 	SKILL_FLAG_PERMANENT,
 	SKILL_FLAG_TEMPORARY,
 	SKILL_FLAG_PLAGIARIZED,

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3805,6 +3805,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 	if( sd && !skill_id ) {	// if no skill_id passed, check for double attack [helvetica]
 		short i;
 		if( ( ( skill_lv = pc_checkskill(sd,TF_DOUBLE) ) > 0 && sd->weapontype1 == W_DAGGER )
+			|| ( pc_checkskill_flag(*sd, TF_DOUBLE) > SKILL_FLAG_PERMANENT && sd->weapontype1 != W_FIST )
 			|| ( sd->bonus.double_rate > 0 && sd->weapontype1 != W_FIST ) // Will fail bare-handed
 			|| ( sc && sc->data[SC_KAGEMUSYA] && sd->weapontype1 != W_FIST )) // Will fail bare-handed
 		{	//Success chance is not added, the higher one is used [Skotlex]

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6695,6 +6695,31 @@ uint8 pc_checkskill(struct map_session_data *sd, uint16 skill_id)
 }
 
 /**
+ * Returns the flag of the given skill (when learned).
+ * @param sd: Player data
+ * @param skill_id: Skill to lookup
+ * @return Skill flag type
+ */
+e_skill_flag pc_checkskill_flag(map_session_data &sd, uint16 skill_id) {
+	uint16 idx;
+
+#ifdef RENEWAL
+	if ((idx = skill_get_index(skill_id)) == 0) {
+#else
+	if ((idx = skill_db.get_index(skill_id, skill_id >= RK_ENCHANTBLADE, __FUNCTION__, __FILE__, __LINE__)) == 0) {
+		if (skill_id >= RK_ENCHANTBLADE) {
+			// Silently fail for now -> future update planned
+			return 0;
+		}
+#endif
+		ShowError("pc_checkskill_flag: Invalid skill id %d (char_id=%d).\n", skill_id, sd.status.char_id);
+		return SKILL_FLAG_NONE;
+	}
+
+	return (sd.status.skill[idx].id == skill_id && sd.status.skill[idx].lv > 0) ? static_cast<e_skill_flag>(sd.status.skill[idx].flag) : SKILL_FLAG_NONE;
+}
+
+/**
  * Returns the amount of skill points invested in a Summoner's Power of Sea/Land/Life
  * @param sd: Player data
  * @param type: Summoner Power Type

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1265,6 +1265,7 @@ void pc_setinventorydata(struct map_session_data *sd);
 
 int pc_get_skillcooldown(struct map_session_data *sd, uint16 skill_id, uint16 skill_lv);
 uint8 pc_checkskill(struct map_session_data *sd,uint16 skill_id);
+e_skill_flag pc_checkskill_flag(map_session_data &sd, uint16 skill_id);
 uint8 pc_checkskill_summoner(map_session_data *sd, e_summoner_power_type type);
 uint8 pc_checkskill_imperial_guard(struct map_session_data *sd, short flag);
 short pc_checkequip(struct map_session_data *sd,int pos,bool checkall=false);


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Items that grant TF_DOUBLE now no longer require bDoubleRate.
  * Adds pc_checkskill_flag() to return a skill's flag value.
Thanks to @eppc0330 and @secretdataz!