### PR TITLE
Update *plagiarizeskill and *plagiarizedreset script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -6309,6 +6309,10 @@ it just removes non-permanent script.
 Enable the player to plagiarize specific skills that are copyable.
 Return 1 on success, 0 otherwise.
 
+Note:
+ - Plagiarism only able to copy skill while SC_PRESERVE is not active and skill is copyable by Plagiarism.
+ - Reproduce can copy skill if SC__REPRODUCE is active and the skill is copyable by Reproduce.
+
 ---------------------------------------
 
 *plagiarizeskillreset <flag>;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -10191,7 +10191,7 @@ BUILDIN_FUNC(skill_plagiarism_reset)
 {
 	TBL_PC *sd;
 
-	if (!script_rid2sd(sd))
+	if (script_rid2sd(sd))
 		script_pushint(st, pc_skill_plagiarism_reset(*sd, script_getnum(st, 2)));
 
 	return SCRIPT_CMD_SUCCESS;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
plagiarized skill doesn't work
fix unable to reset plagiarized skill

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
fix so that allow player to reset plagiarized skill
update `plagiarizeskill(...)` script command documentation to avoid confusion when plagiarize a skill
```
Note:
 - Plagiarism only able to copy skill while SC_PRESERVE is not active and skill is copyable by Plagiarism.
 - Reproduce can copy skill if SC__REPRODUCE is active and the skill is copyable by Reproduce.
```

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
