### PR TITLE
Add debug logs for debugging client connections

### DIFF
--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -818,8 +818,8 @@ void chclif_send_map_data( int fd, std::shared_ptr<struct mmo_charstatus> cd, ui
 	memset(WFIFOP(fd, 28), 0, 128); // Unknown
 #endif
 #ifdef DEBUG
-	ShowDebug("Sending the client to map-server with ip %d.%d.%d.%d and port %hu\n",
-			  CONVIP((subnet_map_ip) ? subnet_map_ip : map_server[map_server_index].ip),
+	ShowDebug("Sending the client (%d %d.%d.%d.%d) to map-server with ip %d.%d.%d.%d and port %hu\n",
+			  cd->account_id, CONVIP(ipl), CONVIP((subnet_map_ip) ? subnet_map_ip : map_server[map_server_index].ip),
 			  map_server[map_server_index].port);
 #endif
 	WFIFOSET(fd,size);

--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -817,6 +817,11 @@ void chclif_send_map_data( int fd, std::shared_ptr<struct mmo_charstatus> cd, ui
 #if PACKETVER >= 20170315
 	memset(WFIFOP(fd, 28), 0, 128); // Unknown
 #endif
+#ifdef DEBUG
+	ShowDebug("Sending the client to map-server with ip %d.%d.%d.%d and port %hu\n",
+			  CONVIP((subnet_map_ip) ? subnet_map_ip : map_server[map_server_index].ip),
+			  map_server[map_server_index].port);
+#endif
 	WFIFOSET(fd,size);
 }
 

--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -146,9 +146,11 @@ static void logclif_auth_ok(struct login_session_data* sd) {
 		memset(WFIFOP(fd, header+n*size+32), 0, 128); // Unknown
 #endif
 #ifdef DEBUG
-		ShowDebug("Sending the client to char-server %s with ip %d.%d.%d.%d and port %hu\n",
-				  ch_server[i].name, CONVIP((subnet_char_ip) ? subnet_char_ip : ch_server[i].ip),
-				  ch_server[i].port);
+		ShowDebug(
+			"Sending the client (%d %d.%d.%d.%d) to char-server %s with ip %d.%d.%d.%d and port "
+			"%hu\n",
+			sd->account_id, CONVIP(ip), ch_server[i].name,
+			CONVIP((subnet_char_ip) ? subnet_char_ip : ch_server[i].ip), ch_server[i].port);
 #endif
 		n++;
 	}

--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -145,6 +145,11 @@ static void logclif_auth_ok(struct login_session_data* sd) {
 #if PACKETVER >= 20170315
 		memset(WFIFOP(fd, header+n*size+32), 0, 128); // Unknown
 #endif
+#ifdef DEBUG
+		ShowDebug("Sending the client to char-server %s with ip %d.%d.%d.%d and port %hu\n",
+				  ch_server[i].name, CONVIP((subnet_char_ip) ? subnet_char_ip : ch_server[i].ip),
+				  ch_server[i].port);
+#endif
 		n++;
 	}
 	WFIFOSET(fd,header+size*server_num);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2147,6 +2147,10 @@ void clif_changemapserver(map_session_data* sd, const char* map, int x, int y, u
 #if PACKETVER >= 20170315
 	memset(WFIFOP(fd, 28), 0, 128); // Unknown
 #endif
+#ifdef DEBUG
+	ShowDebug("Sending the client (%d %d.%d.%d.%d) to map-server with ip %d.%d.%d.%d and port %hu\n",
+			  cd->account_id, CONVIP(session[fd]->client_addr), CONVIP(ip), port);
+#endif
 	WFIFOSET(fd,packet_len(cmd));
 }
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2150,7 +2150,7 @@ void clif_changemapserver(map_session_data* sd, const char* map, int x, int y, u
 #ifdef DEBUG
 	ShowDebug(
 		"Sending the client (%d %d.%d.%d.%d) to map-server with ip %d.%d.%d.%d and port %hu\n",
-		cd->account_id, CONVIP(session[fd]->client_addr), CONVIP(ip), port);
+		sd->status.account_id, CONVIP(session[fd]->client_addr), CONVIP(ip), port);
 #endif
 	WFIFOSET(fd,packet_len(cmd));
 }

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2148,8 +2148,9 @@ void clif_changemapserver(map_session_data* sd, const char* map, int x, int y, u
 	memset(WFIFOP(fd, 28), 0, 128); // Unknown
 #endif
 #ifdef DEBUG
-	ShowDebug("Sending the client (%d %d.%d.%d.%d) to map-server with ip %d.%d.%d.%d and port %hu\n",
-			  cd->account_id, CONVIP(session[fd]->client_addr), CONVIP(ip), port);
+	ShowDebug(
+		"Sending the client (%d %d.%d.%d.%d) to map-server with ip %d.%d.%d.%d and port %hu\n",
+		cd->account_id, CONVIP(session[fd]->client_addr), CONVIP(ip), port);
 #endif
 	WFIFOSET(fd,packet_len(cmd));
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
This is a diff for server owners to help troubleshoot issues with client connections.

You can enable `DEBUG` with configure/cmake/msvs, or `#define` it somewhere in source.

An example:
```
[Debug]: Sending the client to char-server rAthena with ip 127.0.0.1 and port 6121
...
[Debug]: Sending the client to map-server with ip 127.0.0.1 and port 5121
```

 
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
