### PR TITLE
Fix pincode skip if new character

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -85,14 +85,6 @@ std::unordered_map<uint32, std::shared_ptr<struct auth_node>>& char_get_authdb()
 std::unordered_map<uint32, std::shared_ptr<struct online_char_data>>& char_get_onlinedb() { return online_char_db; }
 std::unordered_map<uint32, std::shared_ptr<struct mmo_charstatus>>& char_get_chardb() { return char_db; }
 
-online_char_data::online_char_data( uint32 account_id ){
-	this->account_id = account_id;
-	this->char_id = -1;
-	this->server = -1;
-	this->fd = -1;
-	this->waiting_disconnect = INVALID_TIMER;
-}
-
 void char_set_charselect(uint32 account_id) {
 	std::shared_ptr<struct online_char_data> character = util::umap_find( char_get_onlinedb(), account_id );
 

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -235,15 +235,15 @@ struct auth_node {
 std::unordered_map<uint32, std::shared_ptr<struct auth_node>>& char_get_authdb();
 
 struct online_char_data {
-	uint32 account_id;
-	uint32 char_id;
-	int fd;
-	int waiting_disconnect;
-	short server; // -2: unknown server, -1: not connected, 0+: id of server
-	bool pincode_success;
+	uint32 account_id{-1};
+	uint32 char_id{-1};
+	int fd{-1};
+	int waiting_disconnect{INVALID_TIMER};
+	short server{-1}; // -2: unknown server, -1: not connected, 0+: id of server
+	bool pincode_success{false};
 
-public: 
-	online_char_data( uint32 account_id );
+public:
+	online_char_data(uint32 account_id) : account_id(account_id) {};
 };
 
 std::unordered_map<uint32, std::shared_ptr<struct online_char_data>>& char_get_onlinedb();


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7700 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: We create a dummy character when we log into char select for the first time. Because we don't initialize `pincode_success`, it's possible that it's true when we check it later.

This pr adds defaults for all values in online_char_data, and remakes the constructor to a cleaner version.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
