### PR TITLE
Rebalance elemental master 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40961,15 +40961,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
-        - Level: 2
-          Amount: 88
-        - Level: 3
           Amount: 92
+        - Level: 2
+          Amount: 97
+        - Level: 3
+          Amount: 102
         - Level: 4
-          Amount: 96
+          Amount: 107
         - Level: 5
-          Amount: 100
+          Amount: 112
     Unit:
       Id: Venom_Swamp
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40879,20 +40879,20 @@ Body:
     AfterCastActDelay: 500
     Duration1: 100
     Duration2: 10000
-    Cooldown: 2000
+    Cooldown: 1000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 80
         - Level: 2
-          Amount: 88
+          Amount: 84
         - Level: 3
-          Amount: 92
+          Amount: 88
         - Level: 4
-          Amount: 96
+          Amount: 92
         - Level: 5
-          Amount: 100
+          Amount: 96
     Unit:
       Id: Dummyskill
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41000,15 +41000,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 70
+          Amount: 97
         - Level: 2
-          Amount: 80
+          Amount: 101
         - Level: 3
-          Amount: 90
+          Amount: 105
         - Level: 4
-          Amount: 100
+          Amount: 109
         - Level: 5
-          Amount: 110
+          Amount: 113
     Unit:
       Id: Conflagration
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40922,15 +40922,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 65
+          Amount: 94
         - Level: 2
-          Amount: 70
+          Amount: 98
         - Level: 3
-          Amount: 80
+          Amount: 102
         - Level: 4
-          Amount: 85
+          Amount: 106
         - Level: 5
-          Amount: 95
+          Amount: 110
     Unit:
       Id: Lightning_Land
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41176,11 +41176,11 @@ Body:
     CastCancel: true
     CastTime: 8000
     AfterCastActDelay: 500
-    Cooldown: 60000
-    FixedCastTime: 2000
+    Cooldown: 5000
+    FixedCastTime: 1500
     Requires:
-      SpCost: 150
-      ApCost: 150
+      SpCost: 140
+      ApCost: 30
   - Id: 5381
     Name: EM_ELEMENTAL_VEIL
     Description: Elemental Veil

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41034,20 +41034,20 @@ Body:
     AfterCastActDelay: 500
     Duration1: 100
     Duration2: 10000
-    Cooldown: 2000
+    Cooldown: 1000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 80
         - Level: 2
-          Amount: 88
+          Amount: 84
         - Level: 3
-          Amount: 92
+          Amount: 88
         - Level: 4
-          Amount: 96
+          Amount: 92
         - Level: 5
-          Amount: 100
+          Amount: 96
     Unit:
       Id: Dummyskill
       Range: 4

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7966,7 +7966,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_LIGHTNING_LAND:
-						skillratio += -100 + 400 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_PROCELLA ) ){
 							skillratio += 400 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7960,7 +7960,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_DILUVIO ) ){
-							skillratio += 5000 + 250 * skill_lv  + 10 * sstatus->spl;
+							skillratio += 5000 + 250 * skill_lv  + 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);
@@ -7996,7 +7996,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_TERREMOTUS ) ){
-							skillratio += 5000 + 250 * skill_lv + 10 * sstatus->spl;
+							skillratio += 5000 + 250 * skill_lv + 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8010,9 +8010,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case EM_ELEMENTAL_BUSTER_WIND:
 					case EM_ELEMENTAL_BUSTER_GROUND:
 					case EM_ELEMENTAL_BUSTER_POISON:
-						skillratio += -100 + 480 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 500 + 2200 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_FORMLESS || tstatus->race == RC_DRAGON)
-							skillratio += 620 * skill_lv;
+							skillratio += 150 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case EM_EL_FLAMEROCK:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7957,10 +7957,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case EM_DIAMOND_STORM:
-						skillratio += -100 + 1250 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_DILUVIO ) ){
-							skillratio += 3500 + 500 * skill_lv;
+							skillratio += 5000 + 250 * skill_lv  + 10 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7984,7 +7984,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_CONFLAGRATION:
-						skillratio += -100 + 400 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_ARDOR ) ){
 							skillratio += 400 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7993,10 +7993,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_TERRA_DRIVE:
-						skillratio += -100 + 1250 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_TERREMOTUS ) ){
-							skillratio += 3500 + 500 * skill_lv;
+							skillratio += 5000 + 250 * skill_lv + 10 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7975,7 +7975,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_VENOM_SWAMP:
-						skillratio += -100 + 400 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
 
 						if( sc && sc->getSCE( SC_SUMMON_ELEMENTAL_SERPENS ) ){
 							skillratio += 400 * skill_lv;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Elemental Master
-----------------------------------------------------

1. Conflagration
	- Increases SP consumption from 110 to 113 based on level 5.
	- Increases damage from 2000%/4000%(spirit)Matk to 3750%/5750%(spirit)Matk per hit based on level 5.

2. Diamond Storm
	- Reduces cooldown from 2 seconds to 1 second.
	- Reduces SP consumption from 100 to 96 based on level 5.
	- Increases damage from 6250%/12250%(spirit)Matk to 8150%/14400%(spirit)Matk based on level 5.
	- Increases factor weight of SPL in skill formula from 5/7(spirit) to 5/10(spirit).

3. Lightning Land
	- Increases SP consumption from 95 to 110 based on level 5.
	- Increases damage from 2000%/4000%(spirit)Matk to 3750%/5750%(spirit)Matk per hit based on level 5.

4. Terra Drive
	- Reduces cooldown from 2 seconds to 1 second.
	- Reduces SP consumption from 100 to 96 based on level 5.
	- Increases damage from 6250%/12250%(spirit)Matk to 8150%/14400%(spirit)Matk based on level 5.
	- Increases factor weight of SPL in skill formula from 5/7(spirit) to 5/10(spirit).

5. Venom Swamp
	- Increases SP consumption from 100 to 112 based on level 5.
	- Increases damage from 2000%/4000%(spirit)Matk to 3750%/5750%(spirit)Matk per hit based on level 5.

6. Elemental Buster
	- Reduces fixed casting time from 2 seconds to 1.5 seconds.
	- Reduces cooldown from 60 seconds to 5 seconds.
	- Reduces delay after skill from 1.5 seconds to 0.5 seconds.
	- Reduces SP consumption from 150 to 140.
	- Reduces AP consumption from 150 to 30.
	- Increases damage from 4800%/11000%(formless and dragon race)Matk to 22500%/24000%(formless and dragon race)Matk based on level 10. 

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
