### PR TITLE
Fix ASAN crashes and LSAN leaks

### DIFF
--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -920,8 +920,8 @@ int chclif_parse_select_accessible_map( int fd, struct char_session_data* sd, ui
 	// FIXME: is this case even possible? [ultramage]
 	if( ( map_fd = map_server[mapserver].fd ) < 1 || session[map_fd] == nullptr ){
 		ShowError( "parse_char: Attempting to write to invalid session %d! Map Server #%d disconnected.\n", map_fd, mapserver );
+		map_server[mapserver] = {};
 		map_server[mapserver].fd = -1;
-		memset( &map_server[mapserver], 0, sizeof( struct mmo_map_server ) );
 		chclif_send_auth_result( fd, 1 ); // Send server closed.
 		return 1;
 	}
@@ -1090,8 +1090,8 @@ int chclif_parse_charselect(int fd, struct char_session_data* sd,uint32 ipl){
 		if ((map_fd = map_server[i].fd) < 1 || session[map_fd] == NULL)
 		{
 			ShowError("parse_char: Attempting to write to invalid session %d! Map Server #%d disconnected.\n", map_fd, i);
+			map_server[i] = {};
 			map_server[i].fd = -1;
-			memset(&map_server[i], 0, sizeof(struct mmo_map_server));
 			chclif_send_auth_result(fd,1);  //Send server closed.
 			return 1;
 		}

--- a/src/char/char_mapif.cpp
+++ b/src/char/char_mapif.cpp
@@ -1493,6 +1493,7 @@ void chmapif_server_destroy(int id){
 		do_close(map_server[id].fd);
 		map_server[id].fd = -1;
 	}
+	map_server[id].maps.clear();
 }
 
 /**

--- a/src/char/char_mapif.cpp
+++ b/src/char/char_mapif.cpp
@@ -1480,7 +1480,7 @@ int chmapif_init(int fd){
  * @param id: id of map-serv (should be >0, FIXME)
  */
 void chmapif_server_init(int id) {
-	memset(&map_server[id], 0, sizeof(map_server[id]));
+	map_server[id] = {};
 	map_server[id].fd = -1;
 }
 
@@ -1493,7 +1493,6 @@ void chmapif_server_destroy(int id){
 		do_close(map_server[id].fd);
 		map_server[id].fd = -1;
 	}
-	map_server[id].maps.clear();
 }
 
 /**

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10812,7 +10812,6 @@ void clif_parse_WantToConnection(int fd, map_session_data* sd)
 	}
 
 	CREATE(sd, TBL_PC, 1);
-	// placement new
 	new(sd) map_session_data();
 	sd->fd = fd;
 #ifdef PACKET_OBFUSCATION

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -453,6 +453,8 @@ int mob_parse_dataset(struct spawn_data *data)
 struct mob_data* mob_spawn_dataset(struct spawn_data *data)
 {
 	struct mob_data *md = (struct mob_data*)aCalloc(1, sizeof(struct mob_data));
+	// placement new!
+	new(md) mob_data();
 	md->bl.id= npc_get_new_npc_id();
 	md->bl.type = BL_MOB;
 	md->bl.m = data->m;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -453,7 +453,6 @@ int mob_parse_dataset(struct spawn_data *data)
 struct mob_data* mob_spawn_dataset(struct spawn_data *data)
 {
 	struct mob_data *md = (struct mob_data*)aCalloc(1, sizeof(struct mob_data));
-	// placement new!
 	new(md) mob_data();
 	md->bl.id= npc_get_new_npc_id();
 	md->bl.type = BL_MOB;
@@ -689,7 +688,6 @@ int mob_once_spawn(map_session_data* sd, int16 m, int16 x, int16 y, const char* 
 			if (gc)
 			{
 				md->guardian_data = (struct guardian_data*)aCalloc(1, sizeof(struct guardian_data));
-				// placement new
 				new(md->guardian_data) guardian_data();
 				md->guardian_data->castle = gc;
 				md->guardian_data->number = MAX_GUARDIANS;
@@ -894,7 +892,6 @@ int mob_spawn_guardian(const char* mapname, int16 x, int16 y, const char* mobnam
 
 	md = mob_spawn_dataset(&data);
 	md->guardian_data = (struct guardian_data*)aCalloc(1, sizeof(struct guardian_data));
-	// placement new
 	new (md->guardian_data) guardian_data();
 	md->guardian_data->number = guardian;
 	md->guardian_data->guild_id = gc->guild_id;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -687,6 +687,8 @@ int mob_once_spawn(map_session_data* sd, int16 m, int16 x, int16 y, const char* 
 			if (gc)
 			{
 				md->guardian_data = (struct guardian_data*)aCalloc(1, sizeof(struct guardian_data));
+				// placement new
+				new(md->guardian_data) guardian_data();
 				md->guardian_data->castle = gc;
 				md->guardian_data->number = MAX_GUARDIANS;
 				md->guardian_data->guild_id = gc->guild_id;
@@ -890,6 +892,8 @@ int mob_spawn_guardian(const char* mapname, int16 x, int16 y, const char* mobnam
 
 	md = mob_spawn_dataset(&data);
 	md->guardian_data = (struct guardian_data*)aCalloc(1, sizeof(struct guardian_data));
+	// placement new
+	new (md->guardian_data) guardian_data();
 	md->guardian_data->number = guardian;
 	md->guardian_data->guild_id = gc->guild_id;
 	md->guardian_data->castle = gc;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3552,6 +3552,7 @@ int npc_unload(struct npc_data* nd, bool single) {
 		}
 	}
 
+	nd->~npc_data();
 	aFree(nd);
 
 	return 0;
@@ -4136,6 +4137,7 @@ static const char* npc_parse_shop(char* w1, char* w2, char* w3, char* w4, const 
 	}
 	if( nd->u.shop.count == 0 ) {
 		ShowWarning("npc_parse_shop: Ignoring empty shop in file '%s', line '%d'.\n", filepath, strline(buffer,start-buffer));
+		nd->~npc_data();
 		aFree(nd);
 		return strchr(start,'\n');// continue
 	}

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1022,7 +1022,9 @@ bool pet_data_init(map_session_data *sd, struct s_pet *pet)
 		return false;
 	}
 
-	sd->pd = pd = (struct pet_data *)aCalloc(1,sizeof(struct pet_data));
+	pd = (struct pet_data *)aCalloc(1,sizeof(struct pet_data));
+	new(pd) pet_data();
+	sd->pd = pd;
 	pd->bl.type = BL_PET;
 	pd->bl.id = npc_get_new_npc_id();
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -18020,7 +18020,7 @@ BUILDIN_FUNC(npcshopdelitem)
 		ARR_FIND( 0, size, n, nd->u.shop.shop_item[n].nameid == nameid );
 		if( n < size ) {
 			if (n+1 != size)
-				memmove(&nd->u.shop.shop_item[n], &nd->u.shop.shop_item[n+1], sizeof(nd->u.shop.shop_item[0])*(size-n));
+				memmove(&nd->u.shop.shop_item[n], &nd->u.shop.shop_item[n+1], sizeof(nd->u.shop.shop_item[0])*(size-(n + 1)));
 #if PACKETVER >= 20131223
 			if (nd->subtype == NPCTYPE_MARKETSHOP)
 				npc_market_delfromsql_(nd->exname, nameid, false);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3565,6 +3565,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 
 			if( md->tomb_nid )
 				mvptomb_destroy(md);
+			md->~mob_data();
 			break;
 		}
 		case BL_HOM:

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3536,6 +3536,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 						gc->temp_guardians[i] = 0;
 				}
 
+				md->guardian_data->~guardian_data();
 				aFree(md->guardian_data);
 				md->guardian_data = NULL;
 			}

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3501,6 +3501,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 
 			skill_clear_unitgroup(bl);
 			status_change_clear(bl,1);
+			pd->~pet_data();
 			break;
 		}
 		case BL_MOB: {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
* The first two commits are from #7648, but this branch is based off that so I can disable the memory manager.
* ASAN found a heap buffer overflow!!! in *npcshopdelitem, when we memmove we read data outside the array.
* LSAN found a couple of leaks, fix them

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
