### PR TITLE
Fixed zero-length packet warning on party member logoff. Fixes #7324

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10166,6 +10166,8 @@ void clif_disp_overhead_(struct block_list *bl, const char* mes, enum send_targe
  *--------------------------*/
 void clif_party_xy_remove(struct map_session_data* sd)
 {
+	nullpo_retv(sd);
+
 	PACKET_ZC_NOTIFY_POSITION_TO_GROUPM p{};
 	p.PacketType = HEADER_ZC_NOTIFY_POSITION_TO_GROUPM;
 	p.AID = sd->status.account_id;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10164,15 +10164,15 @@ void clif_disp_overhead_(struct block_list *bl, const char* mes, enum send_targe
  * Minimap fix [Kevin]
  * Remove dot from minimap
  *--------------------------*/
-void clif_party_xy_remove(struct map_session_data *sd)
+void clif_party_xy_remove(struct map_session_data* sd)
 {
-	unsigned char buf[16];
-	nullpo_retv(sd);
-	WBUFW(buf,0)=0x107;
-	WBUFL(buf,2)=sd->status.account_id;
-	WBUFW(buf,6)=-1;
-	WBUFW(buf,8)=-1;
-	clif_send(buf,packet_len(0x107),&sd->bl,PARTY_SAMEMAP_WOS);
+	PACKET_ZC_NOTIFY_POSITION_TO_GROUPM p{};
+	p.PacketType = HEADER_ZC_NOTIFY_POSITION_TO_GROUPM;
+	p.AID = sd->status.account_id;
+	p.xPos = -1;
+	p.yPos = -1;
+
+	clif_send(&p, sizeof(p), &sd->bl, PARTY_SAMEMAP_WOS);
 }
 
 

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -163,6 +163,7 @@
 	parseable_packet(0x0102,6,clif_parse_PartyChangeOption,2);
 	parseable_packet(0x0103,30,clif_parse_RemovePartyMember,2,6);
 	packet(0x0104,79);
+	packet(HEADER_ZC_NOTIFY_POSITION_TO_GROUPM, sizeof(struct PACKET_ZC_NOTIFY_POSITION_TO_GROUPM));
 	parseable_packet(0x0108,-1,clif_parse_PartyMessage,2,4);
 	packet(0x0109,-1);
 	packet( HEADER_ZC_MVP_GETTING_ITEM, sizeof( struct PACKET_ZC_MVP_GETTING_ITEM ) );

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -163,7 +163,6 @@
 	parseable_packet(0x0102,6,clif_parse_PartyChangeOption,2);
 	parseable_packet(0x0103,30,clif_parse_RemovePartyMember,2,6);
 	packet(0x0104,79);
-	packet(HEADER_ZC_NOTIFY_POSITION_TO_GROUPM, sizeof(struct PACKET_ZC_NOTIFY_POSITION_TO_GROUPM));
 	parseable_packet(0x0108,-1,clif_parse_PartyMessage,2,4);
 	packet(0x0109,-1);
 	packet( HEADER_ZC_MVP_GETTING_ITEM, sizeof( struct PACKET_ZC_MVP_GETTING_ITEM ) );


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7324
* **Server Mode**: Both
* **Description of Pull Request**: Fixed clif_party_xy_remove calling packet_len(0x107) which is not registered in packet db causing the warning in the linked issue. Also changed the function to use packet struct instead of manual buffer writing.