### PR TITLE
Fixes Lux Anima applying Giant Growth

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10690,6 +10690,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		break;
 	case RK_LUXANIMA:
 		status_change_clear_buffs(bl, SCCB_LUXANIMA); // For bonus_script
+		break;
 	case RK_GIANTGROWTH:
 	case RK_STONEHARDSKIN:
 	case RK_VITALITYACTIVATION:


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Adds a missing break which was resulting in Lux Anima attempting to cast the Giant Growth Rune.
  * This is in conjunction with the revamp of this skill not applying other Runes effects anymore.