### PR TITLE
fix clone skill behavior

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3667,7 +3667,7 @@ int status_calc_pc_sub(map_session_data* sd, uint8 opt)
 
 	// !FIXME: Most of these stuff should be calculated once, but how do I fix the memset above to do that? [Skotlex]
 	// Give them all modes except these (useful for clones)
-	base_status->mode = static_cast<e_mode>(MD_MASK&~(MD_STATUSIMMUNE|MD_IGNOREMELEE|MD_IGNOREMAGIC|MD_IGNORERANGED|MD_IGNOREMISC|MD_DETECTOR|MD_ANGRY|MD_TARGETWEAK));
+	base_status->mode = static_cast<e_mode>(MD_MASK&~(MD_STATUSIMMUNE|MD_IGNOREMELEE|MD_IGNOREMAGIC|MD_IGNORERANGED|MD_IGNOREMISC|MD_DETECTOR|MD_ANGRY|MD_TARGETWEAK|MD_NOCAST|MD_NORANDOMWALK|MD_RANDOMTARGET));
 
 	base_status->size = (sd->class_&JOBL_BABY) ? SZ_SMALL : (((sd->class_&MAPID_BASEMASK) == MAPID_SUMMONER) ? battle_config.summoner_size : SZ_MEDIUM);
 	if (battle_config.character_size && pc_isriding(sd)) { // [Lupus]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
Clone are not able to use skill and it cast self/support skill to his target enemy which is wrong behavior. i already mentioned this to @aleos89 but it seems he was too busy right now.

* **Server Mode**: 
any

* **Description of Pull Request**: 
I add in base status mode exception the "Nocast", "NoRandomWalk", "RandomTarget" to correct the behavior of clone.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
