### PR TITLE
Fixes bSkillCooldown bonus duration

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3588,7 +3588,7 @@ static void pc_bonus_itembonus(std::vector<s_item_bonus> &bonus, uint16 id, int 
 	struct s_item_bonus entry = {};
 
 	entry.id = id;
-	entry.val = cap_value(val, -10000, 10000);
+	entry.val = cap_rate ? cap_value(val, -10000, 10000) : val;
 
 	bonus.push_back(entry);
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Fixes #7770.
  * Follow up to ba86a76.
  * Adds a missing cap rate option for bSkillCooldown which wouldn't allow addition/reduction more than 10000 milliseconds. Thanks to @attackjom!