### PR TITLE
Updated Gunslinger Job Change Quests's Reward Items

### DIFF
--- a/npc/jobs/1-1e/gunslinger.txt
+++ b/npc/jobs/1-1e/gunslinger.txt
@@ -183,10 +183,16 @@ que_ng,152,167,3	script	Master Miller	901,{
 			callfunc "Job_Change",Job_Gunslinger;
 			set GUNS_Q,6;
 			completequest 6024;
-			if (rand(1,2) == 1) {
-				getitem 13100,1; // Six_Shooter
+			if(checkre(0) == 1){
+				getitem 13180,1;		// Novice_Rifle
+				getitem 12149,2;		// Bullet_Case
+				getitem 12151,1;		// Bullet_Case_Silver
 			} else {
-				getitem 13150,1; // Branch
+				if (rand(1,2) == 1) {
+					getitem 13100,1;	// Six_Shooter
+				} else {
+					getitem 13150,1;	// Branch
+				}
 			}
 			close;
 		}


### PR DESCRIPTION
Checked against reliable source to confirm items.
Added a check instead of a separate file as only the items have changed between Pre-RE and RE.

* **Addressed Issue(s)**:  #3690 

* **Server Mode**:  Renewal

* **Description of Pull Request**: 
Adds a `checkre()` function to determine which items the new Gunslinger should be rewarded with. This allows players to exchange their rifle instead of being stuck with the Pre-RE items.

I used the function instead of creating separate (pre-)re files as the rewards are the only lines that change between server modes, and code duplication is not beneficial to anybody.