### PR TITLE
Added missing state checks in banking functions

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -14518,6 +14518,9 @@ void pc_expire_check(map_session_data *sd) {
 enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
 	unsigned int limit_check = money + sd->bank_vault;
 
+	if (!sd->state.banking) {
+		return BDA_ERROR;
+	}
 	if( money <= 0 || limit_check > MAX_BANK_ZENY ) {
 		return BDA_OVERFLOW;
 	} else if ( money > sd->status.zeny ) {
@@ -14541,7 +14544,10 @@ enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
 **/
 enum e_BANKING_WITHDRAW_ACK pc_bank_withdraw(map_session_data *sd, int money) {
 	unsigned int limit_check = money + sd->status.zeny;
-	
+
+	if (!sd->state.banking) {
+		return BWA_UNKNOWN_ERROR;
+	}
 	if( money <= 0 ) {
 		return BWA_UNKNOWN_ERROR;
 	} else if ( money > sd->bank_vault ) {

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -14516,11 +14516,11 @@ void pc_expire_check(map_session_data *sd) {
 * @param money Amount of money to deposit
 **/
 enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
-	unsigned int limit_check = money + sd->bank_vault;
-
 	if (!sd->state.banking) {
 		return BDA_ERROR;
 	}
+
+	unsigned int limit_check = money + sd->bank_vault;
 	if( money <= 0 || limit_check > MAX_BANK_ZENY ) {
 		return BDA_OVERFLOW;
 	} else if ( money > sd->status.zeny ) {
@@ -14543,11 +14543,11 @@ enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
 * @param money Amount of money that will be withdrawn
 **/
 enum e_BANKING_WITHDRAW_ACK pc_bank_withdraw(map_session_data *sd, int money) {
-	unsigned int limit_check = money + sd->status.zeny;
-
 	if (!sd->state.banking) {
 		return BWA_UNKNOWN_ERROR;
 	}
+
+	unsigned int limit_check = money + sd->status.zeny;
 	if( money <= 0 ) {
 		return BWA_UNKNOWN_ERROR;
 	} else if ( money > sd->bank_vault ) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
`pc_bank_deposit` and `pc_bank_withdraw` function never actually checked `sd->state.banking` flag when they get called. This PR adds the missing checks.
