### PR TITLE
Adds a battle config for Guild Skill saving

### DIFF
--- a/conf/battle/guild.conf
+++ b/conf/battle/guild.conf
@@ -17,7 +17,13 @@ guild_exp_limit: 50
 guild_max_castles: 0
 
 // Activate guild skills delay by relog?
-// Official setting is 5 minutes (300000 ms), otherwise allow guild leaders to relog to cancel the 5 minute delay.
+// 0 - Save cooldown and resume on relog.
+// 1 - Don't save cooldown and restart the timer on relog.
+// Default on official servers: 1 for Pre-renewal, 0 for Renewal
+//guild_skill_relog_type: 0
+
+// Delay in milliseconds that are applied to guild skills.
+// Official setting is 5 minutes (300000 ms).
 // Note: This was changed in renewal in favor of individual skill cooldown.
 guild_skill_relog_delay: 300000
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9739,7 +9739,7 @@ static const struct _battle_data {
 	{ "guild_skill_relog_delay",            &battle_config.guild_skill_relog_delay,         300000, 0,      INT_MAX,        },
 #ifdef RENEWAL
 	{ "guild_skill_relog_type",             &battle_config.guild_skill_relog_type,          0,      0,      1,              },
-#elif
+#else
 	{ "guild_skill_relog_type",             &battle_config.guild_skill_relog_type,          1,      0,      1,              },
 #endif
 	{ "emergency_call",                     &battle_config.emergency_call,                  11,     0,      31,             },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9737,6 +9737,11 @@ static const struct _battle_data {
 	{ "gtb_sc_immunity",                    &battle_config.gtb_sc_immunity,                 50,     0,      INT_MAX,        },
 	{ "guild_max_castles",                  &battle_config.guild_max_castles,               0,      0,      INT_MAX,        },
 	{ "guild_skill_relog_delay",            &battle_config.guild_skill_relog_delay,         300000, 0,      INT_MAX,        },
+#ifdef RENEWAL
+	{ "guild_skill_relog_type",             &battle_config.guild_skill_relog_type,          0,      0,      1,              },
+#elif
+	{ "guild_skill_relog_type",             &battle_config.guild_skill_relog_type,          1,      0,      1,              },
+#endif
 	{ "emergency_call",                     &battle_config.emergency_call,                  11,     0,      31,             },
 	{ "atcommand_spawn_quantity_limit",     &battle_config.atc_spawn_quantity_limit,        100,    0,      INT_MAX,        },
 	{ "atcommand_slave_clone_limit",        &battle_config.atc_slave_clone_limit,           25,     0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -216,6 +216,7 @@ struct Battle_Config
 	int guild_exp_limit;
 	int guild_max_castles;
 	int guild_skill_relog_delay;
+	int guild_skill_relog_type;
 	int emergency_call;
 	int guild_aura;
 	int pc_invincible_time;

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1371,10 +1371,8 @@ int chrif_skillcooldown_save(struct map_session_data *sd) {
 		if (!sd->scd[i])
 			continue;
 
-#ifndef RENEWAL
-		if (!battle_config.guild_skill_relog_delay && (sd->scd[i]->skill_id >= GD_BATTLEORDER && sd->scd[i]->skill_id <= GD_EMERGENCYCALL))
+		if (battle_config.guild_skill_relog_type == 1 && (sd->scd[i]->skill_id >= GD_BATTLEORDER && sd->scd[i]->skill_id <= GD_EMERGENCYCALL))
 			continue;
-#endif
 
 		timer = get_timer(sd->scd[i]->timer);
 		if (timer == NULL || timer->func != skill_blockpc_end || DIFF_TICK(timer->tick, tick) < 0)

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1371,7 +1371,7 @@ int chrif_skillcooldown_save(struct map_session_data *sd) {
 		if (!sd->scd[i])
 			continue;
 
-		if (battle_config.guild_skill_relog_type == 1 && (sd->scd[i]->skill_id >= GD_BATTLEORDER && sd->scd[i]->skill_id <= GD_EMERGENCYCALL))
+		if (battle_config.guild_skill_relog_type == 1 && SKILL_CHK_GUILD(sd->scd[i]->skill_id))
 			continue;
 
 		timer = get_timer(sd->scd[i]->timer);


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7256

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds battle config guild_skill_relog_type to allow the ability to save Guild Skill cooldowns on relog or reset them.
Thanks to @Xypr0!