### PR TITLE
Corrected the critical rate in status window for katar type weapons

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -274,6 +274,18 @@ static inline unsigned int mes_len_check(char* mes, unsigned int len, unsigned i
 	return len;
 }
 
+// To show Critical Hit Rate on Status Window.
+static inline short critical_rate_shown(map_session_data *sd) {
+#ifndef RENEWAL
+	return (sd->battle_status.cri/10);
+#else
+	if (sd->status.weapon == W_KATAR)
+		return (sd->battle_status.cri/20);	// Critical Hit Rate is doubled when wielding a Katar type weapon (but not shown on Status Window)
+	else
+		return (sd->battle_status.cri/10);
+#endif
+}
+
 
 static char map_ip_str[128];
 static uint32 map_ip;
@@ -3597,7 +3609,7 @@ void clif_updatestatus(map_session_data *sd,int type)
 		}
 		break;
 	case SP_CRITICAL:
-		WFIFOL(fd,4)=sd->battle_status.cri/10;
+		WFIFOL(fd,4)=critical_rate_shown(sd);
 		break;
 	case SP_MATK1:
 		WFIFOL(fd,4)=pc_rightside_matk(sd);
@@ -4115,7 +4127,7 @@ void clif_initialstatus(map_session_data *sd) {
 	WBUFW(buf,32) = sd->battle_status.hit;
 	WBUFW(buf,34) = sd->battle_status.flee;
 	WBUFW(buf,36) = sd->battle_status.flee2/10;
-	WBUFW(buf,38) = sd->battle_status.cri/10;
+	WBUFW(buf,38) = critical_rate_shown(sd);
 	WBUFW(buf,40) = sd->battle_status.amotion; // aspd
 	WBUFW(buf,42) = 0;  // always 0 (plusASPD)
 
@@ -15711,7 +15723,7 @@ void clif_check(int fd, map_session_data* pl_sd)
 	WFIFOW(fd,30) = pl_sd->battle_status.hit;
 	WFIFOW(fd,32) = pl_sd->battle_status.flee;
 	WFIFOW(fd,34) = pl_sd->battle_status.flee2/10;
-	WFIFOW(fd,36) = pl_sd->battle_status.cri/10;
+	WFIFOW(fd,36) = critical_rate_shown(pl_sd);
 	WFIFOW(fd,38) = (2000-pl_sd->battle_status.amotion)/10;  // aspd
 	WFIFOW(fd,40) = 0;  // FIXME: What is 'plusASPD' supposed to be? Maybe adelay?
 	WFIFOSET(fd,packet_len(0x214));

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -275,14 +275,14 @@ static inline unsigned int mes_len_check(char* mes, unsigned int len, unsigned i
 }
 
 // To show Critical Hit Rate on Status Window.
-static inline short critical_rate_shown(map_session_data *sd) {
+static inline short critical_rate_shown(map_session_data &sd) {
 #ifndef RENEWAL
-	return (sd->battle_status.cri/10);
+	return (sd.battle_status.cri/10);
 #else
-	if (sd->status.weapon == W_KATAR)
-		return (sd->battle_status.cri/20);	// Critical Hit Rate is doubled when wielding a Katar type weapon (but not shown on Status Window)
+	if (sd.status.weapon == W_KATAR)
+		return (sd.battle_status.cri/20);	// Critical Hit Rate is doubled when wielding a Katar type weapon (but not shown on Status Window)
 	else
-		return (sd->battle_status.cri/10);
+		return (sd.battle_status.cri/10);
 #endif
 }
 
@@ -3609,7 +3609,7 @@ void clif_updatestatus(map_session_data *sd,int type)
 		}
 		break;
 	case SP_CRITICAL:
-		WFIFOL(fd,4)=critical_rate_shown(sd);
+		WFIFOL(fd,4)=critical_rate_shown(*sd);
 		break;
 	case SP_MATK1:
 		WFIFOL(fd,4)=pc_rightside_matk(sd);
@@ -4127,7 +4127,7 @@ void clif_initialstatus(map_session_data *sd) {
 	WBUFW(buf,32) = sd->battle_status.hit;
 	WBUFW(buf,34) = sd->battle_status.flee;
 	WBUFW(buf,36) = sd->battle_status.flee2/10;
-	WBUFW(buf,38) = critical_rate_shown(sd);
+	WBUFW(buf,38) = critical_rate_shown(*sd);
 	WBUFW(buf,40) = sd->battle_status.amotion; // aspd
 	WBUFW(buf,42) = 0;  // always 0 (plusASPD)
 
@@ -15723,7 +15723,7 @@ void clif_check(int fd, map_session_data* pl_sd)
 	WFIFOW(fd,30) = pl_sd->battle_status.hit;
 	WFIFOW(fd,32) = pl_sd->battle_status.flee;
 	WFIFOW(fd,34) = pl_sd->battle_status.flee2/10;
-	WFIFOW(fd,36) = critical_rate_shown(pl_sd);
+	WFIFOW(fd,36) = critical_rate_shown(*pl_sd);
 	WFIFOW(fd,38) = (2000-pl_sd->battle_status.amotion)/10;  // aspd
 	WFIFOW(fd,40) = 0;  // FIXME: What is 'plusASPD' supposed to be? Maybe adelay?
 	WFIFOSET(fd,packet_len(0x214));


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7869

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The critical rate is doubled with katar-type weapons however the double value shouldn't be shown in the status window.

On KRO
-------------------------------

No weapon:
![aegis_hand](https://github.com/rathena/rathena/assets/5231893/5d1c3279-0012-4efd-ab97-a1c630d1154b)

Katar equipped:
![aegis_katar](https://github.com/rathena/rathena/assets/5231893/1d8180ce-36e0-488d-9d64-013da6ad634c)


Before the commit
-----------------------------

On rAthena
No weapon:
![ra_hand](https://github.com/rathena/rathena/assets/5231893/0b0a791e-8167-4da8-9e86-1c1a466e6b22)

Katar equipped:
![ra_katar](https://github.com/rathena/rathena/assets/5231893/17d29452-57a8-403b-bada-675b260532ac)


After the commit
-----------------------------

On rAthena
No weapon:
![ra_hand](https://github.com/rathena/rathena/assets/5231893/0b0a791e-8167-4da8-9e86-1c1a466e6b22)

Katar equipped:
![ra_katar_2](https://github.com/rathena/rathena/assets/5231893/86fcf690-afc2-4190-afc6-4a1ffad5661b)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
