### PR TITLE
Resolves spawn direction not saving at relog

### DIFF
--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -282,7 +282,7 @@ CREATE TABLE IF NOT EXISTS `char` (
   `title_id` INT(11) unsigned NOT NULL default '0',
   `show_equip` tinyint(3) unsigned NOT NULL default '0',
   `inventory_slots` smallint(6) NOT NULL default '100',
-  `dir` tinyint(1) unsigned NOT NULL default '0',
+  `body_direction` tinyint(1) unsigned NOT NULL default '0',
   PRIMARY KEY  (`char_id`),
   UNIQUE KEY `name_key` (`name`),
   KEY `account_id` (`account_id`),

--- a/sql-files/main.sql
+++ b/sql-files/main.sql
@@ -282,6 +282,7 @@ CREATE TABLE IF NOT EXISTS `char` (
   `title_id` INT(11) unsigned NOT NULL default '0',
   `show_equip` tinyint(3) unsigned NOT NULL default '0',
   `inventory_slots` smallint(6) NOT NULL default '100',
+  `dir` tinyint(1) unsigned NOT NULL default '0',
   PRIMARY KEY  (`char_id`),
   UNIQUE KEY `name_key` (`name`),
   KEY `account_id` (`account_id`),

--- a/sql-files/upgrades/upgrade_20220825.sql
+++ b/sql-files/upgrades/upgrade_20220825.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `mob_db`
+ALTER TABLE `char`
 	ADD COLUMN `dir` tinyint unsigned NOT NULL default '0'
 ;

--- a/sql-files/upgrades/upgrade_20220825.sql
+++ b/sql-files/upgrades/upgrade_20220825.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `mob_db`
+	ADD COLUMN `dir` tinyint unsigned NOT NULL default '0'
+;

--- a/sql-files/upgrades/upgrade_20220825.sql
+++ b/sql-files/upgrades/upgrade_20220825.sql
@@ -1,3 +1,0 @@
-ALTER TABLE `char`
-	ADD COLUMN `dir` tinyint unsigned NOT NULL default '0'
-;

--- a/sql-files/upgrades/upgrade_20220830.sql
+++ b/sql-files/upgrades/upgrade_20220830.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `char`
+	ADD COLUMN `body_direction` tinyint unsigned NOT NULL default '0'
+;

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -346,18 +346,21 @@ int char_mmo_char_tosql(uint32 char_id, struct mmo_charstatus* p){
 		(p->partner_id != cp->partner_id) || (p->father != cp->father) ||
 		(p->mother != cp->mother) || (p->child != cp->child) ||
  		(p->karma != cp->karma) || (p->manner != cp->manner) ||
-		(p->fame != cp->fame) || (p->inventory_slots != cp->inventory_slots)
+		(p->fame != cp->fame) || (p->inventory_slots != cp->inventory_slots) ||
+		(p->dir != cp->dir)
 	)
 	{
 		if( SQL_ERROR == Sql_Query(sql_handle, "UPDATE `%s` SET `class`='%d',"
 			"`hair`='%d', `hair_color`='%d', `clothes_color`='%d', `body`='%d',"
 			"`partner_id`='%u', `father`='%u', `mother`='%u', `child`='%u',"
-			"`karma`='%d',`manner`='%d', `fame`='%d', `inventory_slots`='%hu'"
+			"`karma`='%d',`manner`='%d', `fame`='%d', `inventory_slots`='%hu',"
+			"`dir`='%d'"
 			" WHERE  `account_id`='%d' AND `char_id` = '%d'",
 			schema_config.char_db, p->class_,
 			p->hair, p->hair_color, p->clothes_color, p->body,
 			p->partner_id, p->father, p->mother, p->child,
 			p->karma, p->manner, p->fame, p->inventory_slots,
+			p->dir,
 			p->account_id, p->char_id) )
 		{
 			Sql_ShowDebug(sql_handle);
@@ -936,7 +939,7 @@ int char_mmo_chars_fromsql(struct char_session_data* sd, uint8* buf, uint8* coun
 		"`robe`,`moves`,`unban_time`,`font`,`uniqueitem_counter`,`sex`,`hotkey_rowshift`,`title_id`,`show_equip`,"
 		"`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`"
+		"`inventory_slots`,`dir`"
 		" FROM `%s` WHERE `account_id`='%d' AND `char_num` < '%d'", schema_config.char_db, sd->account_id, MAX_CHARS)
 	||	SQL_ERROR == SqlStmt_Execute(stmt)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 0,  SQLDT_INT,    &p.char_id, 0, NULL, NULL)
@@ -995,6 +998,7 @@ int char_mmo_chars_fromsql(struct char_session_data* sd, uint8* buf, uint8* coun
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 53, SQLDT_SHORT,  &p.con, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 54, SQLDT_SHORT,  &p.crt, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 55, SQLDT_UINT16, &p.inventory_slots, 0, NULL, NULL)
+	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 56, SQLDT_UINT8,  &p.dir, 0, NULL, NULL)
 	)
 	{
 		SqlStmt_ShowDebug(stmt);
@@ -1064,7 +1068,7 @@ int char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_ev
 		"`save_map`,`save_x`,`save_y`,`partner_id`,`father`,`mother`,`child`,`fame`,`rename`,`delete_date`,`robe`, `moves`,"
 		"`unban_time`,`font`,`uniqueitem_counter`,`sex`,`hotkey_rowshift`,`clan_id`,`title_id`,`show_equip`,`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`"
+		"`inventory_slots`,`dir`"
 		" FROM `%s` WHERE `char_id`=? LIMIT 1", schema_config.char_db)
 	||	SQL_ERROR == SqlStmt_BindParam(stmt, 0, SQLDT_INT, &char_id, 0)
 	||	SQL_ERROR == SqlStmt_Execute(stmt)
@@ -1141,6 +1145,7 @@ int char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_ev
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 70, SQLDT_SHORT,  &p->con, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 71, SQLDT_SHORT,  &p->crt, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 72, SQLDT_UINT16, &p->inventory_slots, 0, NULL, NULL)
+	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 73, SQLDT_UINT8,  &p->dir, 0, NULL, NULL)
 	)
 	{
 		SqlStmt_ShowDebug(stmt);
@@ -2334,7 +2339,7 @@ bool char_checkdb(void){
 		"`moves`,`unban_time`,`font`,`sex`,`hotkey_rowshift`,`clan_id`,`last_login`,`title_id`,`show_equip`,"
 		"`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`"
+		"`inventory_slots`,`dir`"
 		" FROM `%s` LIMIT 1;", schema_config.char_db) ){
 		Sql_ShowDebug(sql_handle);
 		return false;

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -347,20 +347,20 @@ int char_mmo_char_tosql(uint32 char_id, struct mmo_charstatus* p){
 		(p->mother != cp->mother) || (p->child != cp->child) ||
  		(p->karma != cp->karma) || (p->manner != cp->manner) ||
 		(p->fame != cp->fame) || (p->inventory_slots != cp->inventory_slots) ||
-		(p->dir != cp->dir)
+		(p->body_direction != cp->body_direction)
 	)
 	{
 		if( SQL_ERROR == Sql_Query(sql_handle, "UPDATE `%s` SET `class`='%d',"
 			"`hair`='%d', `hair_color`='%d', `clothes_color`='%d', `body`='%d',"
 			"`partner_id`='%u', `father`='%u', `mother`='%u', `child`='%u',"
 			"`karma`='%d',`manner`='%d', `fame`='%d', `inventory_slots`='%hu',"
-			"`dir`='%d'"
+			"`body_direction`='%d'"
 			" WHERE  `account_id`='%d' AND `char_id` = '%d'",
 			schema_config.char_db, p->class_,
 			p->hair, p->hair_color, p->clothes_color, p->body,
 			p->partner_id, p->father, p->mother, p->child,
 			p->karma, p->manner, p->fame, p->inventory_slots,
-			p->dir,
+			p->body_direction,
 			p->account_id, p->char_id) )
 		{
 			Sql_ShowDebug(sql_handle);
@@ -939,7 +939,7 @@ int char_mmo_chars_fromsql(struct char_session_data* sd, uint8* buf, uint8* coun
 		"`robe`,`moves`,`unban_time`,`font`,`uniqueitem_counter`,`sex`,`hotkey_rowshift`,`title_id`,`show_equip`,"
 		"`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`,`dir`"
+		"`inventory_slots`,`body_direction`"
 		" FROM `%s` WHERE `account_id`='%d' AND `char_num` < '%d'", schema_config.char_db, sd->account_id, MAX_CHARS)
 	||	SQL_ERROR == SqlStmt_Execute(stmt)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 0,  SQLDT_INT,    &p.char_id, 0, NULL, NULL)
@@ -998,7 +998,7 @@ int char_mmo_chars_fromsql(struct char_session_data* sd, uint8* buf, uint8* coun
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 53, SQLDT_SHORT,  &p.con, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 54, SQLDT_SHORT,  &p.crt, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 55, SQLDT_UINT16, &p.inventory_slots, 0, NULL, NULL)
-	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 56, SQLDT_UINT8,  &p.dir, 0, NULL, NULL)
+	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 56, SQLDT_UINT8,  &p.body_direction, 0, NULL, NULL)
 	)
 	{
 		SqlStmt_ShowDebug(stmt);
@@ -1068,7 +1068,7 @@ int char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_ev
 		"`save_map`,`save_x`,`save_y`,`partner_id`,`father`,`mother`,`child`,`fame`,`rename`,`delete_date`,`robe`, `moves`,"
 		"`unban_time`,`font`,`uniqueitem_counter`,`sex`,`hotkey_rowshift`,`clan_id`,`title_id`,`show_equip`,`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`,`dir`"
+		"`inventory_slots`,`body_direction`"
 		" FROM `%s` WHERE `char_id`=? LIMIT 1", schema_config.char_db)
 	||	SQL_ERROR == SqlStmt_BindParam(stmt, 0, SQLDT_INT, &char_id, 0)
 	||	SQL_ERROR == SqlStmt_Execute(stmt)
@@ -1145,7 +1145,7 @@ int char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_ev
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 70, SQLDT_SHORT,  &p->con, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 71, SQLDT_SHORT,  &p->crt, 0, NULL, NULL)
 	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 72, SQLDT_UINT16, &p->inventory_slots, 0, NULL, NULL)
-	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 73, SQLDT_UINT8,  &p->dir, 0, NULL, NULL)
+	||	SQL_ERROR == SqlStmt_BindColumn(stmt, 73, SQLDT_UINT8,  &p->body_direction, 0, NULL, NULL)
 	)
 	{
 		SqlStmt_ShowDebug(stmt);
@@ -2339,7 +2339,7 @@ bool char_checkdb(void){
 		"`moves`,`unban_time`,`font`,`sex`,`hotkey_rowshift`,`clan_id`,`last_login`,`title_id`,`show_equip`,"
 		"`hotkey_rowshift2`,"
 		"`max_ap`,`ap`,`trait_point`,`pow`,`sta`,`wis`,`spl`,`con`,`crt`,"
-		"`inventory_slots`,`dir`"
+		"`inventory_slots`,`body_direction`"
 		" FROM `%s` LIMIT 1;", schema_config.char_db) ){
 		Sql_ShowDebug(sql_handle);
 		return false;

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -572,7 +572,7 @@ struct mmo_charstatus {
 	short shield; // view-id
 	short head_top,head_mid,head_bottom;
 	short robe;
-	uint8 dir;
+	uint8 body_direction;
 
 	char name[NAME_LENGTH];
 	unsigned int base_level,job_level;

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -572,6 +572,7 @@ struct mmo_charstatus {
 	short shield; // view-id
 	short head_top,head_mid,head_bottom;
 	short robe;
+	uint8 dir;
 
 	char name[NAME_LENGTH];
 	unsigned int base_level,job_level;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11045,6 +11045,9 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 			//Login Event
 			npc_script_event(sd, NPCE_LOGIN);
 		}
+
+		// Set facing direction before battle_config.spawn_direction
+		sd->ud.dir = sd->status.dir;
 	} else {
 		//For some reason the client "loses" these on warp/map-change.
 		clif_updatestatus(sd,SP_STR);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11046,8 +11046,9 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 			npc_script_event(sd, NPCE_LOGIN);
 		}
 
-		// Set facing direction before battle_config.spawn_direction
-		sd->ud.dir = sd->status.dir;
+		// Set facing direction before check below to update client
+		if (battle_config.spawn_direction)
+			unit_setdir(&sd->bl, sd->status.dir);
 	} else {
 		//For some reason the client "loses" these on warp/map-change.
 		clif_updatestatus(sd,SP_STR);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11048,7 +11048,7 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 
 		// Set facing direction before check below to update client
 		if (battle_config.spawn_direction)
-			unit_setdir(&sd->bl, sd->status.dir);
+			unit_setdir(&sd->bl, sd->status.dir, false);
 	} else {
 		//For some reason the client "loses" these on warp/map-change.
 		clif_updatestatus(sd,SP_STR);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11048,7 +11048,7 @@ void clif_parse_LoadEndAck(int fd,struct map_session_data *sd)
 
 		// Set facing direction before check below to update client
 		if (battle_config.spawn_direction)
-			unit_setdir(&sd->bl, sd->status.dir, false);
+			unit_setdir(&sd->bl, sd->status.body_direction, false);
 	} else {
 		//For some reason the client "loses" these on warp/map-change.
 		clif_updatestatus(sd,SP_STR);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -121,8 +121,10 @@ int unit_walktoxy_sub(struct block_list *bl)
 	ud->state.change_walk_target=0;
 
 	if (bl->type == BL_PC) {
-		((TBL_PC *)bl)->head_dir = 0;
-		clif_walkok((TBL_PC*)bl);
+		map_session_data *sd = map_id2sd(bl->id);
+
+		sd->head_dir = DIR_NORTH;
+		clif_walkok(sd);
 	}
 #if PACKETVER >= 20170726
 	// If this is a walking NPC and it will use a player sprite
@@ -1110,10 +1112,8 @@ int unit_setdir(struct block_list *bl, unsigned char dir)
 	if (bl->type == BL_PC) {
 		map_session_data *sd = map_id2sd(bl->id);
 
-		if (sd != nullptr) {
-			sd->head_dir = 0;
-			sd->status.dir = ud->dir;
-		}
+		sd->head_dir = DIR_NORTH;
+		sd->status.dir = ud->dir;
 	}
 
 	clif_changed_dir(bl, AREA);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1112,7 +1112,7 @@ bool unit_setdir(block_list *bl, uint8 dir, bool send_update)
 		map_session_data *sd = BL_CAST(BL_PC, bl);
 
 		sd->head_dir = DIR_NORTH;
-		sd->status.dir = ud->dir;
+		sd->status.body_direction = ud->dir;
 	}
 
 	if (send_update)

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -125,7 +125,7 @@ int unit_escape(struct block_list *bl, struct block_list *target, short dist, ui
 // Instant unit changes
 bool unit_movepos(struct block_list *bl, short dst_x, short dst_y, int easy, bool checkpath);
 int unit_warp(struct block_list *bl, short map, short x, short y, clr_type type);
-int unit_setdir(struct block_list *bl, unsigned char dir);
+bool unit_setdir(block_list *bl, uint8 dir, bool send_update = true);
 uint8 unit_getdir(struct block_list *bl);
 int unit_blown(struct block_list* bl, int dx, int dy, int count, enum e_skill_blown flag);
 enum e_unit_blown unit_blown_immune(struct block_list* bl, uint8 flag);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7195

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds a new save field for battle config spawn_direction which was not working for players who log out and in.
Thanks to @SapitoSucio!