### PR TITLE
Added a config for banking state check

### DIFF
--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -33,6 +33,11 @@ feature.warp_suggestions: off
 // Requires: 2013-07-24aRagexe or later
 feature.banking: on
 
+// Should Banking strictly checks the UI state on zeny deposit and withdrawal? (Note 1)
+// Note: Disabled by default because existing official clients do not report the banking UI state to the server.
+// But this config could be useful in case of clients that actually report the UI state or custom clients.
+feature.banking_state_enforce: off
+
 // Autotrade persistency (Note 1)
 // Should vendors that used @autotrade be restored after a restart?
 feature.autotrade: on

--- a/conf/battle/feature.conf
+++ b/conf/battle/feature.conf
@@ -36,7 +36,7 @@ feature.banking: on
 // Should Banking strictly checks the UI state on zeny deposit and withdrawal? (Note 1)
 // Note: Disabled by default because existing official clients do not report the banking UI state to the server.
 // But this config could be useful in case of clients that actually report the UI state or custom clients.
-feature.banking_state_enforce: off
+feature.banking_state_enforce: no
 
 // Autotrade persistency (Note 1)
 // Should vendors that used @autotrade be restored after a restart?

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10340,6 +10340,7 @@ static const struct _battle_data {
 	{ "mob_respawn_time",                   &battle_config.mob_respawn_time,                1000,   1000,   INT_MAX,        },
 
 	{ "feature.stylist",                    &battle_config.feature_stylist,                 1,      0,      1,              },
+	{ "feature.banking_state_enforce",      &battle_config.feature_banking_state_enforce,   0,      0,      1,              },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -729,6 +729,7 @@ struct Battle_Config
 	int mob_respawn_time;
 
 	int feature_stylist;
+	int feature_banking_state_enforce;
 
 #include <custom/battle_config_struct.inc>
 };

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -14524,7 +14524,7 @@ void pc_expire_check(map_session_data *sd) {
 * @param money Amount of money to deposit
 **/
 enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
-	if (!sd->state.banking) {
+	if (battle_config.feature_banking_state_enforce && !sd->state.banking) {
 		return BDA_ERROR;
 	}
 
@@ -14551,7 +14551,7 @@ enum e_BANKING_DEPOSIT_ACK pc_bank_deposit(map_session_data *sd, int money) {
 * @param money Amount of money that will be withdrawn
 **/
 enum e_BANKING_WITHDRAW_ACK pc_bank_withdraw(map_session_data *sd, int money) {
-	if (!sd->state.banking) {
+	if (battle_config.feature_banking_state_enforce && !sd->state.banking) {
 		return BWA_UNKNOWN_ERROR;
 	}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Both
* **Description of Pull Request**: 

I've received reports the banking UI no longer work with commit 22abdf8. This seems to be caused by clients not reporting its banking UI state to the server, but instead only querying the player's balance when the UI is opened. I apologize for not testing my previous pull request thoroughly.

I thought of reverting 22abdf8 entirely, but it could still be useful in some scenarios, so I'm adding a battle config to re-enable the check instead.