### PR TITLE
Speed up YAML DB loading by removing ShowStatus

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -154,13 +154,12 @@ void YamlDatabase::parse( const ryml::Tree& tree ){
 	if( this->nodeExists( tree.rootref(), "Body" ) ){
 		const ryml::NodeRef& bodyNode = tree["Body"];
 		size_t childNodesCount = bodyNode.num_children();
-		size_t childNodesProgressed = 0;
 		const char* fileName = this->currentFile.c_str();
+
+		ShowStatus("Loading '" CL_WHITE "%" PRIdPTR CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\n", childNodesCount, fileName);
 
 		for( const ryml::NodeRef &node : bodyNode ){
 			count += this->parseBodyNode( node );
-
-			ShowStatus( "Loading [%" PRIdPTR "/%" PRIdPTR "] entries from '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++childNodesProgressed, childNodesCount, fileName );
 		}
 
 		ShowStatus( "Done reading '" CL_WHITE "%" PRIu64 CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\n", count, fileName );

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -155,11 +155,17 @@ void YamlDatabase::parse( const ryml::Tree& tree ){
 		const ryml::NodeRef& bodyNode = tree["Body"];
 		size_t childNodesCount = bodyNode.num_children();
 		const char* fileName = this->currentFile.c_str();
+#ifdef DEBUG
+		size_t childNodesProgressed = 0;
+#endif
 
-		ShowStatus("Loading '" CL_WHITE "%" PRIdPTR CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\n", childNodesCount, fileName);
+		ShowStatus("Loading '" CL_WHITE "%" PRIdPTR CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'\n", childNodesCount, fileName);
 
 		for( const ryml::NodeRef &node : bodyNode ){
 			count += this->parseBodyNode( node );
+#ifdef DEBUG
+			ShowStatus( "Loading [%" PRIdPTR "/%" PRIdPTR "] entries from '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++childNodesProgressed, childNodesCount, fileName );
+#endif
 		}
 
 		ShowStatus( "Done reading '" CL_WHITE "%" PRIu64 CL_RESET "' entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\n", count, fileName );


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A
* **Server Mode**: Both
* **Description of Pull Request**: 

Speed up YAML DB Loading by removing ShowStatus for every node in Body

On my machine, it reduces windows parsing from 18s to .79 seconds
On linux, reduces parsing from 2.9s to 1.8s

<details>
<summary>Benchmark Code</summary>

Replace the `YamlDatabase::load` method with this:

```C++
#include <chrono>
#define PARSEINARENA

bool YamlDatabase::load(const std::string& path) {
	ShowStatus("Loading '" CL_WHITE "%s" CL_RESET "'..." CL_CLL "\r", path.c_str());
	auto t1 = std::chrono::high_resolution_clock::now();
	FILE* f = fopen(path.c_str(), "r");
	if (f == nullptr) {
		ShowError("Failed to open %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), path.c_str());
		return false;
	}
	fseek(f, 0, SEEK_END);
	size_t size = ftell(f);
	char* buf = (char *)aMalloc(size+1);
	rewind(f);
	size_t real_size = fread(buf, sizeof(char), size, f);
	// Zero terminate
	buf[real_size] = '\0';
	fclose(f);

	auto t2 = std::chrono::high_resolution_clock::now();
	parser = {};
	ryml::Tree tree;

	try{
#ifdef PARSEINARENA
		tree = parser.parse_in_arena(c4::to_csubstr(path), c4::to_csubstr(buf));
#else
		tree = parser.parse_in_place(c4::to_csubstr(path), c4::to_substr(buf));
#endif
	}catch( const std::runtime_error& e ){
		ShowError( "Failed to load %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), path.c_str() );
		ShowError( "There is likely a syntax error in the file.\n" );
		ShowError( "Error message: %s\n", e.what() );
		return false;
	}

	auto t3 = std::chrono::high_resolution_clock::now();
	// Required here already for header error reporting
	this->currentFile = path;

	if (!this->verifyCompatibility(tree)){
		ShowError("Failed to verify compatibility with %s database file from '" CL_WHITE "%s" CL_RESET "'.\n", this->type.c_str(), this->currentFile.c_str());
		aFree(buf);
		return false;
	}

	const ryml::NodeRef& header = tree["Header"];

	if( this->nodeExists( header, "Clear" ) ){
		bool clear;

		if( this->asBool( header, "Clear", clear ) && clear ){
			this->clear();
		}
	}

	this->parse( tree );

	auto t4 = std::chrono::high_resolution_clock::now();
	this->parseImports( tree );

	aFree(buf);

	auto t5 = std::chrono::high_resolution_clock::now();

	auto ms21 = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
	auto ms32 = std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2);
	auto ms43 = std::chrono::duration_cast<std::chrono::microseconds>(t4 - t3);
	auto ms54 = std::chrono::duration_cast<std::chrono::microseconds>(t5 - t4);
	auto ms51 = std::chrono::duration_cast<std::chrono::microseconds>(t5 - t1);

	
	ShowInfo("Parsing [%s](%s)...\n", path.c_str(), this->type.c_str());
	ShowInfo("File Load to Buffer:\t\t%lld\n", ms21.count());
#ifdef PARSEINARENA
	ShowInfo("Fill Tree (arena):\t\t%lld\n", ms32.count());
#else
	ShowInfo("Fill Tree(place):\t\t%lld\n", ms32.count());
#endif
	ShowInfo("Parse Tree to DB:\t\t%lld\n", ms43.count());
	ShowInfo("Parse Imports DB:\t\t%lld\n", ms54.count());
	ShowInfo("Total:\t\t\t%lld\n", ms51.count());

	return true;
}
```
</details>

<details>
<summary>Benchmark Data</summary>

```
// windows with message
[Info]: Parsing [db/item_db.yml](ITEM_DB)...
[Info]: File Load to Buffer:            166
[Info]: Fill Tree (arena):              32
[Info]: Parse Tree to DB:               2
[Info]: Parse Imports DB:               17748015
[Info]: Total:                          17748216

// windows nomsg
[Info]: Parsing [db/item_db.yml](ITEM_DB)...
[Info]: File Load to Buffer:            4621
[Info]: Fill Tree (arena):              30
[Info]: Parse Tree to DB:               2
[Info]: Parse Imports DB:               789978
[Info]: Total:                          794631

// linux with message
[Info]: Parsing [db/item_db.yml](ITEM_DB)...
[Info]: File Load to Buffer:          20
[Info]: Fill Tree (arena):            42
[Info]: Parse Tree to DB:             3
[Info]: Parse Imports DB:             2985617
[Info]: Total:                        2985683

// linux nomsg
[Info]: Parsing [db/item_db.yml](ITEM_DB)...
[Info]: File Load to Buffer:          19
[Info]: Fill Tree (arena):            34
[Info]: Parse Tree to DB:             3
[Info]: Parse Imports DB:             1837567
[Info]: Total:                        1837624
```
</details>

Pros:
Much faster on windows
Faster on linux

Cons:
We don't see every showmsg, so we're not sure if the map server has stalled or not.
However, if the yaml parsing doesn't finish within 10 seconds for a file, there should be something wrong.