### PR TITLE
Fix some items' names for Alberta stylish npc

### DIFF
--- a/npc/quests/quests_alberta.txt
+++ b/npc/quests/quests_alberta.txt
@@ -608,7 +608,7 @@ alberta,120,53,1	script	Stylish Merchant#new30	51,{
 			mes "[Zic]";
 			mes "Let's see, I'll need...";
 			mes "1 ^0000FFSilk Ribbon^000000";
-			mes "50 ^0000FFHeroic Emlbem^000000";
+			mes "50 ^0000FFHeroic Emblem^000000";
 			mes "...Did you know this already?";
 			close;
 		case 2:
@@ -617,7 +617,7 @@ alberta,120,53,1	script	Stylish Merchant#new30	51,{
 			next;
 			mes "[Zic]";
 			mes "Okay, I'll need...";
-			mes "1 ^0000FFHeart hair pin^000000";
+			mes "1 ^0000FFHeart hairpin^000000";
 			mes "10 ^0000FFSteel^000000";
 			mes "...Did you know this already?";
 			close;
@@ -627,7 +627,7 @@ alberta,120,53,1	script	Stylish Merchant#new30	51,{
 			next;
 			mes "[Zic]";
 			mes "I need to have...";
-			mes "1 ^0000FFJack a Dandy^000000";
+			mes "1 ^0000FFJack be Dandy^000000";
 			mes "1 ^0000FFScarlet Dyestuffs^000000";
 			mes "...Did you know this already?";
 			close;
@@ -760,7 +760,7 @@ alberta,136,79,1	script	Hat store girl#new30	71,{
 					mes "^0000FF1 Wizard Hat^000000";
 					mes "^0000FF400 Dragon Scale^000000";
 					mes "^0000FF50 Mould Powder^000000";
-					mes "^0000FF1 Elder Wilow Card^000000";
+					mes "^0000FF1 Elder Willow Card^000000";
 					next;
 					if ((countitem(2252) > 0) && (countitem(1036) > 399) && (countitem(4052) > 0) && (countitem(7001) > 49)) {
 						mes "[Tempestra]";
@@ -782,7 +782,7 @@ alberta,136,79,1	script	Hat store girl#new30	71,{
 							next;
 							delitem 2252,1; //Star_Sparkling
 							delitem 1036,400; //Dragon_Scale
-							delitem 4052,1; //Elder_Wilow_Card
+							delitem 4052,1; //Elder_Willow_Card
 							delitem 7001,50; //Mould_Powder
 							mes "[Tempestra]";
 							mes "Here it is, tee hee~";

--- a/npc/quests/quests_alberta.txt
+++ b/npc/quests/quests_alberta.txt
@@ -617,7 +617,7 @@ alberta,120,53,1	script	Stylish Merchant#new30	51,{
 			next;
 			mes "[Zic]";
 			mes "Okay, I'll need...";
-			mes "1 ^0000FFHeart hairpin^000000";
+			mes "1 ^0000FFHeart Hairpin^000000";
 			mes "10 ^0000FFSteel^000000";
 			mes "...Did you know this already?";
 			close;
@@ -782,7 +782,7 @@ alberta,136,79,1	script	Hat store girl#new30	71,{
 							next;
 							delitem 2252,1; //Star_Sparkling
 							delitem 1036,400; //Dragon_Scale
-							delitem 4052,1; //Elder_Willow_Card
+							delitem 4052,1; //Elder_Wilow_Card
 							delitem 7001,50; //Mould_Powder
 							mes "[Tempestra]";
 							mes "Here it is, tee hee~";


### PR DESCRIPTION
NPC: `'Bao Bao', 'Crescent Hairpin', 'Fashionable Glasses', 'Heart Hairpin' Quest`

Fixed names to match db's english name

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
NPC: `'Bao Bao', 'Crescent Hairpin', 'Fashionable Glasses', 'Heart Hairpin' Quest`

Fixed names to match db's english name

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  Just updating strings

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
