### PR TITLE
Change memcpy for safestrncpy for char *

### DIFF
--- a/src/char/int_party.cpp
+++ b/src/char/int_party.cpp
@@ -536,7 +536,7 @@ int mapif_parse_CreateParty(int fd, char *name, int item, int item2, struct part
 
 	p = std::make_shared<struct party_data>();
 
-	memcpy(p->party.name,name,NAME_LENGTH);
+	safestrncpy(p->party.name,name,NAME_LENGTH);
 	p->party.exp=0;
 	p->party.item=(item?1:0)|(item2?2:0);
 

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -111,7 +111,7 @@ int intif_create_pet(uint32 account_id,uint32 char_id,short pet_class,short pet_
 	WFIFOW(inter_fd, 24) = hungry;
 	WFIFOB(inter_fd, 26) = rename_flag;
 	WFIFOB(inter_fd, 27) = incubate;
-	memcpy(WFIFOP(inter_fd, 28), pet_name, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd, 28), pet_name, NAME_LENGTH);
 	WFIFOSET(inter_fd, 28 + NAME_LENGTH);
 
 	return 1;
@@ -192,7 +192,7 @@ int intif_rename(map_session_data *sd, int type, char *name)
 	WFIFOL(inter_fd,2) = sd->status.account_id;
 	WFIFOL(inter_fd,6) = sd->status.char_id;
 	WFIFOB(inter_fd,10) = type;  //Type: 0 - PC, 1 - PET, 2 - HOM
-	memcpy(WFIFOP(inter_fd,11),name, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,11),name, NAME_LENGTH);
 	WFIFOSET(inter_fd,NAME_LENGTH+12);
 	return 1;
 }
@@ -233,7 +233,7 @@ int intif_broadcast(const char* mes, int len, int type)
 		WFIFOL(inter_fd,16) = 0x65756c62; //If there's "blue" at the beginning of the message, game client will display it in blue instead of yellow.
 	else if (type|BC_WOE)
 		WFIFOL(inter_fd,16) = 0x73737373; //If there's "ssss", game client will recognize message as 'WoE broadcast'.
-	memcpy(WFIFOP(inter_fd,16 + lp), mes, len);
+	safestrncpy(WFIFOCP(inter_fd,16 + lp), mes, len);
 	WFIFOSET(inter_fd, WFIFOW(inter_fd,2));
 	return 1;
 }
@@ -272,7 +272,7 @@ int intif_broadcast2(const char* mes, int len, unsigned long fontColor, short fo
 	WFIFOW(inter_fd,10) = fontSize;
 	WFIFOW(inter_fd,12) = fontAlign;
 	WFIFOW(inter_fd,14) = fontY;
-	memcpy(WFIFOP(inter_fd,16), mes, len);
+	safestrncpy(WFIFOCP(inter_fd,16), mes, len);
 	WFIFOSET(inter_fd, WFIFOW(inter_fd,2));
 	return 1;
 }
@@ -595,7 +595,7 @@ int intif_create_party(struct party_member *member,char *name,int item,int item2
 	WFIFOHEAD(inter_fd, 6+NAME_LENGTH+sizeof(struct party_member));
 	WFIFOW(inter_fd,0) = 0x3020;
 	WFIFOW(inter_fd,2) = 6+NAME_LENGTH+sizeof(struct party_member);
-	memcpy(WFIFOP(inter_fd,4),name, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,4),name, NAME_LENGTH);
 	WFIFOB(inter_fd,28)= item;
 	WFIFOB(inter_fd,29)= item2;
 	memcpy(WFIFOP(inter_fd,30), member, sizeof(struct party_member));
@@ -678,7 +678,7 @@ int intif_party_leave(int party_id, uint32 account_id, uint32 char_id, const cha
 	WFIFOL(inter_fd,2) = party_id;
 	WFIFOL(inter_fd,6) = account_id;
 	WFIFOL(inter_fd,10) = char_id;
-	memcpy(WFIFOCP(inter_fd,14), name, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,14), name, NAME_LENGTH);
 	WFIFOB(inter_fd,14+NAME_LENGTH) = type;
 	WFIFOSET(inter_fd,15+NAME_LENGTH);
 	return 1;
@@ -761,7 +761,7 @@ int intif_party_message(int party_id,uint32 account_id,const char *mes,int len)
 	WFIFOW(inter_fd,2)=len+12;
 	WFIFOL(inter_fd,4)=party_id;
 	WFIFOL(inter_fd,8)=account_id;
-	memcpy(WFIFOP(inter_fd,12),mes,len);
+	safestrncpy(WFIFOCP(inter_fd,12),mes,len);
 	WFIFOSET(inter_fd,len+12);
 	return 1;
 }
@@ -818,7 +818,7 @@ int intif_guild_create(const char *name,const struct guild_member *master)
 	WFIFOW(inter_fd,0)=0x3030;
 	WFIFOW(inter_fd,2)=sizeof(struct guild_member)+(8+NAME_LENGTH);
 	WFIFOL(inter_fd,4)=master->account_id;
-	memcpy(WFIFOP(inter_fd,8),name,NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,8),name,NAME_LENGTH);
 	memcpy(WFIFOP(inter_fd,8+NAME_LENGTH),master,sizeof(struct guild_member));
 	WFIFOSET(inter_fd,WFIFOW(inter_fd,2));
 	return 1;
@@ -874,7 +874,7 @@ int intif_guild_change_gm(int guild_id, const char* name, int len)
 	WFIFOW(inter_fd, 0)=0x3033;
 	WFIFOW(inter_fd, 2)=len+8;
 	WFIFOL(inter_fd, 4)=guild_id;
-	memcpy(WFIFOP(inter_fd,8),name,len);
+	safestrncpy(WFIFOCP(inter_fd,8),name,len);
 	WFIFOSET(inter_fd,len+8);
 	return 1;
 }
@@ -967,7 +967,7 @@ int intif_guild_message(int guild_id,uint32 account_id,const char *mes,int len)
 	WFIFOW(inter_fd,2)=len+12;
 	WFIFOL(inter_fd,4)=guild_id;
 	WFIFOL(inter_fd,8)=account_id;
-	memcpy(WFIFOP(inter_fd,12),mes,len);
+	safestrncpy(WFIFOCP(inter_fd,12),mes,len);
 	WFIFOSET(inter_fd,len+12);
 
 	return 1;
@@ -1103,8 +1103,8 @@ int intif_guild_notice(int guild_id,const char *mes1,const char *mes2)
 	WFIFOHEAD(inter_fd,186);
 	WFIFOW(inter_fd,0)=0x303e;
 	WFIFOL(inter_fd,2)=guild_id;
-	memcpy(WFIFOP(inter_fd,6),mes1,MAX_GUILDMES1);
-	memcpy(WFIFOP(inter_fd,66),mes2,MAX_GUILDMES2);
+	safestrncpy(WFIFOCP(inter_fd,6),mes1,MAX_GUILDMES1);
+	safestrncpy(WFIFOCP(inter_fd,66),mes2,MAX_GUILDMES2);
 	WFIFOSET(inter_fd,186);
 	return 1;
 }
@@ -2711,7 +2711,7 @@ int intif_Auction_requestlist(uint32 char_id, short type, int price, const char*
 	WFIFOW(inter_fd,8) = type;
 	WFIFOL(inter_fd,10) = price; //min price for search
 	WFIFOW(inter_fd,14) = page;
-	memcpy(WFIFOP(inter_fd,16), searchtext, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,16), searchtext, NAME_LENGTH);
 	WFIFOSET(inter_fd,len);
 
 	return 1;
@@ -2894,7 +2894,7 @@ int intif_Auction_bid(uint32 char_id, const char* name, unsigned int auction_id,
 	WFIFOL(inter_fd,4) = char_id;
 	WFIFOL(inter_fd,8) = auction_id;
 	WFIFOL(inter_fd,12) = bid;
-	memcpy(WFIFOP(inter_fd,16), name, NAME_LENGTH);
+	safestrncpy(WFIFOCP(inter_fd,16), name, NAME_LENGTH);
 	WFIFOSET(inter_fd,len);
 
 	return 1;
@@ -3693,7 +3693,7 @@ int intif_clan_message(int clan_id,uint32 account_id,const char *mes,int len){
 	WFIFOW(inter_fd,2)=len+12;
 	WFIFOL(inter_fd,4)=clan_id;
 	WFIFOL(inter_fd,8)=account_id;
-	memcpy(WFIFOP(inter_fd,12),mes,len);
+	safestrncpy(WFIFOCP(inter_fd,12),mes,len);
 	WFIFOSET(inter_fd,len+12);
 
 	return 1;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1473,7 +1473,7 @@ int pet_change_name_ack(map_session_data *sd, char* name, int flag)
 		return 0;
 	}
 
-	memcpy(pd->pet.name, name, NAME_LENGTH);
+	safestrncpy(pd->pet.name, name, NAME_LENGTH);
 	clif_name_area(&pd->bl);
 	pd->pet.rename_flag = 1;
 	clif_pet_equip_area(pd);

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -14496,7 +14496,7 @@ BUILDIN_FUNC(getitemname)
 
 	char* item_name = (char *)aMalloc( ITEM_NAME_LENGTH * sizeof( char ) );
 
-	memcpy(item_name, i_data->ename.c_str(), ITEM_NAME_LENGTH);
+	safestrncpy(item_name, i_data->ename.c_str(), ITEM_NAME_LENGTH);
 	script_pushstr(st,item_name);
 
 	return SCRIPT_CMD_SUCCESS;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: There are a lot of places where we `memcpy()` from a `char *` to a buffer, but we don't actually know how much data is readable from the `char *`.

The easiest example here is `intif_party_leave`. we `memcpy` `NAME_LENGTH` characters from `name`, but in many cases, we pass an empty string for data: https://github.com/rathena/rathena/blob/b22e186e77c1bc0df33a00accf5c1bf2de042373/src/map/party.cpp#L175

This is a buffer overflow, an invalid read, and causes ASAN to crash the map server



<!-- Describe how this pull request will resolve the issue(s) listed above. -->
