### PR TITLE
Change copied bl type to BL_NUL for delayed clif_clearunit

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1007,6 +1007,7 @@ void clif_clearunit_delayed(struct block_list* bl, clr_type type, t_tick tick)
 {
 	struct block_list *tbl = ers_alloc(delay_clearunit_ers, struct block_list);
 	memcpy (tbl, bl, sizeof (struct block_list));
+	tbl->type = BL_NUL;
 	add_timer(tick, clif_clearunit_delayed_sub, (int)type, (intptr_t)tbl);
 }
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1006,7 +1006,12 @@ static TIMER_FUNC(clif_clearunit_delayed_sub){
 void clif_clearunit_delayed(struct block_list* bl, clr_type type, t_tick tick)
 {
 	struct block_list *tbl = ers_alloc(delay_clearunit_ers, struct block_list);
-	memcpy (tbl, bl, sizeof (struct block_list));
+	tbl->next = nullptr;
+	tbl->prev = nullptr;
+	tbl->id = bl->id;
+	tbl->m = bl->m;
+	tbl->x = bl->x;
+	tbl->y = bl->y;
 	tbl->type = BL_NUL;
 	add_timer(tick, clif_clearunit_delayed_sub, (int)type, (intptr_t)tbl);
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: We create a new block_list and copy the original bl into the newly allocated bl.
 However, it still has the bl->type of the original. So if you try to use any of our BL_CAST() functions, we mistakenly think the bl is a valid type and we read random values. Instead, let's set the type to BL_NUL, so no cast can succeed.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
