### PR TITLE
Add channel_join script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11132,6 +11132,13 @@ Returns 1 on success.
 
 ---------------------------------------
 
+*channel_join "<chname>"{, <char_id>};
+
+Join an existing public or private channel.
+Returns 1 on success.
+
+---------------------------------------
+
 *channel_setopt "<chname>",<option>,<value>;
 
 Set option for the channel. Use 1 in <value> to set it, or 0 to unset.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11132,10 +11132,14 @@ Returns 1 on success.
 
 ---------------------------------------
 
-*channel_join "<chname>"{, <char_id>};
+*channel_join "<channel_name>"{, <char_id>};
 
-Join an existing public or private channel.
-Returns 1 on success.
+Join an existing channel.
+The command returns 0 upon success, and these values upon failure:
+ -1 : Invalid channel or player
+ -2 : Player already in channel
+ -3 : Player banned
+ -4 : Reached max limit
 
 ---------------------------------------
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -24657,27 +24657,32 @@ BUILDIN_FUNC(channel_create) {
 }
 
 // ===================================
-// *channel_join "<chname>"{, <char_id>};
-// Join an existing public or private channel.
-// Returns 1 on success.
+// *channel_join "<channel_name>"{, <char_id>};
+// Join an existing channel.
+// The command returns 0 upon success, andthese values upon failure :
+// -1 : Invalid channel or player
+// -2 : Player already in channel
+// -3 : Player banned
+// -4 : Reached max limit
 // ===================================
 BUILDIN_FUNC(channel_join) {
 	map_session_data *sd;
 
-	if (!script_charid2sd(3, sd))
-		return SCRIPT_CMD_FAILURE;
-
-	struct Channel *ch = NULL;
-	const char *chname = script_getstr(st, 2);
-
-	if (!(ch = channel_name2channel((char *)chname, NULL, 0))) {
-		ShowError("buildin_channel_join: Channel name '%s' is invalid.\n", chname);
-		script_pushint(st, 0);
+	if (!script_charid2sd(3, sd)) {
+		script_pushint(st, false);
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	channel_join(ch, sd);
-	script_pushint(st, 1);
+	struct Channel *channel = nullptr;
+	const char *chname = script_getstr(st, 2);
+
+	if (!(channel = channel_name2channel((char *)chname, nullptr, 0))) {
+		ShowError("buildin_channel_join: Channel name '%s' is invalid.\n", chname);
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	script_pushint(st, channel_join(channel, sd));
 
 	return SCRIPT_CMD_SUCCESS;
 }

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -24656,6 +24656,32 @@ BUILDIN_FUNC(channel_create) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+// ===================================
+// *channel_join "<chname>"{, <char_id>};
+// Join an existing public or private channel.
+// Returns 1 on success.
+// ===================================
+BUILDIN_FUNC(channel_join) {
+	map_session_data *sd;
+
+	if (!script_charid2sd(3, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	struct Channel *ch = NULL;
+	const char *chname = script_getstr(st, 2);
+
+	if (!(ch = channel_name2channel((char *)chname, NULL, 0))) {
+		ShowError("buildin_channel_join: Channel name '%s' is invalid.\n", chname);
+		script_pushint(st, 0);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	channel_join(ch, sd);
+	script_pushint(st, 1);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 /**
  * Set channel option
  * channel_setopt "<chname>",<option>,<value>;
@@ -27600,6 +27626,7 @@ struct script_function buildin_func[] = {
 
 	// Channel System
 	BUILDIN_DEF(channel_create,"ss?????"),
+	BUILDIN_DEF(channel_join, "s?"),
 	BUILDIN_DEF(channel_setopt,"sii"),
 	BUILDIN_DEF(channel_getopt,"si"),
 	BUILDIN_DEF(channel_setcolor,"si"),

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -24659,17 +24659,17 @@ BUILDIN_FUNC(channel_create) {
 // ===================================
 // *channel_join "<channel_name>"{, <char_id>};
 // Join an existing channel.
-// The command returns 0 upon success, andthese values upon failure :
+// The command returns 0 upon success, and these values upon failure:
 // -1 : Invalid channel or player
 // -2 : Player already in channel
 // -3 : Player banned
 // -4 : Reached max limit
 // ===================================
 BUILDIN_FUNC(channel_join) {
-	map_session_data *sd;
+	map_session_data *sd = nullptr;
 
 	if (!script_charid2sd(3, sd)) {
-		script_pushint(st, false);
+		script_pushint(st, -1);
 		return SCRIPT_CMD_FAILURE;
 	}
 
@@ -24678,7 +24678,7 @@ BUILDIN_FUNC(channel_join) {
 
 	if (!(channel = channel_name2channel((char *)chname, nullptr, 0))) {
 		ShowError("buildin_channel_join: Channel name '%s' is invalid.\n", chname);
-		script_pushint(st, false);
+		script_pushint(st, -1);
 		return SCRIPT_CMD_FAILURE;
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
The existing channel system that used by NPC script, doesn't have a method that add players into an existing channel, the only method it have, is the auto join upon login.
This is inconvenient when try to create a new channel, and unable to configure who should auto join the channel by npc script

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
any
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable NPC script to configure player to join a channel.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
