### PR TITLE
Allow Blacksmith Blessing usage on level 5 weapons and level 2 armors

### DIFF
--- a/db/re/refine.yml
+++ b/db/re/refine.yml
@@ -470,6 +470,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 8
             Bonus: 1440
+            BlacksmithBlessingAmount: 1
             Chances:
               - Type: Normal
                 Rate: 2000
@@ -483,6 +484,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 9
             Bonus: 1800
+            BlacksmithBlessingAmount: 2
             Chances:
               - Type: Normal
                 Rate: 2000
@@ -496,6 +498,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 10
             Bonus: 2160
+            BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
                 Rate: 900
@@ -509,6 +512,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 11
             Bonus: 2520
+            BlacksmithBlessingAmount: 7
             Chances:
               - Type: Normal
                 Rate: 800
@@ -522,6 +526,7 @@ Body:
                 BreakingRate: 10000
           - Level: 12
             Bonus: 2880
+            BlacksmithBlessingAmount: 11
             Chances:
               - Type: Normal
                 Rate: 800
@@ -535,6 +540,7 @@ Body:
                 BreakingRate: 10000
           - Level: 13
             Bonus: 3360
+            BlacksmithBlessingAmount: 16
             BroadcastSuccess: true
             BroadcastFailure: true
             Chances:
@@ -550,6 +556,7 @@ Body:
                 BreakingRate: 10000
           - Level: 14
             Bonus: 3840
+            BlacksmithBlessingAmount: 22
             BroadcastSuccess: true
             BroadcastFailure: true
             Chances:
@@ -2116,6 +2123,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 8
             Bonus: 6400
+            BlacksmithBlessingAmount: 1
             Chances:
               - Type: Normal
                 Rate: 2000
@@ -2129,6 +2137,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 9
             Bonus: 7200
+            BlacksmithBlessingAmount: 2
             Chances:
               - Type: Normal
                 Rate: 2000
@@ -2142,6 +2151,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 10
             Bonus: 8000
+            BlacksmithBlessingAmount: 4
             Chances:
               - Type: Normal
                 Rate: 900
@@ -2155,6 +2165,7 @@ Body:
                 DowngradeAmount: 1
           - Level: 11
             Bonus: 8800
+            BlacksmithBlessingAmount: 7
             Chances:
               - Type: Normal
                 Rate: 800
@@ -2168,6 +2179,7 @@ Body:
                 BreakingRate: 10000
           - Level: 12
             Bonus: 9600
+            BlacksmithBlessingAmount: 11
             Chances:
               - Type: Normal
                 Rate: 800
@@ -2181,6 +2193,7 @@ Body:
                 BreakingRate: 10000
           - Level: 13
             Bonus: 10400
+            BlacksmithBlessingAmount: 16
             BroadcastSuccess: true
             BroadcastFailure: true
             Chances:
@@ -2196,6 +2209,7 @@ Body:
                 BreakingRate: 10000
           - Level: 14
             Bonus: 11200
+            BlacksmithBlessingAmount: 22
             BroadcastSuccess: true
             BroadcastFailure: true
             Chances:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Allow Blacksmith Blessing usage on level 5 weapons and level 2 armors
