### PR TITLE
Rebalance archmage 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36221,24 +36221,24 @@ Body:
         Area: 5
       - Level: 5
         Area: 6
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 450
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 45
+          Amount: 84
         - Level: 2
-          Amount: 55
+          Amount: 87
         - Level: 3
-          Amount: 65
+          Amount: 90
         - Level: 4
-          Amount: 75
+          Amount: 93
         - Level: 5
-          Amount: 85
+          Amount: 96
   - Id: 5238
     Name: IQ_POWERFUL_FAITH
     Description: Powerful Faith

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35448,29 +35448,29 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Ground
-    GiveAp: 4
+    GiveAp: 5
     Range: 9
     Hit: Single
     HitCount: 1
     Element: Dark
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration1: 4000
     Cooldown: 4000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 78
         - Level: 2
-          Amount: 90
+          Amount: 86
         - Level: 3
-          Amount: 100
+          Amount: 94
         - Level: 4
-          Amount: 110
+          Amount: 102
         - Level: 5
-          Amount: 120
+          Amount: 110
     Unit:
       Id: Mystery_Illusion
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35910,22 +35910,22 @@ Body:
     Element: Fire
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 250
     Duration1: 5000
     Cooldown: 5000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 30
-        - Level: 2
-          Amount: 40
-        - Level: 3
-          Amount: 50
-        - Level: 4
-          Amount: 60
-        - Level: 5
           Amount: 70
+        - Level: 2
+          Amount: 76
+        - Level: 3
+          Amount: 82
+        - Level: 4
+          Amount: 88
+        - Level: 5
+          Amount: 94
     Unit:
       Id: Floral_Flare_Road
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35817,22 +35817,22 @@ Body:
         Area: 7
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration2: 900000
-    Cooldown: 6000
+    Cooldown: 2000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
-        - Level: 2
-          Amount: 90
-        - Level: 3
           Amount: 100
+        - Level: 2
+          Amount: 108
+        - Level: 3
+          Amount: 116
         - Level: 4
-          Amount: 110
+          Amount: 124
         - Level: 5
-          Amount: 120
+          Amount: 132
     Status: Climax_CryImp
   - Id: 5226
     Name: AG_CRYSTAL_IMPACT_ATK

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35512,7 +35512,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 1200
@@ -35530,15 +35530,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
-        - Level: 2
-          Amount: 90
-        - Level: 3
-          Amount: 100
-        - Level: 4
           Amount: 110
+        - Level: 2
+          Amount: 114
+        - Level: 3
+          Amount: 118
+        - Level: 4
+          Amount: 122
         - Level: 5
-          Amount: 120
+          Amount: 126
     Unit:
       Id: Violent_Quake
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35346,15 +35346,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 70
         - Level: 2
-          Amount: 90
+          Amount: 75
         - Level: 3
-          Amount: 100
+          Amount: 80
         - Level: 4
-          Amount: 110
+          Amount: 85
         - Level: 5
-          Amount: 120
+          Amount: 90
     Status: Deadly_Defeasance
   - Id: 5215
     Name: AG_DESTRUCTIVE_HURRICANE

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35619,15 +35619,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
-        - Level: 2
           Amount: 90
+        - Level: 2
+          Amount: 95
         - Level: 3
           Amount: 100
         - Level: 4
-          Amount: 110
+          Amount: 105
         - Level: 5
-          Amount: 120
+          Amount: 110
   - Id: 5221
     Name: AG_STRANTUM_TREMOR
     Description: Strantum Tremor
@@ -35979,12 +35979,12 @@ Body:
     CastCancel: true
     CastTime: 8000
     AfterCastActDelay: 500
-    Duration1: 15000
-    Cooldown: 60000
+    Duration1: 6000
+    Cooldown: 6000
     FixedCastTime: 2000
     Requires:
-      SpCost: 150
-      ApCost: 150
+      SpCost: 130
+      ApCost: 25
     Unit:
       Id: Astral_Strike
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35408,22 +35408,22 @@ Body:
     Element: Water
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 250
     Duration1: 4000
     Cooldown: 5000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 84
         - Level: 2
-          Amount: 50
+          Amount: 88
         - Level: 3
-          Amount: 60
+          Amount: 92
         - Level: 4
-          Amount: 70
+          Amount: 96
         - Level: 5
-          Amount: 80
+          Amount: 100
     Unit:
       Id: Rain_Of_Crystal
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35697,7 +35697,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration1:
       - Level: 1
         Time: 1200
@@ -35715,15 +35715,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 94
         - Level: 2
-          Amount: 90
+          Amount: 102
         - Level: 3
-          Amount: 100
-        - Level: 4
           Amount: 110
+        - Level: 4
+          Amount: 118
         - Level: 5
-          Amount: 120
+          Amount: 126
     Unit:
       Id: All_Bloom
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35640,22 +35640,22 @@ Body:
     Element: Earth
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 250
     Duration1: 4000
     Cooldown: 5000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 35
+          Amount: 74
         - Level: 2
-          Amount: 45
+          Amount: 79
         - Level: 3
-          Amount: 55
+          Amount: 84
         - Level: 4
-          Amount: 65
+          Amount: 89
         - Level: 5
-          Amount: 75
+          Amount: 94
     Unit:
       Id: Strantum_Tremor
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35859,22 +35859,22 @@ Body:
     Element: Wind
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 250
     Duration1: 3000
     Cooldown: 5000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 45
+          Amount: 78
         - Level: 2
-          Amount: 55
+          Amount: 82
         - Level: 3
-          Amount: 65
+          Amount: 86
         - Level: 4
-          Amount: 75
+          Amount: 90
         - Level: 5
-          Amount: 85
+          Amount: 94
     Unit:
       Id: Tornado_Storm
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36106,7 +36106,7 @@ Body:
     Element: Wind
     SplashArea: 1
     ActiveInstance: 14
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
@@ -36125,15 +36125,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 60
+          Amount: 78
         - Level: 2
-          Amount: 70
+          Amount: 82
         - Level: 3
-          Amount: 80
+          Amount: 86
         - Level: 4
           Amount: 90
         - Level: 5
-          Amount: 100
+          Amount: 94
   - Id: 5235
     Name: AG_CRIMSON_ARROW
     Description: Crimson Arrow

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36146,7 +36146,7 @@ Body:
     Element: Fire
     SplashArea: 1
     ActiveInstance: 14
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
@@ -36165,15 +36165,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 65
+          Amount: 86
         - Level: 2
-          Amount: 75
+          Amount: 88
         - Level: 3
-          Amount: 85
+          Amount: 90
         - Level: 4
-          Amount: 95
+          Amount: 92
         - Level: 5
-          Amount: 105
+          Amount: 94
   - Id: 5236
     Name: AG_CRIMSON_ARROW_ATK
     Description: Crimson Arrow Attack

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36066,7 +36066,7 @@ Body:
         Area: 3
       - Level: 5
         Area: 3
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
@@ -36085,15 +36085,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 65
+          Amount: 68
         - Level: 2
-          Amount: 70
+          Amount: 74
         - Level: 3
-          Amount: 75
-        - Level: 4
           Amount: 80
+        - Level: 4
+          Amount: 86
         - Level: 5
-          Amount: 85
+          Amount: 92
   - Id: 5234
     Name: AG_STORM_CANNON
     Description: Storm Cannon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35380,22 +35380,22 @@ Body:
         Area: 5
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration2: 900000
-    Cooldown: 6000
+    Cooldown: 2000
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 108
         - Level: 2
-          Amount: 90
+          Amount: 114
         - Level: 3
-          Amount: 100
-        - Level: 4
-          Amount: 110
-        - Level: 5
           Amount: 120
+        - Level: 4
+          Amount: 126
+        - Level: 5
+          Amount: 132
     Status: Climax_Des_Hu
   - Id: 5216
     Name: AG_RAIN_OF_CRYSTAL

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7762,14 +7762,14 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE:
-						skillratio += -100 + 1600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 250 + 2800 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX))
 						{
 							if (sc->getSCE(SC_CLIMAX)->val1 == 3)
-								skillratio *= 2;
+								skillratio *= 3;
 							else if (sc->getSCE(SC_CLIMAX)->val1 == 5)
-								skillratio += skillratio * 70 / 100;
+								skillratio += skillratio * 50 / 100;
 						}
 						break;
 					case AG_RAIN_OF_CRYSTAL:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7852,10 +7852,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ROCK_DOWN:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
-							skillratio += 250 * skill_lv;
+							skillratio += 300 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7878,10 +7878,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 250 + 900 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
-							skillratio += 250 * skill_lv;
+							skillratio += 150 + 350 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7791,7 +7791,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case AG_SOUL_VC_STRIKE:
-						skillratio += -100 + 180 * skill_lv + 3 * sstatus->spl;
+						skillratio += -100 + 250 * skill_lv + 3 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STRANTUM_TREMOR:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7773,7 +7773,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case AG_RAIN_OF_CRYSTAL:
-						skillratio += -100 + 150 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 180 + 760 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_MYSTERY_ILLUSION:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7758,7 +7758,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += 200 * skill_lv;
 						break;
 					case AG_DEADLY_PROJECTION:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 2800 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7835,13 +7835,13 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ASTRAL_STRIKE:
-						skillratio += -100 + 500 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 1800 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DRAGON)
-							skillratio += 600 * skill_lv;
+							skillratio += 340 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ASTRAL_STRIKE_ATK:
-						skillratio += -100 + 200 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 650 * skill_lv + 10 * sstatus->spl;
 						// Not confirmed, but if the main hit deal additional damage
 						// on certain races then the repeated damage should too right?
 						// Guessing a formula here for now. [Rytech]

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7833,7 +7833,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FLORAL_FLARE_ROAD:
-						skillratio += -100 + 200 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 50 + 740 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ASTRAL_STRIKE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7811,7 +7811,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRYSTAL_IMPACT:
-						skillratio += -100 + 800 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 250 + 1300 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX)) {
 							if (sc->getSCE(SC_CLIMAX)->val1 == 3)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7795,7 +7795,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STRANTUM_TREMOR:
-						skillratio += -100 + 250 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 100 + 730 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ALL_BLOOM_ATK:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7829,7 +7829,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 							skillratio += skillratio * 150 / 100;
 						break;
 					case AG_TORNADO_STORM:
-						skillratio += -100 + 90 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 100 + 760 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FLORAL_FLARE_ROAD:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7777,7 +7777,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_MYSTERY_ILLUSION:
-						skillratio += -100 + 500 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_VIOLENT_QUAKE_ATK:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7861,10 +7861,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STORM_CANNON:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
-							skillratio += 250 * skill_lv;
+							skillratio += 300 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7799,17 +7799,15 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ALL_BLOOM_ATK:
-						skillratio += -100 + 100 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX)) {
-							if (sc->getSCE(SC_CLIMAX)->val1 == 2)
-								skillratio /= 2;
-							else if (sc->getSCE(SC_CLIMAX)->val1 == 3)
-								skillratio *= 2;
+							if (sc->getSCE(SC_CLIMAX)->val1 == 3)
+								skillratio *= 4;
 						}
 						break;
 					case AG_ALL_BLOOM_ATK2:// Is this affected by BaseLV and SPL too??? [Rytech]
-						skillratio += -100 + 7000 + 5 * sstatus->spl;
+						skillratio += -100 + 85000 + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRYSTAL_IMPACT:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7781,13 +7781,13 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_VIOLENT_QUAKE_ATK:
-						skillratio += -100 + 120 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX)) {
 							if (sc->getSCE(SC_CLIMAX)->val1 == 1)
 								skillratio /= 2;
 							else if (sc->getSCE(SC_CLIMAX)->val1 == 3)
-								skillratio *= 2;
+								skillratio *= 3;
 						}
 						break;
 					case AG_SOUL_VC_STRIKE:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Arch Mage
-------------------------------

1. Floral Flare Road
	- Reduces delay after skill from 0.5 seconds to 0.25 seconds.
	- Increases SP consumption from 70 to 94 based on level 5.
	- Increases damage from 1000%Matk to 3750%Matk per hit based on level 5.

2. Rain of Crystal
	- Reduces delay after skill from 0.5 seconds to 0.25 seconds.
	- Increases SP consumption from 80 to 100 based on level 5.
	- Increases damage from 750%Matk to 3980%Matk per hit based on level 5.

3. Tornado Storm
	- Reduces delay after skill from 0.5 seconds to 0.25 seconds.
	- Increases SP consumption from 75 to 94 based on level 5.
	- Increases damage from 450%Matk to 3900%Matk per hit based on level 5.

4. Stratum Tremor
	- Reduces delay after skill from 0.5 seconds to 0.25 seconds.
	- Increases SP consumption from 75 to 94 based on level 5.
	- Increases damage from 1250%Matk to 3750%Matk per hit based on level 5.

5. Crimson Arrow
	- Reduces SP consumption from 105 to 94 based on level 5.
	- Increases AP recovery rate from 1 to 2.

6. Frozen Slash
	- Increases cooldown from 0.3 seconds to 0.45 seconds.
	- Increases SP consumption from 85 to 96 based on level 5.
	- Increases AP recovery rate from 1 to 2.
	- Increases damage from 3000%/4250%(Climax)Matk to 4750%/6650%(Climax)Matk based on level 5.

7. Storm Cannon
	- Reduces SP consumption from 100 to 94 based on level 5.
	- Increases AP recovery rate from 1 to 2.
	- Increases damage from 3000%/4250%(Climax)Matk to 4750%/6250%(Climax)Matk based on level 5.

8. Rock Down
	- Increases SP consumption from 85 to 92 based on level 5.
	- Increases AP recovery rate from 1 to 2.
	- Increases damage from 3000%/4250%(Climax)Matk to 4750%/6250%(Climax)Matk based on level 5.

9. All Bloom
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Increases SP consumption from 100 to 126 based on level 5.
	- Increases damage from 500%Matk to 6200%Matk per hit based on level 5.
	- No longer reduce skill damage on Climax level 2.
	- Increases bonus damage on Climax level 3 from 100% to 300%.
	- Increases damage of additional explosion on Climax level 5.

10. Crystal Impact
	- Reduces cooldown from 6 seconds to 2 seconds.
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Increases SP consumption from 120 to 132 based on level 5.
	- Increases damage from 4000%/4000%(secondary)Matk to 6750%/6750%(secondary)Matk based on level 5.

11. Destructive Hurricane
	- Reduces cooldown from 6 seconds to 2 seconds.
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Increases SP consumption from 120 to 132 based on level 5.
	- Increases damage from 8000%Matk to 14250%Matk based on level 5.
	- Increases damage of additional hit on Climax level 1.
	- Increases bonus damage on Climax level 3 from 100% to 200%.
	- Reduces bonus damage on Climax level 5 from 70% to 50%.

12. Violent Quake
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Increases SP consumption from 100 to 126 based on level 5.
	- Increases damage from 600%Matk to 6200%Matk per hit based on level 5. 
	- Increases bonus damage on Climax level 3 from 100% to 200%.

13. Deadly Projection
	- Reduces SP consumption from 120 to 90 based on level 5.
	- Increases damage from 3600%Matk to 14000%Matk based on level 5. 

14. Mystery Illusion
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Reduces SP consumption from 120 to 110 based on level 5.
	- Increases AP recovery rate from 4 to 5.
	- Increases damage from 2500%Matk to 4750%Matk per hit based on level 5.

15. Soul Vulcan Strike
	- Reduces SP consumption from 120 to 110 based on level 5.
	- Increases damage from 900%Matk to 1250%Matk per hit based on level 5.

16. Astral Strike
	- Reduces cooldown from 60 second to 6 seconds.
	- Reduces SP consumption from 150 to 130.
	- Reduces AP consumption from 150 to 25.
	- Increases initial damage from 5000%/11000%(undead and dragon race)Matk to 18000%/21400%(undead and dragon race)Matk based on level 10.
	- Increases over time damage from 2000%Matk to 6500%Matk per hit based on level 10.
	- Reduces skill duration from 15 seconds to 6 seconds. 


Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
