### PR TITLE
Set marine sphere walk_count before escape

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9757,8 +9757,10 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case NPC_RANDOMMOVE:
 		if (md) {
 			md->next_walktime = tick - 1;
-			if (md->special_state.ai == AI_SPHERE)
+			if (md->special_state.ai == AI_SPHERE){
+				md->ud.walk_count = WALK_SKILL_INTERVAL - 1;
 				unit_escape(&md->bl, bl, 7, 2);
+			}
 			else
 				mob_randomwalk(md,tick);
 		}


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#7904
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This sets the walk_count of the marine sphere when fleeing to make it start the cast of NPC_EXPLOSION at the begining of its movement.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
