### PR TITLE
Adds official Wand of Hermode clear list

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -245,6 +245,7 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -273,6 +274,7 @@ Body:
       BossResist: true
       Debuff: true
       NoSaveInfinite: true
+      RemoveOnHermode: true
     EndOnStart:
       Freeze: true
       Stone: true
@@ -296,6 +298,7 @@ Body:
       Quicken: true
     Flags:
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Decreaseagi: true
   - Status: Concentrate
@@ -306,6 +309,7 @@ Body:
       Dex: true
     Flags:
       FailedMado: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Hiding
@@ -356,6 +360,7 @@ Body:
       Atk_Ele: true
     Flags:
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Aspersio: true
       Fireweapon: true
@@ -368,6 +373,8 @@ Body:
   - Status: Poisonreact
     Icon: EFST_POISONREACT
     DurationLookup: AS_POISONREACT
+    Flags:
+      RemoveOnHermode: true
   - Status: Quagmire
     Icon: EFST_QUAGMIRE
     DurationLookup: WZ_QUAGMIRE
@@ -380,6 +387,7 @@ Body:
       NoSave: true
       NoClearance: true
       Debuff: true
+      RemoveOnHermode: true
     Fail:
       Speedup1: true
     EndOnStart:
@@ -407,6 +415,7 @@ Body:
       Angelus: true
     Flags:
       SendOption: true
+      RemoveOnHermode: true
   - Status: Blessing
     Icon: EFST_BLESSING
     DurationLookup: AL_BLESSING
@@ -417,6 +426,7 @@ Body:
     Flags:
       BossResist: true
       TaekwonAngel: true
+      RemoveOnHermode: true
   - Status: Signumcrucis
     Icon: EFST_CRUCIS
     DurationLookup: AL_CRUCIS
@@ -436,6 +446,7 @@ Body:
     Flags:
       FailedMado: true
       TaekwonAngel: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
     EndOnStart:
@@ -451,6 +462,7 @@ Body:
       BossResist: true
       NoSave: true
       Debuff: true
+      RemoveOnHermode: true
     Fail:
       Speedup1: true
     EndOnStart:
@@ -469,6 +481,7 @@ Body:
     DurationLookup: PR_SLOWPOISON
     Flags:
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Impositio
     Icon: EFST_IMPOSITIO
     DurationLookup: PR_IMPOSITIO
@@ -476,6 +489,7 @@ Body:
       Watk: true
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
     EndOnStart:
       Impositio: true
   - Status: Suffragium
@@ -483,6 +497,7 @@ Body:
     DurationLookup: PR_SUFFRAGIUM
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Aspersio
     Icon: EFST_ASPERSIO
     DurationLookup: PR_ASPERSIO
@@ -490,6 +505,7 @@ Body:
       Atk_Ele: true
     Flags:
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Fireweapon: true
@@ -508,11 +524,13 @@ Body:
       NoSave: true
       NoClearance: true
       #RemoveOnUnequipArmor: true
+      RemoveOnHermode: true
   - Status: Kyrie
     Icon: EFST_KYRIE
     DurationLookup: PR_KYRIE
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
     EndOnStart:
       Assumptio: true
   - Status: Magnificat
@@ -524,6 +542,7 @@ Body:
       FailedMado: true
       NoSave: true
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Gloria
     Icon: EFST_GLORIA
     DurationLookup: PR_GLORIA
@@ -531,11 +550,13 @@ Body:
       Luk: true
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Aeterna
     Icon: EFST_LEXAETERNA
     DurationLookup: PR_LEXAETERNA
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Stone: true
       Freeze: true
@@ -547,6 +568,7 @@ Body:
     Flags:
       MadoCancel: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
       Decreaseagi: true
@@ -555,6 +577,7 @@ Body:
     DurationLookup: BS_WEAPONPERFECT
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
   - Status: Overthrust
     Icon: EFST_OVERTHRUST
     DurationLookup: BS_OVERTHRUST
@@ -562,6 +585,7 @@ Body:
       OverThrust: true
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
     Fail:
       Maxoverthrust: true
   - Status: Maximizepower
@@ -571,6 +595,7 @@ Body:
       Regen: true
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
   - Status: Trickdead
     Icon: EFST_TRICKDEAD
     DurationLookup: NV_TRICKDEAD
@@ -590,6 +615,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
     EndOnStart:
       Dancing: true
   - Status: Loud
@@ -599,11 +625,14 @@ Body:
       Str: true
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
   - Status: Energycoat
     Icon: EFST_ENERGYCOAT
     DurationLookup: MG_ENERGYCOAT
     Opt3:
       EnergyCoat: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Brokenarmor
     Icon: EFST_BROKENARMOR
     DurationLookup: NPC_ARMORBRAKE
@@ -655,12 +684,14 @@ Body:
     Flags:
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Aspdpotion2
     Icon: EFST_ATTHASTE_POTION3
     CalcFlags:
       Aspd: true
     Flags:
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Aspdpotion3
     Icon: EFST_ATTHASTE_INFINITY
     CalcFlags:
@@ -668,6 +699,7 @@ Body:
     Flags:
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Speedup0
     Icon: EFST_MOVHASTE_HORSE
     CalcFlags:
@@ -685,6 +717,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Atkpotion
     Icon: EFST_PLUSATTACKPOWER
     CalcFlags:
@@ -693,6 +726,7 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Matkpotion
     Icon: EFST_PLUSMAGICPOWER
     CalcFlags:
@@ -701,6 +735,7 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Wedding
     States:
       NoAttack: true
@@ -743,6 +778,8 @@ Body:
     CalcFlags:
       Mdef: true
       Def: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Stripweapon
     Icon: EFST_NOEQUIPWEAPON
     DurationLookup: RG_STRIPWEAPON
@@ -755,6 +792,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Stripshield
     Icon: EFST_NOEQUIPSHIELD
     DurationLookup: RG_STRIPSHIELD
@@ -767,6 +805,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Striparmor
     Icon: EFST_NOEQUIPARMOR
     DurationLookup: RG_STRIPARMOR
@@ -779,6 +818,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Striphelm
     Icon: EFST_NOEQUIPHELM
     DurationLookup: RG_STRIPHELM
@@ -791,6 +831,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Cp_Weapon
     Icon: EFST_PROTECTWEAPON
     DurationLookup: AM_CP_WEAPON
@@ -800,6 +841,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Shield
     Icon: EFST_PROTECTSHIELD
     DurationLookup: AM_CP_SHIELD
@@ -809,6 +851,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Armor
     Icon: EFST_PROTECTARMOR
     DurationLookup: AM_CP_ARMOR
@@ -818,6 +861,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Helm
     Icon: EFST_PROTECTHELM
     DurationLookup: AM_CP_HELM
@@ -827,18 +871,21 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Autoguard
     Icon: EFST_AUTOGUARD
     DurationLookup: CR_AUTOGUARD
     Flags:
       NoClearance: true
       RequireShield: true
+      RemoveOnHermode: true
   - Status: Reflectshield
     Icon: EFST_REFLECTSHIELD
     DurationLookup: CR_REFLECTSHIELD
     Flags:
       NoClearance: true
       RequireShield: true
+      RemoveOnHermode: true
     EndOnStart:
       Reflectdamage: true
   - Status: Splasher
@@ -851,6 +898,7 @@ Body:
       All: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Defender
     Icon: EFST_DEFENDER
     DurationLookup: CR_DEFENDER
@@ -859,11 +907,13 @@ Body:
       Aspd: true
     Flags:
       RequireShield: true
+      RemoveOnHermode: true
   - Status: Magicrod
     Icon: EFST_MAGICROD
     DurationLookup: SA_MAGICROD
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Spellbreaker
     Flags:
       NoWarning: true
@@ -897,6 +947,7 @@ Body:
     Flags:
       FailedMado: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Autocounter
@@ -951,6 +1002,7 @@ Body:
       Debuff: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Combo
     Flags:
       NoClearbuff: true
@@ -981,6 +1033,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
   - Status: Fireweapon
     Icon: EFST_PROPERTYFIRE
     DurationLookup: SA_FLAMELAUNCHER
@@ -1049,6 +1102,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Deluge
     Icon: EFST_GROUNDMAGIC
     DurationLookup: SA_DELUGE
@@ -1108,6 +1162,7 @@ Body:
     Flags:
       NoSave: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Parrying
     Icon: EFST_PARRYING
     DurationLookup: LK_PARRYING
@@ -1115,6 +1170,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Concentration
     Icon: EFST_LKCONCENTRATION
     DurationLookup: LK_CONCENTRATION
@@ -1128,6 +1184,7 @@ Body:
       Quicken: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Tensionrelax
     Icon: EFST_TENSIONRELAX
     DurationLookup: LK_TENSIONRELAX
@@ -1136,6 +1193,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Berserk
     Icon: EFST_BERSERK
     DurationLookup: LK_BERSERK
@@ -1176,6 +1234,7 @@ Body:
       Aspd: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Assumptio
     Icon: EFST_ASSUMPTIO
     DurationLookup: HP_ASSUMPTIO
@@ -1184,6 +1243,8 @@ Body:
     EndOnStart:
       Kyrie: true
       Kaite: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Basilica
     DurationLookup: HP_BASILICA
     States:
@@ -1194,6 +1255,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
   - Status: Guildaura
     Flags:
       NoDispell: true
@@ -1206,6 +1268,7 @@ Body:
       Matk: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     EndOnStart:
       Magicpower: true
   - Status: Edp
@@ -1231,6 +1294,7 @@ Body:
     Flags:
       FailedMado: true
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Windwalk
@@ -1242,6 +1306,7 @@ Body:
     Flags:
       FailedMado: true
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Meltdown
@@ -1335,6 +1400,7 @@ Body:
       Debuff: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
     EndOnStart:
       Blessing: true
       Increaseagi: true
@@ -1350,6 +1416,7 @@ Body:
       NoSave: true
       NoClearance: true
       Debuff: true
+      RemoveOnHermode: true
   - Status: Mindbreaker
     Icon: EFST_MINDBREAKER
     DurationLookup: PF_MINDBREAKER
@@ -1359,6 +1426,7 @@ Body:
     Flags:
       NoSave: true
       Debuff: true
+      RemoveOnHermode: true
     EndOnStart:
       Freeze: true
       Stone: true
@@ -1368,6 +1436,7 @@ Body:
     DurationLookup: PF_MEMORIZE
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Fogwall
     Icon: EFST_FOGWALL
     DurationLookup: PF_FOGWALL
@@ -1375,6 +1444,7 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Spiderweb
     Icon: EFST_SPIDERWEB
     DurationLookup: PF_SPIDERWEB
@@ -1397,6 +1467,7 @@ Body:
       NoSave: true
       RemoveOnChangeMap: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
     EndOnEnd:
       Autoguard: true
       Defender: true
@@ -1404,6 +1475,8 @@ Body:
       Endure: true
   - Status: Sacrifice
     DurationLookup: PA_SACRIFICE
+    Flags:
+      RemoveOnHermode: true
   - Status: Steelbody
     Icon: EFST_STEELBODY
     DurationLookup: MO_STEELBODY
@@ -1416,6 +1489,7 @@ Body:
       Speed: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     Opt3:
       SteelBody: true
   - Status: Orcish
@@ -1480,6 +1554,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
   - Status: Shadowweapon
     Icon: EFST_PROPERTYDARK
     DurationLookup: TK_SEVENWIND
@@ -1488,6 +1563,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Aspersio: true
@@ -1505,6 +1581,7 @@ Body:
       MadoCancel: true
       NoSave: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
       Decreaseagi: true
@@ -1516,6 +1593,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Aspersio: true
@@ -1533,6 +1611,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Kaahi: true
   - Status: Kaupe
@@ -1541,6 +1620,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Onehand
     Icon: EFST_ONEHANDQUICKEN
     DurationLookup: KN_ONEHAND
@@ -1552,6 +1632,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Decreaseagi: true
     EndOnStart:
@@ -1564,6 +1645,7 @@ Body:
     DurationLookup: ST_PRESERVE
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Battleorders
     Icon: EFST_GDSKILL_BATTLEORDER
     DurationLookup: GD_BATTLEORDER
@@ -1587,6 +1669,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Gravitation
     Icon: EFST_GRAVITATION
     DurationLookup: HW_GRAVITATION
@@ -1601,6 +1684,7 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Maxoverthrust
     Icon: EFST_OVERTHRUSTMAX
     DurationLookup: WS_OVERTHRUSTMAX
@@ -1609,6 +1693,7 @@ Body:
     Flags:
       MadoCancel: true
       NoSave: true
+      RemoveOnHermode: true
     EndOnStart:
       Overthrust: true
   - Status: Longing
@@ -1855,6 +1940,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       Debuff: true
+      RemoveOnHermode: true
   - Status: Spurt
     Icon: EFST_STRUP
     DurationLookup: TK_RUN
@@ -1864,6 +1950,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Spirit
     Icon: EFST_SOULLINK
     DurationLookup: SL_HIGH
@@ -1875,6 +1962,7 @@ Body:
       NoClearance: true
       NoSave: true
       NoBanishingBuster: true
+      RemoveOnHermode: true
   - Status: Coma
     DurationLookup: NPC_DARKBLESSING
     Flags:
@@ -2222,6 +2310,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Assumptio: true
   - Status: Swoo
@@ -2321,6 +2410,7 @@ Body:
       NoClearance: true
       NoBanishingBuster: true
       NoDispell: true
+      RemoveOnHermode: true
   - Status: Bunsinjyutsu
     Icon: EFST_NJ_BUNSINJYUTSU
     DurationLookup: NJ_BUNSINJYUTSU
@@ -2331,6 +2421,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Kaensin
     Flags:
       NoWarning: true
@@ -2445,6 +2536,7 @@ Body:
       SendVal1: true
       OverlapIgnoreLevel: true
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Enchantarms: true
       Aspersio: true
@@ -5749,6 +5841,7 @@ Body:
       RemoveOnChangeMap: true
       NoBanishingBuster: true
       NoDispell: true
+      RemoveOnHermode: true
   - Status: Mtf_Aspd2
     Icon: EFST_MTF_ASPD2
     CalcFlags:
@@ -6353,6 +6446,7 @@ Body:
     Flags:
       NoRemoveOnDead: true
       NoClearbuff: true
+      RemoveOnHermode: true
   - Status: Geffen_Magic2
     Icon: EFST_GEFFEN_MAGIC2
     CalcFlags:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -254,6 +254,7 @@ Body:
       NoSave: true
       NoClearance: true
       SpreadEffect: true
+      RemoveOnHermode: true
     Fail:
       Refresh: true
       Inspiration: true
@@ -282,6 +283,7 @@ Body:
       BossResist: true
       Debuff: true
       NoSaveInfinite: true
+      RemoveOnHermode: true
     EndOnStart:
       Freeze: true
       Stone: true
@@ -307,6 +309,7 @@ Body:
       Quicken: true
     Flags:
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Decreaseagi: true
   - Status: Concentrate
@@ -317,6 +320,7 @@ Body:
       Dex: true
     Flags:
       FailedMado: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Hiding
@@ -367,6 +371,7 @@ Body:
       Atk_Ele: true
     Flags:
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Aspersio: true
       Fireweapon: true
@@ -378,6 +383,8 @@ Body:
   - Status: Poisonreact
     Icon: EFST_POISONREACT
     DurationLookup: AS_POISONREACT
+    Flags:
+      RemoveOnHermode: true
   - Status: Quagmire
     Icon: EFST_QUAGMIRE
     DurationLookup: WZ_QUAGMIRE
@@ -390,6 +397,7 @@ Body:
       NoSave: true
       NoClearance: true
       Debuff: true
+      RemoveOnHermode: true
     Fail:
       Speedup1: true
     EndOnStart:
@@ -418,6 +426,7 @@ Body:
       Angelus: true
     Flags:
       SendOption: true
+      RemoveOnHermode: true
   - Status: Blessing
     Icon: EFST_BLESSING
     DurationLookup: AL_BLESSING
@@ -429,6 +438,7 @@ Body:
     Flags:
       BossResist: true
       TaekwonAngel: true
+      RemoveOnHermode: true
   - Status: Signumcrucis
     Icon: EFST_CRUCIS
     DurationLookup: AL_CRUCIS
@@ -449,6 +459,7 @@ Body:
     Flags:
       FailedMado: true
       TaekwonAngel: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
     EndOnStart:
@@ -464,6 +475,7 @@ Body:
       BossResist: true
       NoSave: true
       Debuff: true
+      RemoveOnHermode: true
     Fail:
       Speedup1: true
     EndOnStart:
@@ -482,6 +494,7 @@ Body:
     DurationLookup: PR_SLOWPOISON
     Flags:
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Impositio
     Icon: EFST_IMPOSITIO
     DurationLookup: PR_IMPOSITIO
@@ -490,6 +503,7 @@ Body:
       Matk: true
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
     EndOnStart:
       Impositio: true
   - Status: Suffragium
@@ -497,6 +511,7 @@ Body:
     DurationLookup: PR_SUFFRAGIUM
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Aspersio
     Icon: EFST_ASPERSIO
     DurationLookup: PR_ASPERSIO
@@ -504,6 +519,7 @@ Body:
       Atk_Ele: true
     Flags:
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Fireweapon: true
@@ -522,11 +538,13 @@ Body:
       NoSave: true
       NoClearance: true
       #RemoveOnUnequipArmor: true
+      RemoveOnHermode: true
   - Status: Kyrie
     Icon: EFST_KYRIE
     DurationLookup: PR_KYRIE
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Magnificat
     Icon: EFST_MAGNIFICAT
     DurationLookup: PR_MAGNIFICAT
@@ -536,6 +554,7 @@ Body:
       FailedMado: true
       NoSave: true
       SuperNoviceAngel: true
+      RemoveOnHermode: true
     EndOnStart:
       Offertorium: true
   - Status: Gloria
@@ -545,11 +564,13 @@ Body:
       Luk: true
     Flags:
       SuperNoviceAngel: true
+      RemoveOnHermode: true
   - Status: Aeterna
     Icon: EFST_LEXAETERNA
     DurationLookup: PR_LEXAETERNA
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Stone: true
       Freeze: true
@@ -562,6 +583,7 @@ Body:
     Flags:
       MadoCancel: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
       Decreaseagi: true
@@ -570,6 +592,7 @@ Body:
     DurationLookup: BS_WEAPONPERFECT
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
   - Status: Overthrust
     Icon: EFST_OVERTHRUST
     DurationLookup: BS_OVERTHRUST
@@ -577,6 +600,7 @@ Body:
       OverThrust: true
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
     Fail:
       Maxoverthrust: true
   - Status: Maximizepower
@@ -586,6 +610,7 @@ Body:
       Regen: true
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
   - Status: Trickdead
     Icon: EFST_TRICKDEAD
     DurationLookup: NV_TRICKDEAD
@@ -605,6 +630,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
     EndOnStart:
       Dancing: true
   - Status: Loud
@@ -612,6 +638,7 @@ Body:
     DurationLookup: MC_LOUD
     Flags:
       MadoCancel: true
+      RemoveOnHermode: true
     CalcFlags:
       Str: true
       Batk: true
@@ -620,6 +647,8 @@ Body:
     DurationLookup: MG_ENERGYCOAT
     Opt3:
       EnergyCoat: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Brokenarmor
     Icon: EFST_BROKENARMOR
     DurationLookup: NPC_ARMORBRAKE
@@ -672,12 +701,14 @@ Body:
     Flags:
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Aspdpotion2
     Icon: EFST_ATTHASTE_POTION3
     CalcFlags:
       Aspd: true
     Flags:
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Aspdpotion3
     Icon: EFST_ATTHASTE_INFINITY
     CalcFlags:
@@ -685,6 +716,7 @@ Body:
     Flags:
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Speedup0
     Icon: EFST_MOVHASTE_HORSE
     CalcFlags:
@@ -702,6 +734,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Atkpotion
     Icon: EFST_PLUSATTACKPOWER
     CalcFlags:
@@ -710,6 +743,7 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Matkpotion
     Icon: EFST_PLUSMAGICPOWER
     CalcFlags:
@@ -718,6 +752,7 @@ Body:
       NoRemoveOnDead: true
       NoClearance: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
   - Status: Wedding
     States:
       NoAttack: true
@@ -760,6 +795,8 @@ Body:
     CalcFlags:
       Mdef: true
       Def: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Stripweapon
     Icon: EFST_NOEQUIPWEAPON
     DurationLookup: RG_STRIPWEAPON
@@ -772,6 +809,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Stripshield
     Icon: EFST_NOEQUIPSHIELD
     DurationLookup: RG_STRIPSHIELD
@@ -784,6 +822,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Striparmor
     Icon: EFST_NOEQUIPARMOR
     DurationLookup: RG_STRIPARMOR
@@ -796,6 +835,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Striphelm
     Icon: EFST_NOEQUIPHELM
     DurationLookup: RG_STRIPHELM
@@ -808,6 +848,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Cp_Weapon
     Icon: EFST_PROTECTWEAPON
     DurationLookup: AM_CP_WEAPON
@@ -817,6 +858,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Shield
     Icon: EFST_PROTECTSHIELD
     DurationLookup: AM_CP_SHIELD
@@ -826,6 +868,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Armor
     Icon: EFST_PROTECTARMOR
     DurationLookup: AM_CP_ARMOR
@@ -835,6 +878,7 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Cp_Helm
     Icon: EFST_PROTECTHELM
     DurationLookup: AM_CP_HELM
@@ -844,18 +888,21 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       RemoveChemicalProtect: true
+      RemoveOnHermode: true
   - Status: Autoguard
     Icon: EFST_AUTOGUARD
     DurationLookup: CR_AUTOGUARD
     Flags:
       NoClearance: true
       RequireShield: true
+      RemoveOnHermode: true
   - Status: Reflectshield
     Icon: EFST_REFLECTSHIELD
     DurationLookup: CR_REFLECTSHIELD
     Flags:
       NoClearance: true
       RequireShield: true
+      RemoveOnHermode: true
     EndOnStart:
       Reflectdamage: true
   - Status: Splasher
@@ -868,6 +915,7 @@ Body:
       All: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Defender
     Icon: EFST_DEFENDER
     DurationLookup: CR_DEFENDER
@@ -876,11 +924,13 @@ Body:
       Aspd: true
     Flags:
       RequireShield: true
+      RemoveOnHermode: true
   - Status: Magicrod
     Icon: EFST_MAGICROD
     DurationLookup: SA_MAGICROD
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Spellbreaker
     Flags:
       NoWarning: true
@@ -914,6 +964,7 @@ Body:
     Flags:
       FailedMado: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Autocounter
@@ -968,6 +1019,7 @@ Body:
       Debuff: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
   - Status: Combo
     Flags:
       NoClearbuff: true
@@ -998,6 +1050,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
   - Status: Fireweapon
     Icon: EFST_PROPERTYFIRE
     DurationLookup: SA_FLAMELAUNCHER
@@ -1067,6 +1120,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Deluge
     Icon: EFST_GROUNDMAGIC
     DurationLookup: SA_DELUGE
@@ -1126,6 +1180,7 @@ Body:
     Flags:
       NoSave: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Parrying
     Icon: EFST_PARRYING
     DurationLookup: LK_PARRYING
@@ -1133,6 +1188,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Concentration
     Icon: EFST_LKCONCENTRATION
     DurationLookup: LK_CONCENTRATION
@@ -1143,6 +1199,7 @@ Body:
       Quicken: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Tensionrelax
     Icon: EFST_TENSIONRELAX
     DurationLookup: LK_TENSIONRELAX
@@ -1151,6 +1208,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Berserk
     Icon: EFST_BERSERK
     DurationLookup: LK_BERSERK
@@ -1191,6 +1249,7 @@ Body:
       Aspd: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Assumptio
     Icon: EFST_ASSUMPTIO2
     DurationLookup: HP_ASSUMPTIO
@@ -1200,6 +1259,8 @@ Body:
       Assumptio: true
     EndOnStart:
       Kaite: true
+    Flags:
+      RemoveOnHermode: true
   - Status: Basilica
     Icon: EFST_BASILICA_BUFF
     DurationLookup: HP_BASILICA
@@ -1210,6 +1271,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Guildaura
     Flags:
       NoDispell: true
@@ -1222,6 +1284,7 @@ Body:
       Matk: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     EndOnStart:
       Magicpower: true
   - Status: Edp
@@ -1248,6 +1311,7 @@ Body:
     Flags:
       FailedMado: true
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Windwalk
@@ -1259,6 +1323,7 @@ Body:
     Flags:
       FailedMado: true
       NoSave: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
   - Status: Meltdown
@@ -1351,6 +1416,7 @@ Body:
       Debuff: true
       NoClearance: true
       NoSave: true
+      RemoveOnHermode: true
     EndOnStart:
       Blessing: true
       Increaseagi: true
@@ -1366,6 +1432,7 @@ Body:
       NoSave: true
       NoClearance: true
       Debuff: true
+      RemoveOnHermode: true
   - Status: Mindbreaker
     Icon: EFST_MINDBREAKER
     DurationLookup: PF_MINDBREAKER
@@ -1375,6 +1442,7 @@ Body:
     Flags:
       NoSave: true
       Debuff: true
+      RemoveOnHermode: true
     EndOnStart:
       Freeze: true
       Stone: true
@@ -1384,6 +1452,7 @@ Body:
     DurationLookup: PF_MEMORIZE
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Fogwall
     Icon: EFST_FOGWALL
     DurationLookup: PF_FOGWALL
@@ -1391,6 +1460,7 @@ Body:
       BossResist: true
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Spiderweb
     Icon: EFST_SPIDERWEB
     DurationLookup: PF_SPIDERWEB
@@ -1413,6 +1483,7 @@ Body:
       NoSave: true
       RemoveOnChangeMap: true
       OverlapIgnoreLevel: true
+      RemoveOnHermode: true
     EndOnEnd:
       Autoguard: true
       Defender: true
@@ -1420,6 +1491,8 @@ Body:
       Endure: true
   - Status: Sacrifice
     DurationLookup: PA_SACRIFICE
+    Flags:
+      RemoveOnHermode: true
   - Status: Steelbody
     Icon: EFST_STEELBODY
     DurationLookup: MO_STEELBODY
@@ -1432,6 +1505,7 @@ Body:
       Speed: true
     Flags:
       NoSave: true
+      RemoveOnHermode: true
     Opt3:
       SteelBody: true
   - Status: Orcish
@@ -1496,6 +1570,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnChangeMap: true
+      RemoveOnHermode: true
   - Status: Shadowweapon
     Icon: EFST_PROPERTYDARK
     DurationLookup: TK_SEVENWIND
@@ -1504,6 +1579,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Aspersio: true
@@ -1521,6 +1597,7 @@ Body:
       MadoCancel: true
       NoSave: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Quagmire: true
       Decreaseagi: true
@@ -1532,6 +1609,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Encpoison: true
       Aspersio: true
@@ -1549,6 +1627,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Kaahi: true
   - Status: Kaupe
@@ -1557,6 +1636,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Onehand
     Icon: EFST_ONEHANDQUICKEN
     DurationLookup: KN_ONEHAND
@@ -1568,6 +1648,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
     Fail:
       Decreaseagi: true
     EndOnStart:
@@ -1580,6 +1661,7 @@ Body:
     DurationLookup: ST_PRESERVE
     Flags:
       NoSave: true
+      RemoveOnHermode: true
   - Status: Battleorders
     Icon: EFST_GDSKILL_BATTLEORDER
     DurationLookup: GD_BATTLEORDER
@@ -1603,6 +1685,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Maxoverthrust
     Icon: EFST_OVERTHRUSTMAX
     DurationLookup: WS_OVERTHRUSTMAX
@@ -1612,6 +1695,7 @@ Body:
       MadoCancel: true
       NoSave: true
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Overthrust: true
   - Status: Hermode
@@ -1964,6 +2048,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       Debuff: true
+      RemoveOnHermode: true
   - Status: Spurt
     Icon: EFST_STRUP
     DurationLookup: TK_RUN
@@ -1973,6 +2058,7 @@ Body:
       NoSave: true
       NoClearance: true
       RequireWeapon: true
+      RemoveOnHermode: true
   - Status: Spirit
     Icon: EFST_SOULLINK
     DurationLookup: SL_HIGH
@@ -1984,6 +2070,7 @@ Body:
       NoClearance: true
       NoSave: true
       NoBanishingBuster: true
+      RemoveOnHermode: true
     Fail:
       Soulgolem: true
       Soulshadow: true
@@ -2336,6 +2423,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
     EndOnStart:
       Assumptio: true
   - Status: Swoo
@@ -2433,6 +2521,7 @@ Body:
       NoClearance: true
       NoBanishingBuster: true
       NoDispell: true
+      RemoveOnHermode: true
   - Status: Bunsinjyutsu
     Icon: EFST_NJ_BUNSINJYUTSU
     DurationLookup: NJ_BUNSINJYUTSU
@@ -2443,6 +2532,7 @@ Body:
     Flags:
       NoSave: true
       NoClearance: true
+      RemoveOnHermode: true
   - Status: Kaensin
     Flags:
       NoWarning: true
@@ -2557,6 +2647,7 @@ Body:
       SendVal1: true
       OverlapIgnoreLevel: true
       RemoveOnUnequipWeapon: true
+      RemoveOnHermode: true
     EndOnStart:
       Enchantarms: true
       Aspersio: true
@@ -6022,6 +6113,7 @@ Body:
       RemoveOnChangeMap: true
       NoBanishingBuster: true
       NoDispell: true
+      RemoveOnHermode: true
   - Status: Extremityfist2
     Icon: EFST_EXTREMITYFIST
     DurationLookup: MO_EXTREMITYFIST
@@ -6668,6 +6760,7 @@ Body:
     Flags:
       NoRemoveOnDead: true
       NoClearbuff: true
+      RemoveOnHermode: true
   - Status: Geffen_Magic2
     Icon: EFST_GEFFEN_MAGIC2
     CalcFlags:

--- a/doc/status.txt
+++ b/doc/status.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= rAthena Dev Team
 //===== Last Updated: ========================================
-//= 20221013
+//= 20221216
 //===== Description: =========================================
 //= Explanation of the status.yml file and structure.
 //============================================================
@@ -232,6 +232,7 @@ Flags: Various status flags for specific status change events.
 	RemoveOnUnequip       - Removed when unequipping any type of equipment.
 	RemoveOnUnequipWeapon - Removed when unequipping a weapon.
 	RemoveOnUnequipArmor  - Removed when unequipping an armor.
+	RemoveOnHermode       - Removed by CG_HERMODE.
 
 	StopAttacking         - Makes the unit stop attacking.
 	StopCasting           - Makes the unit stop casting skills.

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -9815,6 +9815,7 @@
 	export_constant(SCF_REMOVEONUNEQUIP);
 	export_constant(SCF_REMOVEONUNEQUIPWEAPON);
 	export_constant(SCF_REMOVEONUNEQUIPARMOR);
+	export_constant(SCF_REMOVEONHERMODE);
 
 	/* enchantgrades */
 	export_constant(ENCHANTGRADE_NONE);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6976,7 +6976,7 @@ static int skill_apply_songs(struct block_list* target, va_list ap)
 			return skill_additional_effect(src, target, skill_id, skill_lv, BF_LONG | BF_SKILL | BF_MISC, ATK_DEF, tick);
 		default: // Buff/Debuff type songs
 			if (skill_id == CG_HERMODE && src->id != target->id)
-				status_change_clear_buffs(target, SCCB_BUFFS); // Should dispell only allies.
+				status_change_clear_buffs(target, SCCB_HERMODE); // Should dispell only allies.
 			return sc_start(src, target, skill_get_sc(skill_id), 100, skill_lv, skill_get_time(skill_id, skill_lv));
 		}
 	}
@@ -15188,7 +15188,7 @@ static int skill_unit_onplace(struct skill_unit *unit, struct block_list *bl, t_
 
 		case UNT_HERMODE:
 			if (sg->src_id!=bl->id && battle_check_target(&unit->bl,bl,BCT_PARTY|BCT_GUILD) > 0)
-				status_change_clear_buffs(bl, SCCB_BUFFS); //Should dispell only allies.
+				status_change_clear_buffs(bl, SCCB_HERMODE); //Should dispell only allies.
 		case UNT_RICHMANKIM:
 		case UNT_ETERNALCHAOS:
 		case UNT_DRUMBATTLEFIELD:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14825,7 +14825,10 @@ void status_change_clear_buffs(struct block_list* bl, uint8 type)
 			continue;
 		// &SCCB_BUFFS : Clears buffs
 		if (!(type&SCCB_BUFFS) && !(flag[SCF_DEBUFF]))
-			continue;		
+			continue;
+		// &SCCB_HERMODE : Cleared by CG_HERMODE
+		if (!(type & SCCB_HERMODE) && flag[SCF_REMOVEONHERMODE])
+			continue;
 		if (status == SC_SATURDAYNIGHTFEVER || status == SC_BERSERK) // Mark to not lose HP
 			sc->getSCE(status)->val2 = 0;
 		status_change_end(bl, status);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14809,25 +14809,28 @@ void status_change_clear_buffs(struct block_list* bl, uint8 type)
 		sc_type status = static_cast<sc_type>(it.first);
 		std::bitset<SCF_MAX> flag = it.second->flag;
 
-		if (!sc->getSCE(status) || flag[SCF_NOCLEARBUFF]) //Skip status with SCF_NOCLEARBUFF, no matter what
+		if (!sc->getSCE(status))
 			continue;
-		// &SCCB_LUXANIMA : Cleared by RK_LUXANIMA
-		if (!(type&SCCB_LUXANIMA) && flag[SCF_REMOVEONLUXANIMA])
+		// Skip status with SCF_NOCLEARBUFF, no matter what
+		if (flag[SCF_NOCLEARBUFF])
+			continue;
+		// &SCCB_LUXANIMA : Cleared by RK_LUXANIMA and has the SCF_REMOVEONLUXANIMA flag
+		if ((type & SCCB_LUXANIMA) && !flag[SCF_REMOVEONLUXANIMA])
 			continue;
 		// &SCCB_CHEM_PROTECT : Clears AM_CP_ARMOR/HELP/SHIELD/WEAPON
-		if (!(type&SCCB_CHEM_PROTECT) && flag[SCF_REMOVECHEMICALPROTECT])
+		if ((type & SCCB_CHEM_PROTECT) && !flag[SCF_REMOVECHEMICALPROTECT])
 			continue;
-		// &SCCB_REFRESH : Cleared by RK_REFRESH
-		if (!(type&SCCB_REFRESH) && flag[SCF_REMOVEONREFRESH])
+		// &SCCB_REFRESH : Cleared by RK_REFRESH and has the SCF_REMOVEONREFRESH flag
+		if ((type & SCCB_REFRESH) && !flag[SCF_REMOVEONREFRESH])
 			continue;
-		// &SCCB_DEBUFFS : Clears debuffs
-		if (!(type&SCCB_DEBUFFS) && flag[SCF_DEBUFF])
+		// &SCCB_DEBUFFS : Clears debuffs - skip if it is not a debuff
+		if (type & SCCB_DEBUFFS && !flag[SCF_DEBUFF] && !(type & SCCB_BUFFS))
 			continue;
-		// &SCCB_BUFFS : Clears buffs
-		if (!(type&SCCB_BUFFS) && !(flag[SCF_DEBUFF]))
+		// &SCCB_BUFFS : Clears buffs - skip if it is a debuff
+		if (type & SCCB_BUFFS && flag[SCF_DEBUFF] && !(type & SCCB_DEBUFFS))
 			continue;
-		// &SCCB_HERMODE : Cleared by CG_HERMODE
-		if (!(type & SCCB_HERMODE) && flag[SCF_REMOVEONHERMODE])
+		// &SCCB_HERMODE : Cleared by CG_HERMODE and has the SCF_REMOVEONHERMODE flag
+		if ((type & SCCB_HERMODE) && !flag[SCF_REMOVEONHERMODE])
 			continue;
 		if (status == SC_SATURDAYNIGHTFEVER || status == SC_BERSERK) // Mark to not lose HP
 			sc->getSCE(status)->val2 = 0;

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -2854,6 +2854,7 @@ enum e_status_change_clear_buffs_flags : int64 {
 	SCCB_REFRESH      = 0x04,
 	SCCB_CHEM_PROTECT = 0x08,
 	SCCB_LUXANIMA     = 0x10,
+	SCCB_HERMODE      = 0x20,
 };
 
 ///Enum for bonus_script's flag [Cydh]
@@ -2936,6 +2937,7 @@ enum e_status_change_flag : uint16 {
 	SCF_REMOVEONUNEQUIP,
 	SCF_REMOVEONUNEQUIPWEAPON,
 	SCF_REMOVEONUNEQUIPARMOR,
+	SCF_REMOVEONHERMODE,
 	SCF_MAX
 };
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Wand of Hermode has a unique status clear list separate from the list other skills use.
  * Adds RemoveOnHermode status flag to identify statuses that can be removed from Wand of Hermode.
Thanks to @mrjnumber1!