### PR TITLE
Fixed caching of databases during runtime

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -213,7 +213,7 @@ public:
 	}
 
 	void erase( keytype key ) override{
-		TypesafeYamlDatabase::erase( key );
+		TypesafeYamlDatabase<keytype, datatype>::erase( key );
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){
@@ -222,7 +222,7 @@ public:
 	}
 
 	void put( keytype key, std::shared_ptr<datatype> ptr ) override{
-		TypesafeYamlDatabase::put( key, ptr );
+		TypesafeYamlDatabase<keytype, datatype>::put( key, ptr );
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -111,7 +111,7 @@ public:
 		}
 	}
 
-	void put( keytype key, std::shared_ptr<datatype> ptr ){
+	virtual void put( keytype key, std::shared_ptr<datatype> ptr ){
 		this->data[key] = ptr;
 	}
 
@@ -135,7 +135,7 @@ public:
 		return rathena::util::umap_random( this->data );
 	}
 
-	void erase(keytype key) {
+	virtual void erase(keytype key) {
 		this->data.erase(key);
 	}
 };
@@ -143,20 +143,22 @@ public:
 template <typename keytype, typename datatype> class TypesafeCachedYamlDatabase : public TypesafeYamlDatabase<keytype, datatype>{
 private:
 	std::vector<std::shared_ptr<datatype>> cache;
+	bool loaded;
 
 public:
 	TypesafeCachedYamlDatabase( const std::string& type_, uint16 version_, uint16 minimumVersion_ ) : TypesafeYamlDatabase<keytype, datatype>( type_, version_, minimumVersion_ ){
-
+		this->loaded = false;
 	}
 
 	TypesafeCachedYamlDatabase( const std::string& type_, uint16 version_ ) : TypesafeYamlDatabase<keytype, datatype>( type_, version_, version_ ){
-
+		this->loaded = false;
 	}
 
 	void clear() override{
 		TypesafeYamlDatabase<keytype, datatype>::clear();
 		cache.clear();
 		cache.shrink_to_fit();
+		this->loaded = false;
 	}
 
 	std::shared_ptr<datatype> find( keytype key ) override{
@@ -205,6 +207,26 @@ public:
 				this->cache.shrink_to_fit();
 				break;
 			}
+		}
+
+		this->loaded = true;
+	}
+
+	void erase( keytype key ) override{
+		TypesafeYamlDatabase::erase( key );
+
+		// Prevent excessive usage during loading
+		if( this->loaded ){
+			this->cache[this->calculateCacheKey( key )] = nullptr;
+		}
+	}
+
+	void put( keytype key, std::shared_ptr<datatype> ptr ) override{
+		TypesafeYamlDatabase::put( key, ptr );
+
+		// Prevent excessive usage during loading
+		if( this->loaded ){
+			this->cache[this->calculateCacheKey( key )] = ptr;
 		}
 	}
 };


### PR DESCRIPTION
* **Addressed Issue(s)**: #7268

* **Server Mode**: Both

* **Description of Pull Request**: 
Databases that use the cached variant and get modified during runtime did not store the correct values in their cache and therefore returned nullptr even if an entry was inserted or if an entry was erased an outdated pointer was returned.

Thanks to @jmsngls
