### PR TITLE
Made debug ShowStatus calls easier to disable

### DIFF
--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -164,7 +164,7 @@ void YamlDatabase::parse( const ryml::Tree& tree ){
 
 		for( const ryml::NodeRef &node : bodyNode ){
 			count += this->parseBodyNode( node );
-#ifdef DEBUG
+#ifdef FANCY_LOADING_OUTPUT
 			ShowStatus( "Loading [%" PRIdPTR "/%" PRIdPTR "] entries from '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++childNodesProgressed, childNodesCount, fileName );
 #endif
 		}

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -164,7 +164,7 @@ void YamlDatabase::parse( const ryml::Tree& tree ){
 
 		for( const ryml::NodeRef &node : bodyNode ){
 			count += this->parseBodyNode( node );
-#ifdef FANCY_LOADING_OUTPUT
+#ifdef DETAILED_LOADING_OUTPUT
 			ShowStatus( "Loading [%" PRIdPTR "/%" PRIdPTR "] entries from '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++childNodesProgressed, childNodesCount, fileName );
 #endif
 		}

--- a/src/config/core.hpp
+++ b/src/config/core.hpp
@@ -100,6 +100,13 @@
 /// Uncomment for use with Nemo patch ExtendOldCashShopPreview
 //#define ENABLE_OLD_CASHSHOP_PREVIEW_PATCH
 
+#if defined(_DEBUG) || defined(DEBUG)
+	#define FANCY_LOADING_OUTPUT
+#endif
+
+/// Uncomment to forcibly disable fancy loading output.
+//#undef FANCY_LOADING_OUTPUT
+
 /**
  * No settings past this point
  **/

--- a/src/config/core.hpp
+++ b/src/config/core.hpp
@@ -101,11 +101,12 @@
 //#define ENABLE_OLD_CASHSHOP_PREVIEW_PATCH
 
 #if defined(_DEBUG) || defined(DEBUG)
-	#define FANCY_LOADING_OUTPUT
+	#define DETAILED_LOADING_OUTPUT
 #endif
 
-/// Uncomment to forcibly disable fancy loading output.
-//#undef FANCY_LOADING_OUTPUT
+/// Uncomment to forcibly disable the detailed loading output.
+/// This will noticeably decrease the boot time of the map server by not having to print so many status messages.
+//#undef DETAILED_LOADING_OUTPUT
 
 /**
  * No settings past this point

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -4168,7 +4168,7 @@ static int itemdb_read_sqldb(void) {
 
 		// process rows one by one
 		while( SQL_SUCCESS == Sql_NextRow(mmysql_handle) ) {
-#ifdef FANCY_LOADING_OUTPUT
+#ifdef DETAILED_LOADING_OUTPUT
 			ShowStatus( "Loading [%" PRIu64 "/%" PRIu64 "] entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++rows, total_rows, item_db_name[fi] );
 #endif
 			std::vector<std::string> data = {};

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -4168,7 +4168,7 @@ static int itemdb_read_sqldb(void) {
 
 		// process rows one by one
 		while( SQL_SUCCESS == Sql_NextRow(mmysql_handle) ) {
-#ifdef DEBUG
+#ifdef FANCY_LOADING_OUTPUT
 			ShowStatus( "Loading [%" PRIu64 "/%" PRIu64 "] entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++rows, total_rows, item_db_name[fi] );
 #endif
 			std::vector<std::string> data = {};

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3786,7 +3786,7 @@ int map_readallmaps (void)
 		struct map_data *mapdata = &map[i];
 		char map_cache_decode_buffer[MAX_MAP_SIZE];
 
-#ifdef DEBUG
+#ifdef FANCY_LOADING_OUTPUT
 		// show progress
 		ShowStatus("Loading maps [%i/%i]: %s" CL_CLL "\r", i, map_num, mapdata->name);
 #endif

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3786,7 +3786,7 @@ int map_readallmaps (void)
 		struct map_data *mapdata = &map[i];
 		char map_cache_decode_buffer[MAX_MAP_SIZE];
 
-#ifdef FANCY_LOADING_OUTPUT
+#ifdef DETAILED_LOADING_OUTPUT
 		// show progress
 		ShowStatus("Loading maps [%i/%i]: %s" CL_CLL "\r", i, map_num, mapdata->name);
 #endif

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -5285,7 +5285,7 @@ static int mob_read_sqldb(void)
 
 		// process rows one by one
 		while( SQL_SUCCESS == Sql_NextRow(mmysql_handle) ) {
-#ifdef DEBUG
+#ifdef FANCY_LOADING_OUTPUT
 			ShowStatus("Loading [%" PRIu64 "/%" PRIu64 "] entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++rows, total_rows, mob_db_name[fi]);
 #endif
 			std::vector<std::string> data = {};

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -5285,7 +5285,7 @@ static int mob_read_sqldb(void)
 
 		// process rows one by one
 		while( SQL_SUCCESS == Sql_NextRow(mmysql_handle) ) {
-#ifdef FANCY_LOADING_OUTPUT
+#ifdef DETAILED_LOADING_OUTPUT
 			ShowStatus("Loading [%" PRIu64 "/%" PRIu64 "] entries in '" CL_WHITE "%s" CL_RESET "'" CL_CLL "\r", ++rows, total_rows, mob_db_name[fi]);
 #endif
 			std::vector<std::string> data = {};

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3611,7 +3611,7 @@ void npc_delsrcfile(const char* name)
 void npc_loadsrcfiles() {
 	ShowStatus("Loading NPCs...\n");
 	for (const auto& file : npc_src_files) {
-#ifdef DEBUG
+#ifdef FANCY_LOADING_OUTPUT
 		ShowStatus("Loading NPC file: %s" CL_CLL "\r", file.c_str());
 #endif
 		npc_parsesrcfile(file.c_str());

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3611,7 +3611,7 @@ void npc_delsrcfile(const char* name)
 void npc_loadsrcfiles() {
 	ShowStatus("Loading NPCs...\n");
 	for (const auto& file : npc_src_files) {
-#ifdef FANCY_LOADING_OUTPUT
+#ifdef DETAILED_LOADING_OUTPUT
 		ShowStatus("Loading NPC file: %s" CL_CLL "\r", file.c_str());
 #endif
 		npc_parsesrcfile(file.c_str());


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: N/A

* **Description of Pull Request**: 
In various places like YAML loading and NPC loading, `ShowStatus` calls are disabled with `DEBUG` ifdefs to increase startup performance. However, in practice, when not dealing with NPCs or YAML databases, these outputs can be disabled safely to reduce startup time when developing rAthena.