### PR TITLE
Update/rebalance abyss chaser 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38965,7 +38965,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: 1
-    GiveAp: 4
+    GiveAp: 5
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39030,25 +39030,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 35
+          Amount: 37
         - Level: 2
-          Amount: 45
+          Amount: 39
         - Level: 3
-          Amount: 55
+          Amount: 41
         - Level: 4
-          Amount: 65
+          Amount: 43
         - Level: 5
-          Amount: 75
+          Amount: 45
         - Level: 6
-          Amount: 85
+          Amount: 47
         - Level: 7
-          Amount: 95
+          Amount: 49
         - Level: 8
-          Amount: 105
+          Amount: 51
         - Level: 9
-          Amount: 115
+          Amount: 53
         - Level: 10
-          Amount: 125
+          Amount: 55
       Weapon:
         Bow: true
       Ammo:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38681,15 +38681,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 48
         - Level: 2
-          Amount: 45
+          Amount: 52
         - Level: 3
-          Amount: 50
+          Amount: 56
         - Level: 4
-          Amount: 55
-        - Level: 5
           Amount: 60
+        - Level: 5
+          Amount: 64
       Weapon:
         Dagger: true
         1hSword: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38891,26 +38891,26 @@ Body:
     Element: Weapon
     SplashArea:
       - Level: 1
-        Area: 1
+        Area: 2
       - Level: 2
-        Area: 1
+        Area: 2
       - Level: 3
-        Area: 1
+        Area: 2
       - Level: 4
-        Area: 1
+        Area: 2
       - Level: 5
-        Area: 1
+        Area: 2
       - Level: 6
-        Area: 2
+        Area: 3
       - Level: 7
-        Area: 2
+        Area: 3
       - Level: 8
-        Area: 2
+        Area: 3
       - Level: 9
-        Area: 2
+        Area: 3
       - Level: 10
-        Area: 2
-    GiveAp: 2
+        Area: 3
+    GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
     Cooldown:
@@ -38937,25 +38937,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 28
+          Amount: 35
         - Level: 2
-          Amount: 31
+          Amount: 38
         - Level: 3
-          Amount: 34
+          Amount: 41
         - Level: 4
-          Amount: 37
+          Amount: 44
         - Level: 5
-          Amount: 40
+          Amount: 47
         - Level: 6
-          Amount: 43
+          Amount: 50
         - Level: 7
-          Amount: 46
+          Amount: 53
         - Level: 8
-          Amount: 49
+          Amount: 56
         - Level: 9
-          Amount: 52
+          Amount: 59
         - Level: 10
-          Amount: 55
+          Amount: 62
   - Id: 5321
     Name: ABC_ABYSS_SQUARE
     Description: Abyss Square

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38864,11 +38864,11 @@ Body:
     CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 100
-    Cooldown: 60000
+    Cooldown: 3000
     FixedCastTime: 1000
     Requires:
-      SpCost: 150
-      ApCost: 150
+      SpCost: 125
+      ApCost: 15
     Unit:
       Id: Dummyskill
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41243,8 +41243,8 @@ Body:
     DamageFlags:
       Splash: true
     Range: 1
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: 2
     SplashArea: 4
     Requires:
       SpCost: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38756,21 +38756,20 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
-    Cooldown: 1500
+    Cooldown: 1000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 35
         - Level: 2
-          Amount: 50
+          Amount: 45
         - Level: 3
-          Amount: 60
+          Amount: 55
         - Level: 4
-          Amount: 70
+          Amount: 65
         - Level: 5
-          Amount: 80
+          Amount: 75
       Weapon:
         Bow: true
       Ammo:
@@ -41228,10 +41227,12 @@ Body:
     TargetType: Attack
     DamageFlags:
       IgnoreFlee: true
+      Splash: true
     Range: 9
     Hit: Multi_Hit
     HitCount: -2
     Element: Weapon
+    SplashArea: 3
     Requires:
       SpCost: 1
   - Id: 5383

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8002,7 +8002,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_FROM_THE_ABYSS_ATK:
-						skillratio += 50 + 70 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case EM_ELEMENTAL_BUSTER_FIRE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7939,7 +7939,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_SQUARE:
-						skillratio += -100 + ( 200 + 20 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + ( 570 + 20 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case TR_METALIC_FURY:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5562,7 +5562,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:
-			skillratio += -100 + 350 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 400 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKRUSH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5558,7 +5558,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:
-			skillratio += -100 + 360 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 350 + 550 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5550,11 +5550,11 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_CHAIN_REACTION_SHOT:
-			skillratio += -100 + 600 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 850 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_CHAIN_REACTION_SHOT_ATK:
-			skillratio += -100 + 950 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 600 + 2350 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7933,9 +7933,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_STRIKE:
-						skillratio += -100 + 600 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 2200 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_DEMON || tstatus->race == RC_ANGEL)
-							skillratio += 550 * skill_lv;
+							skillratio += 150 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_SQUARE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5542,7 +5542,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_ABYSS_DAGGER:
-			skillratio += -100 + 350 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_UNLUCKY_RUSH:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2176,9 +2176,6 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 	case ABC_UNLUCKY_RUSH:
 		sc_start(src, bl, SC_HANDICAPSTATE_MISFORTUNE, 30 + 10 * skill_lv, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
-	case ABC_CHAIN_REACTION_SHOT:
-		skill_castend_damage_id(src, bl, ABC_CHAIN_REACTION_SHOT_ATK, skill_lv, tick, SD_LEVEL);
-		break;
 	case TR_ROSEBLOSSOM:// Rose blossom seed can only bloom if the target is hit.
 		sc_start4(src, bl, SC_ROSEBLOSSOM, 100, skill_lv, TR_ROSEBLOSSOM_ATK, src->id, 0, skill_get_time(skill_id, skill_lv));
 	case WM_METALICSOUND:
@@ -5803,13 +5800,16 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				case CD_PETITIO:
 				case CD_FRAMEN:
 				case ABC_DEFT_STAB:
-				case ABC_CHAIN_REACTION_SHOT:
 				case EM_EL_FLAMEROCK:
 				case EM_EL_AGE_OF_ICE:
 				case EM_EL_STORM_WIND:
 				case EM_EL_AVALANCHE:
 				case EM_EL_DEADLY_POISON:
 					clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
+					break;
+				case ABC_CHAIN_REACTION_SHOT:
+					clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
+					map_foreachinrange(skill_area_sub, bl, skill_get_splash(ABC_CHAIN_REACTION_SHOT_ATK, skill_lv), BL_CHAR|BL_SKILL, src, ABC_CHAIN_REACTION_SHOT_ATK, skill_lv, tick + (200 + status_get_amotion(src)), flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);
 					break;
 				case IQ_THIRD_PUNISH:
 					clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 


Abyss Chaser
----------------------

1. Abyss Dagger
	- Increases SP consumption from 60 to 64 based on level 5.
	- Increases damage from 1750%Atk to 2600%Atk per hit based on level 5.

2. Deft Stab
	- Increases SP consumption from 55 to 62 based on level 10.
	- Increases AP recovery rate from 2 to 3.
	- Increases damage from 3600%Atk to 5850%Atk based on level 10.
	- Increases area of effect from 5 x 5 cells to 7 x 7 cells based on level 10.

3. From the Abyss
	- Increases number of hit from 1 hit to 2 hits.
	- Increases damage from 500%Matk to 2600%Matk per hit based on level 5.

4. Abyss Square
	- Increases AP recovery rate from 4 to 5.
	- Increases damage from 2000%Matk to 3850%Matk per hit based on level 5 (Magic Sword Mastery level 10).

5. Chain Reaction Shot
	- Reduces cooldown from 1.5 seconds to 1 second.
	- Removes 0.5 seconds delay after skill.
	- Reduces SP consumption from 80 to 75 based on level 5.
	- Increases area of effect of secondary damage from 3 x 3 cells to 7 x 7 cells.
	- Increases area of effect of primary damage from 7 x 7 cells to 9 x 9 cells based on level 5.
	- Increases damage from 3000%(primary)/4750%(secondary)Atk to 4250%(primary)/12350%(secondary)Atk based on level 5.
	- Increases factor weight of CON in skill formula from 5 to 15.

6. Frenzy Shot
	- Reduces SP consumption from 125 to 55 based on level 10.
	- Increases damage from 3500%Atk to 4000%Atk per hit based on level 10.

7. Omega Abyss Strike
	- Reduces cooldown from 60 seconds to 3 seconds.
	- Reduces SP consumption from 150 to 125.
	- Reduces AP consumption from 150 to 15.
	- Increases damage from 6000%/11500%(angel and demon race)Matk to 22000%/23500%(angel and demon race)Matk based on level 10. 

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

Note
------------------------------
Part of Chain Reaction Shot are taken from https://github.com/rathena/rathena/pull/7024, credit to @datawulf 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
