### PR TITLE
Fixes pre-renewal duet dancing

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5205,7 +5205,7 @@ void status_calc_state( struct block_list *bl, struct status_change *sc, std::bi
 				  || (sc->data[SC_FEAR] && sc->data[SC_FEAR]->val2 > 0)
 				  || (sc->data[SC_SPIDERWEB] && sc->data[SC_SPIDERWEB]->val1)
 				  || (sc->data[SC_HIDING] && (bl->type != BL_PC || (pc_checkskill(BL_CAST(BL_PC,bl),RG_TUNNELDRIVE) <= 0)))
-				  || (sc->data[SC_DANCING] && sc->data[SC_DANCING]->val4 && (
+				  || (sc->data[SC_DANCING] && (
 #ifndef RENEWAL
 						!sc->data[SC_LONGING] ||
 #endif


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7134

* **Server Mode**: Pre-renewal

* **Description of Pull Request**: 
  * Resolves an issue where duet songs resulted in the partner not being able to move when canceling the song early.
Thanks to @hnomkeng!