### PR TITLE
Restores correct drop rate for spawned size-modified mobs

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2447,22 +2447,7 @@ void mob_damage(struct mob_data *md, struct block_list *src, int damage)
 	}
 #endif
 }
-/**
- * Get modified drop rate
- * @param mob: monster
- * @return Modified drop rate
- */
-int mob_getsizedropmodifier(mob_data* md)
-{
-	int size_rate = 100;
-	if (battle_config.mob_size_influence) {  // Change drops depending on monsters size [Valaris]
-		if (md->special_state.size == SZ_MEDIUM)
-			size_rate /= 2; // SZ_MEDIUM actually is small size modification... this is not a bug!
-		else if (md->special_state.size == SZ_BIG)
-			size_rate *= 2;
-	}
-	return size_rate;
-}
+
 /**
  * Get modified drop rate
  * @param src: Source object
@@ -2471,9 +2456,15 @@ int mob_getsizedropmodifier(mob_data* md)
  * @param drop_modifier: RENEWAL_DROP level modifier
  * @return Modified drop rate
  */
-int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier)
+int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, int mob_size)
 {
 	int drop_rate = base_rate;
+	if (battle_config.mob_size_influence) {  // Change drops depending on monsters size [Valaris]
+		if (mob_size == SZ_MEDIUM && drop_rate >= 2)
+			drop_rate /= 2; // SZ_MEDIUM actually is small size modification... this is not a bug!
+		else if (mob_size == SZ_BIG)
+			drop_rate *= 2;
+	}
 	if (src) {
 		if (battle_config.drops_by_luk) // Drops affected by luk as a fixed increase [Valaris]
 			drop_rate += status_get_luk(src) * battle_config.drops_by_luk / 100;
@@ -2795,7 +2786,6 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 		struct item_drop_list *dlist = ers_alloc(item_drop_list_ers, struct item_drop_list);
 		struct item_drop *ditem;
 		int drop_rate, drop_modifier = 100;
-		int size_drop_modifier = mob_getsizedropmodifier(md);
 
 #ifdef RENEWAL_DROP
 		drop_modifier = pc_level_penalty_mod( mvp_sd != nullptr ? mvp_sd : second_sd != nullptr ? second_sd : third_sd, PENALTY_DROP, nullptr, md );
@@ -2817,7 +2807,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 			if ( it == nullptr )
 				continue;
 
-			drop_rate = mob_getdroprate(src, md->db, apply_rate(md->db->dropitem[i].rate,size_drop_modifier), drop_modifier);
+			drop_rate = mob_getdroprate(src, md->db, md->db->dropitem[i].rate, drop_modifier, md->special_state.size);
 
 			// attempt to drop the item
 			if (rnd() % 10000 >= drop_rate)

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2452,7 +2452,7 @@ void mob_damage(struct mob_data *md, struct block_list *src, int damage)
  * @param mob: monster
  * @return Modified drop rate
  */
-int getsizedropmodifier(mob_data* md)
+int mob_getsizedropmodifier(mob_data* md)
 {
 	int size_rate = 100;
 	if (battle_config.mob_size_influence) {  // Change drops depending on monsters size [Valaris]
@@ -2795,7 +2795,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 		struct item_drop_list *dlist = ers_alloc(item_drop_list_ers, struct item_drop_list);
 		struct item_drop *ditem;
 		int drop_rate, drop_modifier = 100;
-		int size_drop_modifier = getsizedropmodifier(md);
+		int size_drop_modifier = mob_getsizedropmodifier(md);
 
 #ifdef RENEWAL_DROP
 		drop_modifier = pc_level_penalty_mod( mvp_sd != nullptr ? mvp_sd : second_sd != nullptr ? second_sd : third_sd, PENALTY_DROP, nullptr, md );

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2456,15 +2456,18 @@ void mob_damage(struct mob_data *md, struct block_list *src, int damage)
  * @param drop_modifier: RENEWAL_DROP level modifier
  * @return Modified drop rate
  */
-int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, int mob_size)
+int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, mob_data* md)
 {
 	int drop_rate = base_rate;
-	if (battle_config.mob_size_influence) {  // Change drops depending on monsters size [Valaris]
+
+	if (md && battle_config.mob_size_influence) {  // Change drops depending on monsters size [Valaris]
+		unsigned int mob_size = md->special_state.size;
 		if (mob_size == SZ_MEDIUM && drop_rate >= 2)
 			drop_rate /= 2; // SZ_MEDIUM actually is small size modification... this is not a bug!
 		else if (mob_size == SZ_BIG)
 			drop_rate *= 2;
 	}
+
 	if (src) {
 		if (battle_config.drops_by_luk) // Drops affected by luk as a fixed increase [Valaris]
 			drop_rate += status_get_luk(src) * battle_config.drops_by_luk / 100;
@@ -2806,8 +2809,8 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 
 			if ( it == nullptr )
 				continue;
-
-			drop_rate = mob_getdroprate(src, md->db, md->db->dropitem[i].rate, drop_modifier, md->special_state.size);
+			
+			drop_rate = mob_getdroprate(src, md->db, md->db->dropitem[i].rate, drop_modifier, md);
 
 			// attempt to drop the item
 			if (rnd() % 10000 >= drop_rate)

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -547,6 +547,7 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 
+int getsizedropmodifier(mob_data* md);
 int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier);
 
 // MvP Tomb System

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -547,7 +547,7 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 
-int getsizedropmodifier(mob_data* md);
+int mob_getsizedropmodifier(mob_data* md);
 int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier);
 
 // MvP Tomb System

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -547,8 +547,7 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 
-int mob_getsizedropmodifier(mob_data* md);
-int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier);
+int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, int mob_size = SZ_SMALL);
 
 // MvP Tomb System
 int mvptomb_setdelayspawn(struct npc_data *nd);

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -547,7 +547,7 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 
-int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, int mob_size = SZ_SMALL);
+int mob_getdroprate(struct block_list *src, std::shared_ptr<s_mob_db> mob, int base_rate, int drop_modifier, mob_data* md = nullptr);
 
 // MvP Tomb System
 int mvptomb_setdelayspawn(struct npc_data *nd);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#7481

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Restores correct drop rate for spawned size-modified mobs instead of database size.