### PR TITLE
Fixed instances with infinite timeout getting destroyed instantly

### DIFF
--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -727,7 +727,7 @@ int instance_addmap(int instance_id) {
 
 	// Set to busy, update timers
 	idata->state = INSTANCE_BUSY;
-	if (db->infinite_timeout) {
+	if (!db->infinite_timeout) {
 		idata->idle_limit = time(nullptr) + db->timeout;
 		idata->idle_timer = add_timer(gettick() + db->timeout * 1000, instance_delete_timer, instance_id, 0);
 	}

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -727,8 +727,10 @@ int instance_addmap(int instance_id) {
 
 	// Set to busy, update timers
 	idata->state = INSTANCE_BUSY;
-	idata->idle_limit = time(nullptr) + db->timeout;
-	idata->idle_timer = add_timer(gettick() + db->timeout * 1000, instance_delete_timer, instance_id, 0);
+	if (db->infinite_timeout) {
+		idata->idle_limit = time(nullptr) + db->timeout;
+		idata->idle_timer = add_timer(gettick() + db->timeout * 1000, instance_delete_timer, instance_id, 0);
+	}
 	idata->nomapflag = db->nomapflag;
 	idata->nonpc = db->nonpc;
 


### PR DESCRIPTION
Follow up to 3464292a31e4b05ca253e007115354223554ae12

* **Addressed Issue(s)**: -
* **Server Mode**: Both
* **Description of Pull Request**: 
In `instance_addmap`, we didn't account for `infinite_timeout` variable, which results in the instance getting destroyed on next tick.