### PR TITLE
Fix incorrect script constants

### DIFF
--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -4405,7 +4405,7 @@ Body:
       bonus bAspdRate,3;
       bonus bAspd,1;
       bonus2 bAddClass,Class_All,-5;
-      if (getequiprefinerycnt(EQI_HAND_R) >= 10 && getiteminfo(getequipid(EQI_HAND_R), II_VIEW) == 11)
+      if (getequiprefinerycnt(EQI_HAND_R) >= 10 && getiteminfo(getequipid(EQI_HAND_R), ITEMINFO_VIEW) == 11)
          bonus bAspd,1;
   - Combos:
       - Combo:
@@ -7291,7 +7291,7 @@ Body:
           - Tree_Of_Sprout_JP
           - Tendrilion_Card
     Script: |
-      .@type = getiteminfo(getequipid(EQI_COMPOUND_ON), II_VIEW);
+      .@type = getiteminfo(getequipid(EQI_COMPOUND_ON), ITEMINFO_VIEW);
       if (.@type == W_BOOK || .@type == W_STAFF || .@type == W_2HSTAFF) {
          bonus2 bMagicAddRace,RC_Player_Human, getequiprefinerycnt(EQI_HAND_R)*2;
       }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: We were using the wrong script constant, it should be ITEMINFO_VIEW instead of II_VIEW
#7746 could possible notify us of this before.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
