### PR TITLE
Rebalance imperial guard 20220608

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37010,12 +37010,12 @@ Body:
     Hit: Multi_Hit
     HitCount: -7
     Element: Weapon
-    GiveAp: 2
+    GiveAp: 3
     CastCancel: true
     CastTime: 500
     AfterCastActDelay: 500
     Duration1: 10000
-    Cooldown: 1000
+    Cooldown: 700
     FixedCastTime: 500
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37086,35 +37086,35 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
-    GiveAp: 5
+    GiveAp: 7
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 150
     Duration1: 4500
-    Cooldown: 5000
+    Cooldown: 4500
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 50
+          Amount: 67
         - Level: 2
-          Amount: 54
-        - Level: 3
-          Amount: 58
-        - Level: 4
-          Amount: 62
-        - Level: 5
-          Amount: 66
-        - Level: 6
           Amount: 70
-        - Level: 7
-          Amount: 74
-        - Level: 8
-          Amount: 78
-        - Level: 9
+        - Level: 3
+          Amount: 73
+        - Level: 4
+          Amount: 76
+        - Level: 5
+          Amount: 79
+        - Level: 6
           Amount: 82
+        - Level: 7
+          Amount: 85
+        - Level: 8
+          Amount: 88
+        - Level: 9
+          Amount: 91
         - Level: 10
-          Amount: 86
+          Amount: 94
     Unit:
       Id: Cross_Rain
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36993,12 +36993,31 @@ Body:
     Element: Holy
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 1000
-    Cooldown: 60000
+    Cooldown: 5000
     FixedCastTime: 1000
     Requires:
-      SpCost: 150
-      ApCost: 150
+      SpCost:
+        - Level: 1
+          Amount: 60
+        - Level: 2
+          Amount: 65
+        - Level: 3
+          Amount: 70
+        - Level: 4
+          Amount: 75
+        - Level: 5
+          Amount: 80
+        - Level: 6
+          Amount: 85
+        - Level: 7
+          Amount: 90
+        - Level: 8
+          Amount: 95
+        - Level: 9
+          Amount: 100
+        - Level: 10
+          Amount: 105
+      ApCost: 10
   - Id: 5265
     Name: IG_SHIELD_SHOOTING
     Description: Shield Shooting

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36949,33 +36949,32 @@ Body:
     SplashArea: 3
     CastCancel: true
     CastTime: 1000
-    AfterCastActDelay: 500
-    Duration1: 300000
-    Cooldown: 60000
+    Duration1: 150000
+    Cooldown: 5000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 41
+          Amount: 51
         - Level: 2
-          Amount: 44
+          Amount: 54
         - Level: 3
-          Amount: 47
+          Amount: 57
         - Level: 4
-          Amount: 50
+          Amount: 60
         - Level: 5
-          Amount: 53
+          Amount: 63
         - Level: 6
-          Amount: 56
+          Amount: 66
         - Level: 7
-          Amount: 59
+          Amount: 69
         - Level: 8
-          Amount: 62
+          Amount: 72
         - Level: 9
-          Amount: 65
+          Amount: 75
         - Level: 10
-          Amount: 68
-      ApCost: 150
+          Amount: 78
+      ApCost: 15
       Weapon:
         1hSpear: true
         2hSpear: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37046,34 +37046,34 @@ Body:
     HitCount: 3
     Element: Weapon
     SplashArea: 3
-    GiveAp: 2
+    GiveAp: 3
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
-    Cooldown: 1000
+    Cooldown: 700
     FixedCastTime: 500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 41
+          Amount: 38
         - Level: 2
-          Amount: 44
+          Amount: 41
         - Level: 3
-          Amount: 47
+          Amount: 44
         - Level: 4
-          Amount: 50
+          Amount: 47
         - Level: 5
-          Amount: 53
+          Amount: 50
         - Level: 6
-          Amount: 56
+          Amount: 53
         - Level: 7
-          Amount: 59
+          Amount: 56
         - Level: 8
-          Amount: 62
+          Amount: 59
         - Level: 9
-          Amount: 65
+          Amount: 62
         - Level: 10
-          Amount: 68
+          Amount: 65
       Status:
         Attack_Stance: true
   - Id: 5267

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5473,7 +5473,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IG_OVERSLASH:
-			skillratio += -100 + 60 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + (120 + pc_checkskill(sd, IG_SPEAR_SWORD_M) * 10) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)
 				skillratio += skillratio * i / 100;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7887,9 +7887,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case IG_JUDGEMENT_CROSS:
-						skillratio += -100 + 750 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 1950 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_PLANT || tstatus->race == RC_INSECT)
-							skillratio += 350 * skill_lv;
+							skillratio += 150 * skill_lv;
 						RE_LVL_DMOD(100);
 						if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)
 							skillratio += skillratio * i / 100;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5454,9 +5454,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IG_GRAND_JUDGEMENT:
-			skillratio += -100 + 750 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 250 + 1500 * skill_lv + 10 * sstatus->pow;
 			if (tstatus->race == RC_PLANT || tstatus->race == RC_INSECT)
-				skillratio += 350 * skill_lv;
+				skillratio += 100 + 150 * skill_lv;
 			RE_LVL_DMOD(100);
 			if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)
 				skillratio += skillratio * i / 100;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5462,13 +5462,15 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * i / 100;
 			break;
 		case IG_SHIELD_SHOOTING:
-			skillratio += -100 + 600 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1400 + 2100 * skill_lv + 5 * sstatus->pow;
 			skillratio += skill_lv * 15 * pc_checkskill( sd, IG_SHIELD_MASTERY );
 			if (sd) { // Damage affected by the shield's weight and refine. Need official formula. [Rytech]
 				short index = sd->equip_index[EQI_HAND_L];
 
-				if (index >= 0 && sd->inventory_data[index] && sd->inventory_data[index]->type == IT_ARMOR)
-					skillratio += sd->inventory_data[index]->weight / 20 * sd->inventory.u.items_inventory[index].refine;
+				if (index >= 0 && sd->inventory_data[index] && sd->inventory_data[index]->type == IT_ARMOR) {
+					skillratio += (sd->inventory_data[index]->weight * 7 / 6) / 10;
+					skillratio += sd->inventory.u.items_inventory[index].refine * 4;
+				}
 			}
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7896,9 +7896,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case IG_CROSS_RAIN:
 						if( sc && sc->getSCE( SC_HOLY_S ) ){
-							skillratio += -100 + ( 250 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 450 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}else{
-							skillratio += -100 + ( 150 + 5 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 320 + 5 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}
 						skillratio += 5 * sstatus->spl;
 						RE_LVL_DMOD(100);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/7857

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Imperial Guard
--------------------------------

1. Overslash
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Reduces SP consumption from 68 to 65 based on level 5.
	- Increases AP recovery rate from 2 to 3.
	- Increases damage from 1800%Atk to 2200%Atk per hit based on level 10 (Spear & Sword Mastery level 10).
	- Increases factor weight of POW in skill formula from 2 to 5.

2. Shield Shooting
	- Reduces cooldown from 1 second to 0.7 seconds.
	- Increases AP recovery rate from 2 to 3.
	- Increases damage from 6440%Atk to 14440%Atk based on level 5 (Shield Mastery level 10, shield refine rate is 10 and shield weight is 150).
	- Increases factor weight of POW in skill formula from 3 to 5.

3. Cross Rain
	- Reduces cooldown from 5 seconds to 4.5 seconds.
	- Reduces delay after skill from 0.5 seconds to 0.15 seconds.
	- Increases SP consumption from 68 to 78 based on level 10.
	- Increases AP recovery rate from 5 to 7.
	- Increases damage from 2000%/3500%(Holy Shield)Matk to 3700%/5500%(Holy Shield)Matk per hit based on level 10 (Spear & Sword Mastery level 10).

4. Grand Judgement
	- Reduces cooldown from 60 seconds to 5 seconds.
	- Removes 0.5 seconds delay after skill.
	- Increases SP consumption from 68 to 78 based on level 10.
	- Reduces AP consumption from 150 to 15.
	- Reduces duration of Grand Judgement buff from 300 seconds to 150 seconds.
	- Increases damage from 7500%/11000%(plant and insect race)Atk to 15250%/16850%(plant and insect race)Atk based on level 10.

5. Judgement Cross
	- Reduces cooldown from 60 seconds to 5 seconds.
	- Removes 0.5 seconds delay after skill.
	- Reduces SP consumption from 150 to 105 based on level 10.
	- Reduces AP consumption from 150 to 10.
	- Increases damage from 7500%/11000%(plant and insect race)Matk to 19500%/21000%(plant and insect race)Matk based on level 10.
	
Checked against https://github.com/rathena/rathena/pull/7024

Source: [Divine pride](https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/13/)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
