### PR TITLE
Fixes itemskill use items being blocked

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1899,7 +1899,7 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 			return false;
 		}
 
-		if (skill_id && sc->cant.cast && skill_id != RK_REFRESH && skill_id != SU_GROOMING && skill_id != SR_GENTLETOUCH_CURE) { // Stuned/Frozen/etc
+		if (skill_id > 0 && sc->opt1 && sc->opt1 != OPT1_STONEWAIT && sc->opt1 != OPT1_BURNING && skill_id != RK_REFRESH && skill_id != SU_GROOMING && skill_id != SR_GENTLETOUCH_CURE) { // Stuned/Frozen/etc
 			if (flag != 1) // Can't cast, casted stuff can't damage.
 				return false;
 			if (skill_get_casttype(skill_id) == CAST_DAMAGE)


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7075

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adjusts the skill status check to look for OPT1 flags again instead of cant.cast as this value is checked later on.
  * Resolves items like Fly Wing not working when Silenced.
Thanks to @LadyNanuia!