### PR TITLE
Add autoloot script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11390,3 +11390,10 @@ Returns current autoloot value on success.
 
 ---------------------------------------
 
+*autoloot(<rate>{, <char_id>});
+
+This command sets the rate of autoloot (default: 10000 = 100%).
+Returns true on success and false on failure.
+Note: It will toggle existing autoloot settings if rate value aren't provided.
+
+---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11396,4 +11396,11 @@ This command sets the rate of autoloot (default: 10000 = 100%).
 Returns true on success and false on failure.
 Note: It will toggle existing autoloot settings if rate value aren't provided.
 
+Example:
+    autoloot();      // toggle on/off depend on existing autoloot
+    autoloot(0);     //   0.00% or off
+    autoloot(100);   //   1.00%
+    autoloot(3333);  //  33.33%
+    autoloot(10000); // 100.00%
+
 ---------------------------------------

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11390,11 +11390,12 @@ Returns current autoloot value on success.
 
 ---------------------------------------
 
-*autoloot(<rate>{, <char_id>});
+*autoloot({<rate>{, <char_id>}});
 
-This command sets the rate of autoloot (default: 10000 = 100%).
+This command sets the rate of autoloot.
+If no rate is provided and the user has autoloot disabled it will default to 10000 = 100% (enabled) or
+if the user has autoloot enabled it will default to 0 = 0% (disabled).
 Returns true on success and false on failure.
-Note: It will toggle existing autoloot settings if rate value aren't provided.
 
 Example:
     autoloot();      // toggle on/off depend on existing autoloot

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27037,7 +27037,7 @@ BUILDIN_FUNC(autoloot) {
 		rate = script_getnum(st, 2);
 
 		if (rate < 0 || rate > 10000) {
-			ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);		
+			ShowWarning("buildin_autoloot: Invalid rate value %d, should be between 0 ~ 10000.\n", rate);		
 			script_pushint(st, false);
 			return SCRIPT_CMD_FAILURE;
 		}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27016,6 +27016,37 @@ BUILDIN_FUNC(has_autoloot) {
 	return SCRIPT_CMD_SUCCESS;
 }
 
+// ===================================
+// *autoloot(<rate>{, <char_id>});
+// This command sets the rate of autoloot (10000 = 100%).
+// Returns true on success and false on failure.
+// Note: It will toggle existing autoloot settings if rate value aren't provided.
+// ===================================
+BUILDIN_FUNC(autoloot) {
+	map_session_data *sd;
+
+	if (!script_charid2sd(3, sd)) {
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
+	}
+
+	int rate = 0;
+	if (script_hasdata(st, 2))
+		rate = script_getnum(st, 2);
+	else if (sd->state.autoloot <= 0)
+		rate = 10000;
+
+	if (rate < 0 || rate > 10000) {
+		ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);
+		rate = cap_value(rate, 0, 10000);
+	}
+
+	sd->state.autoloot = rate;
+	script_pushint(st, true);
+
+	return SCRIPT_CMD_SUCCESS;
+}
+
 BUILDIN_FUNC(opentips){
 #if PACKETVER < 20171122
 	ShowError( "buildin_opentips: This command requires PACKETVER 20171122 or newer.\n" );
@@ -27789,6 +27820,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(isdead, "?"),
 	BUILDIN_DEF(macro_detector, "?"),
 	BUILDIN_DEF(has_autoloot,"?"),
+	BUILDIN_DEF(autoloot,"??"),
 	BUILDIN_DEF(opentips, "i?"),
 
 #include <custom/script_def.inc>

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27017,13 +27017,14 @@ BUILDIN_FUNC(has_autoloot) {
 }
 
 // ===================================
-// *autoloot(<rate>{, <char_id>});
-// This command sets the rate of autoloot (10000 = 100%).
+// *autoloot({<rate>{, <char_id>}});
+// This command sets the rate of autoloot.
+// If no rate is provided and the user has autoloot disabled it will default to 10000 = 100% (enabled) or
+// if the user has autoloot enabled it will default to 0 = 0% (disabled).
 // Returns true on success and false on failure.
-// Note: It will toggle existing autoloot settings if rate value aren't provided.
 // ===================================
 BUILDIN_FUNC(autoloot) {
-	map_session_data *sd;
+	map_session_data *sd = nullptr;
 
 	if (!script_charid2sd(3, sd)) {
 		script_pushint(st, false);
@@ -27035,8 +27036,9 @@ BUILDIN_FUNC(autoloot) {
 		rate = script_getnum(st, 2);
 
 	if (rate < 0 || rate > 10000) {
-		ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);
-		rate = cap_value(rate, 0, 10000);
+		ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);		
+		script_pushint(st, false);
+		return SCRIPT_CMD_FAILURE;
 	}
 
 	sd->state.autoloot = rate;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27031,14 +27031,18 @@ BUILDIN_FUNC(autoloot) {
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int rate = (sd->state.autoloot > 0 ? 0 : 10000);
-	if (script_hasdata(st, 2))
+	int rate;
+
+	if (script_hasdata(st, 2)) {
 		rate = script_getnum(st, 2);
 
-	if (rate < 0 || rate > 10000) {
-		ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);		
-		script_pushint(st, false);
-		return SCRIPT_CMD_FAILURE;
+		if (rate < 0 || rate > 10000) {
+			ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);		
+			script_pushint(st, false);
+			return SCRIPT_CMD_FAILURE;
+		}
+	} else {
+		rate = (sd->state.autoloot > 0 ? 0 : 10000);
 	}
 
 	sd->state.autoloot = rate;

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27030,11 +27030,9 @@ BUILDIN_FUNC(autoloot) {
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int rate = 0;
+	int rate = (sd->state.autoloot > 0 ? 0 : 10000);
 	if (script_hasdata(st, 2))
 		rate = script_getnum(st, 2);
-	else if (sd->state.autoloot <= 0)
-		rate = 10000;
 
 	if (rate < 0 || rate > 10000) {
 		ShowWarning("buildin_autoloot: invalid rate value %d, shall be between 0 ~ 10000.\n", rate);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
NPC script unable to adjust the autoloot settings unless it use something like `atcmd "@autoloot";` which create unnecessary atcommandlog at server side.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
any
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
enable NPC script to configure the autoloot setting of players without need use the `@autoloot` commands which could create unnecessary atcommandlog if configured.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
