### PR TITLE
Rebalance inquisitor 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36491,46 +36491,26 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
-    Range: 2
+    Range: 3
     Hit: Single
     HitCount: 1
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
-    Duration1:
-      - Level: 1
-        Time: 1000
-      - Level: 2
-        Time: 2000
-      - Level: 3
-        Time: 3000
-      - Level: 4
-        Time: 4000
-      - Level: 5
-        Time: 5000
-    Cooldown: 500
+    Duration1: 5000
+    Cooldown: 300
     Requires:
       SpCost:
         - Level: 1
-          Amount: 22
+          Amount: 46
         - Level: 2
-          Amount: 29
-        - Level: 3
-          Amount: 36
-        - Level: 4
-          Amount: 43
-        - Level: 5
           Amount: 50
+        - Level: 3
+          Amount: 54
+        - Level: 4
+          Amount: 58
+        - Level: 5
+          Amount: 62
     Status: First_Brand
   - Id: 5246
     Name: IQ_FIRST_FAITH_POWER

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36551,22 +36551,32 @@ Body:
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500
-    Duration1:
+    Duration1: 300000
+    Cooldown:
       - Level: 1
-        Time: 60000
-      - Level: 2
-        Time: 120000
-      - Level: 3
         Time: 180000
+      - Level: 2
+        Time: 150000
+      - Level: 3
+        Time: 120000
       - Level: 4
-        Time: 240000
+        Time: 90000
       - Level: 5
-        Time: 300000
-    Cooldown: 150000
+        Time: 60000
     FixedCastTime: 1000
     Requires:
       SpCost: 60
-      ApCost: 50
+      ApCost:
+        - Level: 1
+          Amount: 80
+        - Level: 2
+          Amount: 70
+        - Level: 3
+          Amount: 60
+        - Level: 4
+          Amount: 50
+        - Level: 5
+          Amount: 40
       Status:
         First_Faith_Power: true
     Status: Second_Judge

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36523,18 +36523,18 @@ Body:
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500
-    Duration1:
+    Duration1: 300000
+    Cooldown:
       - Level: 1
-        Time: 60000
-      - Level: 2
-        Time: 120000
-      - Level: 3
         Time: 180000
+      - Level: 2
+        Time: 150000
+      - Level: 3
+        Time: 120000
       - Level: 4
-        Time: 240000
+        Time: 90000
       - Level: 5
-        Time: 300000
-    Cooldown: 150000
+        Time: 60000
     FixedCastTime: 1000
     Requires:
       SpCost: 60

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36653,33 +36653,23 @@ Body:
     Hit: Multi_Hit
     HitCount: -3
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
-    GiveAp: 2
+    SplashArea: 3
+    GiveAp: 4
     CastCancel: true
     Duration1: 5000
-    Cooldown: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 45
-        - Level: 2
           Amount: 50
-        - Level: 3
+        - Level: 2
           Amount: 55
-        - Level: 4
+        - Level: 3
           Amount: 60
-        - Level: 5
+        - Level: 4
           Amount: 65
+        - Level: 5
+          Amount: 70
     Status: Second_Brand
   - Id: 5251
     Name: IQ_THIRD_PUNISH

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36765,22 +36765,32 @@ Body:
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500
-    Duration1:
+    Duration1: 300000
+    Cooldown:
       - Level: 1
-        Time: 30000
+        Time: 180000
       - Level: 2
-        Time: 60000
-      - Level: 3
-        Time: 90000
-      - Level: 4
-        Time: 120000
-      - Level: 5
         Time: 150000
-    Cooldown: 150000
+      - Level: 3
+        Time: 120000
+      - Level: 4
+        Time: 90000
+      - Level: 5
+        Time: 60000
     FixedCastTime: 1000
     Requires:
       SpCost: 60
-      ApCost: 100
+      ApCost:
+        - Level: 1
+          Amount: 120
+        - Level: 2
+          Amount: 105
+        - Level: 3
+          Amount: 90
+        - Level: 4
+          Amount: 75
+        - Level: 5
+          Amount: 60
       Status:
         Second_Judge: true
     Status: Third_Exor_Flame

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36423,14 +36423,13 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    SplashArea: 4
+    SplashArea: 5
     CastCancel: true
-    AfterCastActDelay: 500
-    Duration1: 300000
-    Cooldown: 60000
+    Duration1: 150000
+    Cooldown: 5000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 12
     Status: Massive_F_Blaster
   - Id: 5244
     Name: IQ_EXPOSION_BLASTER

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36623,33 +36623,23 @@ Body:
     Hit: Multi_Hit
     HitCount: -2
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
-    GiveAp: 1
+    SplashArea: 3
+    GiveAp: 4
     CastCancel: true
     Duration1: 5000
-    Cooldown: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 36
+          Amount: 41
         - Level: 2
-          Amount: 42
+          Amount: 47
         - Level: 3
-          Amount: 48
+          Amount: 53
         - Level: 4
-          Amount: 54
+          Amount: 59
         - Level: 5
-          Amount: 60
+          Amount: 65
     Status: Second_Brand
   - Id: 5250
     Name: IQ_SECOND_JUDGEMENT

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36583,33 +36583,23 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
-    GiveAp: 3
+    SplashArea: 3
+    GiveAp: 4
     CastCancel: true
     Duration1: 5000
-    Cooldown: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 46
+          Amount: 51
         - Level: 2
-          Amount: 52
+          Amount: 57
         - Level: 3
-          Amount: 58
+          Amount: 63
         - Level: 4
-          Amount: 64
+          Amount: 69
         - Level: 5
-          Amount: 70
+          Amount: 75
     Status: Second_Brand
   - Id: 5249
     Name: IQ_SECOND_FAITH

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36447,15 +36447,15 @@ Body:
     Element: Weapon
     SplashArea:
       - Level: 1
-        Area: 2
+        Area: 3
       - Level: 2
-        Area: 2
+        Area: 3
       - Level: 3
-        Area: 3
-      - Level: 4
-        Area: 3
-      - Level: 5
         Area: 4
+      - Level: 4
+        Area: 4
+      - Level: 5
+        Area: 5
     GiveAp: 4
     CastCancel: true
     AfterCastActDelay:
@@ -36469,19 +36469,19 @@ Body:
         Time: 200
       - Level: 5
         Time: 0
-    Cooldown: 4000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 70
         - Level: 2
-          Amount: 90
+          Amount: 75
         - Level: 3
-          Amount: 100
+          Amount: 80
         - Level: 4
-          Amount: 110
+          Amount: 85
         - Level: 5
-          Amount: 120
+          Amount: 90
   - Id: 5245
     Name: IQ_FIRST_BRAND
     Description: First Brand

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36672,22 +36672,12 @@ Body:
       Critical: true
     Range: 3
     Hit: Multi_Hit
-    HitCount: 2
+    HitCount: 3
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
     Duration1: 600000
-    Cooldown: 2000
+    Cooldown: 1000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36739,19 +36739,9 @@ Body:
     Hit: Multi_Hit
     HitCount: 5
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
-    Cooldown: 2000
+    Cooldown: 1000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36334,17 +36334,16 @@ Body:
     Element: Weapon
     SplashArea:
       - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
         Area: 3
+      - Level: 2
+        Area: 3
+      - Level: 3
+        Area: 4
+      - Level: 4
+        Area: 4
+      - Level: 5
+        Area: 5
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 3000
@@ -36356,19 +36355,19 @@ Body:
         Time: 6000
       - Level: 5
         Time: 7000
-    Cooldown: 3000
+    Cooldown: 2000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 30
+          Amount: 45
         - Level: 2
-          Amount: 40
+          Amount: 55
         - Level: 3
-          Amount: 50
+          Amount: 65
         - Level: 4
-          Amount: 60
+          Amount: 75
         - Level: 5
-          Amount: 70
+          Amount: 85
       ItemCost:
         - Item: Holy_Water
           Amount: 1
@@ -36702,19 +36701,9 @@ Body:
     Hit: Multi_Hit
     HitCount: 1
     Element: Weapon
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 2
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 3
+    SplashArea: 3
     CastCancel: true
-    Cooldown: 2000
+    Cooldown: 1000
     Requires:
       SpCost:
         - Level: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5441,7 +5441,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_PUNISH:
-			skillratio += -100 + 650 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 350 + 1500 * skill_lv + 10 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_FLAME_BOMB:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5410,9 +5410,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_MASSIVE_F_BLASTER:
-			skillratio += -100 + 800 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 2150 * skill_lv + 15 * sstatus->pow;
 			if (tstatus->race == RC_BRUTE || tstatus->race == RC_DEMON)
-				skillratio += 300 * skill_lv;
+				skillratio += 150 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_EXPOSION_BLASTER:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5437,7 +5437,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_JUDGEMENT:
-			skillratio += -100 + 500 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 150 + 2600 * skill_lv + 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_PUNISH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5433,7 +5433,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_FAITH:
-			skillratio += -100 + 500 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 100 + 2300 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_JUDGEMENT:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5406,7 +5406,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio *= 2;
 			break;
 		case IQ_OLEUM_SANCTUM:
-			skillratio += -100 + 400 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 500 + 2000 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_MASSIVE_F_BLASTER:
@@ -5445,7 +5445,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_FLAME_BOMB:
-			skillratio += -100 + 650 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 650 * skill_lv + 10 * sstatus->pow;
 			skillratio += sstatus->max_hp * 20 / 100;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5429,7 +5429,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_FLAME:
-			skillratio += -100 + 550 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + 2900 * skill_lv + 9 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_FAITH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5416,10 +5416,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_EXPOSION_BLASTER:
-			skillratio += -100 + 650 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 2800 * skill_lv + 15 * sstatus->pow;
 
 			if( tsc != nullptr && tsc->getSCE( SC_HOLY_OIL ) ){
-				skillratio += 200 * skill_lv;
+				skillratio += 400 * skill_lv;
 			}
 
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5450,7 +5450,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_CONSECRATION:
-			skillratio += -100 + 650 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 700 * skill_lv + 10 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IG_GRAND_JUDGEMENT:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5425,7 +5425,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_FIRST_BRAND:
-			skillratio += -100 + 450 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1200 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_SECOND_FLAME:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Inquisitor
------------------------------------

1. First Brand
	- Reduces cooldown from 0.5 seconds to 0.3 seconds.
	- Increases SP consumption from 50 to 62 based on level 5.
	- Unifies brand duration to 5 second regardless of skill level.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases cast range from 2 cells to 3 cells.
	- Increases damage from 2250%Atk to 6000%Atk based on level 5.
	- Increases factor weight of POW in skill formula from 3 to 5.

2. Second Faith
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Increases SP consumption from 60 to 65 based on level 5.
	- Increases AP recovery rate from 1 to 4.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases damage from 2500%Atk to 11600%Atk based on level 5.
	- Increases factor weight of POW in skill formula from 4 to 5.

3. Second Judgement
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Increases SP consumption from 65 to 70 based on level 5.
	- Increases AP recovery rate from 2 to 4.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases damage from 2625%Atk to 13150%Atk based on level 5.
	- Increases factor weight of POW in skill formula from 4 to 7.

4. Second Flame
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Increases SP consumption from 70 to 75 based on level 5.
	- Increases AP recovery rate from 3 to 4.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases damage from 2750%Atk to 14700%Atk based on level 5.
	- Increases factor weight of POW in skill formula from 4 to 9.

5. Third Punish
	- Reduces cooldown from 2 seconds to 1 second.
	- Increases number of hit from 2 hits to 3 hits.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases damage from 3250%Atk to 7850%Atk per hit based on level 5.
	- Increases factor weight of POW in skill formula from 5 to 10.

6. Third Consecration
	- Reduces cooldown from 2 seconds to 1 second.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases damage from 3250%Atk to 3500%Atk per hit based on level 5.
	- Increases factor weight of POW in skill formula from 5 to 10.

7. Third Flame Bomb
	- Reduces cooldown from 2 seconds to 1 second.
	- Unifies area of effect to 7 x 7 cells regardless of skill level.
	- Increases factor weight of POW in skill formula from 5 to 10.

8. Oleum Sanctum
	- Reduces cooldown from 3 seconds to 2 seconds.
	- Removes 0.5 seconds delay after skill.
	- Increases SP consumption from 70 to 85 based on level 5.
	- Increases damage from 2000%Atk to 10500%Atk based on level 5.
	- Increases area of effect from 7 x 7 cells to 11 x 11 cells based on level 5.
	- Increases factor weight of POW in skill formula from 3 to 5.

9. Explosion Blaster
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Reduces SP consumption from 120 to 90 based on level 5.
	- Increases damage from 3250%/4250%(Oleum Sanctum)Atk to 14000%/16000%(Oleum Sanctum)Atk per hit based on level 5.
	- Increases area of effect from 9 x 9 cells to 11 x 11 cells based on level 5.
	- Increases factor weight of POW in skill formula from 3/5 to 15/15.

10. First Faith Power
	- Reworks cooldown from 30-150 seconds to 180-60 seconds (level 1-5).
	- Unifies duration to 300 seconds regardless of skill level.

11. Judge
	- Reworks cooldown from 30-150 seconds to 180-60 seconds (level 1-5).
	- Unifies duration to 300 seconds regardless of skill level.
	- Changes AP consumption from 50 regardless of skill level to scaling with skill level, from 80 on level 1 down to 40 on level 5.

12. Third Exorcism Flame
	- Reworks cooldown from 30-150 seconds to 180-60 seconds (level 1-5).
	- Unifies duration to 300 seconds regardless of skill level.
	- Changes AP consumption from 100 regardless of skill level to scaling with skill level, from 120 on level 1 down to 60 on level 5.

13. Massive Flame Blaster
	- Reduces cooldown from 60 seconds to 5 seconds.
	- Removes 1 second delay after skill.
	- Reduces AP consumption from 150 to 12.
	- Increases damage from 8000%/11000%(demon and brute race)Atk to 21500%/23000%(demon and brute race)Atk based on level 10.
	- Increases area of effect from 9 x 9 cells to 11 x 11 cells.
	- Increases factor weight of POW in skill formula from 10/10(demon and brute race) to 15/15(demon and brute race).
	- Reduces duration of Massive Flame Blaster buff from 300 seconds to 150 seconds. 

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
