### PR TITLE
Remove deprecated global sql settings code

### DIFF
--- a/conf/inter_athena.conf
+++ b/conf/inter_athena.conf
@@ -30,10 +30,6 @@ emblem_transparency_limit: 80
 // "Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)"
 // and you have localhost, switch it to 127.0.0.1
 
-// Global SQL settings
-// overridden by local settings when the hostname is defined there
-// (currently only the login-server reads/obeys these settings)
-
 // MySQL Login server
 login_server_ip: 127.0.0.1
 login_server_port: 3306


### PR DESCRIPTION
### Reasons 

- The conf option corresponding to global sql settings in `loginlog.cpp` has been removed from the configuration file for a long time.
- The global sql settings mechanism is only used for login-server and is not "global" enough anymore.

### What Next

I'll change some of the database connection option variables from `char[]` to `std::string` to fix a password truncation error when a user uses a just-right 32-bit password in MySQL.