### PR TITLE
Rebalance Windhawk 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39493,9 +39493,10 @@ Body:
     GiveAp: 1
     CastCancel: true
     CastTime: 800
-    AfterCastActDelay: 300
+    AfterCastActDelay: 700
     Duration1: 10000
     FixedCastTime: 200
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39167,8 +39167,8 @@ Body:
     HitCount: 1
     CastCancel: true
     AfterCastActDelay: 500
-    Duration1: 60000
-    Cooldown: 300000
+    Duration1: 180000
+    Cooldown: 180000
     FixedCastTime: 1000
     Requires:
       SpCost: 300

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39225,38 +39225,38 @@ Body:
       - Level: 7
         Area: 3
       - Level: 8
-        Area: 4
+        Area: 3
       - Level: 9
         Area: 4
       - Level: 10
-        Area: 5
+        Area: 4
     CastCancel: true
     CastTime: 3500
     AfterCastActDelay: 500
-    Cooldown: 1500
+    Cooldown: 1200
     FixedCastTime: 500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 64
+          Amount: 93
         - Level: 2
-          Amount: 68
-        - Level: 3
-          Amount: 72
-        - Level: 4
-          Amount: 76
-        - Level: 5
-          Amount: 80
-        - Level: 6
-          Amount: 84
-        - Level: 7
-          Amount: 88
-        - Level: 8
-          Amount: 92
-        - Level: 9
           Amount: 96
+        - Level: 3
+          Amount: 99
+        - Level: 4
+          Amount: 102
+        - Level: 5
+          Amount: 105
+        - Level: 6
+          Amount: 108
+        - Level: 7
+          Amount: 111
+        - Level: 8
+          Amount: 114
+        - Level: 9
+          Amount: 117
         - Level: 10
-          Amount: 100
+          Amount: 120
       Weapon:
         Bow: true
       Ammo:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39270,6 +39270,8 @@ Body:
     TargetType: Ground
     DamageFlags:
       IgnoreFlee: true
+    Flags:
+      AllowOnWarg: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -39333,7 +39335,6 @@ Body:
       Flag:
         NoOverlap: true
         PathCheck: true
-    Status: Handicapstate_Deepblind
   - Id: 5332
     Name: WH_SOLIDTRAP
     Description: Solid Trap
@@ -39342,6 +39343,8 @@ Body:
     TargetType: Ground
     DamageFlags:
       IgnoreFlee: true
+    Flags:
+      AllowOnWarg: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -39387,7 +39390,6 @@ Body:
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
-    Status: HandicapState_Crystallization
     Unit:
       Id: Solidtrap
       Range:
@@ -39414,6 +39416,8 @@ Body:
     TargetType: Ground
     DamageFlags:
       IgnoreFlee: true
+    Flags:
+      AllowOnWarg: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -39459,7 +39463,6 @@ Body:
       ItemCost:
         - Item: Special_Alloy_Trap
           Amount: 2
-    Status: HandicapState_LightningStrike
     Unit:
       Id: Swifttrap
       Range:
@@ -39533,6 +39536,8 @@ Body:
     TargetType: Ground
     DamageFlags:
       IgnoreFlee: true
+    Flags:
+      AllowOnWarg: true
     Range: 1
     Hit: Single
     HitCount: 1
@@ -39596,7 +39601,6 @@ Body:
       Flag:
         NoOverlap: true
         PathCheck: true
-    Status: HandicapState_Conflagration
   - Id: 5336
     Name: BO_BIONIC_PHARMACY
     Description: Bionic Pharmacy

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7635,7 +7635,7 @@ Body:
       RemoveOnDamaged: true
   - Status: Handicapstate_Lightningstrike
     Icon: EFST_HANDICAPSTATE_LIGHTNINGSTRIKE
-    DurationLookup: WH_SWIFTTRAP
+    DurationLookup: EM_LIGHTNING_LAND
     States:
       #NoMove: true
       #NoCast: true
@@ -7648,7 +7648,7 @@ Body:
       RemoveOnDamaged: true
   - Status: Handicapstate_Crystallization
     Icon: EFST_HANDICAPSTATE_CRYSTALLIZATION
-    DurationLookup: WH_SOLIDTRAP
+    DurationLookup: EM_TERRA_DRIVE
     States:
       #NoMove: true
       #NoCast: true
@@ -7662,7 +7662,7 @@ Body:
       RemoveOnDamaged: true
   - Status: Handicapstate_Conflagration
     Icon: EFST_HANDICAPSTATE_CONFLAGRATION
-    DurationLookup: WH_FLAMETRAP
+    DurationLookup: EM_CONFLAGRATION
     Flags:
       BlEffect: true
       DisplayPc: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -5732,6 +5732,8 @@ Body:
     DurationLookup: RA_UNLIMIT
     Flags:
       DisplayPc: true
+      NoDispell: true
+      NoClearance: true
   - Status: Kings_Grace
     Icon: EFST_KINGS_GRACE
     DurationLookup: LG_KINGS_GRACE

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5603,8 +5603,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 500 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
-		case WH_HAWKBOOMERANG:// Affected by trait stats??? CON for sure but the other one unknown. Likely POW. [Rytech]
-			skillratio += -100 + 600 * skill_lv + 10 * sstatus->pow + 10 * sstatus->con;
+		case WH_HAWKBOOMERANG:
+			skillratio += -100 + 600 * skill_lv + 10 * sstatus->con;
+			if (sd)
+				skillratio += pc_checkskill(sd, WH_NATUREFRIENDLY) / 10;
 			if (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH)
 				skillratio += skillratio * 50 / 100;
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5601,12 +5601,14 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case WH_HAWKRUSH:
 			skillratio += -100 + 500 * skill_lv + 5 * sstatus->con;
+			if (sd)
+				skillratio += skillratio * pc_checkskill(sd, WH_NATUREFRIENDLY) / 10;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKBOOMERANG:
 			skillratio += -100 + 600 * skill_lv + 10 * sstatus->con;
 			if (sd)
-				skillratio += pc_checkskill(sd, WH_NATUREFRIENDLY) / 10;
+				skillratio += skillratio * pc_checkskill(sd, WH_NATUREFRIENDLY) / 10;
 			if (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH)
 				skillratio += skillratio * 50 / 100;
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5616,7 +5616,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * 50 / 100;
 			break;
 		case WH_CRESCIVE_BOLT:
-			skillratio += -100 + 340 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc) {
 				if (sc->getSCE(SC_CRESCIVEBOLT))

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5610,7 +5610,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_GALESTORM:
-			skillratio += -100 + 950 * skill_lv + 10 * sstatus->con;
+			skillratio += -100 + 1000 * skill_lv + 10 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_CALAMITYGALE) && (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH))
 				skillratio += skillratio * 50 / 100;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 


Windhawk
---------------------------------

1. No Limits (Ranger)
	- No longer be removed by Dispell or Clearance.

2. Calamity Gale
	- Increases duration from 60 seconds to 180 seconds.
	- Reduces cooldown from 300 seconds to 180 seconds.
	- No longer be removed when using No Limits.

3. Gale Storm
	- Reduces cooldown from 1.5 seconds to 1.2 seconds.
	- Increases SP consumption from 100 to 120 based on level 10.
	- Increases base damage from 9500%Atk to 10000%Atk based on level 5.
	- Reduces area of effect from 11 x 11 cells to 9 x 9 cells based on level 10.
	- Increases factor weight of CON in skill formula from 5 to 10.

4. Crescive Bolt
	- Increases cooldown from 0.15 seconds to 0.35 seconds.
	- Increases global cool time from 0.3 seconds to 0.7 seconds.
	- Increases base damage from 3400%Atk to 9400%Atk based on level 10. 


Additionnally
------------------------------------

- Removed leftover Deep Blind Trap / Solid Trap / Swift Trap / Flame Trap status ailments in `skills_db.yml` (from previous rebalance)
- Corrected WH HAWK BOOMERANG and WH_HAWKBOOMERANG formula according to the Korean description of the skill.
- Included WH_NATUREFRIENDLY in the damage formula of WH_HAWKRUSH and WH_HAWKBOOMERANG (x1.5 at level 5) (source: tests on KRO)
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
