### PR TITLE
Rebalance dragon knight 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35272,7 +35272,7 @@ Body:
     Cooldown: 60000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 125
     Status: Vigor
   - Id: 5213
     Name: DK_STORMSLASH

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34999,10 +34999,10 @@ Body:
     HitCount: 5
     Element: Weapon
     SplashArea: 6
-    GiveAp: 3
+    GiveAp: 2
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown: 3000
+    Cooldown: 500
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35188,7 +35188,7 @@ Body:
     HitCount: 1
     Element: Weapon
     CastCancel: true
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 500
     Duration1: 300000
     Cooldown: 60000
     Requires:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34861,8 +34861,6 @@ Body:
     TargetType: Self
     DamageFlags:
       NoDamage: true
-    Hit: Single
-    HitCount: 1
     GiveAp:
       - Level: 1
         Amount: 6
@@ -34931,8 +34929,8 @@ Body:
       Splash: true
       Critical: true
     Range: 1
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: 2
     Element: Weapon
     Requires:
       SpCost: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35296,10 +35296,10 @@ Body:
       - Level: 5
         Count: 5
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 2
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown: 350
+    Cooldown: 300
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35218,7 +35218,7 @@ Body:
         Area: 3
       - Level: 5
         Area: 3
-    GiveAp: 2
+    GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
     Cooldown: 350
@@ -35226,15 +35226,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 34
+          Amount: 36
         - Level: 2
-          Amount: 38
+          Amount: 44
         - Level: 3
-          Amount: 42
+          Amount: 52
         - Level: 4
-          Amount: 46
+          Amount: 60
         - Level: 5
-          Amount: 50
+          Amount: 68
       Weapon:
         2hSword: true
         2hSpear: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34978,9 +34978,8 @@ Body:
     Element: Weapon
     SplashArea: 2
     CastCancel: true
-    AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 2000
+    Cooldown: 500
     FixedCastTime: 500
     Requires:
       SpCost: 40

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35087,8 +35087,8 @@ Body:
     DamageFlags:
       Splash: true
     Range: 2
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: 2
     Element: Weapon
     SplashArea:
       - Level: 1
@@ -35112,30 +35112,30 @@ Body:
       - Level: 10
         Area: 4
     CastCancel: true
-    AfterCastActDelay: 500
-    Cooldown: 300
+    AfterCastActDelay: 250
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 34
+          Amount: 36
         - Level: 2
-          Amount: 38
+          Amount: 40
         - Level: 3
-          Amount: 42
+          Amount: 44
         - Level: 4
-          Amount: 46
+          Amount: 48
         - Level: 5
-          Amount: 50
+          Amount: 52
         - Level: 6
-          Amount: 54
+          Amount: 56
         - Level: 7
-          Amount: 58
+          Amount: 60
         - Level: 8
-          Amount: 62
+          Amount: 64
         - Level: 9
-          Amount: 66
+          Amount: 68
         - Level: 10
-          Amount: 70
+          Amount: 72
       Weapon:
         2hSword: true
         2hSpear: true
@@ -35148,8 +35148,8 @@ Body:
     DamageFlags:
       Splash: true
     Range: 2
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: 2
     Element: Weapon
     SplashArea:
       - Level: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5363,7 +5363,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * sc->getSCE(SC_LIGHTOFSTAR)->val2 / 100;
 			break;
 		case DK_SERVANTWEAPON_ATK:
-			skillratio += -100 + 200 + 50 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 500 + 400 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_SERVANT_W_PHANTOM:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5367,7 +5367,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_SERVANT_W_PHANTOM:
-			skillratio += 100 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + 300 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_SERVANT_W_DEMOL:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5371,7 +5371,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_SERVANT_W_DEMOL:
-			skillratio += 600 + 120 * skill_lv;
+			skillratio += -100 + 500 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_HACKANDSLASHER:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5381,9 +5381,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_DRAGONIC_AURA:
-			skillratio += 950 * skill_lv + 10 * sstatus->pow;
+			skillratio += 3650 * skill_lv + 10 * sstatus->pow;
 			if (tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_ANGEL)
-				skillratio += 450 * skill_lv;
+				skillratio += 150 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_MADNESS_CRUSHER:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5376,8 +5376,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case DK_HACKANDSLASHER:
 		case DK_HACKANDSLASHER_ATK:
-			skillratio += -100 + 500 + 250 * skill_lv;
-			skillratio += 5 * sstatus->pow;
+			skillratio += -100 + 300 + 700 * skill_lv;
+			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_DRAGONIC_AURA:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5387,7 +5387,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_MADNESS_CRUSHER:
-			skillratio += -100 + 600 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 400 + 800 * skill_lv + 7 * sstatus->pow;
 			if( sd != nullptr ){
 				int16 index = sd->equip_index[EQI_HAND_R];
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9234,7 +9234,10 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 			wd.damage += wd.damage * 150 / 100; // 2.5 times damage
 
 		if( sc->getSCE( SC_VIGOR ) && ( wd.flag&BF_SHORT ) && !is_infinite_defense( target, wd.flag ) && !vellum_damage ){
-			int mod = 200;
+			int mod = 100 + sc->getSCE(SC_VIGOR)->val1 * 15;
+
+			if (tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_ANGEL)
+				mod += sc->getSCE(SC_VIGOR)->val1 * 10;
 
 			wd.damage += wd.damage * mod / 100;
 		}

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5400,9 +5400,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio *= 2;
 			break;
 		case DK_STORMSLASH:
-			skillratio += -100 + 120 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 100 + 170 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
-			if (sc && sc->getSCE(SC_GIANTGROWTH))
+			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 30)
 				skillratio *= 2;
 			break;
 		case IQ_OLEUM_SANCTUM:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5199,7 +5199,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case RL_BANISHING_BUSTER:
 	case RL_SLUGSHOT:
 	case RL_AM_BLAST:
-	case DK_SERVANTWEAPON_ATK:
 	case BO_ACIDIFIED_ZONE_WATER_ATK:
 	case BO_ACIDIFIED_ZONE_GROUND_ATK:
 	case BO_ACIDIFIED_ZONE_WIND_ATK:
@@ -5611,6 +5610,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case SP_CURSEEXPLOSION:
 	case SP_SHA:
 	case SP_SWHOO:
+	case DK_SERVANTWEAPON_ATK:
 	case DK_SERVANT_W_PHANTOM:
 	case DK_SERVANT_W_DEMOL:
 	case DK_MADNESS_CRUSHER:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -4723,18 +4723,11 @@ int status_calc_pc_sub(map_session_data* sd, uint8 opt)
 		}
 		if (sc->getSCE(SC_STRIKING))
 			sd->bonus.perfect_hit += 20 + 10 * pc_checkskill(sd, SO_STRIKING);
-		if (sc->getSCE(SC_VIGOR)) {
-			// Skill desc says increases physical damage. Supposed to affect damage from base ATK right???
-			// Because this is only boosting the ATK from the equipped weapon and not from base ATK. [Rytech]
-			sd->right_weapon.addrace[RC_DEMIHUMAN] += 50;
-			sd->left_weapon.addrace[RC_ANGEL] += 50;
-		}
 
 		if( sc->getSCE( SC_RUSH_QUAKE2 ) ){
 			sd->bonus.short_attack_atk_rate += 5 * sc->getSCE( SC_RUSH_QUAKE2 )->val1;
 			sd->bonus.long_attack_atk_rate += 5 * sc->getSCE( SC_RUSH_QUAKE2 )->val1;
 		}
-
 		if (sc->getSCE(SC_DEADLY_DEFEASANCE))
 			sd->special_state.no_magic_damage = 0;
 		if (sc->getSCE(SC_CLIMAX_DES_HU))
@@ -12533,7 +12526,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			val2 = min(10*val1, 99); // % damage received reduced from 10 * skill lvl up to 99%
 			break;
 		case SC_VIGOR: {
-				uint8 hp_loss[10] = { 15, 14, 12, 11, 9, 8, 6, 5, 3, 2 };
+				uint8 hp_loss[10] = { 100, 90, 80, 70, 60, 50, 40, 30, 20, 10 };
 
 				val2 = hp_loss[val1- 1];
 			}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12525,11 +12525,9 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_RELIEVE_ON:
 			val2 = min(10*val1, 99); // % damage received reduced from 10 * skill lvl up to 99%
 			break;
-		case SC_VIGOR: {
-				uint8 hp_loss[10] = { 100, 90, 80, 70, 60, 50, 40, 30, 20, 10 };
-
-				val2 = hp_loss[val1- 1];
-			}
+		case SC_VIGOR:
+			val2 = 100 - 10 * (val1 - 1); // HP consumption with each attack is reduced by skill lvl
+			val2 = min(val2, 0);
 			break;
 		case SC_POWERFUL_FAITH:
 			val2 = 5 + 5 * val1;// ATK Increase

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12527,7 +12527,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			break;
 		case SC_VIGOR:
 			val2 = 100 - 10 * (val1 - 1); // HP consumption with each attack is reduced by skill lvl
-			val2 = min(val2, 0);
+			val2 = max(val2, 0);
 			break;
 		case SC_POWERFUL_FAITH:
 			val2 = 5 + 5 * val1;// ATK Increase


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Dragon Knight
------------------------------

1. Hack and Slasher
	- Changes damage logic from 2 split hits to 2 cumulative hits.
	- Increases damage from 3000%Atk to 7300%Atk per hit based on level 10.
	- Increases cooldown from 0.3 seconds to 0.7 seconds.
	- Reduces delay after skill from 0.5 seconds to 0.25 seconds.
	- Increases SP consumption from 70 to 72 based on level 10.
	- Increases factor weight of POW in skill formula from 5 to 7.

2. Servant Weapon
	- Increases number of hit from 1 hit to 2 hits.
	- Increases damage from 450%Atk to 2500%Atk per hit based on level 5.

3. Servant Weapon - Phantom
	- Removes 0.8 seconds variable casting time.
	- Reduces cooldown from 2 seconds to 0.5 seconds.
	- Removes 0.8 seconds delay after skill.
	- Increases damage from 600%Atk to 1700%Atk per hit based on level 5.

4. Servant Weapon - Demolition
	- Reduces cooldown from 3 seconds to 0.5 seconds.
	- Reduces AP recovery rate from 3 to 2.
	- Increases damage from 750%Atk to 2500%Atk per hit based on level 5.

5. Storm Slash
	- Reduces cooldown from 0.35 seconds to 0.3 seconds.
	- Increases AP recovery rate from 1 to 2.
	- Increases damage from 600%Atk to 950%Atk per hit based on level 5.
	- Increases the chance to double skill damage while under Giant Growth buff from 15% to 30%.

6. Madness Crusher
	- Removes 0.4 seconds variable casting time.
	- Increases fixed casting time from 0.4 seconds to 0.5 seconds.
	- Increases damage from 1350%Atk to 5150%Atk based on level 5 (using level 5 weapon and weapon weight is 150).
	- Increases SP consumption from 50 to 68 based on level 5.
	- Increases AP recovery rate from 2 to 3.
	- Increases factor weight of POW in skill formula from 5 to 7.

7. Vigor
	- Changes bonus flat damage from +200% regardless of skill level to scaling with skill level up to +250% based on level 10.
	- Increases bonus damage against demihuman and angel race monsters from 50% to 100%.
	- Reduces AP consumption from 150 to 125.
	- Increases HP consumption on each attack from 2 to 10 based on level 10.

8. Dragonic Aura
	- Reduces delay after skill from 1 second to 0.5 seconds.
	- Increases damage from 9500%/14000%(demihuman and angel race)Atk to 36500%/38000%(demihuman and angel race)Atk based on level 10. 

Checked against https://github.com/rathena/rathena/pull/7024

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
