### PR TITLE
Fix displayed damage when it is dodged

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8268,7 +8268,9 @@ struct Damage battle_calc_attack(int attack_type,struct block_list *bl,struct bl
 		if (d.dmg_lv == ATK_DEF /*&& attack_type&(BF_MAGIC|BF_MISC)*/) // Isn't it that additional effects don't apply if miss?
 			d.dmg_lv = ATK_MISS;
 		d.dmotion = 0;
-
+		if(bl->type == BL_PC)
+			d.div_ = 1;
+		
 		status_change *tsc = status_get_sc(target);
 
 		// Weapon Blocking has the ability to trigger on ATK_MISS as well.


### PR DESCRIPTION
Fix miss when a unit dodges attack from player

Thanks to @Haydrich!

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

    As I tested in KRo, when player attack is dodged, miss is shown just once though dodged attack is muti hit skill.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
