### PR TITLE
Fixes Skill Damage Database reflecting damage

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8491,7 +8491,7 @@ int64 battle_calc_return_damage(struct block_list* tbl, struct block_list *src, 
 
 	if (skill_damage != 0) {
 		rdamage += rdamage * skill_damage / 100;
-		rdamage = i64max(rdamage, 1);
+		rdamage = i64max(rdamage, 0);
 	}
 
 	if (rdamage == 0)


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7248

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves an issue where skills defined in the Skill Damage Database would always reflect at least 1 damage even when no reflective gear or skills are active.
Thanks to @dev1-juan!