### PR TITLE
Fixes SA_DRAGONOLOGY MATK behavior

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -4414,14 +4414,13 @@ int status_calc_pc_sub(struct map_session_data* sd, uint8 opt)
 		sd->indexed_bonus.subele[ELE_FIRE] += skill*5;
 	}
 	if((skill=pc_checkskill(sd,SA_DRAGONOLOGY))>0) {
-#ifdef RENEWAL
-		skill = skill * 2;
-#else
+		uint8 dragon_matk = skill * 2;
+
 		skill = skill * 4;
-#endif
+
 		sd->right_weapon.addrace[RC_DRAGON]+=skill;
 		sd->left_weapon.addrace[RC_DRAGON]+=skill;
-		sd->indexed_bonus.magic_addrace[RC_DRAGON]+=skill;
+		sd->indexed_bonus.magic_addrace[RC_DRAGON]+=dragon_matk;
 		sd->indexed_bonus.subrace[RC_DRAGON]+=skill;
 	}
 	if ((skill = pc_checkskill(sd, AB_EUCHARISTICA)) > 0) {


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * The MATK bonus should only be doubled versus Dragons, not quadrupled like the other bonuses.
  * Confirmed the behaviors between pre-renewal and renewal.
Thanks to @mrjnumber1!