### PR TITLE
Add PC Fame script commands

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11117,7 +11117,7 @@ See 'achievementinfo' for valid <type> values.
 
 *addfame(<amount>,{,<char id>})
 
-ncreases the fame of the attached player or the supplied <char id> by the <amount> given.
+Increases the fame of the attached player or the supplied <char id> by the <amount> given.
 Note: Only works with Blacksmith, Alchemist and Taekwon classes.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11114,3 +11114,23 @@ See 'achievementinfo' for valid <type> values.
 - Excludes ACHIEVEINFO_LEVEL and ACHIEVEINFO_SCORE.
 
 ---------------------------------------
+
+*addfame(<amount>,{,<char id>})
+
+Increase the fame of character by a specific amount.
+Note: Only work for blacksmith, alchemist and taekwon class.
+
+---------------------------------------
+
+*getfame({<char id>})
+
+Gets the fame for the attached player or the given character ID.
+
+---------------------------------------
+
+*getfamerank({<char id>})
+
+Check if player is in the fame rankers list of its job.
+Returns fame rank (start from 1 to MAX_FAME_LIST), else 0.
+
+---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11117,20 +11117,21 @@ See 'achievementinfo' for valid <type> values.
 
 *addfame(<amount>,{,<char id>})
 
-Increase the fame of character by a specific amount.
-Note: Only work for blacksmith, alchemist and taekwon class.
+ncreases the fame of the attached player or the supplied <char id> by the <amount> given.
+Note: Only works with Blacksmith, Alchemist and Taekwon classes.
 
 ---------------------------------------
 
 *getfame({<char id>})
 
-Gets the fame for the attached player or the given character ID.
+Gets the fame points of the attached player or the supplied <char id>.
+Note: Only works with Blacksmith, Alchemist and Taekwon classes.
 
 ---------------------------------------
 
 *getfamerank({<char id>})
 
-Check if player is in the fame rankers list of its job.
 Returns fame rank (start from 1 to MAX_FAME_LIST), else 0.
+Note: Only works with Blacksmith, Alchemist and Taekwon classes.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11118,20 +11118,20 @@ See 'achievementinfo' for valid <type> values.
 *addfame(<amount>,{,<char id>})
 
 Increases the fame of the attached player or the supplied <char id> by the <amount> given.
-Note: Only works with Blacksmith, Alchemist and Taekwon classes.
+Note: Only works with classes that use the ranking system.
 
 ---------------------------------------
 
 *getfame({<char id>})
 
 Gets the fame points of the attached player or the supplied <char id>.
-Note: Only works with Blacksmith, Alchemist and Taekwon classes.
+Note: Only works with classes that use the ranking system.
 
 ---------------------------------------
 
 *getfamerank({<char id>})
 
 Returns fame rank (start from 1 to MAX_FAME_LIST), else 0.
-Note: Only works with Blacksmith, Alchemist and Taekwon classes.
+Note: Only works with classes that use the ranking system.
 
 ---------------------------------------

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26535,9 +26535,7 @@ BUILDIN_FUNC(addfame) {
 	if (!script_charid2sd(3, sd))
 		return SCRIPT_CMD_FAILURE;
 
-	int amount = script_getnum(st, 2);
-
-	pc_addfame(*sd, amount);
+	pc_addfame(*sd, script_getnum(st, 2));
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -26560,8 +26558,7 @@ BUILDIN_FUNC(getfamerank) {
 	if (!script_charid2sd(2, sd))
 		return SCRIPT_CMD_FAILURE;
 
-	int rank = pc_famerank(sd->status.char_id, sd->class_ & MAPID_UPPERMASK);
-	script_pushint(st, rank);
+	script_pushint(st, pc_famerank(sd->status.char_id, sd->class_ & MAPID_UPPERMASK));
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26535,8 +26535,9 @@ BUILDIN_FUNC(addfame) {
 	if (!script_charid2sd(3, sd))
 		return SCRIPT_CMD_FAILURE;
 
-	pc_addfame(*sd, script_getnum(st, 2));
-
+	if (!pc_addfame(*sd, script_getnum(st, 2)))
+		return SCRIPT_CMD_FAILURE;
+	
 	return SCRIPT_CMD_SUCCESS;
 }
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26528,6 +26528,44 @@ BUILDIN_FUNC(item_enchant){
 #endif
 }
 
+
+BUILDIN_FUNC(addfame) {
+	struct map_session_data *sd;
+
+	if (!script_charid2sd(3, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	int amount = script_getnum(st, 2);
+
+	pc_addfame(*sd, amount);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+
+BUILDIN_FUNC(getfame) {
+	struct map_session_data *sd;
+
+	if (!script_charid2sd(2, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	script_pushint(st, sd->status.fame);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
+BUILDIN_FUNC(getfamerank) {
+	struct map_session_data *sd;
+
+	if (!script_charid2sd(2, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	int rank = pc_famerank(sd->status.char_id, sd->class_ & MAPID_UPPERMASK);
+	script_pushint(st, rank);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include "../custom/script.inc"
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -27269,6 +27307,9 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(get_reputation_points, "i?"),
 	BUILDIN_DEF(item_reform, "??"),
 	BUILDIN_DEF(item_enchant, "i?"),
+	BUILDIN_DEF(addfame, "i?"),
+	BUILDIN_DEF(getfame, "?"),
+	BUILDIN_DEF(getfamerank, "?"),
 #include "../custom/script_def.inc"
 
 	{NULL,NULL,NULL},


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
npc script unable to update fame value 
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable to update and retrieve fame info of a character.
useful if you want to have different scenario to update the fame value other than refine a +10 forged elemental weapon or potions, and no need to adjust source code.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
