### PR TITLE
Added support mob name as parameter in mob spawn definition

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5053,7 +5053,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 {
 	int num, mob_id, mob_lv = -1, size = -1, w1count;
 	short m, x = 0, y = 0, xs = -1, ys = -1;
-	char mapname[MAP_NAME_LENGTH_EXT], mobname[NAME_LENGTH];
+	char mapname[MAP_NAME_LENGTH_EXT], mobname[NAME_LENGTH], sprite[NAME_LENGTH];
 	struct spawn_data mob, *data;
 	int ai = AI_NONE; // mob_ai
 
@@ -5066,7 +5066,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	// w4=<mob id>,<amount>{,<delay1>{,<delay2>{,<event>{,<mob size>{,<mob ai>}}}}}
 	if( ( w1count = sscanf(w1, "%15[^,],%6hd,%6hd,%6hd,%6hd", mapname, &x, &y, &xs, &ys) ) < 1
 	||	sscanf(w3, "%23[^,],%11d", mobname, &mob_lv) < 1
-	||	sscanf(w4, "%11d,%11d,%11u,%11u,%77[^,],%11d,%11d[^\t\r\n]", &mob_id, &num, &mob.delay1, &mob.delay2, mob.eventname, &size, &ai) < 2 )
+	||	sscanf(w4, "%23[^,],%11d,%11u,%11u,%77[^,],%11d,%11d[^\t\r\n]", sprite, &num, &mob.delay1, &mob.delay2, mob.eventname, &size, &ai) < 2 )
 	{
 		ShowError("npc_parse_mob: Invalid mob definition in file '%s', line '%d'.\n * w1=%s\n * w2=%s\n * w3=%s\n * w4=%s\n", filepath, strline(buffer,start-buffer), w1, w2, w3, w4);
 		return strchr(start,'\n');// skip and continue
@@ -5087,6 +5087,17 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	{
 		ShowError("npc_parse_mob: Spawn coordinates out of range: %s (%d,%d), map size is (%d,%d) - %s %s (file '%s', line '%d').\n", mapdata->name, x, y, (mapdata->xs-1), (mapdata->ys-1), w1, w3, filepath, strline(buffer,start-buffer));
 		return strchr(start,'\n');// skip and continue
+	}
+
+	// Check if sprite is the mob name or ID
+	char *pid;
+	mob_id = strtol(sprite, &pid, 0);
+
+	if (pid != nullptr && *pid != '\0') {
+		std::shared_ptr<s_mob_db> mob = mobdb_search_aegisname(sprite);
+
+		if (mob != nullptr)
+			mob_id = mob->id;
 	}
 
 	// check monster ID if exists!

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5091,6 +5091,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 
 	// Check if sprite is the mob name or ID
 	char *pid;
+	sprite[NAME_LENGTH-1] = '\0';
 	mob_id = strtol(sprite, &pid, 0);
 
 	if (pid != nullptr && *pid != '\0') {

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5097,13 +5097,13 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	if (pid != nullptr && *pid != '\0') {
 		std::shared_ptr<s_mob_db> mob = mobdb_search_aegisname(sprite);
 
-		if (mob != nullptr)
-			mob_id = mob->id;
+		if (mob == nullptr) {
+			ShowError("npc_parse_mob: Unknown mob name %s (file '%s', line '%d').\n", sprite, filepath, strline(buffer,start-buffer));
+			return strchr(start,'\n');// skip and continue
+		}
+		mob_id = mob->id;
 	}
-
-	// check monster ID if exists!
-	if( mobdb_checkid(mob_id) == 0 )
-	{
+	else if (mobdb_checkid(mob_id) == 0) {	// check monster ID if exists!
 		ShowError("npc_parse_mob: Unknown mob ID %d (file '%s', line '%d').\n", mob_id, filepath, strline(buffer,start-buffer));
 		return strchr(start,'\n');// skip and continue
 	}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

This is a suggestion to support mob name as parameter in mob spawn definition.

Example
----------------------------------------------------------------------------------
Currently permanent monster can be defined with the mob ID only :
`tra_fild,57,159	monster	Dummy (Small)	21064,1`

With this PR (mob ID is still supported)
`tra_fild,57,159	monster	Dummy (Small)	S_DUMMY_100_SMALL,1`




<!-- Describe how this pull request will resolve the issue(s) listed above. -->
