### PR TITLE
Fix pet_endautobonus crash

### DIFF
--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -2428,7 +2428,7 @@ void pet_exeautobonus(map_session_data &sd, std::vector<std::shared_ptr<s_petaut
 		script_run_petautobonus(autobonus->other_script, sd);
 	}
 
-	autobonus->timer = add_timer(gettick() + autobonus->duration, pet_endautobonus, sd.bl.id, (intptr_t)&bonus);
+	autobonus->timer = add_timer(gettick() + autobonus->duration, pet_endautobonus, sd.bl.id, (intptr_t)bonus);
 	status_calc_pc(&sd, SCO_FORCE);
 }
 


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7292 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Fixes #7292

pet_endautobonus expects a `std::vector<...> *`, we were passing in a `std::vector<...> **`

Thanks @mazvi
