### PR TITLE
Fixes npc last loaded path caching

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -99,7 +99,6 @@ static struct eri *timer_event_ers; //For the npc timer data. [Skotlex]
 
 /* hello */
 static char *npc_last_path;
-static char *npc_last_ref;
 
 struct npc_path_data {
 	char* path;
@@ -3471,7 +3470,6 @@ int npc_unload(struct npc_data* nd, bool single) {
 
 			if (npd == npc_last_npd) {
 				npc_last_npd = NULL;
-				npc_last_ref = NULL;
 				npc_last_path = NULL;
 			}
 		}
@@ -3706,10 +3704,9 @@ static void npc_parsename(struct npc_data* nd, const char* name, const char* sta
 		npd->references++;
 
 		npc_last_npd = npd;
-		npc_last_ref = npd->path;
-		npc_last_path = (char*) filepath;
+		npc_last_path = npd->path;
 	} else {
-		nd->path = npc_last_ref;
+		nd->path = npc_last_path;
 		if( npc_last_npd )
 			npc_last_npd->references++;
 	}


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#7766
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This removes a redundant pointer that kept track of last loaded npc path, which was always pointing to newly loaded paths. This was preventing a correct unloading and causing duplicates.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
