### PR TITLE
Fixes Lif - Brain Surgery SP bonus

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -4798,7 +4798,7 @@ int status_calc_homunculus_(struct homun_data *hd, uint8 opt)
 		status->max_hp += skill_lv * 2 * status->max_hp / 100;
 
 	if((skill_lv = hom_checkskill(hd, HLIF_BRAIN)) > 0)
-		status->max_sp += (1 + skill_lv / 2 - skill_lv / 4 + skill_lv / 5) * status->max_sp / 100;
+		status->max_sp += skill_lv * status->max_sp / 100;
 
 	if (opt&SCO_FIRST) {
 		hd->battle_status.hp = hom->hp;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7221

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Corrects the SP bonus of Lif's Brain Surgery to be skill_lv%.
Thanks to @Daraen1!