### PR TITLE
Fix out-of-bounds in TypesafeCachedYamlDatabase

### DIFF
--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -216,7 +216,11 @@ public:
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){
-			this->cache[this->calculateCacheKey( key )] = nullptr;
+			auto cache_key = this->calculateCacheKey(key);
+			if (this->cache.size() <= cache_key) {
+				return;
+			}
+			this->cache[cache_key] = nullptr;
 		}
 	}
 
@@ -225,7 +229,11 @@ public:
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){
-			this->cache[this->calculateCacheKey( key )] = ptr;
+			auto cache_key = this->calculateCacheKey(key);
+			if (this->cache.size() <= cache_key) {
+				this->cache.resize(cache_key + 1, nullptr);
+			}
+			this->cache[cache_key] = ptr;
 		}
 	}
 };

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -216,7 +216,7 @@ public:
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){
-			auto cache_key = this->calculateCacheKey(key);
+			size_t cache_key = this->calculateCacheKey(key);
 			if (this->cache.size() <= cache_key) {
 				return;
 			}
@@ -229,7 +229,7 @@ public:
 
 		// Prevent excessive usage during loading
 		if( this->loaded ){
-			auto cache_key = this->calculateCacheKey(key);
+			size_t cache_key = this->calculateCacheKey(key);
 			if (this->cache.size() <= cache_key) {
 				this->cache.resize(cache_key + 1, nullptr);
 			}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7664 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: `mob_clone_spawn` creates a new mob_db entry in the MobDatabase. However, because the MobDatabase is a TypesafeCachedYamlDatabase, it uses a vector for a cache. The id that this function creates could be out of bounds of the cache.

The fix for this is to check the cache size and resize it if needed.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
