### PR TITLE
Refactoring of chat struct

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4370,7 +4370,7 @@ ACMD_FUNC(partysharelvl) {
 ACMD_FUNC(mapinfo) {
 	map_session_data* pl_sd;
 	struct s_mapiterator* iter;
-	struct chat_data *cd = NULL;
+	chats::ChatData *cd = nullptr;
 	char direction[12];
 	int i, m_id, chat_num = 0, list = 0, vend_num = 0;
 	unsigned short m_index;
@@ -4411,7 +4411,7 @@ ACMD_FUNC(mapinfo) {
 		if( pl_sd->mapindex == m_index ) {
 			if( pl_sd->state.vending )
 				vend_num++;
-			else if( (cd = (struct chat_data*)map_id2bl(pl_sd->chatID)) != NULL && cd->usersd[0] == pl_sd )
+			else if( (cd = (chats::ChatData*)map_id2bl(pl_sd->chatID)) != NULL && cd->usersd[0] == pl_sd )
 				chat_num++;
 		}
 	}
@@ -4674,7 +4674,7 @@ ACMD_FUNC(mapinfo) {
 		iter = mapit_getallusers();
 		for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) )
 		{
-			if ((cd = (struct chat_data*)map_id2bl(pl_sd->chatID)) != NULL &&
+			if ((cd = (chats::ChatData*)map_id2bl(pl_sd->chatID)) != NULL &&
 			    pl_sd->mapindex == m_index &&
 			    cd->usersd[0] == pl_sd)
 			{

--- a/src/map/chat.cpp
+++ b/src/map/chat.cpp
@@ -21,27 +21,36 @@
 #include "pc.hpp"
 #include "pc_groups.hpp"
 
-int chat_triggerevent(struct chat_data *cd); // forward declaration
+namespace chats{
 
 /// Initializes a chatroom object (common functionality for both pc and npc chatrooms).
-/// Returns a chatroom object on success, or NULL on failure.
-static struct chat_data* chat_createchat(struct block_list* bl, const char* title, const char* pass, int limit, bool pub, int trigger, const char* ev, int zeny, int minLvl, int maxLvl)
-{
-	struct chat_data* cd;
-	nullpo_retr(NULL, bl);
+/// Returns a chatroom object on success, or nullptr on failure.
+ChatData* ChatData::CreateChat(
+		block_list* bl,
+		const char* title,
+		const char* pass,
+		int limit,
+		bool pub,
+		int trigger,
+		const char* ev,
+		int zeny,
+		int min_level,
+		int max_level) {
 
-	cd = (struct chat_data *) aMalloc(sizeof(struct chat_data));
+	nullpo_retr(nullptr, bl);
+
+	ChatData* cd = (ChatData *) aMalloc(sizeof(ChatData));
 
 	safestrncpy(cd->title, title, sizeof(cd->title));
 	safestrncpy(cd->pass, pass, sizeof(cd->pass));
 	cd->pub = pub;
 	cd->users = 0;
-	cd->limit = min(limit, ARRAYLENGTH(cd->usersd));
+	cd->limit = min(limit, cd->usersd.size());
 	cd->trigger = trigger;
 	cd->zeny = zeny;
-	cd->minLvl = minLvl;
-	cd->maxLvl = maxLvl;
-	memset(cd->usersd, 0, sizeof(cd->usersd));
+	cd->min_level = min_level;
+	cd->max_level = max_level;
+	cd->usersd.fill(nullptr);
 	cd->owner = bl;
 	safestrncpy(cd->npc_event, ev, sizeof(cd->npc_event));
 
@@ -50,11 +59,11 @@ static struct chat_data* chat_createchat(struct block_list* bl, const char* titl
 	cd->bl.x    = bl->x;
 	cd->bl.y    = bl->y;
 	cd->bl.type = BL_CHAT;
-	cd->bl.next = cd->bl.prev = NULL;
+	cd->bl.next = cd->bl.prev = nullptr;
 
 	if( cd->bl.id == 0 ) {
 		aFree(cd);
-		cd = NULL;
+		cd = nullptr;
 	}
 
 	map_addiddb(&cd->bl);
@@ -72,33 +81,28 @@ static struct chat_data* chat_createchat(struct block_list* bl, const char* titl
  * @param pass : password for chat room
  * @param limit : amount allowed to enter
  * @param pub : public or private
- * @return 0
  */
-int chat_createpcchat(map_session_data* sd, const char* title, const char* pass, int limit, bool pub)
-{
-	struct chat_data* cd;
+void CreatePcChat(map_session_data* sd, const char* title, const char* pass, int limit, bool pub){
 
-	nullpo_ret(sd);
+	nullpo_retv(sd);
 
 	if( sd->chatID )
-		return 0; //Prevent people abusing the chat system by creating multiple chats, as pointed out by End of Exam. [Skotlex]
+		return; //Prevent people abusing the chat system by creating multiple chats, as pointed out by End of Exam. [Skotlex]
 
 	if( sd->state.vending || sd->state.buyingstore ) // not chat, when you already have a store open
-		return 0;
+		return;
 
 	if( map_getmapflag(sd->bl.m, MF_NOCHAT) ) {
 		clif_displaymessage(sd->fd, msg_txt(sd,281));
-		return 0; //Can't create chatrooms on this map.
+		return; //Can't create chatrooms on this map.
 	}
 
 	if( map_getcell(sd->bl.m,sd->bl.x,sd->bl.y,CELL_CHKNOCHAT) ) {
 		clif_displaymessage (sd->fd, msg_txt(sd,665));
-		return 0;
+		return;
 	}
-
 	pc_stop_walking(sd,1);
-
-	cd = chat_createchat(&sd->bl, title, pass, limit, pub, 0, "", 0, 1, MAX_LEVEL);
+	ChatData* cd = ChatData::CreateChat(&sd->bl, title, pass, limit, pub, 0, "", 0, 1, MAX_LEVEL);
 
 	if( cd ) {
 		cd->users = 1;
@@ -115,7 +119,7 @@ int chat_createpcchat(map_session_data* sd, const char* title, const char* pass,
 	} else
 		clif_createchat(sd,1);
 
-	return 0;
+	return;
 }
 
  /**
@@ -123,43 +127,39 @@ int chat_createpcchat(map_session_data* sd, const char* title, const char* pass,
  * @param sd : player requesting
  * @param chatid : ID of the chat room
  * @param pass : password of chat room
- * @return 0
  */
-int chat_joinchat(map_session_data* sd, int chatid, const char* pass)
-{
-	struct chat_data* cd;
+void JoinChat(map_session_data* sd, int chatid, const char* pass){
+	nullpo_retv(sd);
 
-	nullpo_ret(sd);
+	ChatData* cd = (ChatData*)map_id2bl(chatid);
 
-	cd = (struct chat_data*)map_id2bl(chatid);
-
-	if( cd == NULL || cd->bl.type != BL_CHAT || cd->bl.m != sd->bl.m || sd->state.vending || sd->state.buyingstore || sd->chatID || ((cd->owner->type == BL_NPC) ? cd->users+1 : cd->users) >= cd->limit ) {
+	if( cd == nullptr || cd->bl.type != BL_CHAT || cd->bl.m != sd->bl.m || sd->state.vending || sd->state.buyingstore || sd->chatID || ((cd->owner->type == BL_NPC) ? cd->users+1 : cd->users) >= cd->limit ) {
 		clif_joinchatfail(sd,0);
-		return 0;
+		return;
 	}
 
 	if( !cd->pub && strncmp(pass, cd->pass, sizeof(cd->pass)) != 0 && !pc_has_permission(sd, PC_PERM_JOIN_ALL_CHAT) ) {
 		clif_joinchatfail(sd,1);
-		return 0;
+		return;
 	}
 
-	if( sd->status.base_level < cd->minLvl || sd->status.base_level > cd->maxLvl ) {
-		if(sd->status.base_level < cd->minLvl)
+	if( sd->status.base_level < cd->min_level || sd->status.base_level > cd->max_level ) {
+		if(sd->status.base_level < cd->min_level)
 			clif_joinchatfail(sd,5);
 		else
 			clif_joinchatfail(sd,6);
 
-		return 0;
+		return;
 	}
 
 	if( sd->status.zeny < cd->zeny ) {
 		clif_joinchatfail(sd,4);
-		return 0;
+		return;
 	}
 
 	if( cd->owner->type != BL_NPC && idb_exists(cd->kick_list,sd->status.char_id) ) {
 		clif_joinchatfail(sd,2);//You have been kicked out of the room.
-		return 0;
+		return;
 	}
 
 	pc_stop_walking(sd,1);
@@ -175,104 +175,85 @@ int chat_joinchat(map_session_data* sd, int chatid, const char* pass)
 	if (cd->owner->type == BL_PC)
 		achievement_update_objective(map_id2sd(cd->owner->id), AG_CHATTING_COUNT, 1, cd->users);
 
-	chat_triggerevent(cd); //Event
+	cd->TriggerEvent(); //Event
 
-	return 0;
+	return;
 }
 
 /**
  * Make player (sd) leave a chat room.
  * @param sd : player requesting
  * @param kicked : for clif notification, kicked=1 or regular leave
- * @return 0:success, 1:failed
  */
-int chat_leavechat(map_session_data* sd, bool kicked)
-{
-	struct chat_data* cd;
-	int i;
-	int leavechar;
-
-	nullpo_retr(1, sd);
-
-	cd = (struct chat_data*)map_id2bl(sd->chatID);
-
-	if( cd == NULL ) {
+void LeaveChat(map_session_data* sd, bool kicked){
+	nullpo_retv(sd);
+	ChatData* cd = (ChatData*)map_id2bl(sd->chatID);
+	if( cd == nullptr ) {
 		pc_setchatid(sd, 0);
-		return 1;
+		return;
 	}
 
-	ARR_FIND( 0, cd->users, i, cd->usersd[i] == sd );
-	if ( i == cd->users ) { // Not found in the chatroom?
+	auto i = std::find(cd->usersd.begin(), cd->usersd.end(), sd) - cd->usersd.begin();
+	if (i == cd->users){ // Not found in the chatroom?
 		pc_setchatid(sd, 0);
-		return -1;
+		return;
 	}
 
 	clif_leavechat(cd, sd, kicked);
 	pc_setchatid(sd, 0);
 	cd->users--;
 
-	leavechar = i;
+	int leavechar = i;
 
-	for( i = leavechar; i < cd->users; i++ )
+	for( i = leavechar; i <= cd->users && i < cd->usersd.size() - 1; i++ )
 		cd->usersd[i] = cd->usersd[i+1];
 
-	if( cd->users == 0 && cd->owner->type == BL_PC ) { // Delete empty chatroom
+	if (cd->users == 0 && cd->owner->type == BL_PC) { // Delete empty chatroom
 		clif_clearchat(cd, 0);
 		db_destroy(cd->kick_list);
 		map_deliddb(&cd->bl);
 		map_delblock(&cd->bl);
 		map_freeblock(&cd->bl);
 
-		skill_unit *unit = map_find_skill_unit_oncell(&sd->bl, sd->bl.x, sd->bl.y, AL_WARP, nullptr, 0);
+		skill_unit* unit = map_find_skill_unit_oncell(&sd->bl, sd->bl.x, sd->bl.y, AL_WARP, nullptr, 0);
 
 		if (unit != nullptr && unit->group != nullptr)
 			ext_skill_unit_onplace(unit, &sd->bl, unit->group->tick);
-
-		return 1;
+		return;
 	}
 
-	if( leavechar == 0 && cd->owner->type == BL_PC ) { // Set and announce new owner
-		cd->owner = (struct block_list*) cd->usersd[0];
+	if ( leavechar == 0 && cd->owner->type == BL_PC) { // Set and announce new owner
+		cd->owner = (struct block_list*)cd->usersd[0];
 		clif_changechatowner(cd, cd->usersd[0]);
 		clif_clearchat(cd, 0);
 
 		//Adjust Chat location after owner has been changed.
-		map_delblock( &cd->bl );
+		map_delblock(&cd->bl);
 		cd->bl.x = cd->usersd[0]->bl.x;
 		cd->bl.y = cd->usersd[0]->bl.y;
-
-		if(map_addblock( &cd->bl ))
-			return 1;
-
-		clif_dispchat(cd,0);
-	} else
-		clif_dispchat(cd,0); // refresh chatroom
-
-	return 0;
+		if (map_addblock( &cd->bl ))
+			return;
+	}
+	clif_dispchat(cd, 0); // refresh chatroom
 }
 
 /**
  * Change a chat room's owner.
  * @param sd : player requesting
  * @param nextownername : string of new owner (name should be in chatroom)
- * @return 0:success, 1:failure
  */
-int chat_changechatowner(map_session_data* sd, const char* nextownername)
-{
-	struct chat_data* cd;
-	map_session_data* tmpsd;
-	int i;
+void ChangeChatOwner(const map_session_data* sd, const char* nextownername){
+	nullpo_retv(sd);
 
-	nullpo_retr(1, sd);
+	ChatData* cd = (ChatData*)map_id2bl(sd->chatID);
 
-	cd = (struct chat_data*)map_id2bl(sd->chatID);
+	if( cd == nullptr || (block_list*) sd != cd->owner )
+		return;
 
-	if( cd == NULL || (struct block_list*) sd != cd->owner )
-		return 1;
-
-	ARR_FIND( 1, cd->users, i, strncmp(cd->usersd[i]->status.name, nextownername, NAME_LENGTH) == 0 );
+	auto has_name = [&nextownername](auto* usd){return strncmp(usd->status.name, nextownername, NAME_LENGTH) == 0;};
+	auto i = std::find_if(cd->usersd.begin() + 1, cd->usersd.end(), has_name) - cd->usersd.begin();
 	if( i == cd->users )
-		return -1;  // name not found
+		return;  // name not found
 
 	// erase temporarily
 	clif_clearchat(cd,0);
@@ -282,7 +263,7 @@ int chat_changechatowner(map_session_data* sd, const char* nextownername)
 	clif_changechatowner(cd,cd->usersd[i]);
 
 	// swap the old and new owners' positions
-	tmpsd = cd->usersd[i];
+	map_session_data *tmpsd = cd->usersd[i];
 	cd->usersd[i] = cd->usersd[0];
 	cd->usersd[0] = tmpsd;
 
@@ -292,12 +273,12 @@ int chat_changechatowner(map_session_data* sd, const char* nextownername)
 	cd->bl.y = cd->owner->y;
 
 	if(map_addblock( &cd->bl ))
-		return 1;
+		return;
 
 	// and display again
 	clif_dispchat(cd,0);
 
-	return 0;
+	return;
 }
 
 /**
@@ -307,18 +288,15 @@ int chat_changechatowner(map_session_data* sd, const char* nextownername)
  * @param pass : new password
  * @param limit : new limit
  * @param pub : public or private
- * @return 1:success, 0:failure
  */
-int chat_changechatstatus(map_session_data* sd, const char* title, const char* pass, int limit, bool pub)
+void ChangeChatStatus(const map_session_data* sd, const char* title, const char* pass, int limit, bool pub)
 {
-	struct chat_data* cd;
+	nullpo_retv(sd);
 
-	nullpo_retr(1, sd);
+	ChatData* cd = (ChatData*)map_id2bl(sd->chatID);
 
-	cd = (struct chat_data*)map_id2bl(sd->chatID);
-
-	if( cd == NULL || (struct block_list *)sd != cd->owner )
-		return 1;
+	if( cd == nullptr || (block_list*)sd != cd->owner )
+		return;
 
 	safestrncpy(cd->title, title, CHATROOM_TITLE_SIZE);
 	safestrncpy(cd->pass, pass, CHATROOM_PASS_SIZE);
@@ -328,57 +306,44 @@ int chat_changechatstatus(map_session_data* sd, const char* title, const char* p
 	clif_changechatstatus(cd);
 	clif_dispchat(cd,0);
 
-	return 0;
 }
 
 /**
  * Kicks a user from the chat room.
  * @param cd : chat to be kicked from
- * @param kickusername : player name to be kicked
- * @retur 1:success, 0:failure
+ * @param kick_user_name : player name to be kicked
  */
-int chat_npckickchat(struct chat_data* cd, const char* kickusername)
-{
-	int i;
-	nullpo_ret(cd);
-
-	ARR_FIND( 0, cd->users, i, strncmp(cd->usersd[i]->status.name, kickusername, NAME_LENGTH) == 0 );
-	if( i == cd->users )
-		return -1;
-	chat_leavechat(cd->usersd[i],1);
-	return 0;
+void ChatData::NpcKickChat(const char* kick_user_name){
+	auto has_name = [&](map_session_data *sd){return strncmp(sd->status.name, kick_user_name, NAME_LENGTH) == 0;};
+	if(auto it = std::find_if(usersd.cbegin(),usersd.cbegin() + users, has_name); it != usersd.cbegin() + users)
+		LeaveChat(*it, 1);
 }
 
 /**
  * Kick a member from a chat room.
  * @param sd : player requesting
- * @param kickusername : player name to be kicked
- * @retur 1:success, 0:failure
+ * @param kick_user_name : player name to be kicked
  */
-int chat_kickchat(map_session_data* sd, const char* kickusername)
-{
-	struct chat_data* cd;
-	int i;
+void KickPcFromChat(map_session_data* sd, const char* kickusername){
+	nullpo_retv(sd);
 
-	nullpo_retr(1, sd);
+	ChatData* cd = (ChatData *)map_id2bl(sd->chatID);
 
-	cd = (struct chat_data *)map_id2bl(sd->chatID);
+	if( cd == nullptr || (block_list*)sd != cd->owner)
+		return;
 
-	if( cd == NULL || (struct block_list *)sd != cd->owner )
-		return -1;
-
-	ARR_FIND( 0, cd->users, i, strncmp(cd->usersd[i]->status.name, kickusername, NAME_LENGTH) == 0 );
+	auto has_name = [&kickusername](auto* usd){return strncmp(usd->status.name, kickusername, NAME_LENGTH) == 0;};
+	auto i = std::find_if(cd->usersd.begin(), cd->usersd.end(), has_name) - cd->usersd.begin();
 	if( i == cd->users )
-		return -1;
+		return;
 
 	if (pc_has_permission(cd->usersd[i], PC_PERM_NO_CHAT_KICK))
-		return 0; //gm kick protection [Valaris]
+		return; //gm kick protection [Valaris]
 
 	idb_put(cd->kick_list,cd->usersd[i]->status.char_id,(void*)1);
 
-	chat_leavechat(cd->usersd[i],1);
+	LeaveChat(cd->usersd[i],1);
 
-	return 0;
 }
 
 /**
@@ -390,59 +355,55 @@ int chat_kickchat(map_session_data* sd, const char* kickusername)
  * @param trigger : event trigger
  * @param ev : event name
  * @param zeny : zeny cost
- * @param minLvl : minimum level to enter
- * @param maxLvl : maximum level to enter
- * @return 0
+ * @param min_level : minimum level to enter
+ * @param max_level : maximum level to enter
  */
-int chat_createnpcchat(struct npc_data* nd, const char* title, int limit, bool pub, int trigger, const char* ev, int zeny, int minLvl, int maxLvl)
+void CreateNpcChat(
+		npc_data* nd,
+		const char* title,
+		int limit,
+		bool pub,
+		int trigger,
+		const char* ev,
+		int zeny,
+		int minLvl,
+		int maxLvl)
 {
-	struct chat_data* cd;
-
-	nullpo_ret(nd);
+	nullpo_retv(nd);
 
 	if( nd->chat_id ) {
-		ShowError("chat_createnpcchat: npc '%s' already has a chatroom, cannot create new one!\n", nd->exname);
-		return 0;
+		ShowError("chats::CreateNpcChat: npc '%s' already has a chatroom, cannot create new one!\n", nd->exname);
 	}
 
 	if( zeny > MAX_ZENY || maxLvl > MAX_LEVEL ) {
-		ShowError("chat_createnpcchat: npc '%s' has a required lvl or amount of zeny over the max limit!\n", nd->exname);
-		return 0;
+		ShowError("chats::CreateNpcChat: npc '%s' has a required lvl or amount of zeny over the max limit!\n", nd->exname);
 	}
 
-	cd = chat_createchat(&nd->bl, title, "", limit, pub, trigger, ev, zeny, minLvl, maxLvl);
 
-	if( cd ) {
+	if(ChatData* cd = ChatData::CreateChat(&nd->bl, title, "", limit, pub, trigger, ev, zeny, minLvl, maxLvl); cd != nullptr) {
 		nd->chat_id = cd->bl.id;
 		clif_dispchat(cd,0);
 	}
-
-	return 0;
 }
 
 /**
  * Removes a chat room for a NPC.
  * @param nd : NPC requesting
  */
-int chat_deletenpcchat(struct npc_data* nd)
-{
-	struct chat_data *cd;
+void DeleteNpcChat(npc_data* nd){
+	nullpo_retv(nd);
 
-	nullpo_ret(nd);
+	ChatData *cd = (ChatData*)map_id2bl(nd->chat_id);
 
-	cd = (struct chat_data*)map_id2bl(nd->chat_id);
+	if(cd == nullptr)
+		return;
 
-	if( cd == NULL )
-		return 0;
-
-	chat_npckickall(cd);
+	cd->NpcKickAll();
 	clif_clearchat(cd, 0);
 	map_deliddb(&cd->bl);
 	map_delblock(&cd->bl);
 	map_freeblock(&cd->bl);
 	nd->chat_id = 0;
-
-	return 0;
 }
 
  /**
@@ -450,14 +411,10 @@ int chat_deletenpcchat(struct npc_data* nd)
  * @param cd : chat room to trigger event
  * @return 0
  */
-int chat_triggerevent(struct chat_data *cd)
+void ChatData::TriggerEvent()
 {
-	nullpo_ret(cd);
-
-	if( cd->users >= cd->trigger && cd->npc_event[0] )
-		npc_event_do(cd->npc_event);
-
-	return 0;
+	if( this->users >= this->trigger && this->npc_event[0] )
+		npc_event_do(this->npc_event);
 }
 
  /**
@@ -465,39 +422,27 @@ int chat_triggerevent(struct chat_data *cd)
  * At most, 127 users are needed to trigger the event.
  * @param cd : chat room to trigger event
  */
-int chat_enableevent(struct chat_data* cd)
-{
-	nullpo_ret(cd);
-
-	cd->trigger &= 0x7f;
-	chat_triggerevent(cd);
-
-	return 0;
+void ChatData::EnableEvent(){
+	this->trigger &= 0x7f;
+	this->TriggerEvent();
 }
 
 /**
  * Disables the event of the chat room.
  * @param cd : chat room to trigger event
  */
-int chat_disableevent(struct chat_data* cd)
-{
-	nullpo_ret(cd);
+void ChatData::DisableEvent(){
 
-	cd->trigger |= 0x80;
-
-	return 0;
+	this->trigger |= 0x80;
 }
 
 /**
  * Kicks all the users from the chat room.
  * @param cd : chat room to trigger event
  */
-int chat_npckickall(struct chat_data* cd)
-{
-	nullpo_ret(cd);
+void ChatData::NpcKickAll(){
+	while( this->users > 0 )
+		LeaveChat(this->usersd[this->users-1],0);
+}
 
-	while( cd->users > 0 )
-		chat_leavechat(cd->usersd[cd->users-1],0);
-
-	return 0;
 }

--- a/src/map/chat.hpp
+++ b/src/map/chat.hpp
@@ -5,42 +5,45 @@
 #define CHAT_HPP
 
 #include "map.hpp" // struct block_list, CHATROOM_TITLE_SIZE
+#include <array>
 
-class map_session_data;
-struct chat_data;
+inline constexpr int MAX_CHAT_USERS = 20;
+namespace chats{
 
-#define MAX_CHAT_USERS 20
-
-struct chat_data {
-	struct block_list bl;            // data for this map object
+class ChatData {
+public:
+	block_list bl;            // data for this map object
 	char title[CHATROOM_TITLE_SIZE]; // room title 
 	char pass[CHATROOM_PASS_SIZE];   // password
 	bool pub;                        // private/public flag
-	uint8 users;                     // current user count
-	uint8 limit;                     // join limit
-	uint8 trigger;                   // number of users needed to trigger event
+	uint32 trigger;                   // number of users needed to trigger event
+	uint32 users;                     // current user count
+	uint32 limit;                     // join limit
 	uint32 zeny;						 // required zeny to join
-	uint32 minLvl;					 // minimum base level to join
-	uint32 maxLvl;					 // maximum base level allowed to join
-	map_session_data* usersd[MAX_CHAT_USERS];
-	struct block_list* owner;
+	uint32 min_level;					 // minimum base level to join
+	uint32 max_level;					 // maximum base level allowed to join
+	std::array<map_session_data*,MAX_CHAT_USERS> usersd;
+	block_list* owner;
 	char npc_event[EVENT_NAME_LENGTH];
 	DBMap* kick_list;				//DBMap of users who were kicked from this chat
+
+	void TriggerEvent();
+	void EnableEvent();
+	void DisableEvent();
+	void NpcKickAll();
+	void NpcKickChat(const char* kick_user_name);
+
+	static ChatData* CreateChat(block_list* bl, const char* title, const char* pass, int limit, bool pub, int trigger, const char* ev, int zeny, int min_level, int max_level);
+
 };
+void JoinChat(map_session_data* sd, int chatid, const char* pass);
+void CreatePcChat(map_session_data* sd, const char* title, const char* pass, int limit, bool pub);
+void LeaveChat(map_session_data* sd, bool kicked);
+void ChangeChatOwner(const map_session_data* sd, const char* nextownername);
+void ChangeChatStatus(const map_session_data* sd, const char* title, const char* pass, int limit, bool pub);
+void KickPcFromChat(map_session_data* sd, const char* kickusername);
+void CreateNpcChat(npc_data* nd, const char* title, int limit, bool pub, int trigger, const char* ev, int zeny, int minLvl, int maxLvl);
+void DeleteNpcChat(npc_data* nd);
 
-int chat_createpcchat(map_session_data* sd, const char* title, const char* pass, int limit, bool pub);
-int chat_joinchat(map_session_data* sd, int chatid, const char* pass);
-int chat_leavechat(map_session_data* sd, bool kicked);
-int chat_changechatowner(map_session_data* sd, const char* nextownername);
-int chat_changechatstatus(map_session_data* sd, const char* title, const char* pass, int limit, bool pub);
-int chat_kickchat(map_session_data* sd, const char* kickusername);
-
-int chat_createnpcchat(struct npc_data* nd, const char* title, int limit, bool pub, int trigger, const char* ev, int zeny, int minLvl, int maxLvl);
-int chat_deletenpcchat(struct npc_data* nd);
-int chat_enableevent(struct chat_data* cd);
-int chat_disableevent(struct chat_data* cd);
-int chat_npckickall(struct chat_data* cd);
-
-int chat_npckickchat(struct chat_data* cd, const char* kickusername);
-
+}
 #endif /* CHAT_HPP */

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -540,11 +540,11 @@ int clif_send(const void* buf, int len, struct block_list* bl, enum send_target 
 	case CHAT:
 	case CHAT_WOS:
 		{
-			struct chat_data *cd;
+			chats::ChatData *cd;
 			if (sd) {
-				cd = (struct chat_data*)map_id2bl(sd->chatID);
+				cd = (chats::ChatData*)map_id2bl(sd->chatID);
 			} else if (bl->type == BL_CHAT) {
-				cd = (struct chat_data*)bl;
+				cd = (chats::ChatData*)bl;
 			} else break;
 			if (cd == NULL)
 				break;
@@ -4497,7 +4497,7 @@ void clif_createchat(map_session_data* sd, int flag)
 ///     1 = public
 ///     2 = arena (npc waiting room)
 ///     3 = PK zone (non-clickable)
-void clif_dispchat(struct chat_data* cd, int fd)
+void clif_dispchat(chats::ChatData* cd, int fd)
 {
 	unsigned char buf[128];
 	uint8 type;
@@ -4535,7 +4535,7 @@ void clif_dispchat(struct chat_data* cd, int fd)
 ///     1 = public
 ///     2 = arena (npc waiting room)
 ///     3 = PK zone (non-clickable)
-void clif_changechatstatus(struct chat_data* cd)
+void clif_changechatstatus(chats::ChatData* cd)
 {
 	unsigned char buf[128];
 	uint8 type;
@@ -4562,7 +4562,7 @@ void clif_changechatstatus(struct chat_data* cd)
 
 /// Removes the chatroom (ZC_DESTROY_ROOM).
 /// 00d8 <chat id>.L
-void clif_clearchat(struct chat_data *cd,int fd)
+void clif_clearchat(chats::ChatData *cd,int fd)
 {
 	unsigned char buf[32];
 
@@ -4611,7 +4611,7 @@ void clif_joinchatfail(map_session_data *sd,int flag)
 /// role:
 ///     0 = owner (menu)
 ///     1 = normal
-void clif_joinchatok(map_session_data *sd,struct chat_data* cd)
+void clif_joinchatok(map_session_data *sd,chats::ChatData* cd)
 {
 	int fd;
 	int i,t;
@@ -4648,7 +4648,7 @@ void clif_joinchatok(map_session_data *sd,struct chat_data* cd)
 
 /// Notifies clients in a chat about a new member (ZC_MEMBER_NEWENTRY).
 /// 00dc <users>.W <name>.24B
-void clif_addchat(struct chat_data* cd,map_session_data *sd)
+void clif_addchat(chats::ChatData* cd,map_session_data *sd)
 {
 	unsigned char buf[29];
 
@@ -4667,7 +4667,7 @@ void clif_addchat(struct chat_data* cd,map_session_data *sd)
 /// role:
 ///     0 = owner (menu)
 ///     1 = normal
-void clif_changechatowner(struct chat_data* cd, map_session_data* sd)
+void clif_changechatowner(chats::ChatData* cd, map_session_data* sd)
 {
 	unsigned char buf[64];
 
@@ -4691,7 +4691,7 @@ void clif_changechatowner(struct chat_data* cd, map_session_data* sd)
 /// flag:
 ///     0 = left
 ///     1 = kicked
-void clif_leavechat(struct chat_data* cd, map_session_data* sd, bool flag)
+void clif_leavechat(chats::ChatData* cd, map_session_data* sd, bool flag)
 {
 	unsigned char buf[32];
 
@@ -5012,8 +5012,8 @@ static void clif_getareachar_pc(map_session_data* sd,map_session_data* dstsd)
 	int i;
 
 	if( dstsd->chatID ) {
-		struct chat_data *cd = NULL;
-		if( (cd = (struct chat_data*)map_id2bl(dstsd->chatID)) && cd->usersd[0]==dstsd)
+		chats::ChatData *cd = NULL;
+		if( (cd = (chats::ChatData*)map_id2bl(dstsd->chatID)) && cd->usersd[0]==dstsd)
 			clif_dispchat(cd,sd->fd);
 	} else if( dstsd->state.vending )
 		clif_showvendingboard( *dstsd, SELF, &sd->bl );
@@ -5110,7 +5110,7 @@ void clif_getareachar_unit( map_session_data* sd,struct block_list *bl ){
 		{
 			TBL_NPC* nd = (TBL_NPC*)bl;
 			if( nd->chat_id )
-				clif_dispchat((struct chat_data*)map_id2bl(nd->chat_id),sd->fd);
+				clif_dispchat((chats::ChatData*)map_id2bl(nd->chat_id),sd->fd);
 			if( nd->size == SZ_BIG )
 				clif_specialeffect_single(bl,EF_GIANTBODY2,sd->fd);
 			else if( nd->size == SZ_MEDIUM )
@@ -5630,8 +5630,8 @@ int clif_outsight(struct block_list *bl,va_list ap)
 			if(sd->vd.class_ != JT_INVISIBLE)
 				clif_clearunit_single(bl->id,CLR_OUTSIGHT,tsd->fd);
 			if(sd->chatID){
-				struct chat_data *cd;
-				cd=(struct chat_data*)map_id2bl(sd->chatID);
+				chats::ChatData *cd;
+				cd=(chats::ChatData*)map_id2bl(sd->chatID);
 				if(cd->usersd[0]==sd)
 					clif_dispchat(cd,tsd->fd);
 			}
@@ -9991,7 +9991,7 @@ void clif_refresh(map_session_data *sd)
 	map_foreachinallrange(clif_getareachar,&sd->bl,AREA_SIZE,BL_ALL,sd);
 	clif_weather_check(sd);
 	if( sd->chatID )
-		chat_leavechat(sd,0);
+		chats::LeaveChat(sd,0);
 	if( sd->state.vending )
 		clif_openvending(sd, sd->bl.id, sd->vending);
 	if( pc_issit(sd) )
@@ -12440,7 +12440,7 @@ void clif_parse_CreateChatRoom(int fd, map_session_data* sd)
 	safestrncpy(s_password, password, CHATROOM_PASS_SIZE);
 	safestrncpy(s_title, title, min(len+1,CHATROOM_TITLE_SIZE)); //NOTE: assumes that safestrncpy will not access the len+1'th byte
 
-	chat_createpcchat(sd, s_title, s_password, limit, pub);
+	chats::CreatePcChat(sd, s_title, s_password, limit, pub);
 }
 
 
@@ -12451,7 +12451,7 @@ void clif_parse_ChatAddMember(int fd, map_session_data* sd){
 	int chatid = RFIFOL(fd,info->pos[0]);
 	const char* password = RFIFOCP(fd,info->pos[1]); // not zero-terminated
 
-	chat_joinchat(sd,chatid,password);
+	chats::JoinChat(sd,chatid,password);
 }
 
 
@@ -12476,7 +12476,7 @@ void clif_parse_ChatRoomStatusChange(int fd, map_session_data* sd){
 	safestrncpy(s_password, password, CHATROOM_PASS_SIZE);
 	safestrncpy(s_title, title, min(len+1,CHATROOM_TITLE_SIZE)); //NOTE: assumes that safestrncpy will not access the len+1'th byte
 
-	chat_changechatstatus(sd, s_title, s_password, limit, pub);
+	chats::ChangeChatStatus(sd, s_title, s_password, limit, pub);
 }
 
 
@@ -12488,7 +12488,7 @@ void clif_parse_ChatRoomStatusChange(int fd, map_session_data* sd){
 void clif_parse_ChangeChatOwner(int fd, map_session_data* sd)
 {
 	//int role = RFIFOL(fd,packet_db[RFIFOW(fd,0)].pos[0]);
-	chat_changechatowner(sd,RFIFOCP(fd,packet_db[RFIFOW(fd,0)].pos[1]));
+	chats::ChangeChatOwner(sd,RFIFOCP(fd,packet_db[RFIFOW(fd,0)].pos[1]));
 }
 
 
@@ -12496,7 +12496,7 @@ void clif_parse_ChangeChatOwner(int fd, map_session_data* sd)
 /// 00e2 <name>.24B
 void clif_parse_KickFromChat(int fd,map_session_data *sd)
 {
-	chat_kickchat(sd,RFIFOCP(fd,packet_db[RFIFOW(fd,0)].pos[0]));
+	chats::KickPcFromChat(sd,RFIFOCP(fd,packet_db[RFIFOW(fd,0)].pos[0]));
 }
 
 
@@ -12504,7 +12504,7 @@ void clif_parse_KickFromChat(int fd,map_session_data *sd)
 /// 00e3
 void clif_parse_ChatLeave(int fd, map_session_data* sd)
 {
-	chat_leavechat(sd,0);
+	chats::LeaveChat(sd,0);
 }
 
 

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -28,7 +28,7 @@ struct homun_data;
 struct pet_data;
 struct mob_data;
 struct npc_data;
-struct chat_data;
+namespace chats{class ChatData;}
 struct flooritem_data;
 struct skill_unit;
 struct s_vending;
@@ -685,14 +685,14 @@ void clif_changeoption2(struct block_list* bl);	// area
 void clif_useitemack(map_session_data *sd,int index,int amount,bool ok);	// self
 void clif_GlobalMessage(struct block_list* bl, const char* message,enum send_target target);
 void clif_createchat(map_session_data* sd, int flag);	// self
-void clif_dispchat(struct chat_data* cd, int fd);	// area or fd
+void clif_dispchat(chats::ChatData* cd, int fd);	// area or fd
 void clif_joinchatfail(map_session_data *sd,int flag);	// self
-void clif_joinchatok(map_session_data *sd,struct chat_data* cd);	// self
-void clif_addchat(struct chat_data* cd,map_session_data *sd);	// chat
-void clif_changechatowner(struct chat_data* cd, map_session_data* sd);	// chat
-void clif_clearchat(struct chat_data *cd,int fd);	// area or fd
-void clif_leavechat(struct chat_data* cd, map_session_data* sd, bool flag);	// chat
-void clif_changechatstatus(struct chat_data* cd);	// chat
+void clif_joinchatok(map_session_data *sd,chats::ChatData* cd);	// self
+void clif_addchat(chats::ChatData* cd,map_session_data *sd);	// chat
+void clif_changechatowner(chats::ChatData* cd, map_session_data* sd);	// chat
+void clif_clearchat(chats::ChatData *cd,int fd);	// area or fd
+void clif_leavechat(chats::ChatData* cd, map_session_data* sd, bool flag);	// chat
+void clif_changechatstatus(chats::ChatData* cd);	// chat
 void clif_refresh_storagewindow(map_session_data *sd);
 void clif_refresh(map_session_data *sd);	// self
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2198,12 +2198,12 @@ struct s_elemental_data* map_id2ed(int id) {
 	struct block_list* bl = map_id2bl(id);
 	return BL_CAST(BL_ELEM, bl);
 }
-
-struct chat_data* map_id2cd(int id){
+namespace chats{
+ChatData* map_id2cd(int id){
 	struct block_list* bl = map_id2bl(id);
 	return BL_CAST(BL_CHAT, bl);
 }
-
+}
 /// Returns the nick of the target charid or NULL if unknown (requests the nick to the char server).
 const char* map_charid2nick(int charid)
 {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1144,7 +1144,7 @@ struct homun_data* map_id2hd(int id);
 struct s_mercenary_data* map_id2mc(int id);
 struct pet_data* map_id2pd(int id);
 struct s_elemental_data* map_id2ed(int id);
-struct chat_data* map_id2cd(int id);
+namespace chats{class ChatData* map_id2cd(int id);}
 struct block_list * map_id2bl(int id);
 bool map_blid_exists( int id );
 
@@ -1245,12 +1245,12 @@ typedef map_session_data TBL_PC;
 typedef struct npc_data         TBL_NPC;
 typedef struct mob_data         TBL_MOB;
 typedef struct flooritem_data   TBL_ITEM;
-typedef struct chat_data        TBL_CHAT;
 typedef struct skill_unit       TBL_SKILL;
 typedef struct pet_data         TBL_PET;
 typedef struct homun_data       TBL_HOM;
 typedef struct s_mercenary_data   TBL_MER;
 typedef struct s_elemental_data	TBL_ELEM;
+using TBL_CHAT = chats::ChatData;
 
 #define BL_CAST(type_, bl) \
 	( ((bl) == (struct block_list*)NULL || (bl)->type != (type_)) ? (T ## type_ *)NULL : (T ## type_ *)(bl) )

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -3452,7 +3452,7 @@ int npc_unload(struct npc_data* nd, bool single) {
 		strdb_remove(npcname_db, nd->exname);
 
 	if (nd->chat_id) // remove npc chatroom object and kick users
-		chat_deletenpcchat(nd);
+		chats::DeleteNpcChat(nd);
 
 #ifdef PCRE_SUPPORT
 	npc_chat_finalize(nd); // deallocate npc PCRE data structures

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3024,8 +3024,8 @@ int pc_disguise(map_session_data *sd, int class_)
 			clif_updatestatus(sd,SP_CARTINFO);
 		}
 		if (sd->chatID) {
-			struct chat_data* cd;
-			if ((cd = (struct chat_data*)map_id2bl(sd->chatID)) != NULL)
+			chats::ChatData* cd;
+			if ((cd = (chats::ChatData*)map_id2bl(sd->chatID)) != NULL)
 				clif_dispchat(cd,0);
 		}
 	}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -12915,7 +12915,7 @@ BUILDIN_FUNC(waitingroom)
 
 	nd = (struct npc_data *)map_id2bl(st->oid);
 	if( nd != NULL )
-		chat_createnpcchat(nd, title, limit, 1, trigger, ev, zeny, minLvl, maxLvl);
+		chats::CreateNpcChat(nd, title, limit, 1, trigger, ev, zeny, minLvl, maxLvl);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -12932,7 +12932,7 @@ BUILDIN_FUNC(delwaitingroom)
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 	if( nd != NULL )
-		chat_deletenpcchat(nd);
+		chats::DeleteNpcChat(nd);
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -12942,14 +12942,14 @@ BUILDIN_FUNC(delwaitingroom)
 BUILDIN_FUNC(waitingroomkick)
 {
 	struct npc_data* nd;
-	struct chat_data* cd;
+	chats::ChatData* cd;
 	const char* kickusername;
 	
 	nd = npc_name2id(script_getstr(st,2));
 	kickusername = script_getstr(st,3);
 
-	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL )
-		chat_npckickchat(cd, kickusername);
+	if( nd != NULL && (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) != NULL )
+		cd->NpcKickChat(kickusername);
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -12960,7 +12960,7 @@ BUILDIN_FUNC(waitingroomkick)
 BUILDIN_FUNC(getwaitingroomusers)
 {
 	struct npc_data* nd;
-	struct chat_data* cd;
+	chats::ChatData* cd;
 
 	int i, j=0;
 
@@ -12969,7 +12969,7 @@ BUILDIN_FUNC(getwaitingroomusers)
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 	
-	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL ) {
+	if( nd != NULL && (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) != NULL ) {
 		for(i = 0; i < cd->users; ++i) {
 			setd_sub_num( st, NULL, ".@waitingroom_users", j, cd->usersd[i]->status.account_id, NULL );
 			j++;
@@ -12986,15 +12986,15 @@ BUILDIN_FUNC(getwaitingroomusers)
 BUILDIN_FUNC(waitingroomkickall)
 {
 	struct npc_data* nd;
-	struct chat_data* cd;
+	chats::ChatData* cd;
 
 	if( script_hasdata(st,2) )
 		nd = npc_name2id(script_getstr(st,2));
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 
-	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL )
-		chat_npckickall(cd);
+	if( nd != NULL && (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) != NULL )
+		cd->NpcKickAll();
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -13005,15 +13005,15 @@ BUILDIN_FUNC(waitingroomkickall)
 BUILDIN_FUNC(enablewaitingroomevent)
 {
 	struct npc_data* nd;
-	struct chat_data* cd;
+	chats::ChatData* cd;
 
 	if( script_hasdata(st,2) )
 		nd = npc_name2id(script_getstr(st, 2));
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 
-	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL )
-		chat_enableevent(cd);
+	if( nd != NULL && (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) != NULL )
+		cd->EnableEvent();
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -13024,15 +13024,15 @@ BUILDIN_FUNC(enablewaitingroomevent)
 BUILDIN_FUNC(disablewaitingroomevent)
 {
 	struct npc_data *nd;
-	struct chat_data *cd;
+	chats::ChatData *cd;
 
 	if( script_hasdata(st,2) )
 		nd = npc_name2id(script_getstr(st, 2));
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 
-	if( nd != NULL && (cd=(struct chat_data *)map_id2bl(nd->chat_id)) != NULL )
-		chat_disableevent(cd);
+	if( nd != NULL && (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) != NULL )
+		cd->DisableEvent();
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -13053,7 +13053,7 @@ BUILDIN_FUNC(disablewaitingroomevent)
 BUILDIN_FUNC(getwaitingroomstate)
 {
 	struct npc_data *nd;
-	struct chat_data *cd;
+	chats::ChatData *cd;
 	int type;
 
 	type = script_getnum(st,2);
@@ -13062,7 +13062,7 @@ BUILDIN_FUNC(getwaitingroomstate)
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 
-	if( nd == NULL || (cd=(struct chat_data *)map_id2bl(nd->chat_id)) == NULL )
+	if( nd == NULL || (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) == NULL )
 	{
 		script_pushint(st, -1);
 		return SCRIPT_CMD_SUCCESS;
@@ -13104,10 +13104,10 @@ BUILDIN_FUNC(warpwaitingpc)
 	int n;
 	const char* map_name;
 	struct npc_data* nd;
-	struct chat_data* cd;
+	chats::ChatData* cd;
 
 	nd = (struct npc_data *)map_id2bl(st->oid);
-	if( nd == NULL || (cd=(struct chat_data *)map_id2bl(nd->chat_id)) == NULL )
+	if( nd == NULL || (cd=(chats::ChatData *)map_id2bl(nd->chat_id)) == NULL )
 		return SCRIPT_CMD_SUCCESS;
 
 	map_name = script_getstr(st,2);
@@ -20869,7 +20869,7 @@ BUILDIN_FUNC(showevent)
 BUILDIN_FUNC(waitingroom2bg)
 {
 	struct npc_data *nd;
-	struct chat_data *cd;
+	chats::ChatData *cd;
 	const char *map_name;
 	int mapindex = 0, bg_id;
 	unsigned char i,c=0;
@@ -20880,7 +20880,7 @@ BUILDIN_FUNC(waitingroom2bg)
 	else
 		nd = (struct npc_data *)map_id2bl(st->oid);
 
-	if( nd == NULL || (cd = (struct chat_data *)map_id2bl(nd->chat_id)) == NULL )
+	if( nd == NULL || (cd = (chats::ChatData *)map_id2bl(nd->chat_id)) == NULL )
 	{
 		script_pushint(st,0);
 		return SCRIPT_CMD_SUCCESS;
@@ -20929,7 +20929,7 @@ BUILDIN_FUNC(waitingroom2bg_single)
 {
 	const char* map_name;
 	struct npc_data *nd;
-	struct chat_data *cd;
+	chats::ChatData *cd;
 	map_session_data *sd;
 	int x, y, mapindex, bg_id = script_getnum(st,2);
 	std::shared_ptr<s_battleground_data> bg = util::umap_find(bg_team_db, bg_id);
@@ -20960,7 +20960,7 @@ BUILDIN_FUNC(waitingroom2bg_single)
 
 	nd = npc_name2id(script_getstr(st,6));
 
-	if( nd == NULL || (cd = (struct chat_data *)map_id2bl(nd->chat_id)) == NULL || cd->users <= 0 )
+	if( nd == NULL || (cd = (chats::ChatData *)map_id2bl(nd->chat_id)) == NULL || cd->users <= 0 )
 		return SCRIPT_CMD_SUCCESS;
 
 	if( (sd = cd->usersd[0]) == NULL )

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -20872,7 +20872,6 @@ BUILDIN_FUNC(waitingroom2bg)
 	chats::ChatData *cd;
 	const char *map_name;
 	int mapindex = 0, bg_id;
-	unsigned char i,c=0;
 	struct s_battleground_team team;
 
 	if( script_hasdata(st,7) )
@@ -20912,7 +20911,8 @@ BUILDIN_FUNC(waitingroom2bg)
 		return SCRIPT_CMD_SUCCESS;
 	}
 
-	for (i = 0; i < cd->users; i++) { // Only add those who are in the chat room
+	uint32 c = 0;
+	for (uint32 i = 0; i < cd->users; i++) { // Only add those who are in the chat room
 		map_session_data *sd;
 		if( (sd = cd->usersd[i]) != NULL && bg_team_join(bg_id, sd, false) ){
 			mapreg_setreg(reference_uid(add_str("$@arenamembers"), c), sd->bl.id);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3101,7 +3101,7 @@ int unit_remove_map_(struct block_list *bl, clr_type clrtype, const char* file, 
 
 			// Leave/reject all invitations.
 			if(sd->chatID)
-				chat_leavechat(sd,0);
+				chats::LeaveChat(sd,0);
 
 			if(sd->trade_partner)
 				trade_tradecancel(sd);


### PR DESCRIPTION
### Refactoring of chat struct
Converted C constructs to modern cpp
 * Conversion of regular arrays to std::array, that allows iterating and holds size info
 * Conversion of functions to class methods when appropriate
 * Conversion of Macros to inline constexpr for easier:
   * Scoping
   * Rebuild
   * Debugging
 * Declaration and definition on the same line, the closest to where it's used
 * Removed class-specifiers when possible
 Converted unused int return types to void

Added namespace chats::
Applied google guidelines for naming conventions
 * CamelCase for structs, classes, typedefs, templates and functions
 * Underscore for local variables and namespaces
 * A trailing _ for private members
