### PR TITLE
fix(docs): fixed wrong effect description

### DIFF
--- a/doc/effect_list.txt
+++ b/doc/effect_list.txt
@@ -72,8 +72,8 @@ Number	Description
 53.	Puff of Purpulish Smoke?
 54.	Cast Initiation Aura (Water Element)
 55.	Cast Initiation Aura (Fire Element)
-56.	Cast Initiation Aura (Wind Element)
-57.	Cast Initiation Aura (Earth Element)
+56.	Cast Initiation Aura (Earth Element)
+57.	Cast Initiation Aura (Wind Element)
 58.	Cast Initiation Aura (Holy Element)
 59.	Cast Initiation Aura (Poison Element)
 60.	Cast target circle
@@ -277,7 +277,7 @@ Number	Description
 258.	Elemental Endow (Earth)
 259.	Map Light Pillar Animation 3
 260.	Map Light Pillar Animation 4
-261.	Fury Cast Animation 
+261.	Fury Cast Animation
 262.	Raging Quadruple Blow
 263.	Raging Quadruple Blow 2
 264.	(Nothing)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Two effect descriptions were wrong. Also fixed a trailing whitespace

* **Server Mode**: Both

* **Description of Pull Request**: Simple txt file change

Doing `@effect 56`
![image](https://github.com/rathena/rathena/assets/47922762/b6d9a426-6433-493c-b71c-3fd513e83015)

Using earth skill:
![image](https://github.com/rathena/rathena/assets/47922762/c3febcd5-5459-4058-a449-e8d8075a0322)

Doing `@effect 57`
![image](https://github.com/rathena/rathena/assets/47922762/56b2490c-1ba6-4130-8a83-3824135346b8)

Using wind skill:
![image](https://github.com/rathena/rathena/assets/47922762/021fb5a9-53ee-42e1-8732-92741a8b5b9f)


As you can see 56 is Earth and 57 is Wind.