### PR TITLE
Rebalance windhawk 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39201,10 +39201,11 @@ Body:
     CastCancel: true
     CastTime: 800
     AfterCastActDelay: 500
+    Cooldown: 150
     FixedCastTime: 200
     Requires:
-      SpCost: 120
-      ApCost: 15
+      SpCost: 80
+      ApCost: 12
       Weapon:
         Bow: true
       State: Falcon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39448,31 +39448,31 @@ Body:
     GiveAp: 1
     CastCancel: true
     CastTime: 800
-    AfterCastActDelay: 500
+    AfterCastActDelay: 300
     Duration1: 10000
     FixedCastTime: 200
     Requires:
       SpCost:
         - Level: 1
-          Amount: 55
+          Amount: 47
         - Level: 2
-          Amount: 60
+          Amount: 49
         - Level: 3
-          Amount: 65
+          Amount: 51
         - Level: 4
-          Amount: 70
+          Amount: 53
         - Level: 5
-          Amount: 75
+          Amount: 55
         - Level: 6
-          Amount: 80
+          Amount: 57
         - Level: 7
-          Amount: 85
+          Amount: 59
         - Level: 8
-          Amount: 90
+          Amount: 61
         - Level: 9
-          Amount: 95
+          Amount: 63
         - Level: 10
-          Amount: 100
+          Amount: 65
       Weapon:
         Bow: true
       Ammo:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39286,42 +39286,61 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Dark
-    GiveAp: 3
+    GiveAp:
+      - Level: 1
+        Amount: 1
+      - Level: 2
+        Amount: 1
+      - Level: 3
+        Amount: 2
+      - Level: 4
+        Amount: 2
+      - Level: 5
+        Amount: 3
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 12000
+        Time: 3000
       - Level: 2
-        Time: 24000
+        Time: 3500
       - Level: 3
-        Time: 36000
+        Time: 4000
       - Level: 4
-        Time: 48000
+        Time: 4500
       - Level: 5
-        Time: 60000
-    Duration2: 20000
-    Cooldown: 30000
+        Time: 5000
+    Cooldown: 2500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 50
+          Amount: 68
         - Level: 2
-          Amount: 53
+          Amount: 72
         - Level: 3
-          Amount: 56
+          Amount: 76
         - Level: 4
-          Amount: 59
+          Amount: 80
         - Level: 5
-          Amount: 62
+          Amount: 84
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
     Unit:
       Id: Deepblindtrap
-      Range: 1
-      Interval: 3000
+      Range:
+        - Level: 1
+          Size: 1
+        - Level: 2
+          Size: 1
+        - Level: 3
+          Size: 2
+        - Level: 4
+          Size: 2
+        - Level: 5
+          Size: 3
+      Interval: 500
       Target: Enemy
       Flag:
         NoOverlap: true
@@ -39339,43 +39358,62 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Earth
-    GiveAp: 3
+    GiveAp:
+      - Level: 1
+        Amount: 1
+      - Level: 2
+        Amount: 1
+      - Level: 3
+        Amount: 2
+      - Level: 4
+        Amount: 2
+      - Level: 5
+        Amount: 3
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 12000
+        Time: 3000
       - Level: 2
-        Time: 24000
+        Time: 3500
       - Level: 3
-        Time: 36000
+        Time: 4000
       - Level: 4
-        Time: 48000
+        Time: 4500
       - Level: 5
-        Time: 60000
-    Duration2: 10000
-    Cooldown: 30000
+        Time: 5000
+    Cooldown: 2500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 70
+          Amount: 68
         - Level: 2
-          Amount: 80
+          Amount: 72
         - Level: 3
-          Amount: 90
+          Amount: 76
         - Level: 4
-          Amount: 100
+          Amount: 80
         - Level: 5
-          Amount: 110
+          Amount: 84
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
     Status: HandicapState_Crystallization
     Unit:
       Id: Solidtrap
-      Range: 1
-      Interval: 3000
+      Range:
+        - Level: 1
+          Size: 1
+        - Level: 2
+          Size: 1
+        - Level: 3
+          Size: 2
+        - Level: 4
+          Size: 2
+        - Level: 5
+          Size: 3
+      Interval: 500
       Target: Enemy
       Flag:
         NoOverlap: true
@@ -39392,43 +39430,62 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Wind
-    GiveAp: 3
+    GiveAp:
+      - Level: 1
+        Amount: 1
+      - Level: 2
+        Amount: 1
+      - Level: 3
+        Amount: 2
+      - Level: 4
+        Amount: 2
+      - Level: 5
+        Amount: 3
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 12000
+        Time: 3000
       - Level: 2
-        Time: 24000
+        Time: 3500
       - Level: 3
-        Time: 36000
+        Time: 4000
       - Level: 4
-        Time: 48000
+        Time: 4500
       - Level: 5
-        Time: 60000
-    Duration2: 10000
-    Cooldown: 30000
+        Time: 5000
+    Cooldown: 2500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 60
-        - Level: 2
-          Amount: 62
-        - Level: 3
-          Amount: 64
-        - Level: 4
-          Amount: 66
-        - Level: 5
           Amount: 68
+        - Level: 2
+          Amount: 72
+        - Level: 3
+          Amount: 76
+        - Level: 4
+          Amount: 80
+        - Level: 5
+          Amount: 84
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
     Status: HandicapState_LightningStrike
     Unit:
       Id: Swifttrap
-      Range: 1
-      Interval: 3000
+      Range:
+        - Level: 1
+          Size: 1
+        - Level: 2
+          Size: 1
+        - Level: 3
+          Size: 2
+        - Level: 4
+          Size: 2
+        - Level: 5
+          Size: 3
+      Interval: 500
       Target: Enemy
       Flag:
         NoOverlap: true
@@ -39491,42 +39548,61 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Fire
-    GiveAp: 3
+    GiveAp:
+      - Level: 1
+        Amount: 1
+      - Level: 2
+        Amount: 1
+      - Level: 3
+        Amount: 2
+      - Level: 4
+        Amount: 2
+      - Level: 5
+        Amount: 3
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
     Duration1:
       - Level: 1
-        Time: 12000
+        Time: 3000
       - Level: 2
-        Time: 24000
+        Time: 3500
       - Level: 3
-        Time: 36000
+        Time: 4000
       - Level: 4
-        Time: 48000
+        Time: 4500
       - Level: 5
-        Time: 60000
-    Duration2: 20000
-    Cooldown: 30000
+        Time: 5000
+    Cooldown: 2500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 68
         - Level: 2
-          Amount: 44
+          Amount: 72
         - Level: 3
-          Amount: 48
+          Amount: 76
         - Level: 4
-          Amount: 52
+          Amount: 80
         - Level: 5
-          Amount: 56
+          Amount: 84
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
     Unit:
       Id: Flametrap
-      Range: 1
-      Interval: 3000
+      Range:
+        - Level: 1
+          Size: 1
+        - Level: 2
+          Size: 1
+        - Level: 3
+          Size: 2
+        - Level: 4
+          Size: 2
+        - Level: 5
+          Size: 3
+      Interval: 500
       Target: Enemy
       Flag:
         NoOverlap: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39245,7 +39245,7 @@ Body:
     CastCancel: true
     CastTime: 3500
     AfterCastActDelay: 500
-    Cooldown: 2000
+    Cooldown: 1500
     FixedCastTime: 500
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39251,25 +39251,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 64
         - Level: 2
-          Amount: 91
+          Amount: 68
         - Level: 3
-          Amount: 102
+          Amount: 72
         - Level: 4
-          Amount: 113
+          Amount: 76
         - Level: 5
-          Amount: 124
+          Amount: 80
         - Level: 6
-          Amount: 135
+          Amount: 84
         - Level: 7
-          Amount: 146
+          Amount: 88
         - Level: 8
-          Amount: 157
+          Amount: 92
         - Level: 9
-          Amount: 168
+          Amount: 96
         - Level: 10
-          Amount: 179
+          Amount: 100
       Weapon:
         Bow: true
       Ammo:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5562,9 +5562,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKBOOMERANG:// Affected by trait stats??? CON for sure but the other one unknown. Likely POW. [Rytech]
-			skillratio += -100 + 500 * skill_lv + 10 * sstatus->pow + 10 * sstatus->con;
+			skillratio += -100 + 600 * skill_lv + 10 * sstatus->pow + 10 * sstatus->con;
 			if (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH)
-				skillratio += 250 * skill_lv;
+				skillratio += skillratio * 50 / 100;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_GALESTORM:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5576,9 +5576,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 		case WH_CRESCIVE_BOLT:
 			skillratio += -100 + 340 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
-			if (sc) { // At level 10 the SP usage of 100 increased by 20 on each count. So maybe damage increase is 20%??? [Rytech]
+			if (sc) {
 				if (sc->getSCE(SC_CRESCIVEBOLT))
-					skillratio += skillratio * (20 * sc->getSCE(SC_CRESCIVEBOLT)->val1) / 100;
+					skillratio += skillratio * (10 * sc->getSCE(SC_CRESCIVEBOLT)->val1) / 100;
 
 				if (sc->getSCE(SC_CALAMITYGALE)) {
 					skillratio += skillratio * 20 / 100;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5568,10 +5568,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_GALESTORM:
-			skillratio += -100 + 250 * skill_lv + 10 * sstatus->con;
+			skillratio += -100 + 950 * skill_lv + 10 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_CALAMITYGALE) && (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH))
-					skillratio += skillratio * 50 / 100;
+				skillratio += skillratio * 50 / 100;
 			break;
 		case WH_CRESCIVE_BOLT:
 			skillratio += -100 + 300 * skill_lv + 5 * sstatus->con;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5592,7 +5592,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 		case WH_SOLIDTRAP:
 		case WH_SWIFTTRAP:
 		case WH_FLAMETRAP:
-			skillratio += -100 + 250 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 850 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			skillratio += skillratio * (20 * (sd ? pc_checkskill(sd, WH_ADVANCED_TRAP) : 5)) / 100;
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5574,7 +5574,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * 50 / 100;
 			break;
 		case WH_CRESCIVE_BOLT:
-			skillratio += -100 + 300 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 340 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc) { // At level 10 the SP usage of 100 increased by 20 on each count. So maybe damage increase is 20%??? [Rytech]
 				if (sc->getSCE(SC_CRESCIVEBOLT))

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5558,7 +5558,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKRUSH:
-			skillratio += -100 + 200 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 500 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKBOOMERANG:// Affected by trait stats??? CON for sure but the other one unknown. Likely POW. [Rytech]

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -12961,7 +12961,6 @@ TIMER_FUNC(skill_castend_id){
 	map_session_data *sd;
 	struct mob_data *md;
 	struct unit_data *ud;
-	status_change *sc = NULL;
 	int flag = 0;
 
 	src = map_id2bl(id);
@@ -12980,6 +12979,7 @@ TIMER_FUNC(skill_castend_id){
 
 	sd = BL_CAST(BL_PC,  src);
 	md = BL_CAST(BL_MOB, src);
+	status_change *sc = status_get_sc(src);
 
 	if( src->prev == NULL ) {
 		ud->skilltimer = INVALID_TIMER;
@@ -13143,6 +13143,11 @@ TIMER_FUNC(skill_castend_id){
 								sd->skill_id_old = ud->skill_id; // Prevents AP bonus on non Retro Spection use.
 							}
 							break;
+						case WH_CRESCIVE_BOLT:
+							if (sc && sc->getSCE(SC_CRESCIVEBOLT) && sc->getSCE(SC_CRESCIVEBOLT)->val1 >= 3) {
+								add_ap += 2;
+							}
+							break;
 					}
 
 					status_heal(&sd->bl, 0, 0, add_ap, 0);
@@ -13192,7 +13197,7 @@ TIMER_FUNC(skill_castend_id){
 				else
 					type = SC_STRIPSHIELD;
 
-				if ((sc = status_get_sc(src)) && sc->getSCE(type)) {
+				if (sc && sc->getSCE(type)) {
 					const struct TimerData* timer = get_timer(sc->getSCE(type)->timer);
 
 					if (timer && timer->func == status_change_timer && DIFF_TICK(timer->tick, gettick() + skill_get_time(ud->skill_id, ud->skill_lv)) > 0)
@@ -13221,7 +13226,6 @@ TIMER_FUNC(skill_castend_id){
 			sd->skill_keep_using.tid = add_timer( sd->ud.canact_tick + 100, skill_keep_using, sd->bl.id, 0 );
 		}
 
-		sc = status_get_sc(src);
 		if(sc && sc->count) {
 			if (ud->skill_id != RA_CAMOUFLAGE)
 				status_change_end(src, SC_CAMOUFLAGE); // Applies to the first skill if active

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2179,18 +2179,6 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 	case ABC_CHAIN_REACTION_SHOT:
 		skill_castend_damage_id(src, bl, ABC_CHAIN_REACTION_SHOT_ATK, skill_lv, tick, SD_LEVEL);
 		break;
-	case WH_DEEPBLINDTRAP:// Need official success chances for all 4 Windhawk traps.
-		sc_start(src, bl, SC_HANDICAPSTATE_DEEPBLIND, 50, skill_lv, skill_get_time2(skill_id, skill_lv));
-		break;
-	case WH_SOLIDTRAP:
-		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 50, skill_lv, skill_get_time2(skill_id, skill_lv));
-		break;
-	case WH_SWIFTTRAP:
-		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 50, skill_lv, skill_get_time2(skill_id, skill_lv));
-		break;
-	case WH_FLAMETRAP:
-		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 50, skill_lv, skill_get_time2(skill_id, skill_lv));
-		break;
 	case TR_ROSEBLOSSOM:// Rose blossom seed can only bloom if the target is hit.
 		sc_start4(src, bl, SC_ROSEBLOSSOM, 100, skill_lv, TR_ROSEBLOSSOM_ATK, src->id, 0, skill_get_time(skill_id, skill_lv));
 	case WM_METALICSOUND:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Wind Hawk
----------------------------------

1. Hawk Rush
	- Increases damage from 1000%Atk to 2500%Atk based on level 5.

2. Gale Storm
	- Reduces cooldown from 2 seconds to 1.5 seconds.
	- Increases damage from 2500%Atk to 9500%Atk based on level 10.
	- Reduces SP consumption from 179 to 100 based on level 10.

3. Crescive Bolt
	- Reduces delay after skill from 0.5 seconds to 0.3 seconds.
	- Reduces SP consumption from 100 to 65 based on level 10.
	- Increases damage from 3000%Atk to 3400%Atk based on level 10.
	- When reach 3 stacks of Crescive Bolt consecutive attack buff, the duration of buff will be refreshed when reusing Crescive Bolt. (= give +3 ap after 3 stacks)

4. Deep Blind Trap / Solid Trap / Swift Trap / Flame Trap
	- Reduces cooldown to 2.5 seconds.
	- Increases SP consumption from 62 to 84 based on level 5.
	- Increases area of effect to 7 x 7 cells based on level 5.
	- Reduces trap duration to 5 seconds.
	- Changes damage interval to 0.5 seconds.
	- Reduces AP recovery rate from 4 to 3 based on level 5.
	- No longer inflict status ailment to the target.
	- Increases damage from 1250%Atk to 4250%Atk per hit based on level 5.
	- **Already implemented:** Increases factor weight of CON in skill formula from 3 to 5.

5. Hawk Boomerang
	- Adds 0.15 seconds cooldown.
	- Reduces SP consumption from 120 to 80.
	- Reduces AP consumption from 15 to 12.
	- Increases damage from 2500%Atk to 3000%Atk based on level 5. 

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

Additionally:
	- Updated Crescive Bolt ratio (+10% each hit)
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
