### PR TITLE
Rebalance cardinal 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37327,34 +37327,35 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
+    GiveAp: 2
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 1500
+    Cooldown: 1000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 94
+          Amount: 107
         - Level: 2
-          Amount: 96
+          Amount: 109
         - Level: 3
-          Amount: 98
+          Amount: 111
         - Level: 4
-          Amount: 100
+          Amount: 113
         - Level: 5
-          Amount: 102
+          Amount: 115
         - Level: 6
-          Amount: 104
+          Amount: 117
         - Level: 7
-          Amount: 106
+          Amount: 119
         - Level: 8
-          Amount: 108
+          Amount: 121
         - Level: 9
-          Amount: 110
+          Amount: 123
         - Level: 10
-          Amount: 112
+          Amount: 125
     Status: HandicapState_DeepSilence
   - Id: 5274
     Name: CD_ARBITRIUM_ATK

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37683,19 +37683,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5503,7 +5503,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case CD_PETITIO:
-			skillratio += -100 + (1050 + pc_checkskill(sd,CD_MACE_BOOK_M) * 10) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + (1050 + pc_checkskill(sd,CD_MACE_BOOK_M) * 50) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_DANCING_KNIFE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7992,7 +7992,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_FRAMEN:
-						skillratio += -100 + (800 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + (950 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DEMON)
 							skillratio += 100 * skill_lv;
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7973,13 +7973,13 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_ARBITRIUM:
-						skillratio += -100 + 1000 * skill_lv + 7 * sstatus->spl;
+						skillratio += -100 + 1000 * skill_lv + 10 * sstatus->spl;
 						skillratio += 10 * pc_checkskill( sd, CD_FIDUS_ANIMUS ) * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case CD_ARBITRIUM_ATK:
-						skillratio += -100 + 1250 * skill_lv + 7 * sstatus->spl;
-						skillratio += 10 * pc_checkskill( sd, CD_FIDUS_ANIMUS ) * skill_lv;
+						skillratio += -100 + 1750 * skill_lv + 10 * sstatus->spl;
+						skillratio += 50 * pc_checkskill( sd, CD_FIDUS_ANIMUS ) * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case CD_PNEUMATICUS_PROCELLA:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Cardinal
---------------------------------

1. Framen
	- Increases base damage from 4000%/4500%Matk to 4750%/5250%Matk based on level 5.

2. Arbitrium
	- Reduces cooldown from 1.5 seconds to 1 second.
	- Increases SP consumption from 112 to 125 based on level 10.
	- Applies AP recovery rate by 2.
	- Increases base damage of area damage from 12500%Matk to 17500%Matk based on level 10.
	- Increases factor weight of Fidus Animus skill level in skill formula of area damage from 100 to 500 based on level 10.
	- Increases factor weight of SPL in skill formula from 7 to 10.

3. Petitio
	- Reduces area of effect from 9 x 9 cells to 7 x 7 cells based on level 10.
	- Increases factor weight of Mace & Book Mastery skill level in skill formula from 100 to 500 based on level 10.
	
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
