### PR TITLE
Initialize all the random options

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -3232,6 +3232,13 @@ void s_random_opt_group::apply( struct item& item ){
 		item_option.param = option->param;
 	};
 
+	// (Re)initialize all the options
+	for( size_t i = 0; i < MAX_ITEM_RDM_OPT; i++ ){
+		item.option[i].id = 0;
+		item.option[i].value = 0;
+		item.option[i].param = 0;
+	};
+
 	// Apply Must options
 	for( size_t i = 0; i < this->slots.size(); i++ ){
 		// Try to apply an entry


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Re

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Fixed an issue in the current random option system when the options are re-applied.
All the options are now initialized first, because the options are not applied to all slots.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
