### PR TITLE
Fixes an issue with weapon swapping and statuses

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -11720,8 +11720,6 @@ static void pc_unequipitem_sub(struct map_session_data *sd, int n, int flag) {
 	pc_deleteautobonus( sd->autobonus3, sd->inventory.u.items_inventory[n].equip );
 
 	sd->inventory.u.items_inventory[n].equip = 0;
-	if (!(flag & 4))
-		pc_checkallowskill(sd);
 	iflag = sd->npc_item_flag;
 
 	// Check for combos (MUST be before status_calc_pc)
@@ -11751,7 +11749,8 @@ static void pc_unequipitem_sub(struct map_session_data *sd, int n, int flag) {
 	}
 
 	if (flag & 1 || status_calc) {
-		pc_checkallowskill(sd);
+		if (!(flag & 4))
+			pc_checkallowskill(sd);
 		status_calc_pc(sd, SCO_FORCE);
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Resolves statuses ending early when swapping weapons of the same type.
  * Removes a duplicate check.
Thanks to @Aristeus09!