### PR TITLE
Better error message for YAML syntax errors

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -110,7 +110,7 @@ bool YamlDatabase::load(const std::string& path) {
 
 	try{
 		tree = parser.parse_in_arena(c4::to_csubstr(path), c4::to_csubstr(buf));
-	}catch( std::runtime_error e ){
+	}catch( const std::runtime_error& e ){
 		ShowError( "Failed to load %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), path.c_str() );
 		ShowError( "You most likely have a syntax error in your file.\n" );
 		ShowError( "Error message: %s\n", e.what() );

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -112,7 +112,7 @@ bool YamlDatabase::load(const std::string& path) {
 		tree = parser.parse_in_arena(c4::to_csubstr(path), c4::to_csubstr(buf));
 	}catch( const std::runtime_error& e ){
 		ShowError( "Failed to load %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), path.c_str() );
-		ShowError( "You most likely have a syntax error in your file.\n" );
+		ShowError( "There is likely a syntax error in the file.\n" );
 		ShowError( "Error message: %s\n", e.what() );
 		return false;
 	}

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -106,7 +106,16 @@ bool YamlDatabase::load(const std::string& path) {
 	fclose(f);
 
 	parser = {};
-	ryml::Tree tree = parser.parse_in_arena(c4::to_csubstr(path), c4::to_csubstr(buf));
+	ryml::Tree tree;
+
+	try{
+		tree = parser.parse_in_arena(c4::to_csubstr(path), c4::to_csubstr(buf));
+	}catch( std::runtime_error e ){
+		ShowError( "Failed to load %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), path.c_str() );
+		ShowError( "You most likely have a syntax error in your file.\n" );
+		ShowError( "Error message: %s\n", e.what() );
+		return false;
+	}
 
 	// Required here already for header error reporting
 	this->currentFile = path;


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Since it has been a problem a few times in the Discord support channel, we should provide a better error message when there is a YAML syntax error in a database file.
