### PR TITLE
Fixes getrefine failing in OnEquip/OnUnequip scripts

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -11948,6 +11948,7 @@ bool pc_equipitem(map_session_data *sd,short n,int req_pos,bool equipswitch)
 	//OnEquip script [Skotlex]
 	if (id) {
 		current_equip_item_index = n;
+		current_equip_card_id = 0;
 		//only run the script if item isn't restricted
 		if (id->equip_script && (pc_has_permission(sd,PC_PERM_USE_ALL_EQUIPMENT) || !itemdb_isNoEquip(id,sd->bl.m)))
 			run_script(id->equip_script,0,sd->bl.id,fake_nd->bl.id);
@@ -11957,12 +11958,13 @@ bool pc_equipitem(map_session_data *sd,short n,int req_pos,bool equipswitch)
 			for( i = 0; i < MAX_SLOTS; i++ ) {
 				if (!sd->inventory.u.items_inventory[n].card[i])
 					continue;
-				current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 				std::shared_ptr<item_data> data = item_db.find(sd->inventory.u.items_inventory[n].card[i]);
 
 				if ( data != nullptr ) {
-					if (data->equip_script && (pc_has_permission(sd,PC_PERM_USE_ALL_EQUIPMENT) || !itemdb_isNoEquip(data.get(), sd->bl.m)))
+					if (data->equip_script && (pc_has_permission(sd,PC_PERM_USE_ALL_EQUIPMENT) || !itemdb_isNoEquip(data.get(), sd->bl.m))) {
+						current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 						run_script(data->equip_script,0,sd->bl.id,fake_nd->bl.id);
+					}
 				}
 				current_equip_card_id = 0;
 			}
@@ -12046,6 +12048,7 @@ static void pc_unequipitem_sub(map_session_data *sd, int n, int flag) {
 	//OnUnEquip script [Skotlex]
 	if (sd->inventory_data[n]) {
 		current_equip_item_index = n;
+		current_equip_card_id = 0;
 		if (sd->inventory_data[n]->unequip_script)
 			run_script(sd->inventory_data[n]->unequip_script, 0, sd->bl.id, fake_nd->bl.id);
 		if (itemdb_isspecial(sd->inventory.u.items_inventory[n].card[0]))
@@ -12055,12 +12058,13 @@ static void pc_unequipitem_sub(map_session_data *sd, int n, int flag) {
 				if (!sd->inventory.u.items_inventory[n].card[i])
 					continue;
 
-				current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 				std::shared_ptr<item_data> data = item_db.find(sd->inventory.u.items_inventory[n].card[i]);
 
 				if (data != nullptr) {
-					if (data->unequip_script)
+					if (data->unequip_script) {
+						current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 						run_script(data->unequip_script, 0, sd->bl.id, fake_nd->bl.id);
+					}
 				}
 				current_equip_card_id = 0;
 			}

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -11947,6 +11947,7 @@ bool pc_equipitem(map_session_data *sd,short n,int req_pos,bool equipswitch)
 
 	//OnEquip script [Skotlex]
 	if (id) {
+		current_equip_item_index = n;
 		//only run the script if item isn't restricted
 		if (id->equip_script && (pc_has_permission(sd,PC_PERM_USE_ALL_EQUIPMENT) || !itemdb_isNoEquip(id,sd->bl.m)))
 			run_script(id->equip_script,0,sd->bl.id,fake_nd->bl.id);
@@ -11956,15 +11957,17 @@ bool pc_equipitem(map_session_data *sd,short n,int req_pos,bool equipswitch)
 			for( i = 0; i < MAX_SLOTS; i++ ) {
 				if (!sd->inventory.u.items_inventory[n].card[i])
 					continue;
-
+				current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 				std::shared_ptr<item_data> data = item_db.find(sd->inventory.u.items_inventory[n].card[i]);
 
 				if ( data != nullptr ) {
 					if (data->equip_script && (pc_has_permission(sd,PC_PERM_USE_ALL_EQUIPMENT) || !itemdb_isNoEquip(data.get(), sd->bl.m)))
 						run_script(data->equip_script,0,sd->bl.id,fake_nd->bl.id);
 				}
+				current_equip_card_id = 0;
 			}
 		}
+		current_equip_item_index = -1;
 	}
 	sd->npc_item_flag = iflag;
 
@@ -12042,6 +12045,7 @@ static void pc_unequipitem_sub(map_session_data *sd, int n, int flag) {
 
 	//OnUnEquip script [Skotlex]
 	if (sd->inventory_data[n]) {
+		current_equip_item_index = n;
 		if (sd->inventory_data[n]->unequip_script)
 			run_script(sd->inventory_data[n]->unequip_script, 0, sd->bl.id, fake_nd->bl.id);
 		if (itemdb_isspecial(sd->inventory.u.items_inventory[n].card[0]))
@@ -12051,15 +12055,17 @@ static void pc_unequipitem_sub(map_session_data *sd, int n, int flag) {
 				if (!sd->inventory.u.items_inventory[n].card[i])
 					continue;
 
+				current_equip_card_id = sd->inventory.u.items_inventory[n].card[i];
 				std::shared_ptr<item_data> data = item_db.find(sd->inventory.u.items_inventory[n].card[i]);
 
 				if (data != nullptr) {
 					if (data->unequip_script)
 						run_script(data->unequip_script, 0, sd->bl.id, fake_nd->bl.id);
 				}
-
+				current_equip_card_id = 0;
 			}
 		}
+		current_equip_item_index = -1;
 	}
 
 	sd->npc_item_flag = iflag;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4132,8 +4132,11 @@ int run_func(struct script_state *st)
 		}
 #endif
 
-		if (str_data[func].func(st) == SCRIPT_CMD_FAILURE) //Report error
+		if (str_data[func].func(st) == SCRIPT_CMD_FAILURE) {
+			//Report error
+			ShowWarning("'%s' returned failure.\n", get_str(func));
 			script_reportsrc(st);
+		}
 	} else {
 		ShowError("script:run_func: '%s' (id=%d type=%s) has no C function. please report this!!!\n", get_str(func), func, script_op2name(str_data[func].type));
 		script_reportsrc(st);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -4134,7 +4134,7 @@ int run_func(struct script_state *st)
 
 		if (str_data[func].func(st) == SCRIPT_CMD_FAILURE) {
 			//Report error
-			ShowWarning("'%s' returned failure.\n", get_str(func));
+			ShowWarning("Script command '%s' returned failure.\n", get_str(func));
 			script_reportsrc(st);
 		}
 	} else {


### PR DESCRIPTION
This also adds a warning naming which function returns failure


* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

We don't set current_equip_item_index when we run the equip/unequip scripts in pc_(un)equipitem
We also should set the current_equip_card_id


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
