### PR TITLE
Suggestion : pc_isdead script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11250,3 +11250,9 @@ Returns fame rank (start from 1 to MAX_FAME_LIST), else 0.
 Note: Only works with classes that use the ranking system.
 
 ---------------------------------------
+
+*pc_isdead({<char id>})
+
+Returns 1 if the player is dead else 0.
+
+---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11251,7 +11251,7 @@ Note: Only works with classes that use the ranking system.
 
 ---------------------------------------
 
-*pc_isdead({<char id>})
+*isdead({<account id>})
 
 Returns true if the player is dead else false.
 

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11253,6 +11253,6 @@ Note: Only works with classes that use the ranking system.
 
 *pc_isdead({<char id>})
 
-Returns 1 if the player is dead else 0.
+Returns true if the player is dead else false.
 
 ---------------------------------------

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26845,10 +26845,10 @@ BUILDIN_FUNC(getfamerank) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
-BUILDIN_FUNC(pc_isdead) {
+BUILDIN_FUNC(isdead) {
 	struct map_session_data *sd;
 
-	if (!script_charid2sd(2, sd))
+	if (!script_mapid2sd(2, sd))
 		return SCRIPT_CMD_FAILURE;
 
 	script_pushint(st, pc_isdead(sd));
@@ -27608,7 +27608,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(addfame, "i?"),
 	BUILDIN_DEF(getfame, "?"),
 	BUILDIN_DEF(getfamerank, "?"),
-	BUILDIN_DEF(pc_isdead, "?"),
+	BUILDIN_DEF(isdead, "?"),
 #include "../custom/script_def.inc"
 
 	{NULL,NULL,NULL},

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26845,6 +26845,17 @@ BUILDIN_FUNC(getfamerank) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+BUILDIN_FUNC(pc_isdead) {
+	struct map_session_data *sd;
+
+	if (!script_charid2sd(2, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	script_pushint(st, pc_isdead(sd));
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include "../custom/script.inc"
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -27597,6 +27608,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(addfame, "i?"),
 	BUILDIN_DEF(getfame, "?"),
 	BUILDIN_DEF(getfamerank, "?"),
+	BUILDIN_DEF(pc_isdead, "?"),
 #include "../custom/script_def.inc"
 
 	{NULL,NULL,NULL},


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Simple script command to check if a player is dead.
The `readparam(Hp)` script command currently does the job but due to the visual on the client (https://github.com/rathena/rathena/issues/758), the result of this command may be misleading. As such, it seems a good idea to implement a command to clarify if a player is dead or not.



<!-- Describe how this pull request will resolve the issue(s) listed above. -->
