### PR TITLE
Clean-up script.cpp

### DIFF
--- a/src/map/script.hpp
+++ b/src/map/script.hpp
@@ -135,6 +135,7 @@
 enum script_cmd_result {
 	SCRIPT_CMD_SUCCESS = 0, ///when a buildin cmd was correctly done
 	SCRIPT_CMD_FAILURE = 1, ///when an errors appear in cmd, show_debug will follow
+	SCRIPT_CMD_END = 2, ///when an errors appear in cmd, show_debug will follow and the script state END
 };
 
 #define SCRIPT_BLOCK_SIZE 512


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Introduced `SCRIPT_CMD_END` which displays an error and set the script state to `END`.

Removed `script_reportfunc(st)`, `script_reportsrc(st)` and `st->state = END;` from `script_rid2sd_`, which are no longer needed.

This also fixes the logic where `script_charid2sd`, `script_accid2sd`, `script_nick2sd`, `script_mapid2sd` and `script_rid2bl` should set the script state to `END` when the command fails.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
