### PR TITLE
Resolves a mapflag overlap warning with PK Mode

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4739,7 +4739,8 @@ bool map_setmapflag_sub(int16 m, enum e_mapflag mapflag, bool status, union u_ma
 
 				if (mapdata->flag[MF_PVP]) {
 					mapdata->flag[MF_PVP] = false;
-					ShowWarning("map_setmapflag: Unable to set PvP and Battleground flags for the same map! Removing PvP flag from %s.\n", mapdata->name);
+					if (!battle_config.pk_mode)
+						ShowWarning("map_setmapflag: Unable to set PvP and Battleground flags for the same map! Removing PvP flag from %s.\n", mapdata->name);
 				}
 				if (mapdata->flag[MF_GVG]) {
 					mapdata->flag[MF_GVG] = false;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7099

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Hides a warning message when PK Mode is enabled and a Battleground mapflag is attempted to overwrite the PvP mapflag.
Thanks to @LolyAll!