### PR TITLE
Dont exit the process during a crash

### DIFF
--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -475,10 +475,6 @@ void Core::signal_crash(){
 		this->handle_crash();
 	}
 
-#ifdef WIN32
-	// Now stop the process
-	exit( EXIT_FAILURE );
-#endif
 }
 
 void Core::signal_shutdown(){

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -475,8 +475,10 @@ void Core::signal_crash(){
 		this->handle_crash();
 	}
 
+#ifdef WIN32
 	// Now stop the process
 	exit( EXIT_FAILURE );
+#endif
 }
 
 void Core::signal_shutdown(){


### PR DESCRIPTION
…em will make core dump correctly in Linux.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fix the problem that server won't make core dump when crashing in Linux environments.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
