### PR TITLE
Fix an issue when running map-server-generator in opt mode

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3706,6 +3706,8 @@ struct npc_data *npc_create_npc(int16 m, int16 x, int16 y){
 	struct npc_data *nd = nullptr;
 
 	CREATE(nd, struct npc_data, 1);
+	new (nd) npc_data();
+
 	nd->bl.id = npc_get_new_npc_id();
 	nd->bl.prev = nd->bl.next = nullptr;
 	nd->bl.m = m;


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Generator

* **Description of Pull Request**: 

Agron on discord reported the map-server-generator was segfaulting.

We use `std::string` and `std::vector` in `npc_data`, which when we `CREATE` it we never call the constructor.
By using the placement new, we can run the constructor on the already-allocated memory.
