### PR TITLE
Forcefully disable SSL for MySQL

### DIFF
--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -120,6 +120,13 @@ int Sql_Connect(Sql* self, const char* user, const char* passwd, const char* hos
 		return SQL_ERROR;
 
 	StringBuf_Clear(&self->buf);
+
+	unsigned int md = SSL_MODE_DISABLED;
+
+	if( mysql_options( &self->handle, MYSQL_OPT_SSL_MODE, &md ) ){
+		ShowSQL( "Your MySQL version does not understand \"MYSQL_OPT_SSL_MODE\" yet. Please consider upgrading - especially if you encounter SSL related error messages from your MySQL server.\n" );
+	}
+
 	if( !mysql_real_connect(&self->handle, host, user, passwd, db, (unsigned int)port, NULL/*unix_socket*/, 0/*clientflag*/) )
 	{
 		ShowSQL("%s\n", mysql_error(&self->handle));

--- a/tools/ci/sql.sh
+++ b/tools/ci/sql.sh
@@ -36,5 +36,8 @@ mysql -u $DB_ROOT -p$DB_ROOTPW $DB_NAME < sql-files/mob_skill_db2.sql || aborter
 mysql -u $DB_ROOT -p$DB_ROOTPW $DB_NAME < sql-files/mob_skill_db_re.sql || aborterror "Unable to import renewal monster skill table."
 mysql -u $DB_ROOT -p$DB_ROOTPW $DB_NAME < sql-files/mob_skill_db2_re.sql || aborterror "Unable to import renewal monster skill 2 table."
 mysql -u $DB_ROOT -p$DB_ROOTPW $DB_NAME < sql-files/roulette_default_data.sql || aborterror "Unable to import roulette table."
-mysql -u $DB_ROOT -p$DB_ROOTPW -e "CREATE USER '$DB_USER'@'$DB_HOST' IDENTIFIED BY '$DB_PASS';"
+# MariaDB
+mysql -u $DB_ROOT -p$DB_ROOTPW -e "SET old_passwords=0; CREATE USER '$DB_USER'@'$DB_HOST' IDENTIFIED BY '$DB_PASS';"
+# MySQL
+mysql -u $DB_ROOT -p$DB_ROOTPW -e "CREATE USER '$DB_USER'@'$DB_HOST' IDENTIFIED WITH mysql_native_password BY '$DB_PASS';"
 mysql -u $DB_ROOT -p$DB_ROOTPW -e "GRANT SELECT,INSERT,UPDATE,DELETE ON $DB_NAME.* TO '$DB_USER'@'$DB_HOST';"


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**:
Newer MySQL versions are a little troublesome with outdated SSL/TLS versions and do not seem to correctly fall back to other authentication plugins anmyore, so we forcefully disable using those authentication methods now.
