### PR TITLE
Fix memory leak on map quit

### DIFF
--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1902,6 +1902,7 @@ int auth_db_final(DBKey key, DBData *data, va_list ap) {
 		if (node->sd->regs.arrays)
 			node->sd->regs.arrays->destroy(node->sd->regs.arrays, script_free_array_db);
 
+		node->sd->~map_session_data();
 		aFree(node->sd);
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: On map quit, we call `do_final_chrif`, which calls `auth_db_final` on all `map_session_data`s in the db. We need to call the destructor here.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
