### PR TITLE
Add has_autoloot script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11360,7 +11360,7 @@ Returns true if the player is dead else false.
 
 ---------------------------------------
 
-*is_autoloot({<char_id>});
+*has_autoloot({<char_id>});
 
 This command checks whether a player configured autoloot.
 Returns current autoloot value on success.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11359,3 +11359,11 @@ Note: Only works with classes that use the ranking system.
 Returns true if the player is dead else false.
 
 ---------------------------------------
+
+*is_autoloot({<char_id>});
+
+This command checks whether a player configured autoloot.
+Returns current autoloot value on success.
+
+---------------------------------------
+

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26939,6 +26939,24 @@ BUILDIN_FUNC(macro_detector) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+// ===================================
+// *is_autoloot({<char_id>});
+// This command checks whether a player configured autoloot.
+// Returns current autoloot value on success.
+// ===================================
+BUILDIN_FUNC(is_autoloot) {
+	map_session_data *sd;
+
+	if (!script_charid2sd(2, sd)) {
+		script_pushint(st, 0);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	script_pushint(st, sd->state.autoloot);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include <custom/script.inc>
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -27694,6 +27712,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getfamerank, "?"),
 	BUILDIN_DEF(isdead, "?"),
 	BUILDIN_DEF(macro_detector, "?"),
+	BUILDIN_DEF(is_autoloot,"?"),
 
 #include <custom/script_def.inc>
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -26940,11 +26940,11 @@ BUILDIN_FUNC(macro_detector) {
 }
 
 // ===================================
-// *is_autoloot({<char_id>});
+// *has_autoloot({<char_id>});
 // This command checks whether a player configured autoloot.
 // Returns current autoloot value on success.
 // ===================================
-BUILDIN_FUNC(is_autoloot) {
+BUILDIN_FUNC(has_autoloot) {
 	map_session_data *sd;
 
 	if (!script_charid2sd(2, sd)) {
@@ -27712,7 +27712,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(getfamerank, "?"),
 	BUILDIN_DEF(isdead, "?"),
 	BUILDIN_DEF(macro_detector, "?"),
-	BUILDIN_DEF(is_autoloot,"?"),
+	BUILDIN_DEF(has_autoloot,"?"),
 
 #include <custom/script_def.inc>
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
NPC script unable to retrieve what is the current configured autoloot settings of players.
This is troublesome when players access event hunting/farming maps with pre-configured autoloot.
NPC unable to prevent it.
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
any 
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Enable NPC script to access to current configured autoloot settings of players.
Useful when we need to check if users enabled/disable it before access any event maps.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
