### PR TITLE
Adds SC_WEAPONBREAKER status

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -9325,15 +9325,13 @@ Body:
     Name: NPC_WEAPONBRAKER
     Description: Break weapon
     MaxLevel: 10
-    Type: Weapon
-    TargetType: Attack
+    TargetType: Self
     Flags:
       IsNpc: true
-    Range: 9
     Hit: Single
     HitCount: 1
-    Element: Weapon
-    Status: BrokenWeapon
+    Duration: 30000
+    Status: WeaponBreaker
   - Id: 344
     Name: NPC_ARMORBRAKE
     Description: Break armor

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -6933,3 +6933,5 @@ Body:
       NoDispell: true
       NoClearance: true
       NoClearbuff: true
+  - Status: WeaponBreaker
+    DurationLookup: NPC_WEAPONBRAKER

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -9635,15 +9635,13 @@ Body:
     Name: NPC_WEAPONBRAKER
     Description: Break weapon
     MaxLevel: 10
-    Type: Weapon
-    TargetType: Attack
+    TargetType: Self
     Flags:
       IsNpc: true
-    Range: 9
     Hit: Single
     HitCount: 1
-    Element: Weapon
-    Status: BrokenWeapon
+    Duration: 30000
+    Status: WeaponBreaker
   - Id: 344
     Name: NPC_ARMORBRAKE
     Description: Break armor

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -8400,3 +8400,5 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+  - Status: WeaponBreaker
+    DurationLookup: NPC_WEAPONBRAKER

--- a/doc/status_change.txt
+++ b/doc/status_change.txt
@@ -2827,3 +2827,8 @@ SC_PACKING_ENVELOPE9	(EFST_PACKING_ENVELOPE9)
 SC_PACKING_ENVELOPE10	(EFST_PACKING_ENVELOPE10)
 	desc: Increases HIT
 	val1: + HIT
+
+SC_WEAPONBREAKER
+	desc: Bonus given when using NPC_WEAPONBRAKER skill
+	val1: Skill level
+	val2: val1 * 2 weapon break chance

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -1865,6 +1865,7 @@
 	export_constant(SC_SKF_CAST);
 	export_constant(SC_BEEF_RIB_STEW);
 	export_constant(SC_PORK_RIB_STEW);
+	export_constant(SC_WEAPONBREAKER);
 
 #ifdef RENEWAL
 	export_constant(SC_EXTREMITYFIST2);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1657,9 +1657,6 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 			break;
 		}
 	// Equipment breaking monster skills [Celest]
-	case NPC_WEAPONBRAKER:
-		skill_break_equip(src,bl, EQP_WEAPON, 150*skill_lv, BCT_ENEMY);
-		break;
 	case NPC_ARMORBRAKE:
 		skill_break_equip(src,bl, EQP_ARMOR, 150*skill_lv, BCT_ENEMY);
 		break;
@@ -2226,8 +2223,12 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 			rate = 0;
 			if( sd )
 				rate += sd->bonus.break_weapon_rate;
-			if( sc && sc->data[SC_MELTDOWN] )
-				rate += sc->data[SC_MELTDOWN]->val2;
+			if (sc) {
+				if (sc->data[SC_MELTDOWN])
+					rate += sc->data[SC_MELTDOWN]->val2;
+				if (sc->data[SC_WEAPONBREAKER])
+					rate += sc->data[SC_WEAPONBREAKER]->val2;
+			}
 			if( rate )
 				skill_break_equip(src,bl, EQP_WEAPON, rate, BCT_ENEMY);
 
@@ -5016,7 +5017,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case NPC_UNDEADATTACK:
 	case NPC_CHANGEUNDEAD:
 	case NPC_ARMORBRAKE:
-	case NPC_WEAPONBRAKER:
 	case NPC_HELMBRAKE:
 	case NPC_SHIELDBRAKE:
 	case NPC_BLINDATTACK:
@@ -7612,6 +7612,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case NPC_MAGICMIRROR:
 	case ST_PRESERVE:
 	case NPC_KEEPING:
+	case NPC_WEAPONBRAKER:
 	case NPC_BARRIER:
 	case NPC_INVINCIBLE:
 	case NPC_INVINCIBLEOFF:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12473,7 +12473,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			}
 			break;
 		case SC_WEAPONBREAKER:
-			val2 = val1 * 2; // Chance to break weapon
+			val2 = val1 * 2 * 100; // Chance to break weapon
 			break;
 
 		default:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12472,6 +12472,9 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 				}
 			}
 			break;
+		case SC_WEAPONBREAKER:
+			val2 = val1 * 2; // Chance to break weapon
+			break;
 
 		default:
 			if (calc_flag.none() && scdb->skill_id == 0 && scdb->icon == EFST_BLANK && scdb->opt1 == OPT1_NONE && scdb->opt2 == OPT2_NONE && scdb->state.none() && scdb->flag.none() && scdb->end.empty() && scdb->endreturn.empty() && scdb->fail.empty()) {

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -1253,6 +1253,8 @@ enum sc_type : int16 {
 	SC_BEEF_RIB_STEW,
 	SC_PORK_RIB_STEW,
 
+	SC_WEAPONBREAKER,
+
 #ifdef RENEWAL
 	SC_EXTREMITYFIST2, //! NOTE: This SC should be right before SC_MAX, so it doesn't disturb if RENEWAL is disabled
 #endif


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #6915

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Adds the SC_WEAPONBREAKER status which is applied via NPC_WEAPONBRAKER's self cast ability.
  * Adds a chance to break a target's weapon at 2 * skill_lv% for 30 seconds.
Thanks to @Playtester!