### PR TITLE
Fixed wrong index check in clif_parse_laphine_synthesis

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -23297,7 +23297,7 @@ void clif_parse_laphine_synthesis( int fd, map_session_data* sd ){
 			return;
 		}
 
-		if( sd->inventory_data[i] == nullptr ){
+		if( sd->inventory_data[index] == nullptr ){
 			return;
 		}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Both

* **Description of Pull Request**: The check in `clif_parse_laphine_synthesis` used the iteration count `i` to access `sd->inventory_data` array instead of `index`, which can cause the function to return early.