### PR TITLE
Fix maximum ratio for MOB_ITEM_RATIO_DB

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -6175,9 +6175,9 @@ uint64 MobItemRatioDatabase::parseBodyNode(const ryml::NodeRef& node) {
 	}
 	
 	if (this->nodeExists(node, "Ratio")) {
-		uint16 ratio;
+		uint32 ratio;
 
-		if (!this->asUInt16(node, "Ratio", ratio))
+		if (!this->asUInt32(node, "Ratio", ratio))
 			return 0;
 
 		data->drop_ratio = ratio;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -219,7 +219,7 @@ public:
 
 struct s_mob_item_drop_ratio {
 	t_itemid nameid;
-	uint16 drop_ratio;
+	uint32 drop_ratio;
 	std::vector<uint16> mob_ids;
 };
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Fixes #7835 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
```
Body:
  - Item: Berzebub_Card
    Ratio: 65500
    List:
      BEELZEBUB_: true
  - Item: Kiel_Card
    Ratio: 400000
    List:
      KIEL_: true
```
Using the above yaml with default rates, we see the results:
![image](https://github.com/rathena/rathena/assets/6844975/aa46883c-6c96-4317-a08c-cfca50f448fe)


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
