### PR TITLE
Add *getrandmobid script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3585,26 +3585,26 @@ This command does not count skills which are set as flag 4 (permament granted) (
 *getrandmobid(<type>{,<flag>{,<level>}})
 
 This command returns a random monster ID from the random monster group.
-If <level> is provided it will check against the monster level.
-Returns 0 if invalid.
+With <flag> you can apply certain restrictions which monsters of the group can be returned.
+Returns 0 if one of the parameters is invalid or no monster could be found with the given parameters.
 
 Valid <type> are:
-	MOBG_BRANCH_OF_DEAD_TREE    = 0 // (default)
-	MOBG_PORING_BOX             = 1
-	MOBG_BLOODY_DEAD_BRANCH     = 2
-	MOBG_RED_POUCH_OF_SURPRISE  = 3
-	MOBG_CLASSCHANGE            = 4
-	MOBG_TAEKWON_MISSION        = 5
+	MOBG_BRANCH_OF_DEAD_TREE
+	MOBG_PORING_BOX
+	MOBG_BLOODY_DEAD_BRANCH
+	MOBG_RED_POUCH_OF_SURPRISE
+	MOBG_CLASSCHANGE
+	MOBG_TAEKWON_MISSION
 	
 Valid <flag> are:
-	RMF_NONE            = 0x00, // Apply no flags
-	RMF_DB_RATE         = 0x01, // Apply the summon success chance found in the list (otherwise get any monster from the db)
-	RMF_CHECK_MOB_LV    = 0x02, // Apply a monster level check
-	RMF_MOB_NOT_BOSS    = 0x04, // Selected monster should not be a Boss type (default)
-	                            // (except those from MOBG_BLOODY_DEAD_BRANCH)
-	RMF_MOB_NOT_SPAWN   = 0x08, // Selected monster must have normal spawn
-	RMF_MOB_NOT_PLANT   = 0x10, // Selected monster should not be a Plant type
-	RMF_ALL             = 0xFF, // Apply all flags
+	RMF_NONE            = 0x00 - Apply no flags
+	RMF_DB_RATE         = 0x01 - Apply the summon success chance found in the list (otherwise get any monster from the db)
+	RMF_CHECK_MOB_LV    = 0x02 - Apply a monster level check
+	RMF_MOB_NOT_BOSS    = 0x04 - Selected monster should not be a Boss type (default)
+	                           - (except those from MOBG_BLOODY_DEAD_BRANCH)
+	RMF_MOB_NOT_SPAWN   = 0x08 - Selected monster must have normal spawn
+	RMF_MOB_NOT_PLANT   = 0x10 - Selected monster should not be a Plant type
+	RMF_ALL             = 0xFF - Apply all flags
 	
 ---------------------------------------
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3582,6 +3582,32 @@ This command does not count skills which are set as flag 4 (permament granted) (
 
 ---------------------------------------
 
+*getrandmobid(<type>{,<flag>{,<level>}})
+
+This command return a random monster ID from the random monster group.
+If <level> is provided it will check against the monster level.
+It will return 0 if invalid.
+
+Valid <type> are:
+	MOBG_BRANCH_OF_DEAD_TREE    = 0 // (default)
+	MOBG_PORING_BOX             = 1
+	MOBG_BLOODY_DEAD_BRANCH     = 2
+	MOBG_RED_POUCH_OF_SURPRISE  = 3
+	MOBG_CLASSCHANGE            = 4
+	MOBG_TAEKWON_MISSION        = 5
+	
+Valid <flag> are:
+	RMF_NONE            = 0x00, // Apply no flags
+	RMF_DB_RATE         = 0x01, // Apply the summon success chance found in the list (otherwise get any monster from the db)
+	RMF_CHECK_MOB_LV    = 0x02, // Apply a monster level check
+	RMF_MOB_NOT_BOSS    = 0x04, // Selected monster should not be a Boss type (default)
+	                            // (except those from MOBG_BLOODY_DEAD_BRANCH)
+	RMF_MOB_NOT_SPAWN   = 0x08, // Selected monster must have normal spawn
+	RMF_MOB_NOT_PLANT   = 0x10, // Selected monster should not be a Plant type
+	RMF_ALL             = 0xFF, // Apply all flags
+	
+---------------------------------------
+
 *getmonsterinfo(<mob ID>,<type>)
 *getmonsterinfo(<mob name>,<type>)
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -3584,9 +3584,9 @@ This command does not count skills which are set as flag 4 (permament granted) (
 
 *getrandmobid(<type>{,<flag>{,<level>}})
 
-This command return a random monster ID from the random monster group.
+This command returns a random monster ID from the random monster group.
 If <level> is provided it will check against the monster level.
-It will return 0 if invalid.
+Returns 0 if invalid.
 
 Valid <type> are:
 	MOBG_BRANCH_OF_DEAD_TREE    = 0 // (default)

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18218,6 +18218,7 @@ BUILDIN_FUNC(getrandmobid)
 
 	if (type < MOBG_BRANCH_OF_DEAD_TREE || type >= MOBG_MAX) {
 		ShowWarning("buildin_getrandmobid: Invalid type %d.\n", type);
+		script_pushint(st, 0);
 		return SCRIPT_CMD_FAILURE;
 	}
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18229,11 +18229,20 @@ BUILDIN_FUNC(getrandmobid)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int lv = script_hasdata(st, 4) ? script_getnum(st, 4) : MAX_LEVEL;
-	if (lv <= 0) {
-		ShowWarning("buildin_getrandmobid: Invalid level %d.\n", lv);
-		script_pushint(st, 0);
-		return SCRIPT_CMD_FAILURE;
+	int lv;
+	if ( script_hasdata(st, 4) ) {
+		lv = script_getnum(st, 4);
+		
+		if (lv <= 0) {
+			ShowWarning("buildin_getrandmobid: Invalid level %d.\n", lv);
+			script_pushint(st, 0);
+			return SCRIPT_CMD_FAILURE;
+		}
+		
+		// If a level is provided, make sure it is respected
+		flag |= RMF_CHECK_MOB_LV;
+	} else {
+		lv = MAX_LEVEL;
 	}
 
 	script_pushint(st, mob_get_random_id(type, (enum e_random_monster_flags)flag, lv));

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18223,7 +18223,19 @@ BUILDIN_FUNC(getrandmobid)
 	}
 
 	int flag = script_hasdata(st, 3) ? script_getnum(st, 3) : RMF_MOB_NOT_BOSS;
+	if (flag < RMF_NONE || flag > RMF_ALL) {
+		ShowWarning("buildin_getrandmobid: Invalid flag %d.\n", flag);
+		script_pushint(st, 0);
+		return SCRIPT_CMD_FAILURE;
+	}
+
 	int lv = script_hasdata(st, 4) ? script_getnum(st, 4) : MAX_LEVEL;
+	if (lv <= 0) {
+		ShowWarning("buildin_getrandmobid: Invalid level %d.\n", lv);
+		script_pushint(st, 0);
+		return SCRIPT_CMD_FAILURE;
+	}
+
 	int mob_id = mob_get_random_id(type, (enum e_random_monster_flags)flag, lv);
 
 	script_pushint(st, mob_id);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18236,9 +18236,7 @@ BUILDIN_FUNC(getrandmobid)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int mob_id = mob_get_random_id(type, (enum e_random_monster_flags)flag, lv);
-
-	script_pushint(st, mob_id);
+	script_pushint(st, mob_get_random_id(type, (enum e_random_monster_flags)flag, lv));
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18205,6 +18205,32 @@ BUILDIN_FUNC(delmonsterdrop)
 }
 
 
+
+/*==========================================
+ * Returns a random mob_id
+ * type: Where to fetch from (see enum e_random_monster)
+ * flag: Type of checks to apply (see enum e_random_monster_flags)
+ * lv: Mob level to check against
+ *------------------------------------------*/
+BUILDIN_FUNC(getrandmobid)
+{
+	int type = script_hasdata(st, 2) ? script_getnum(st, 2) : MOBG_BRANCH_OF_DEAD_TREE;
+
+	if (type < MOBG_BRANCH_OF_DEAD_TREE || type >= MOBG_MAX) {
+		ShowWarning("buildin_getrandmobid: Invalid type %d.\n", type);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	int flag = script_hasdata(st, 3) ? script_getnum(st, 3) : RMF_MOB_NOT_BOSS;
+	int lv = script_hasdata(st, 4) ? script_getnum(st, 4) : MAX_LEVEL;
+	int mob_id = mob_get_random_id(type, (enum e_random_monster_flags)flag, lv);
+
+	script_pushint(st, mob_id);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+
 /*==========================================
  * Returns some values of a monster [Lupus]
  * Name, Level, race, size, etc...
@@ -26954,6 +26980,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(setitemscript,"is?"), //Set NEW item bonus script. Lupus
 	BUILDIN_DEF(disguise,"i?"), //disguise player. Lupus
 	BUILDIN_DEF(undisguise,"?"), //undisguise player. Lupus
+	BUILDIN_DEF(getrandmobid, "i??"),
 	BUILDIN_DEF(getmonsterinfo,"vi"), //Lupus
 	BUILDIN_DEF(addmonsterdrop,"vii??"), //Akinari [Lupus]
 	BUILDIN_DEF(delmonsterdrop,"vi"), //Akinari [Lupus]

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18214,7 +18214,7 @@ BUILDIN_FUNC(delmonsterdrop)
  *------------------------------------------*/
 BUILDIN_FUNC(getrandmobid)
 {
-	int type = script_hasdata(st, 2) ? script_getnum(st, 2) : MOBG_BRANCH_OF_DEAD_TREE;
+	int type = script_getnum(st, 2);
 
 	if (type < MOBG_BRANCH_OF_DEAD_TREE || type >= MOBG_MAX) {
 		ShowWarning("buildin_getrandmobid: Invalid type %d.\n", type);

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -4943,6 +4943,15 @@
 	export_constant(MOBG_CLASSCHANGE);
 	export_constant(MOBG_TAEKWON_MISSION);
 
+	/* mob random groups flags */
+	export_constant(RMF_NONE);
+	export_constant(RMF_DB_RATE);
+	export_constant(RMF_CHECK_MOB_LV);
+	export_constant(RMF_MOB_NOT_BOSS);
+	export_constant(RMF_MOB_NOT_SPAWN);
+	export_constant(RMF_MOB_NOT_PLANT);
+	export_constant(RMF_ALL);
+
 	/* random option attributes */
 	export_constant(ROA_ID);
 	export_constant(ROA_VALUE);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
hard to generate a random mob id using existing way, often caused map-server prompt unnecessary warnings
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable to return a `mob_id` from the random monster group.
useful for Disguise Event or anytime when you need a random monster.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
