### PR TITLE
Fixed login_check_password

### DIFF
--- a/src/common/md5calc.cpp
+++ b/src/common/md5calc.cpp
@@ -235,10 +235,11 @@ void MD5_String(const char * string, char * output)
 }
 
 /** output is a sequence of non-zero characters to be used as password salt. */
-void MD5_Salt(unsigned int len, char * output)
-{
-	unsigned int i;
-	for( i = 0; i < len; ++i )
-		output[i] = (char)(1 + rnd() % 255);
+void MD5_Salt( size_t len, char* output ){
+	for( size_t i = 0, max = len - 1; i < max; ++i ){
+		output[i] = static_cast<char>( rnd_value( 1, 255 ) );
+	}
 
+	// Zero terminate the string
+	output[len - 1] = '\0';
 }

--- a/src/common/md5calc.cpp
+++ b/src/common/md5calc.cpp
@@ -236,10 +236,7 @@ void MD5_String(const char * string, char * output)
 
 /** output is a sequence of non-zero characters to be used as password salt. */
 void MD5_Salt( size_t len, char* output ){
-	for( size_t i = 0, max = len - 1; i < max; ++i ){
+	for( size_t i = 0; i < len; ++i ){
 		output[i] = static_cast<char>( rnd_value( 1, 255 ) );
 	}
-
-	// Zero terminate the string
-	output[len - 1] = '\0';
 }

--- a/src/common/md5calc.hpp
+++ b/src/common/md5calc.hpp
@@ -4,8 +4,10 @@
 #ifndef MD5CALC_HPP
 #define MD5CALC_HPP
 
+#include "cbasetypes.hpp"
+
 void MD5_String(const char * string, char * output);
 void MD5_Binary(const char * string, unsigned char * output);
-void MD5_Salt(unsigned int len, char * output);
+void MD5_Salt(size_t len, char * output);
 
 #endif /* MD5CALC_HPP */

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -56,7 +56,7 @@ int subnet_count = 0; //number of subnet config
 int login_fd; // login server file descriptor socket
 
 //early declaration
-bool login_check_password(const char* md5key, int passwdenc, const char* passwd, const char* refpass);
+bool login_check_password( struct login_session_data& sd, struct mmo_account& acc );
 
 ///Accessors
 AccountDB* login_get_accounts_db(void){
@@ -345,7 +345,7 @@ int login_mmo_auth(struct login_session_data* sd, bool isServer) {
 		return 0; // 0 = Unregistered ID
 	}
 
-	if( !login_check_password(sd->md5key, sd->passwdenc, sd->passwd, acc.pass) ) {
+	if( !login_check_password( *sd, acc ) ) {
 		ShowNotice("Invalid password (account: '%s', ip: %s)\n", sd->userid, ip);
 		return 1; // 1 = Incorrect Password
 	}
@@ -427,24 +427,6 @@ int login_mmo_auth(struct login_session_data* sd, bool isServer) {
 }
 
 /**
- * Sub function of login_check_password.
- *  Checking if password matches the one in db hashed with client md5key.
- *  Test if(md5(str1+str2)==passwd).
- * @param str1: string (atm:md5key or dbpass)
- * @param str2: string (atm:md5key or dbpass)
- * @param passwd: pass to check
- * @return true if matching else false
- */
-bool login_check_encrypted(const char* str1, const char* str2, const char* passwd) {
-	char tmpstr[64+1], md5str[32+1];
-
-	safesnprintf(tmpstr, sizeof(tmpstr), "%s%s", str1, str2);
-	MD5_String(tmpstr, md5str);
-
-	return (0==strcmp(passwd, md5str));
-}
-
-/**
  * Verify if a password is correct.
  * @param md5key: md5key of client
  * @param passwdenc: encode key of client
@@ -452,16 +434,44 @@ bool login_check_encrypted(const char* str1, const char* str2, const char* passw
  * @param refpass: pass register in db
  * @return true if matching else false
  */
-bool login_check_password(const char* md5key, int passwdenc, const char* passwd, const char* refpass) {
-	if(passwdenc == 0){
-		return (0==strcmp(passwd, refpass));
+bool login_check_password( struct login_session_data& sd, struct mmo_account& acc ){
+	if( sd.passwdenc == 0 ){
+		return 0 == strcmp( sd.passwd, acc.pass );
 	}
-	else {
-		// password mode set to 1 -> md5(md5key, refpass) enable with <passwordencrypt></passwordencrypt>
-		// password mode set to 2 -> md5(refpass, md5key) enable with <passwordencrypt2></passwordencrypt2>
-		return ((passwdenc&0x01) && login_check_encrypted(md5key, refpass, passwd)) ||
-		       ((passwdenc&0x02) && login_check_encrypted(refpass, md5key, passwd));
+
+	// password mode set to 1 -> md5(md5key, refpass) enable with <passwordencrypt></passwordencrypt>
+	if( sd.passwdenc & 0x01 ){
+		std::string pwd;
+
+		pwd.append( sd.md5key, sd.md5keylen );
+		pwd.append( acc.pass );
+
+		char md5str[32 + 1];
+
+		MD5_String( pwd.c_str(), md5str );
+
+		if( 0 == strcmp( sd.passwd, md5str ) ){
+			return true;
+		}
 	}
+
+	// password mode set to 2 -> md5(refpass, md5key) enable with <passwordencrypt2></passwordencrypt2>
+	if( sd.passwdenc & 0x02 ){
+		std::string pwd;
+
+		pwd.append( acc.pass );
+		pwd.append( sd.md5key, sd.md5keylen );
+
+		char md5str[32 + 1];
+
+		MD5_String( pwd.c_str(), md5str );
+
+		if( 0 == strcmp( sd.passwd, md5str ) ){
+			return true;
+		}
+	}
+
+	return false;
 }
 
 int login_get_usercount( int users ){

--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -383,7 +383,7 @@ static int logclif_parse_reqkey(int fd, struct login_session_data *sd){
 		WFIFOHEAD(fd,4 + sd->md5keylen);
 		WFIFOW(fd,0) = 0x01dc;
 		WFIFOW(fd,2) = 4 + sd->md5keylen;
-		safestrncpy( WFIFOCP( fd, 4 ), sd->md5key, sd->md5keylen );
+		memcpy(WFIFOP(fd,4), sd->md5key, sd->md5keylen);
 		WFIFOSET(fd,WFIFOW(fd,2));
 	}
 	return 1;

--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -383,7 +383,7 @@ static int logclif_parse_reqkey(int fd, struct login_session_data *sd){
 		WFIFOHEAD(fd,4 + sd->md5keylen);
 		WFIFOW(fd,0) = 0x01dc;
 		WFIFOW(fd,2) = 4 + sd->md5keylen;
-		memcpy(WFIFOP(fd,4), sd->md5key, sd->md5keylen);
+		safestrncpy( WFIFOCP( fd, 4 ), sd->md5key, sd->md5keylen );
 		WFIFOSET(fd,WFIFOW(fd,2));
 	}
 	return 1;


### PR DESCRIPTION
* **Addressed Issue(s)**: #8043

* **Server Mode**: Both

* **Description of Pull Request**: 
The server did not properly take the salt length into account and the array for combination of password and salt was never properly initialized. Rewrote the function and removed login_check_encrypted.

Thanks to @LasherasGH
