### PR TITLE
Simplify GC_POISONREACT counter formula

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10606,7 +10606,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 		case SC_POISONREACT:
 #ifdef RENEWAL
-			val2= val1 / 2 + 1;
+			val2= (val1 + 1) / 2;
 #else
 			val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]
 #endif

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10606,7 +10606,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 		case SC_POISONREACT:
 #ifdef RENEWAL
-			val2=(val1 - ((val1-1) % 1 - 1)) / 2;
+			val2= val1 / 2 + 1;
 #else
 			val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]
 #endif


### PR DESCRIPTION
 Simplify GC_POISONREACT counter formula

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5805

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
I suddenly found GC_POISONREACT counter formula in https://github.com/rathena/rathena/pull/5805 I changed is funny. So I simplify it.