### PR TITLE
Set mob's jname to name if not specified

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4447,6 +4447,8 @@ uint64 MobDatabase::parseBodyNode(const ryml::NodeRef& node) {
 
 		name.resize(NAME_LENGTH);
 		mob->jname = name;
+	} else if (!exists) {
+		mob->jname = mob->name;
 	}
 
 	if (this->nodeExists(node, "Level")) {


### PR DESCRIPTION
* **Addressed Issue(s)**: #8001

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: We need to set jname to name if JapaneseName is not set

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
