### PR TITLE
Fixes to Lullaby, Pang Voice, and Wink of Charm

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -8272,7 +8272,7 @@ Body:
     Hit: Single
     HitCount: 1
     Duration1: 60000
-    Duration2: 15000
+    Duration2: 30000
     Requires:
       SpCost: 20
       Weapon:
@@ -8281,7 +8281,7 @@ Body:
     Unit:
       Id: Lullaby
       Layout: 4
-      Interval: 6000
+      Interval: 4000
       Target: Enemy
       Flag:
         Ensemble: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -8661,7 +8661,7 @@ Body:
     SplashArea: 4
     CastTime: 1000
     Duration1: 60000
-    Duration2: 15000
+    Duration2: 18000
     Cooldown: 20000
     Requires:
       SpCost: 40

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1595,7 +1595,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		break;
 
 	case BD_LULLABY:
-		sc_start(src, bl, SC_SLEEP, sstatus->int_ * 0.2 + rnd_value(10, 30), skill_lv, skill_get_time2(skill_id, skill_lv));
+		status_change_start(src, bl, SC_SLEEP, (sstatus->int_ * 2 + rnd_value(100, 300)) * 10, skill_lv, 0, 0, 0, skill_get_time2(skill_id, skill_lv), SCSTART_NONE);
 		break;
 
 	case DC_UGLYDANCE:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1595,7 +1595,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		break;
 
 	case BD_LULLABY:
-		sc_start(src,bl,SC_SLEEP,15+sstatus->int_/3,skill_lv,skill_get_time2(skill_id,skill_lv)); //(custom chance) "Chance is increased with INT", iRO Wiki
+		sc_start(src, bl, SC_SLEEP, sstatus->int_ * 0.2 + rnd_value(10, 30), skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 
 	case DC_UGLYDANCE:
@@ -8683,7 +8683,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		break;
 
 	case BA_PANGVOICE:
-		clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,50,7,skill_get_time(skill_id,skill_lv)));
+		clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,70,7,skill_get_time(skill_id,skill_lv)));
 #ifdef RENEWAL
 		sc_start(src, bl, SC_BLEEDING, 30, skill_lv, skill_get_time2(skill_id, skill_lv)); // TODO: Confirm success rate
 #endif
@@ -8691,7 +8691,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 
 	case DC_WINKCHARM:
 		if( dstsd ) {
-			clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,30,7,skill_get_time2(skill_id,skill_lv)));
+			clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,10,7,skill_get_time2(skill_id,skill_lv)));
 #ifdef RENEWAL
 			sc_start(src, bl, SC_HALLUCINATION, 30, skill_lv, skill_get_time(skill_id, skill_lv)); // TODO: Confirm success rate and duration
 #endif
@@ -8701,7 +8701,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( status_get_lv(src) > status_get_lv(bl)
 			&&  (tstatus->race == RC_DEMON || tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_PLAYER_HUMAN || tstatus->race == RC_PLAYER_DORAM || tstatus->race == RC_ANGEL)
 			&&  !status_has_mode(tstatus,MD_STATUSIMMUNE) )
-				clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start2(src,bl,type,70,skill_lv,src->id,skill_get_time(skill_id,skill_lv)));
+				clif_skill_nodamage(src,bl,skill_id,skill_lv, sc_start2(src,bl,type,(status_get_lv(src) - status_get_lv(bl)) + 40, skill_lv, src->id, skill_get_time(skill_id, skill_lv)));
 			else
 			{
 				clif_skill_nodamage(src,bl,skill_id,skill_lv,0);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1916,14 +1916,14 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 
 		if (sc->data[SC_WINKCHARM] && target && !flag) { // Prevents skill usage
 			block_list *wink_target = map_id2bl(sc->data[SC_WINKCHARM]->val2);
-			unit_data *wink_ud = unit_bl2ud(src);
 
 			if (wink_target != nullptr) {
+				unit_data *wink_ud = unit_bl2ud(src);
 				if (wink_ud != nullptr && wink_ud->walktimer == INVALID_TIMER)
 					unit_walktobl(src, wink_target, 3, 1);
 				clif_emotion(src, ET_THROB);
 			} else
-				status_change_end(src, SC_WINKCHARM, INVALID_TIMER);
+				status_change_end(src, SC_WINKCHARM);
 		}
 
 		if (sc->data[SC_BLADESTOP]) {

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1915,10 +1915,15 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 			return false;
 
 		if (sc->data[SC_WINKCHARM] && target && !flag) { // Prevents skill usage
-			if (unit_bl2ud(src) && (unit_bl2ud(src))->walktimer == INVALID_TIMER)
-				unit_walktobl(src, map_id2bl(sc->data[SC_WINKCHARM]->val2), 3, 1);
-			clif_emotion(src, ET_THROB);
-			return false;
+			block_list *wink_target = map_id2bl(sc->data[SC_WINKCHARM]->val2);
+			unit_data *wink_ud = unit_bl2ud(src);
+
+			if (wink_target != nullptr) {
+				if (wink_ud != nullptr && wink_ud->walktimer == INVALID_TIMER)
+					unit_walktobl(src, wink_target, 3, 1);
+				clif_emotion(src, ET_THROB);
+			} else
+				status_change_end(src, SC_WINKCHARM, INVALID_TIMER);
 		}
 
 		if (sc->data[SC_BLADESTOP]) {


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6916

* **Server Mode**: Pre-reneawl and Renewal

* **Description of Pull Request**: 
  * Corrects the interval of Lullaby to every 4 seconds in pre-renewal.
  * Corrects the success chance of Lullaby to INT * 0.2 + rand(10%, 30%) for Sleep.
  * Corrects the duration of Lullaby's Sleep to 18 + 2 seconds in renewal and 30 seconds in pre-renewal.
  * Corrects the success chance of Pang Voice to 70% for Confusion.
  * Corrects the success chance of Wink of Charm versus players to 10% for Confusion.
  * Corrects the success chance of Wink of Charm versus monsters to [(srcBaseLevel - tarBaseLevel) + 40]% for Charm.
Thanks to @Playtester!