### PR TITLE
Rebalance shadow cross 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37986,25 +37986,25 @@ Body:
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 30000
+        Time: 75000
       - Level: 2
-        Time: 40000
-      - Level: 3
-        Time: 50000
-      - Level: 4
-        Time: 60000
-      - Level: 5
-        Time: 70000
-      - Level: 6
-        Time: 80000
-      - Level: 7
-        Time: 90000
-      - Level: 8
         Time: 100000
+      - Level: 3
+        Time: 125000
+      - Level: 4
+        Time: 150000
+      - Level: 5
+        Time: 175000
+      - Level: 6
+        Time: 200000
+      - Level: 7
+        Time: 225000
+      - Level: 8
+        Time: 250000
       - Level: 9
-        Time: 110000
+        Time: 275000
       - Level: 10
-        Time: 120000
+        Time: 300000
     Cooldown: 3000
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38084,23 +38084,22 @@ Body:
         Area: 2
       - Level: 5
         Area: 3
-    GiveAp: 5
+    GiveAp: 3
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1: 10000
-    Cooldown: 5000
+    Cooldown: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 43
-        - Level: 2
           Amount: 46
+        - Level: 2
+          Amount: 54
         - Level: 3
-          Amount: 49
+          Amount: 62
         - Level: 4
-          Amount: 52
+          Amount: 70
         - Level: 5
-          Amount: 55
+          Amount: 78
       Weapon:
         Katar: true
       Status:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37960,16 +37960,16 @@ Body:
     TargetType: Attack
     DamageFlags:
       Critical: true
-    Range: 2
+    Range: 3
     Hit: Multi_Hit
     HitCount: 1
     Element: Weapon
     CastCancel: true
     AfterCastActDelay: 500
     Duration1: 3000
-    Cooldown: 750
+    Cooldown: 500
     Requires:
-      SpCost: 40
+      SpCost: 60
       Status:
         Weaponblock_On: true
     Status: E_Slash_Count

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37826,33 +37826,52 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 60000
+        Time: 30000
       - Level: 2
-        Time: 80000
+        Time: 60000
       - Level: 3
-        Time: 100000
+        Time: 90000
       - Level: 4
         Time: 120000
       - Level: 5
-        Time: 140000
+        Time: 150000
       - Level: 6
-        Time: 160000
-      - Level: 7
         Time: 180000
+      - Level: 7
+        Time: 210000
       - Level: 8
-        Time: 200000
-      - Level: 9
-        Time: 220000
-      - Level: 10
         Time: 240000
+      - Level: 9
+        Time: 270000
+      - Level: 10
+        Time: 300000
     Cooldown: 60000
     FixedCastTime: 1000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost:
+        - Level: 1
+          Amount: 152
+        - Level: 2
+          Amount: 149
+        - Level: 3
+          Amount: 146
+        - Level: 4
+          Amount: 143
+        - Level: 5
+          Amount: 140
+        - Level: 6
+          Amount: 137
+        - Level: 7
+          Amount: 134
+        - Level: 8
+          Amount: 131
+        - Level: 9
+          Amount: 128
+        - Level: 10
+          Amount: 125
     Status: Shadow_Exceed
   - Id: 5286
     Name: SHC_DANCING_KNIFE

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38146,9 +38146,10 @@ Body:
     Element: Weapon
     SplashArea: 3
     CastCancel: true
-    AfterCastActDelay: 500
+    CastTime: 500
     Duration1: 20000
     Cooldown: 60000
+    FixedCastTime: 500
     Requires:
       SpCost: 150
       ApCost: 150

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38043,22 +38043,21 @@ Body:
     Hit: Multi_Hit
     HitCount: 1
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
-    AfterCastActDelay: 500
-    Cooldown: 1000
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1
-          Amount: 45
+          Amount: 40
         - Level: 2
-          Amount: 50
+          Amount: 45
         - Level: 3
-          Amount: 55
+          Amount: 50
         - Level: 4
-          Amount: 60
+          Amount: 55
         - Level: 5
-          Amount: 65
+          Amount: 60
       Weapon:
         Dagger: true
   - Id: 5292

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37927,25 +37927,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 28
+          Amount: 45
         - Level: 2
-          Amount: 31
+          Amount: 48
         - Level: 3
-          Amount: 34
+          Amount: 51
         - Level: 4
-          Amount: 37
+          Amount: 54
         - Level: 5
-          Amount: 40
+          Amount: 57
         - Level: 6
-          Amount: 43
+          Amount: 60
         - Level: 7
-          Amount: 46
+          Amount: 63
         - Level: 8
-          Amount: 49
+          Amount: 66
         - Level: 9
-          Amount: 52
+          Amount: 69
         - Level: 10
-          Amount: 55
+          Amount: 72
       Weapon:
         Katar: true
   - Id: 5288

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5519,9 +5519,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_FATAL_SHADOW_CROW:
-			skillratio += -100 + 650 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 1300 * skill_lv + 10 * sstatus->pow;
 			if (tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_DRAGON)
-				skillratio += 300 * skill_lv;
+				skillratio += 150 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_AXE_STOMP:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5496,13 +5496,18 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 90 * skill_lv + 5 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
-				skillratio += 110 * skill_lv;
+				skillratio += 20 * skill_lv;	// !TODO: this should be the total ratio? no POW ratio?
 			}
 
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_ETERNAL_SLASH:
-			skillratio += -100 + 350 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 265 * skill_lv + 2 * sstatus->pow;
+
+			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
+				skillratio += 100 * skill_lv + 3 * sstatus->pow;	// !TODO: this should be the total ratio?
+			}
+
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SHADOW_STAB:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5511,7 +5511,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SHADOW_STAB:
-			skillratio += -100 + 750 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 300 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_IMPACT_CRATER:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5515,7 +5515,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_IMPACT_CRATER:
-			skillratio += -100 + 65 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 80 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_FATAL_SHADOW_CROW:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5496,7 +5496,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 90 * skill_lv + 5 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
-				skillratio += 20 * skill_lv;	// !TODO: this should be the total ratio? no POW ratio?
+				skillratio += 20 * skill_lv + 3 * sstatus->pow;	// !TODO: check POW ratio
 			}
 
 			RE_LVL_DMOD(100);
@@ -5505,7 +5505,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 265 * skill_lv + 2 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
-				skillratio += 100 * skill_lv + 3 * sstatus->pow;	// !TODO: this should be the total ratio?
+				skillratio += 100 * skill_lv + 3 * sstatus->pow;
 			}
 
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5493,10 +5493,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SAVAGE_IMPACT:
-			skillratio += -100 + 60 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 90 * skill_lv + 5 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
-				skillratio += 100 * skill_lv;
+				skillratio += 110 * skill_lv;
 			}
 
 			RE_LVL_DMOD(100);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12590,7 +12590,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			tick_time = 300;
 			break;
 		case SC_POTENT_VENOM:
-			val2 = 3 * val1;// Res Pierce Percentage
+			val2 = 2 * val1;// Res Pierce Percentage
 			break;
 		case SC_A_MACHINE:
 			val4 = tick / 1000;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Shadow Cross
---------------------------------

1. Savage Impact
	- Increases SP consumption from 55 to 72 based on level 10.
	- Increases area of effect from 3 x 3 cells to 5 x 5 cells.
	- Increases damage from 600%/1000%(Shadow Exceed)Atk to 900%/1100%(Shadow Exceed)Atk per hit based on level 10.

2. Eternal Slash
	- Reduces cooldown from 0.75 seconds to 0.5 seconds.
	- Reduces damage from 1750%/2500%(Shadow Exceed)Atk to 1325%/1825%(Shadow Exceed)Atk per hit based on level 5.
	- Increases SP consumption from 40 to 60 based on level 5.
	- Increases cast range from 2 cells to 3 cells.
	- Reduces factor weight of POW in skill formula from 5/7(Shadow Exceed) to 2/3(Shadow Exceed).

3. Impact Crater
	- Reduces cooldown from 5 seconds to 1.5 seconds.
	- Removes delay after skill.
	- Increases SP consumption from 54 to 78 based on level 5.
	- Reduces AP recovery rate from 5 to 3.
	- Increases damage from 325%Atk to 400%Atk per hit based on level 5.

4. Shadow Stab
	- Reduces SP consumption from 65 to 60 based on level 5.
	- Increases AP recovery rate from 1 to 2.
	- Reduces cooldown from 1 seconds to 0.35 seconds.
	- Removes 0.5 seconds delay after skill.
	- Reduces damage from 3750%Atk to 1500%Atk per hit based on level 5.

5. Potent Venom
	- Increases duration from 120 seconds to 300 seconds based on level 10.
	- Reduces physical resistance ignoring from 30% to 20% based on level 10.

6. Fatal Shadow Claw
	- Reduces fixed casting time from 1.5 seconds to 0.5 seconds.
	- Reduces variable casting time from 4 seconds to 0.5 seconds.
	- Removes 0.5 seconds delay after skill.
	- Increases damage from 6500%/9500%(demihuman and dragon race)Atk to 13000%/14500%(demihuman and dragon race)Atk based on level 10.

7. Shadow Exceed
	- Removes 1 second delay after skill.
	- Reduces AP consumption from 150 to 125 based on level 10.
	- Increases duration from 240 seconds to 300 seconds based on level 10. 

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
