### PR TITLE
Fixed names of two timer functions

### DIFF
--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -314,14 +314,14 @@ int delete_timer(int tid, TimerFunc func)
 
 /// Adjusts a timer's expiration time.
 /// Returns the new tick value, or -1 if it fails.
-t_tick addt_tickimer(int tid, t_tick tick)
+t_tick addtick_timer(int tid, t_tick tick)
 {
-	return sett_tickimer(tid, timer_data[tid].tick+tick);
+	return settick_timer(tid, timer_data[tid].tick+tick);
 }
 
 /// Modifies a timer's expiration time (an alternative to deleting a timer and starting a new one).
 /// Returns the new tick value, or -1 if it fails.
-t_tick sett_tickimer(int tid, t_tick tick)
+t_tick settick_timer(int tid, t_tick tick)
 {
 	size_t i;
 

--- a/src/common/timer.hpp
+++ b/src/common/timer.hpp
@@ -56,8 +56,8 @@ int add_timer_interval(t_tick tick, TimerFunc func, int id, intptr_t data, int i
 const struct TimerData* get_timer(int tid);
 int delete_timer(int tid, TimerFunc func);
 
-t_tick addt_tickimer(int tid, t_tick tick);
-t_tick sett_tickimer(int tid, t_tick tick);
+t_tick addtick_timer(int tid, t_tick tick);
+t_tick settick_timer(int tid, t_tick tick);
 
 int add_timer_func_list(TimerFunc func, const char* name);
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -11175,7 +11175,7 @@ void pc_addeventtimercount(struct map_session_data *sd,const char *name,int tick
 	for(i=0;i<MAX_EVENTTIMER;i++)
 		if( sd->eventtimer[i] != INVALID_TIMER && strcmp(
 			(char *)(get_timer(sd->eventtimer[i])->data), name)==0 ){
-				addt_tickimer(sd->eventtimer[i],tick);
+				addtick_timer(sd->eventtimer[i],tick);
 				break;
 		}
 }
@@ -14385,7 +14385,7 @@ struct s_bonus_script_entry *pc_bonus_script_add(struct map_session_data *sd, co
 			if (strcmpi(script_str, StringBuf_Value(entry->script_buf)) == 0) {
 				t_tick newdur = gettick() + dur;
 				if (flag&BSF_FORCE_REPLACE && entry->tick < newdur) { // Change duration
-					sett_tickimer(entry->tid, newdur);
+					settick_timer(entry->tid, newdur);
 					script_free_code(script);
 					return NULL;
 				}


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Two functions were accidentally renamed when introducing t_tick.
Blame it on me in 01f61cfa
