### PR TITLE
Corrects duplicate NPC name in Moscovia Inn

### DIFF
--- a/npc/quests/quests_moscovia.txt
+++ b/npc/quests/quests_moscovia.txt
@@ -3391,7 +3391,6 @@ mosk_in,135,191,5	script	Landlord#mos	4_F_RUSWOMAN3,{
 				mes "Please have a rest, young adventurer.";
 			}
 			else {
-				mes "[Landlord]";
 				mes "Please be comfortable.";
 			}
 			break;


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #7979

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Removes a duplicate NPC name title for the Moscovia Inn script.
Thanks to @Daraen1!