### PR TITLE
Remove range & path check for NPC's skill cast

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1858,10 +1858,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 		}
 	}
 
-	if (src->type == BL_NPC) // NPC-objects can override cast distance
-		range = AREA_SIZE; // Maximum visible distance before NPC goes out of sight
-	else
-		range = skill_get_range2(src, skill_id, skill_lv, true); // Skill cast distance from database
+	range = skill_get_range2(src, skill_id, skill_lv, true); // Skill cast distance from database
 
 	// New action request received, delete previous action request if not executed yet
 	if(ud->stepaction || ud->steptimer != INVALID_TIMER)
@@ -1877,7 +1874,7 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 
 	// Check range when not using skill on yourself or is a combo-skill during attack
 	// (these are supposed to always have the same range as your attack)
-	if( src->id != target_id && (!combo || ud->attacktimer == INVALID_TIMER) ) {
+	if( src->type != BL_NPC && src->id != target_id && (!combo || ud->attacktimer == INVALID_TIMER) ) {
 		if( skill_get_state(ud->skill_id) == ST_MOVE_ENABLE ) {
 			if( !unit_can_reach_bl(src, target, range + 1, 1, NULL, NULL) )
 				return 0; // Walk-path check failed.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  

There are some NPCs giving player buffs, and I checked that
in KRo NPC ignores range and path check when casting skills. 
Check below:
![NPCpathcheck01](https://user-images.githubusercontent.com/47050704/200838413-0a6b4ca0-a72b-4d49-ba11-0af7b9044b8b.gif)
This is from KRo.
If it was rA, NPC must fail to cast skills because of path check, if a character stands on place where the one in screenshot does.

I didn't touch ground skill because I can't confirm if NPC also ignores path check, even in case of ground skill too, 
that I haven't experienced NPC's ground skill in KRo yet. I will change it, if anyone can confirm this.

Thanks @aleos89 for advice!
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
