### PR TITLE
Fix builds that don't use the memory manager

### DIFF
--- a/src/common/strlib.hpp
+++ b/src/common/strlib.hpp
@@ -144,6 +144,7 @@ struct StringBuf
 };
 typedef struct StringBuf StringBuf;
 
+#ifdef USE_MEMGR
 StringBuf* _StringBuf_Malloc(const char *file, int line, const char *func);
 #define StringBuf_Malloc() _StringBuf_Malloc(ALC_MARK)
 void _StringBuf_Init(const char *file, int line, const char *func, StringBuf* self);
@@ -156,6 +157,14 @@ int _StringBuf_Append(const char *file, int line, const char *func, StringBuf* s
 #define StringBuf_Append(self,sbuf) _StringBuf_Append(ALC_MARK,self,sbuf)
 int _StringBuf_AppendStr(const char *file, int line, const char *func, StringBuf* self, const char* str);
 #define StringBuf_AppendStr(self,str) _StringBuf_AppendStr(ALC_MARK,self,str)
+#else
+StringBuf* StringBuf_Malloc();
+void StringBuf_Init(StringBuf* self);
+int StringBuf_Printf(StringBuf* self, const char* fmt, ...);
+int StringBuf_Vprintf(StringBuf* self, const char* fmt, va_list args);
+int StringBuf_Append(StringBuf* self, const StringBuf* sbuf);
+int StringBuf_AppendStr(StringBuf* self, const char* str);
+#endif
 int StringBuf_Length(StringBuf* self);
 char* StringBuf_Value(StringBuf* self);
 void StringBuf_Clear(StringBuf* self);

--- a/src/common/strlib.hpp
+++ b/src/common/strlib.hpp
@@ -144,7 +144,7 @@ struct StringBuf
 };
 typedef struct StringBuf StringBuf;
 
-#ifdef USE_MEMGR
+#ifdef USE_MEMMGR
 StringBuf* _StringBuf_Malloc(const char *file, int line, const char *func);
 #define StringBuf_Malloc() _StringBuf_Malloc(ALC_MARK)
 void _StringBuf_Init(const char *file, int line, const char *func, StringBuf* self);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

* **Server Mode**: Both

* **Description of Pull Request**: 

If we configure with --enable-manager=no, the build breaks. This is because we use functions in strlib that aren't declared when disabling the memory manager.