### PR TITLE
Export script constants for mobs and items

### DIFF
--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1168,6 +1168,10 @@ void ItemDatabase::loadingFinished(){
 			ShowWarning( "Item %s (%u) is a shield and should have a view id. Defaulting to Guard...\n", item->name.c_str(), item->nameid );
 			item->look = 1;
 		}
+
+		// let's export the ITEMID_AEGIS_NAME constants
+		std::string key = "ITEMID_" + item->name;
+		script_set_constant(key.c_str(), item->nameid, false, false);
 	}
 
 	if( !this->exists( ITEMID_DUMMY ) ){

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -5044,6 +5044,10 @@ void MobDatabase::loadingFinished() {
 		mob->status.max_sp = cap_value(mob->status.max_sp, 1, UINT32_MAX);
 		mob->status.hp = mob->status.max_hp;
 		mob->status.sp = mob->status.max_sp;
+
+		// let's export the MOBID_AEGIS_NAME constants
+		std::string key = "MOBID_" + mob->sprite;
+		script_set_constant(key.c_str(), mob->id, false, false);
 	}
 
 	TypesafeCachedYamlDatabase::loadingFinished();


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

* **Server Mode**: Both

* **Description of Pull Request**: Not sure if this will be used, if no one likes it we can just close this pr.
This allows users to use the reader-friendly aegis names of mobs/items, with the performance of uint32_t key lookups in our databases.

Because our script engine is case-insensitive for variables/constants, we can do this:
```
-	script	TestNpc3	-1,{
	end;
OnInit:
	debugmes("Item id of red potion is " + ITEMID_RED_POTION);
	debugmes("mobid of poring is " + mobid_poring);
}
```
And the result:
```
[02:17:03][Status]: NPC file 'npc/custom/custom.txt' was reloaded.
[02:17:03][Debug]: script debug : 0 110015580 : Item id of red potion is 501
[02:17:03][Debug]: script debug : 0 110015580 : mobid of poring is 1002
[02:17:03][Status]: Event 'OnInit' executed with '2' NPCs.
```

> Why do this?

I often see in the code something like `getitem 501; // Red_Potion`, with this we can just do `getitem ITEMID_Red_Potion;`

it's more clear to the reader, and prevents any errors with changing the id or comment, but not both.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
