### PR TITLE
Enabling EPOLL in cmake command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,17 @@ endif()
 
 
 #
+# Enable EPOLL (default=OFF)
+# Only for Linux
+#
+option( ENABLE_EXTRA_SOCKET_POLL "enable SOCKET_EPOLL (default=OFF)" OFF )
+if( ENABLE_EXTRA_SOCKET_POLL )
+	set_property( CACHE GLOBAL_DEFINITIONS  PROPERTY VALUE "${GLOBAL_DEFINITIONS} -DSOCKET_EPOLL" )
+	message( STATUS "Enabled SOCKET_EPOLL" )
+endif()
+
+
+#
 # Enable builtin memory manager (default=default)
 #
 set( MEMMGR_OPTIONS "default;yes;no" )


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
cmake users can't choose epoll over select
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Irrelevant
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Enables cmake users to activate epoll for linux oses
<!-- Describe how this pull request will resolve the issue(s) listed above. -->


Then you can use it like this 
`cmake -G"Unix Makefiles" -DSOCKET_EPOLL=ON ..`

Thanks to Nitrous Senpai 🐸
