### PR TITLE
Add autoloot script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11362,7 +11362,15 @@ Returns true if the player is dead else false.
 
 *autoloot(<rate>{, <char_id>});
 
-This command set the rate of autoloot.
-Returns autoloot value on success.
+This command sets the rate of autoloot (default: 10000 = 100%).
+Returns true on success and false on failure.
+Note: It will toggle existing autoloot settings if rate value aren't provided.
+
+---------------------------------------
+
+*has_autoloot({<char_id>});
+
+This command checks whether a player configured autoloot.
+Returns current autoloot value on success.
 
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11359,3 +11359,10 @@ Note: Only works with classes that use the ranking system.
 Returns true if the player is dead else false.
 
 ---------------------------------------
+
+*autoloot(<rate>{, <char_id>});
+
+This command set the rate of autoloot.
+Returns autoloot value on success.
+
+---------------------------------------

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26939,6 +26939,25 @@ BUILDIN_FUNC(macro_detector) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+// ===================================
+// *autoloot(<rate>{, <char_id>});
+// This command set the rate of autoloot.
+// Returns autoloot value on success.
+// ===================================
+BUILDIN_FUNC(autoloot) {
+	map_session_data *sd;
+
+	if (!script_charid2sd(3, sd)) {
+		script_pushint(st, 0);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	sd->state.autoloot = cap_value(script_getnum(st, 2), 0, 10000);
+	script_pushint(st, sd->state.autoloot);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include <custom/script.inc>
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -27694,6 +27713,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getfamerank, "?"),
 	BUILDIN_DEF(isdead, "?"),
 	BUILDIN_DEF(macro_detector, "?"),
+	BUILDIN_DEF(autoloot,"i?"),
 
 #include <custom/script_def.inc>
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
NPC script unable to adjust the autoloot settings unless it use something like `atcmd "@autoloot";` which create unnecessary atcommandlog at server side.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
any
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable NPC script to configure the autoloot setting of players without need use the `@autoloot` commands which could create unnecessary atcommandlog if configured.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
