### PR TITLE
Fixed a cant.attack bypass

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1922,23 +1922,18 @@ int status_revive(struct block_list *bl, unsigned char per_hp, unsigned char per
  */
 bool status_check_skilluse(struct block_list *src, struct block_list *target, uint16 skill_id, int flag) {
 	struct status_data *status;
-	status_change *sc, *tsc;
 	int hide_flag;
 
 	if (src) {
 		if (src->type != BL_PC && status_isdead(src))
 			return false;
-		sc = status_get_sc(src);
 		status = status_get_status_data(src);
 	}else{
 		status = &dummy_status;
-		sc = nullptr;
 	}
 
-	if(target)
-		tsc = status_get_sc(target);
-	else
-		tsc = nullptr;
+	status_change *sc = status_get_sc(src);
+	status_change *tsc = status_get_sc(target);
 
 	if (!skill_id) { // Normal attack checks.
 		if (sc && sc->cant.attack)
@@ -1956,7 +1951,7 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 #ifndef RENEWAL
 		case PA_PRESSURE:
 			if( flag && tsc && tsc->option&OPTION_HIDE)
-					return false; // Gloria Avoids pretty much everything....
+				return false; // Gloria Avoids pretty much everything....
 			break;
 #endif
 		case GN_WALLOFTHORN:


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#7743
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This moves the pointer assignation before the check so cant.attack can be properly tested for normal attacks.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
