### PR TITLE
Fix Fire Pillar skill to not consume Gemstone if VIP or use Mistress card

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18461,7 +18461,7 @@ struct s_skill_condition skill_get_requirement(map_session_data* sd, uint16 skil
 				}
 				else {
 					// Process level_dependent requirement
-					if (level_dependent && skill_lv <= MAX_SKILL_ITEM_REQUIRE) {
+					if (level_dependent && skill_lv <= MAX_SKILL_ITEM_REQUIRE && i == 0) {
 						req.itemid[0] = skill->require.itemid[skill_lv - 1];
 						req.amount[0] = skill->require.amount[skill_lv - 1];
 					}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18465,6 +18465,18 @@ struct s_skill_condition skill_get_requirement(map_session_data* sd, uint16 skil
 						req.itemid[0] = skill->require.itemid[skill_lv - 1];
 						req.amount[0] = skill->require.amount[skill_lv - 1];
 					}
+
+					if (sd->special_state.no_gemstone == 2) // Remove all Magic Stone required for all skills for VIP.
+						req.itemid[0] = req.amount[0] = 0;
+					else {
+						if (sd->special_state.no_gemstone || (sc && sc->getSCE(SC_INTOABYSS)))
+						{	// Ignore SA_ABRACADABRA & HW_GANBANTEIN from mistress effect
+							if (skill_id != SA_ABRACADABRA && skill_id != HW_GANBANTEIN)
+								req.itemid[0] = req.amount[0] = 0;
+							else if (--req.amount[0] < 1)
+								req.amount[0] = 1; // Hocus Pocus always use at least 1 gem
+						}
+					}
 				}
 
 				// Check requirement for gemstone.

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18465,18 +18465,6 @@ struct s_skill_condition skill_get_requirement(map_session_data* sd, uint16 skil
 						req.itemid[0] = skill->require.itemid[skill_lv - 1];
 						req.amount[0] = skill->require.amount[skill_lv - 1];
 					}
-
-					if (sd->special_state.no_gemstone == 2) // Remove all Magic Stone required for all skills for VIP.
-						req.itemid[0] = req.amount[0] = 0;
-					else {
-						if (sd->special_state.no_gemstone || (sc && sc->getSCE(SC_INTOABYSS)))
-						{	// Ignore SA_ABRACADABRA & HW_GANBANTEIN from mistress effect
-							if (skill_id != SA_ABRACADABRA && skill_id != HW_GANBANTEIN)
-								req.itemid[0] = req.amount[0] = 0;
-							else if (--req.amount[0] < 1)
-								req.amount[0] = 1; // Hocus Pocus always use at least 1 gem
-						}
-					}
 				}
 
 				// Check requirement for gemstone.


### PR DESCRIPTION
Fix Fire Pillar to not consume Gemstone when VIP or using Mistress card.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  #7619 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:

   * Fix the Fire Pillar skill to not consume Gemstone if VIP or wearing Mistress Card.
   * Thank  you @Oysica for mention this bug.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
