### PR TITLE
Fixes after song visual effect bug

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12474,7 +12474,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 
 	switch(type) {
 		case SC_DANCING:
-			if ((val1&0xFFFF) != CG_MOONLIT)
+			if ((val1&0xFFFF) == CG_MOONLIT)
 				sc->opt3 |= OPT3_MOONLIT;
 			break;
 		case SC_INCATKRATE:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->
#7163

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->
Both

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Restores a correct OPT3_MOONLIT option attribution behavior with SC_DANCING status