### PR TITLE
instance_npcname to return existing duplicate

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -21473,8 +21473,13 @@ BUILDIN_FUNC(instance_npcname)
 
 	if( instance_id > 0 && (nd = npc_name2id(str)) != NULL ) {
 		static char npcname[NAME_LENGTH];
-		snprintf(npcname, sizeof(npcname), "dup_%d_%d", instance_id, nd->bl.id);
-		script_pushconststr(st,npcname);
+		if(nd->instance_id > 0){
+			strncpy_s(npcname,str,NAME_LENGTH);
+			ShowWarning("buildin_instance_npcname: npc name already has a duplicate format, returning input name (instance_id: %d, NPC name: \"%s\".)\n", instance_id, str);
+		}else{
+			snprintf(npcname, sizeof(npcname), "dup_%d_%d", instance_id, nd->bl.id);
+		}
+		script_pushconststr(st, npcname);
 	} else {
 		ShowError("buildin_instance_npcname: Invalid instance NPC (instance_id: %d, NPC name: \"%s\".)\n", instance_id, str);
 		st->state = END;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -21475,7 +21475,7 @@ BUILDIN_FUNC(instance_npcname)
 		static char npcname[NAME_LENGTH];
 		if(nd->instance_id > 0){
 			strncpy_s(npcname,str,NAME_LENGTH);
-			ShowWarning("buildin_instance_npcname: npc name already has a duplicate format, returning input name (instance_id: %d, NPC name: \"%s\".)\n", instance_id, str);
+			ShowWarning("buildin_instance_npcname: npc is already in instance and its name has a duplicate format, returning input name (instance_id: %d, NPC name: \"%s\".)\n", instance_id, str);
 		}else{
 			snprintf(npcname, sizeof(npcname), "dup_%d_%d", instance_id, nd->bl.id);
 		}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
N/A
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
The command `instance_npcname` can easily be misused on an npc which is already duplicated in an instance, for example by calling it in such way `instance_npcname(strnpcinfo(3))`.
The proposed modification adds a warning and returns existing name, since it is the most expected behavior.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
