### PR TITLE
Let rnd_value callers not care about order

### DIFF
--- a/src/common/random.hpp
+++ b/src/common/random.hpp
@@ -15,12 +15,15 @@ inline std::mt19937 generator = std::mt19937(device());
 int32 rnd(void);// [0, SINT32_MAX]
 
 /*
- * Generates a random number in the interval [min, max]
+ * Generates a random number in the interval [a, b]
  * @return random number
  */
 template <typename T>
-typename std::enable_if<std::is_integral<T>::value, T>::type rnd_value(T min, T max) {
-	std::uniform_int_distribution<T> dist(min, max);
+typename std::enable_if<std::is_integral<T>::value, T>::type rnd_value(T a, T b) {
+	if (a > b) {
+		std::swap(a, b);
+	}
+	std::uniform_int_distribution<T> dist(a, b);
 	return dist(generator);
 }
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8045

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Server is crashing in the case of `rnd_value(a, b)` where `a > b`.
This just swaps the parameters when `a > b`.

> Why not fix the callers?

Sometimes it's not clear if `b > a`, especially when dealing with stats. So, just swap it for the caller.
`rnd_value(a, b)` returns a random number on the closed interval `[a, b]`; because the interval isn't mixed (`(a, b]` or `[a, b)`) we don't have to worry about the order of the parameters.