### PR TITLE
Adds option to set item buy/sell values to 0

### DIFF
--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -1880,6 +1880,7 @@ Body:
     Name: Trap
     Type: Etc
     Buy: 75
+    Sell: 0
     Weight: 2
     Flags:
       BuyingStore: true
@@ -2098,6 +2099,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 1
+    Sell: 0
     Weight: 1
     Attack: 25
     Jobs:
@@ -2116,6 +2118,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2136,6 +2139,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2156,6 +2160,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 4
+    Sell: 0
     Weight: 1
     Attack: 40
     Jobs:
@@ -2174,6 +2179,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2194,6 +2200,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2214,6 +2221,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2234,6 +2242,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2254,6 +2263,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2274,6 +2284,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2295,6 +2306,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2315,6 +2327,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2335,6 +2348,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2355,6 +2369,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2376,6 +2391,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 20
+    Sell: 0
     Weight: 1
     Attack: 10
     Jobs:
@@ -2396,6 +2412,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 30
+    Sell: 0
     Weight: 1
     Attack: 50
     Jobs:
@@ -2414,6 +2431,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 40
+    Sell: 0
     Weight: 3
     Attack: 50
     Jobs:
@@ -2434,6 +2452,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 5
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2454,6 +2473,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2474,6 +2494,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 1
     Jobs:
@@ -2494,6 +2515,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 3
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -2525,6 +2547,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 3
+    Sell: 0
     Weight: 1
     Attack: 50
     Jobs:
@@ -2546,6 +2569,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 45
     Jobs:
@@ -2564,6 +2588,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 35
     Jobs:
@@ -2582,6 +2607,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 45
     Jobs:
@@ -2600,6 +2626,7 @@ Body:
     Type: Ammo
     SubType: Arrow
     Buy: 10
+    Sell: 0
     Weight: 1
     Attack: 30
     Jobs:
@@ -31291,6 +31318,7 @@ Body:
     Name: Special Alloy Trap
     Type: Etc
     Buy: 300
+    Sell: 0
     Weight: 2
     Flags:
       BuyingStore: true

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -4299,6 +4299,7 @@ Body:
     Name: Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4309,6 +4310,7 @@ Body:
     Name: Iron Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4319,6 +4321,7 @@ Body:
     Name: Steel Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4329,6 +4332,7 @@ Body:
     Name: Oridecon Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4339,6 +4343,7 @@ Body:
     Name: Fire Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4349,6 +4354,7 @@ Body:
     Name: Silver Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4359,6 +4365,7 @@ Body:
     Name: Wind Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4369,6 +4376,7 @@ Body:
     Name: Stone Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4379,6 +4387,7 @@ Body:
     Name: Crystal Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4389,6 +4398,7 @@ Body:
     Name: Shadow Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4399,6 +4409,7 @@ Body:
     Name: Immaterial Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -4409,6 +4420,7 @@ Body:
     Name: Rusty Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -6317,6 +6329,7 @@ Body:
     Name: Holy Arrow Quiver
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -8312,6 +8325,7 @@ Body:
     Name: Special Alloy Trap Box
     Type: Usable
     Buy: 30000
+    Sell: 0
     Weight: 100
     Flags:
       BuyingStore: true
@@ -10918,6 +10932,7 @@ Body:
     Name: Arrow Of Elf Cntr
     Type: Usable
     Buy: 500
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -10928,6 +10943,7 @@ Body:
     Name: Hunting Arrow Cntr
     Type: Usable
     Buy: 500
+    Sell: 0
     Weight: 250
     Flags:
       BuyingStore: true
@@ -12128,6 +12144,7 @@ Body:
     Name: Siege Arrow Quiver S
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 100
     EquipLevelMin: 130
     Flags:
@@ -12139,6 +12156,7 @@ Body:
     Name: Siege Arrow Quiver A
     Type: Usable
     Buy: 2
+    Sell: 0
     Weight: 100
     EquipLevelMin: 95
     Flags:
@@ -57584,6 +57602,7 @@ Body:
     Name: Trap Box
     Type: Usable
     Buy: 20
+    Sell: 0
     Weight: 250
     Script: |
       getitem "Booby_Trap",500;
@@ -60179,6 +60198,7 @@ Body:
     Name: Poison Arrow Quiver
     Type: Usable
     Buy: 20
+    Sell: 0
     Weight: 250
     Script: |
       getitem "Poison_Arrow",500;

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -196,6 +196,8 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			item->subtype = 0;
 	}
 
+	bool has_buy = false, has_sell = false;
+
 	if (this->nodeExists(node, "Buy")) {
 		uint32 buy;
 
@@ -207,7 +209,7 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			buy = MAX_ZENY;
 		}
 
-		item->has_value_buy = true;
+		has_buy = true;
 		item->value_buy = buy;
 	} else {
 		if (!exists) {
@@ -226,13 +228,15 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			sell = MAX_ZENY;
 		}
 
-		item->has_value_sell = true;
+		has_sell = true;
 		item->value_sell = sell;
 	} else {
 		if (!exists) {
 			item->value_sell = 0;
 		}
 	}
+
+	ItemDatabase::hasPriceValue[item->nameid] = { has_buy, has_sell };
 
 	if (this->nodeExists(node, "Weight")) {
 		uint32 weight;
@@ -1155,9 +1159,9 @@ void ItemDatabase::loadingFinished(){
 		}
 
 		// When a particular price is not given, we should base it off the other one
-		if (!item->has_value_buy && item->has_value_sell)
+		if (!ItemDatabase::hasPriceValue[item->nameid].has_buy && ItemDatabase::hasPriceValue[item->nameid].has_sell)
 			item->value_buy = item->value_sell * 2;
-		else if (item->has_value_buy && !item->has_value_sell)
+		else if (ItemDatabase::hasPriceValue[item->nameid].has_buy && !ItemDatabase::hasPriceValue[item->nameid].has_sell)
 			item->value_sell = item->value_buy / 2;
 
 		if (item->value_buy / 124. < item->value_sell / 75.) {

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -207,6 +207,7 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			buy = MAX_ZENY;
 		}
 
+		item->has_value_buy = true;
 		item->value_buy = buy;
 	} else {
 		if (!exists) {
@@ -225,6 +226,7 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			sell = MAX_ZENY;
 		}
 
+		item->has_value_sell = true;
 		item->value_sell = sell;
 	} else {
 		if (!exists) {
@@ -1153,9 +1155,9 @@ void ItemDatabase::loadingFinished(){
 		}
 
 		// When a particular price is not given, we should base it off the other one
-		if (item->value_buy == 0 && item->value_sell > 0)
+		if (!item->has_value_buy && item->has_value_sell)
 			item->value_buy = item->value_sell * 2;
-		else if (item->value_buy > 0 && item->value_sell == 0)
+		else if (item->has_value_buy && !item->has_value_sell)
 			item->value_sell = item->value_buy / 2;
 
 		if (item->value_buy / 124. < item->value_sell / 75.) {

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -1192,6 +1192,7 @@ void ItemDatabase::loadingFinished(){
 	}
 
 	TypesafeCachedYamlDatabase::loadingFinished();
+	ItemDatabase::hasPriceValue.clear();
 }
 
 /**

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -236,7 +236,7 @@ uint64 ItemDatabase::parseBodyNode(const ryml::NodeRef& node) {
 		}
 	}
 
-	ItemDatabase::hasPriceValue[item->nameid] = { has_buy, has_sell };
+	hasPriceValue[item->nameid] = { has_buy, has_sell };
 
 	if (this->nodeExists(node, "Weight")) {
 		uint32 weight;
@@ -1159,9 +1159,9 @@ void ItemDatabase::loadingFinished(){
 		}
 
 		// When a particular price is not given, we should base it off the other one
-		if (!ItemDatabase::hasPriceValue[item->nameid].has_buy && ItemDatabase::hasPriceValue[item->nameid].has_sell)
+		if (!hasPriceValue[item->nameid].has_buy && hasPriceValue[item->nameid].has_sell)
 			item->value_buy = item->value_sell * 2;
-		else if (ItemDatabase::hasPriceValue[item->nameid].has_buy && !ItemDatabase::hasPriceValue[item->nameid].has_sell)
+		else if (hasPriceValue[item->nameid].has_buy && !hasPriceValue[item->nameid].has_sell)
 			item->value_sell = item->value_buy / 2;
 
 		if (item->value_buy / 124. < item->value_sell / 75.) {
@@ -1192,7 +1192,7 @@ void ItemDatabase::loadingFinished(){
 	}
 
 	TypesafeCachedYamlDatabase::loadingFinished();
-	ItemDatabase::hasPriceValue.clear();
+	hasPriceValue.clear();
 }
 
 /**

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -2039,8 +2039,6 @@ struct item_data
 
 	uint32 value_buy;
 	uint32 value_sell;
-	bool has_value_buy;
-	bool has_value_sell;
 	item_types type;
 	uint8 subtype;
 	int maxchance; //For logs, for external game info, for scripts: Max drop chance of this item (e.g. 0.01% , etc.. if it = 0, then monsters don't drop it, -1 denotes items sold in shops only) [Lupus]
@@ -2135,6 +2133,15 @@ private:
 
 	e_sex defaultGender( const ryml::NodeRef& node, std::shared_ptr<item_data> id );
 
+	std::string create_item_link(struct item& item, std::shared_ptr<item_data>& data);
+
+	struct s_pricevalue {
+		bool has_buy;
+		bool has_sell;
+	};
+
+	std::unordered_map<t_itemid, s_pricevalue> hasPriceValue;
+
 public:
 	ItemDatabase() : TypesafeCachedYamlDatabase("ITEM_DB", 3, 1) {
 
@@ -2156,9 +2163,6 @@ public:
 	std::string create_item_link(struct item& item);
 	std::string create_item_link( std::shared_ptr<item_data>& data );
 	std::string create_item_link_for_mes( std::shared_ptr<item_data>& data, bool use_brackets, const char* name );
-
-private:
-	std::string create_item_link(struct item& item, std::shared_ptr<item_data>& data);
 };
 
 extern ItemDatabase item_db;

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -2039,6 +2039,8 @@ struct item_data
 
 	uint32 value_buy;
 	uint32 value_sell;
+	bool has_value_buy;
+	bool has_value_sell;
 	item_types type;
 	uint8 subtype;
 	int maxchance; //For logs, for external game info, for scripts: Max drop chance of this item (e.g. 0.01% , etc.. if it = 0, then monsters don't drop it, -1 denotes items sold in shops only) [Lupus]


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7790

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Arrows and Traps are now sold for 0 Zeny to shops (Renewal only).
  * Adjusts the item database loadingFinished check to now accept 0 as a valid value for buy/sell and not attempt to adjust the buy/sell value when only one is defined.
Thanks to @Atemo and @mazvi!