### PR TITLE
Several status fixes

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1333,6 +1333,7 @@ Body:
     Flags:
       Debuff: true
       NoClearance: true
+      NoSave: true
     End:
       Blessing: true
       Increaseagi: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -79,6 +79,7 @@ Body:
     DurationLookup: NPC_PETRIFYATTACK
     States:
       NoCast: true
+      NoAttack: true
     Opt1: StoneWait
     Flags:
       SendOption: true
@@ -752,6 +753,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Stripshield
     Icon: EFST_NOEQUIPSHIELD
     DurationLookup: RG_STRIPSHIELD
@@ -763,6 +765,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Striparmor
     Icon: EFST_NOEQUIPARMOR
     DurationLookup: RG_STRIPARMOR
@@ -774,6 +777,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Striphelm
     Icon: EFST_NOEQUIPHELM
     DurationLookup: RG_STRIPHELM
@@ -785,6 +789,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Cp_Weapon
     Icon: EFST_PROTECTWEAPON
     DurationLookup: AM_CP_WEAPON
@@ -932,6 +937,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Explosionspirits
     Icon: EFST_EXPLOSIONSPIRITS
     DurationLookup: MO_EXPLOSIONSPIRITS
@@ -943,6 +949,7 @@ Body:
     Flags:
       Debuff: true
       NoClearance: true
+      NoSave: true
   - Status: Combo
     Flags:
       NoClearbuff: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -954,6 +954,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Explosionspirits
     Icon: EFST_EXPLOSIONSPIRITS
     DurationLookup: MO_EXPLOSIONSPIRITS

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -80,6 +80,7 @@ Body:
     DurationLookup: NPC_PETRIFYATTACK
     States:
       NoCast: true
+      NoAttack: true
     Opt1: StoneWait
     Flags:
       SendOption: true
@@ -767,6 +768,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Stripshield
     Icon: EFST_NOEQUIPSHIELD
     DurationLookup: RG_STRIPSHIELD
@@ -778,6 +780,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Striparmor
     Icon: EFST_NOEQUIPARMOR
     DurationLookup: RG_STRIPARMOR
@@ -789,6 +792,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Striphelm
     Icon: EFST_NOEQUIPHELM
     DurationLookup: RG_STRIPHELM
@@ -800,6 +804,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      NoSave: true
   - Status: Cp_Weapon
     Icon: EFST_PROTECTWEAPON
     DurationLookup: AM_CP_WEAPON
@@ -958,6 +963,7 @@ Body:
     Flags:
       Debuff: true
       NoClearance: true
+      NoSave: true
   - Status: Combo
     Flags:
       NoClearbuff: true
@@ -1341,6 +1347,7 @@ Body:
     Flags:
       Debuff: true
       NoClearance: true
+      NoSave: true
     End:
       Blessing: true
       Increaseagi: true


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
Fixes #7215
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
* Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
 Fixed status that must disappear when logging off :
  - Strip skills
  - Asura sp regen malus
  - Critical Explosion
  - npc_changeundead
  
  Enchants will now correctly be cleansed when removing weapon, and won't stay upon death.
  Monsters in StoneWait are correctly prevented from attacking
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
