### PR TITLE
Fixes NPC_COMET duration

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -17022,7 +17022,7 @@ Body:
     Range: 11
     Hit: Multi_Hit
     HitCount: -20
-    Duration1: 18000
+    Duration2: 18000
     SplashArea: 9
     Knockback: 2
     CastCancel: true

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1800,7 +1800,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 		sc_start(src, bl, SC_MAGIC_POISON, 100, skill_lv, 20000);
 		break;
 	case NPC_COMET:
-		sc_start4(src,bl,SC_BURNING,100,skill_lv,1000,src->id,0,skill_get_time(skill_id,skill_lv));
+		sc_start4(src,bl,SC_BURNING,100,skill_lv,1000,src->id,0,skill_get_time2(skill_id,skill_lv));
 		break;
 	case NPC_JACKFROST:
 		sc_start(src,bl,SC_FREEZE,200,skill_lv,skill_get_time(skill_id,skill_lv));


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7355

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Follow up to 2993c0b.
  * Resolves an issue with the duration of Burning overlapping with the duration of NPC_COMET.
Thanks to @sonniez and @OptimusM!