### PR TITLE
Fixed "Unequip All" button not working on main server clients.

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -22364,7 +22364,7 @@ void clif_unequipall_reply( struct map_session_data* sd, bool failed ){
 }
 
 void clif_parse_unequipall( int fd, struct map_session_data* sd ){
-#if PACKETVER_RE_NUM >= 20211103 || PACKETVER_ZERO_NUM >= 20210818
+#if PACKETVER_MAIN_NUM >= 20210818 || PACKETVER_RE_NUM >= 20211103 || PACKETVER_ZERO_NUM >= 20210818
 	if( pc_cant_act( sd ) ){
 		clif_unequipall_reply( sd, true );
 		return;


### PR DESCRIPTION
* **Addressed Issue(s)**: #7337

* **Server Mode**: Both

* **Description of Pull Request**: `clif_parse_unequipall` did not have `PACKETVER_MAIN_NUM` check so the function's code is not compiled when compiling without PACKETVER_RE or PACKETVER_ZERO defined.