### PR TITLE
Fixed market response packet when purchase fails

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2374,7 +2374,7 @@ void clif_npc_market_purchase_ack( map_session_data *sd, e_purchase_result res, 
 	p->result = ( res == e_purchase_result::PURCHASE_SUCCEED ? 1 : 0 );
 #endif
 
-	if( p->result ){
+	if( res == e_purchase_result::PURCHASE_SUCCEED ){
 		for( int i = 0, j, count = 0; i < list.size(); i++ ){
 			ARR_FIND( 0, nd->u.shop.count, j, list[i].nameid == nd->u.shop.shop_item[j].nameid );
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A
* **Server Mode**: Both
* **Description of Pull Request**: The item list was still sent to the client even when the purchase failed because we check for `p->result == 0`, but `p->result` is no longer 0 in failure cases, on PACKETVER >= 20190807. This PR corrects the result check.
