### PR TITLE
Refactor some MySQL connection variables

### DIFF
--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -141,6 +141,8 @@ static void account_db_sql_destroy(AccountDB* self){
 
 	Sql_Free(db->accounts);
 	db->accounts = NULL;
+
+	db->~AccountDB_SQL();
 	aFree(db);
 }
 

--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -22,8 +22,8 @@
 typedef struct AccountDB_SQL {
 	AccountDB vtable;    // public interface
 	Sql* accounts;       // SQL handle accounts storage
-	int db_port = 3306;
 	std::string db_hostname = "127.0.0.1";
+	uint16 db_port = 3306;
 	std::string db_username = "ragnarok";
 	std::string db_password = "";
 	std::string db_database = "ragnarok";
@@ -112,7 +112,7 @@ static bool account_db_sql_init(AccountDB* self) {
 
 	if( SQL_ERROR == Sql_Connect(sql_handle, db->db_username.c_str(), db->db_password.c_str(), db->db_hostname.c_str(), db->db_port, db->db_database.c_str()) )
 	{
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			db->db_username.c_str(), db->db_hostname.c_str(), db->db_port, db->db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(db->accounts);
@@ -167,7 +167,7 @@ static bool account_db_sql_get_property(AccountDB* self, const char* key, char* 
 			safesnprintf(buf, buflen, "%s", db->db_hostname.c_str());
 		else
 		if( strcmpi(key, "port") == 0 )
-			safesnprintf(buf, buflen, "%d", db->db_port);
+			safesnprintf(buf, buflen, "%hu", db->db_port);
 		else
 		if( strcmpi(key, "id") == 0 )
 			safesnprintf(buf, buflen, "%s", db->db_username.c_str());
@@ -226,7 +226,7 @@ static bool account_db_sql_set_property(AccountDB* self, const char* key, const 
 			db->db_hostname = value;
 		else
 		if( strcmpi(key, "port") == 0 )
-			db->db_port = atoi(value);
+			db->db_port = (uint16)strtoul( value, nullptr, 10 );
 		else
 		if( strcmpi(key, "id") == 0 )
 			db->db_username = value;

--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -193,7 +193,7 @@ static bool account_db_sql_get_property(AccountDB* self, const char* key, char* 
 	if( strncmpi(key, signature, strlen(signature)) == 0 ) {
 		key += strlen(signature);
 		if( strcmpi(key, "codepage") == 0 )
-			safesnprintf(buf, buflen, "%s", db->codepage);
+			safesnprintf(buf, buflen, "%s", db->codepage.c_str());
 		else
 		if( strcmpi(key, "case_sensitive") == 0 )
 			safesnprintf(buf, buflen, "%d", (db->case_sensitive ? 1 : 0));

--- a/src/login/account.cpp
+++ b/src/login/account.cpp
@@ -22,12 +22,12 @@
 typedef struct AccountDB_SQL {
 	AccountDB vtable;    // public interface
 	Sql* accounts;       // SQL handle accounts storage
-	char   db_hostname[1024]; // Doubled for long hostnames (bugreport:8003)
-	uint16 db_port;
-	char   db_username[1024];
-	char   db_password[1024];
-	char   db_database[1024];
-	char   codepage[1024];
+	int db_port = 3306;
+	std::string db_hostname = "127.0.0.1";
+	std::string db_username = "ragnarok";
+	std::string db_password = "";
+	std::string db_database = "ragnarok";
+	std::string codepage = "";
 	// other settings
 	bool case_sensitive;
 	//table name
@@ -67,6 +67,7 @@ static bool mmo_auth_tosql(AccountDB_SQL* db, const struct mmo_account* acc, boo
 /// public constructor
 AccountDB* account_db_sql(void) {
 	AccountDB_SQL* db = (AccountDB_SQL*)aCalloc(1, sizeof(AccountDB_SQL));
+	new(db) AccountDB_SQL();
 
 	// set up the vtable
 	db->vtable.init         = &account_db_sql_init;
@@ -85,13 +86,6 @@ AccountDB* account_db_sql(void) {
 
 	// initialize to default values
 	db->accounts = NULL;
-	// local sql settings
-	safestrncpy(db->db_hostname, "127.0.0.1", sizeof(db->db_hostname));
-	db->db_port = 3306;
-	safestrncpy(db->db_username, "ragnarok", sizeof(db->db_username));
-	safestrncpy(db->db_password, "", sizeof(db->db_password));
-	safestrncpy(db->db_database, "ragnarok", sizeof(db->db_database));
-	safestrncpy(db->codepage, "", sizeof(db->codepage));
 	// other settings
 	db->case_sensitive = false;
 	safestrncpy(db->account_db, "login", sizeof(db->account_db));
@@ -112,34 +106,21 @@ AccountDB* account_db_sql(void) {
 static bool account_db_sql_init(AccountDB* self) {
 	AccountDB_SQL* db = (AccountDB_SQL*)self;
 	Sql* sql_handle;
-	const char* username = "ragnarok";
-	const char* password = "";
-	const char* hostname = "127.0.0.1";
-	uint16      port     = 3306;
-	const char* database = "ragnarok";
-	const char* codepage = "";
 
 	db->accounts = Sql_Malloc();
 	sql_handle = db->accounts;
 
-	username = db->db_username;
-	password = db->db_password;
-	hostname = db->db_hostname;
-	port     = db->db_port;
-	database = db->db_database;
-	codepage = db->codepage;
-
-	if( SQL_ERROR == Sql_Connect(sql_handle, username, password, hostname, port, database) )
+	if( SQL_ERROR == Sql_Connect(sql_handle, db->db_username.c_str(), db->db_password.c_str(), db->db_hostname.c_str(), db->db_port, db->db_database.c_str()) )
 	{
-                ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
-                        username, hostname, port, database);
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+			db->db_username.c_str(), db->db_hostname.c_str(), db->db_port, db->db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(db->accounts);
 		db->accounts = NULL;
 		return false;
 	}
 
-	if( codepage[0] != '\0' && SQL_ERROR == Sql_SetEncoding(sql_handle, codepage) )
+	if( !db->codepage.empty() && SQL_ERROR == Sql_SetEncoding(sql_handle, db->codepage.c_str()) )
 		Sql_ShowDebug(sql_handle);
 
 	self->remove_webtokens( self );
@@ -181,19 +162,19 @@ static bool account_db_sql_get_property(AccountDB* self, const char* key, char* 
 	if( strncmpi(key, signature, strlen(signature)) == 0 ) {
 		key += strlen(signature);
 		if( strcmpi(key, "ip") == 0 )
-			safesnprintf(buf, buflen, "%s", db->db_hostname);
+			safesnprintf(buf, buflen, "%s", db->db_hostname.c_str());
 		else
 		if( strcmpi(key, "port") == 0 )
 			safesnprintf(buf, buflen, "%d", db->db_port);
 		else
 		if( strcmpi(key, "id") == 0 )
-			safesnprintf(buf, buflen, "%s", db->db_username);
+			safesnprintf(buf, buflen, "%s", db->db_username.c_str());
 		else
 		if(	strcmpi(key, "pw") == 0 )
-			safesnprintf(buf, buflen, "%s", db->db_password);
+			safesnprintf(buf, buflen, "%s", db->db_password.c_str());
 		else
 		if( strcmpi(key, "db") == 0 )
-			safesnprintf(buf, buflen, "%s", db->db_database);
+			safesnprintf(buf, buflen, "%s", db->db_database.c_str());
 		else
 		if( strcmpi(key, "account_db") == 0 )
 			safesnprintf(buf, buflen, "%s", db->account_db);
@@ -240,19 +221,19 @@ static bool account_db_sql_set_property(AccountDB* self, const char* key, const 
 	if( strncmp(key, signature, strlen(signature)) == 0 ) {
 		key += strlen(signature);
 		if( strcmpi(key, "ip") == 0 )
-			safestrncpy(db->db_hostname, value, sizeof(db->db_hostname));
+			db->db_hostname = value;
 		else
 		if( strcmpi(key, "port") == 0 )
-			db->db_port = (uint16)strtoul(value, NULL, 10);
+			db->db_port = atoi(value);
 		else
 		if( strcmpi(key, "id") == 0 )
-			safestrncpy(db->db_username, value, sizeof(db->db_username));
+			db->db_username = value;
 		else
 		if( strcmpi(key, "pw") == 0 )
-			safestrncpy(db->db_password, value, sizeof(db->db_password));
+			db->db_password = value;
 		else
 		if( strcmpi(key, "db") == 0 )
-			safestrncpy(db->db_database, value, sizeof(db->db_database));
+			db->db_database = value;
 		else
 		if( strcmpi(key, "account_db") == 0 )
 			safestrncpy(db->account_db, value, sizeof(db->account_db));
@@ -271,7 +252,7 @@ static bool account_db_sql_set_property(AccountDB* self, const char* key, const 
 	if( strncmpi(key, signature, strlen(signature)) == 0 ) {
 		key += strlen(signature);
 		if( strcmpi(key, "codepage") == 0 )
-			safestrncpy(db->codepage, value, sizeof(db->codepage));
+			db->codepage = value;
 		else
 		if( strcmpi(key, "case_sensitive") == 0 )
 			db->case_sensitive = (config_switch(value)==1);

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -190,8 +190,8 @@ void ipban_init(void) {
 	sql_handle = Sql_Malloc();
 	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_db_username.c_str(), ipban_db_password.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str()) )
 	{
-		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-			ipban_db_username.c_str(), ipban_db_password.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str());
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+			ipban_db_username.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -196,8 +196,9 @@ void ipban_init(void) {
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);
 	}
-        ShowInfo("Ipban connection made.\n");
-        
+
+	ShowInfo("Ipban connection made.\n");
+
 	if( !ipban_codepage.empty() && SQL_ERROR == Sql_SetEncoding(sql_handle, ipban_codepage.c_str()) )
 		Sql_ShowDebug(sql_handle);
 

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -17,10 +17,10 @@
 
 
 int ipban_db_port = 3306;
-std::string ipban_db_ip = "127.0.0.1";
-std::string ipban_db_id = "ragnarok";
-std::string ipban_db_pw = "";
-std::string ipban_db_db = "ragnarok";
+std::string ipban_db_hostname = "127.0.0.1";
+std::string ipban_db_username = "ragnarok";
+std::string ipban_db_password = "";
+std::string ipban_db_database = "ragnarok";
 std::string ipban_codepage = "";
 std::string ipban_table = "ipbanlist";
 
@@ -123,19 +123,19 @@ bool ipban_config_read(const char* key, const char* value) {
 	{
 		key += strlen(signature);
 		if( strcmpi(key, "ip") == 0 )
-			ipban_db_ip = value;
+			ipban_db_hostname = value;
 		else
 		if( strcmpi(key, "port") == 0 )
 			ipban_db_port = atoi(value);
 		else
 		if( strcmpi(key, "id") == 0 )
-			ipban_db_id = value;
+			ipban_db_username = value;
 		else
 		if( strcmpi(key, "pw") == 0 )
-			ipban_db_pw = value;
+			ipban_db_password = value;
 		else
 		if( strcmpi(key, "db") == 0 )
-			ipban_db_db = value;
+			ipban_db_database = value;
 		else
 			return false;// not found
 		return true;
@@ -188,10 +188,10 @@ void ipban_init(void) {
 
 	// establish connections
 	sql_handle = Sql_Malloc();
-	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_db_id.c_str(), ipban_db_pw.c_str(), ipban_db_ip.c_str(), ipban_db_port, ipban_db_db.c_str()) )
+	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_db_username.c_str(), ipban_db_password.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str()) )
 	{
 		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-			ipban_db_id.c_str(), ipban_db_pw.c_str(), ipban_db_ip.c_str(), ipban_db_port, ipban_db_db.c_str());
+			ipban_db_username.c_str(), ipban_db_password.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -15,14 +15,14 @@
 #include "login.hpp"
 #include "loginlog.hpp"
 
-// login sql settings
-static char   ipban_db_hostname[64] = "127.0.0.1";
-static uint16 ipban_db_port = 3306;
-static char   ipban_db_username[32] = "ragnarok";
-static char   ipban_db_password[32] = "";
-static char   ipban_db_database[32] = "ragnarok";
-static char   ipban_codepage[32] = "";
-static char   ipban_table[32] = "ipbanlist";
+
+int ipban_db_port = 3306;
+std::string ipban_db_ip = "127.0.0.1";
+std::string ipban_db_id = "ragnarok";
+std::string ipban_db_pw = "";
+std::string ipban_db_db = "ragnarok";
+std::string ipban_codepage = "";
+std::string ipban_table = "ipbanlist";
 
 // globals
 static Sql* sql_handle = NULL;
@@ -46,7 +46,7 @@ bool ipban_check(uint32 ip) {
 		return false;// ipban disabled
 
 	if( SQL_ERROR == Sql_Query(sql_handle, "SELECT count(*) FROM `%s` WHERE `rtime` > NOW() AND (`list` = '%u.*.*.*' OR `list` = '%u.%u.*.*' OR `list` = '%u.%u.%u.*' OR `list` = '%u.%u.%u.%u')",
-		ipban_table, p[3], p[3], p[2], p[3], p[2], p[1], p[3], p[2], p[1], p[0]) )
+		ipban_table.c_str(), p[3], p[3], p[2], p[3], p[2], p[1], p[3], p[2], p[1], p[0]) )
 	{
 		Sql_ShowDebug(sql_handle);
 		// close connection because we can't verify their connectivity.
@@ -81,7 +81,7 @@ void ipban_log(uint32 ip) {
 	{
 		uint8* p = (uint8*)&ip;
 		if( SQL_ERROR == Sql_Query(sql_handle, "INSERT INTO `%s`(`list`,`btime`,`rtime`,`reason`) VALUES ('%u.%u.%u.*', NOW() , NOW() +  INTERVAL %d MINUTE ,'Password error ban')",
-			ipban_table, p[3], p[2], p[1], login_config.dynamic_pass_failure_ban_duration) )
+			ipban_table.c_str(), p[3], p[2], p[1], login_config.dynamic_pass_failure_ban_duration) )
 			Sql_ShowDebug(sql_handle);
 	}
 }
@@ -100,7 +100,7 @@ TIMER_FUNC(ipban_cleanup){
 	if( !login_config.ipban )
 		return 0;// ipban disabled
 
-	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `rtime` <= NOW()", ipban_table) )
+	if( SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `rtime` <= NOW()", ipban_table.c_str()) )
 		Sql_ShowDebug(sql_handle);
 
 	return 0;
@@ -123,19 +123,19 @@ bool ipban_config_read(const char* key, const char* value) {
 	{
 		key += strlen(signature);
 		if( strcmpi(key, "ip") == 0 )
-			safestrncpy(ipban_db_hostname, value, sizeof(ipban_db_hostname));
+			ipban_db_ip = value;
 		else
 		if( strcmpi(key, "port") == 0 )
-			ipban_db_port = (uint16)strtoul(value, NULL, 10);
+			ipban_db_port = atoi(value);
 		else
 		if( strcmpi(key, "id") == 0 )
-			safestrncpy(ipban_db_username, value, sizeof(ipban_db_username));
+			ipban_db_id = value;
 		else
 		if( strcmpi(key, "pw") == 0 )
-			safestrncpy(ipban_db_password, value, sizeof(ipban_db_password));
+			ipban_db_pw = value;
 		else
 		if( strcmpi(key, "db") == 0 )
-			safestrncpy(ipban_db_database, value, sizeof(ipban_db_database));
+			ipban_db_db = value;
 		else
 			return false;// not found
 		return true;
@@ -146,10 +146,10 @@ bool ipban_config_read(const char* key, const char* value) {
 	{
 		key += strlen(signature);
 		if( strcmpi(key, "codepage") == 0 )
-			safestrncpy(ipban_codepage, value, sizeof(ipban_codepage));
+			ipban_codepage = value;
 		else
 		if( strcmpi(key, "ipban_table") == 0 )
-			safestrncpy(ipban_table, value, sizeof(ipban_table));
+			ipban_table = value;
 		else
 		if( strcmpi(key, "enable") == 0 )
 			login_config.ipban = (config_switch(value) != 0);
@@ -181,41 +181,24 @@ bool ipban_config_read(const char* key, const char* value) {
  * Launched at login-serv start, create db or other long scope variable here.
  */
 void ipban_init(void) {
-	const char* username = ipban_db_username;
-	const char* password = ipban_db_password;
-	const char* hostname = ipban_db_hostname;
-	uint16      port     = ipban_db_port;
-	const char* database = ipban_db_database;
-	const char* codepage = ipban_codepage;
-
 	ipban_inited = true;
 
 	if( !login_config.ipban )
 		return;// ipban disabled
 
-	if( ipban_db_hostname[0] != '\0' )
-	{// local settings
-		username = ipban_db_username;
-		password = ipban_db_password;
-		hostname = ipban_db_hostname;
-		port     = ipban_db_port;
-		database = ipban_db_database;
-		codepage = ipban_codepage;
-	}
-
 	// establish connections
 	sql_handle = Sql_Malloc();
-	if( SQL_ERROR == Sql_Connect(sql_handle, username, password, hostname, port, database) )
+	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_db_id.c_str(), ipban_db_pw.c_str(), ipban_db_ip.c_str(), ipban_db_port, ipban_db_db.c_str()) )
 	{
-                ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-                        username, password, hostname, port, database);
+		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
+			ipban_db_id.c_str(), ipban_db_pw.c_str(), ipban_db_ip.c_str(), ipban_db_port, ipban_db_db.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);
 	}
         ShowInfo("Ipban connection made.\n");
         
-	if( codepage[0] != '\0' && SQL_ERROR == Sql_SetEncoding(sql_handle, codepage) )
+	if( !ipban_codepage.empty() && SQL_ERROR == Sql_SetEncoding(sql_handle, ipban_codepage.c_str()) )
 		Sql_ShowDebug(sql_handle);
 
 	if( login_config.ipban_cleanup_interval > 0 )

--- a/src/login/ipban.cpp
+++ b/src/login/ipban.cpp
@@ -16,8 +16,8 @@
 #include "loginlog.hpp"
 
 
-int ipban_db_port = 3306;
 std::string ipban_db_hostname = "127.0.0.1";
+uint16 ipban_db_port = 3306;
 std::string ipban_db_username = "ragnarok";
 std::string ipban_db_password = "";
 std::string ipban_db_database = "ragnarok";
@@ -126,7 +126,7 @@ bool ipban_config_read(const char* key, const char* value) {
 			ipban_db_hostname = value;
 		else
 		if( strcmpi(key, "port") == 0 )
-			ipban_db_port = atoi(value);
+			ipban_db_port = (uint16)strtoul( value, nullptr, 10 );
 		else
 		if( strcmpi(key, "id") == 0 )
 			ipban_db_username = value;
@@ -190,7 +190,7 @@ void ipban_init(void) {
 	sql_handle = Sql_Malloc();
 	if( SQL_ERROR == Sql_Connect(sql_handle, ipban_db_username.c_str(), ipban_db_password.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str()) )
 	{
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			ipban_db_username.c_str(), ipban_db_hostname.c_str(), ipban_db_port, ipban_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);

--- a/src/login/loginlog.cpp
+++ b/src/login/loginlog.cpp
@@ -125,7 +125,7 @@ bool loginlog_init(void) {
 
 	if( SQL_ERROR == Sql_Connect(sql_handle, log_db_id.c_str(), log_db_pw.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str()) )
 	{
-        ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
 			log_db_id.c_str(), log_db_pw.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);

--- a/src/login/loginlog.cpp
+++ b/src/login/loginlog.cpp
@@ -125,8 +125,8 @@ bool loginlog_init(void) {
 
 	if( SQL_ERROR == Sql_Connect(sql_handle, log_db_username.c_str(), log_db_password.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str()) )
 	{
-		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-			log_db_username.c_str(), log_db_password.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str());
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+			log_db_username.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);

--- a/src/login/loginlog.cpp
+++ b/src/login/loginlog.cpp
@@ -15,10 +15,10 @@
 
 
 int log_db_port = 3306;
-std::string log_db_ip = "127.0.0.1";
-std::string log_db_id = "ragnarok";
-std::string log_db_pw = "";
-std::string log_db_db = "ragnarok";
+std::string log_db_hostname = "127.0.0.1";
+std::string log_db_username = "ragnarok";
+std::string log_db_password = "";
+std::string log_db_database = "ragnarok";
 std::string log_login_db = "loginlog";
 std::string log_codepage = "";
 
@@ -87,19 +87,19 @@ void login_log(uint32 ip, const char* username, int rcode, const char* message) 
  */
 bool loginlog_config_read(const char* key, const char* value) {
 	if( strcmpi(key, "log_db_ip") == 0 )
-		log_db_ip = value;
+		log_db_hostname = value;
 	else
 	if( strcmpi(key, "log_db_port") == 0 )
 		log_db_port = atoi(value);
 	else
 	if( strcmpi(key, "log_db_id") == 0 )
-		log_db_id = value;
+		log_db_username = value;
 	else
 	if( strcmpi(key, "log_db_pw") == 0 )
-		log_db_pw = value;
+		log_db_password = value;
 	else
 	if( strcmpi(key, "log_db_db") == 0 )
-		log_db_db = value;
+		log_db_database = value;
 	else
 	if( strcmpi(key, "log_codepage") == 0 )
 		log_codepage = value;
@@ -123,10 +123,10 @@ bool loginlog_config_read(const char* key, const char* value) {
 bool loginlog_init(void) {
 	sql_handle = Sql_Malloc();
 
-	if( SQL_ERROR == Sql_Connect(sql_handle, log_db_id.c_str(), log_db_pw.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str()) )
+	if( SQL_ERROR == Sql_Connect(sql_handle, log_db_username.c_str(), log_db_password.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str()) )
 	{
 		ShowError("Couldn't connect with uname='%s',passwd='%s',host='%s',port='%d',database='%s'\n",
-			log_db_id.c_str(), log_db_pw.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str());
+			log_db_username.c_str(), log_db_password.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);
 		exit(EXIT_FAILURE);

--- a/src/login/loginlog.cpp
+++ b/src/login/loginlog.cpp
@@ -3,8 +3,9 @@
 
 #include "loginlog.hpp"
 
-#include <stdlib.h> // exit
 #include <string>
+
+#include <stdlib.h> // exit
 
 #include <common/cbasetypes.hpp>
 #include <common/mmo.hpp>
@@ -14,8 +15,8 @@
 #include <common/strlib.hpp>
 
 
-int log_db_port = 3306;
 std::string log_db_hostname = "127.0.0.1";
+uint16 log_db_port = 3306;
 std::string log_db_username = "ragnarok";
 std::string log_db_password = "";
 std::string log_db_database = "ragnarok";
@@ -90,7 +91,7 @@ bool loginlog_config_read(const char* key, const char* value) {
 		log_db_hostname = value;
 	else
 	if( strcmpi(key, "log_db_port") == 0 )
-		log_db_port = atoi(value);
+		log_db_port = (uint16)strtoul(value, NULL, 10);
 	else
 	if( strcmpi(key, "log_db_id") == 0 )
 		log_db_username = value;
@@ -125,7 +126,7 @@ bool loginlog_init(void) {
 
 	if( SQL_ERROR == Sql_Connect(sql_handle, log_db_username.c_str(), log_db_password.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str()) )
 	{
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			log_db_username.c_str(), log_db_hostname.c_str(), log_db_port, log_db_database.c_str());
 		Sql_ShowDebug(sql_handle);
 		Sql_Free(sql_handle);

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -95,7 +95,7 @@ char guild_storage_log_table[32] = "guild_storage_log";
 
 // log database
 std::string log_db_ip = "127.0.0.1";
-int log_db_port = 3306;
+uint16 log_db_port = 3306;
 std::string log_db_id = "ragnarok";
 std::string log_db_pw = "";
 std::string log_db_db = "log";
@@ -4189,7 +4189,7 @@ int inter_config_read(const char *cfgName)
 			log_db_pw = w2;
 		else
 		if(strcmpi(w1,"log_db_port")==0)
-			log_db_port = atoi(w2);
+			log_db_port = (uint16)strtoul( w2, nullptr, 10 );
 		else
 		if(strcmpi(w1,"log_db_db")==0)
 			log_db_db = w2;
@@ -4274,7 +4274,7 @@ int log_sql_init(void)
 
 	ShowInfo("" CL_WHITE "[SQL]" CL_RESET ": Connecting to the Log Database " CL_WHITE "%s" CL_RESET " At " CL_WHITE "%s" CL_RESET "...\n",log_db_db.c_str(), log_db_ip.c_str());
 	if ( SQL_ERROR == Sql_Connect(logmysql_handle, log_db_id.c_str(), log_db_pw.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str()) ){
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			log_db_id.c_str(), log_db_ip.c_str(), log_db_port, log_db_db.c_str());
 		Sql_ShowDebug(logmysql_handle);
 		Sql_Free(logmysql_handle);

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -44,26 +44,26 @@ struct Web_Config web_config {};
 struct Inter_Config inter_config {};
 std::shared_ptr<httplib::Server> http_server;
 
-int login_server_port = 3306;
 std::string login_server_ip = "127.0.0.1";
+uint16 login_server_port = 3306;
 std::string login_server_id = "ragnarok";
 std::string login_server_pw = "";
 std::string login_server_db = "ragnarok";
 
-int  char_server_port = 3306;
 std::string char_server_ip = "127.0.0.1";
+uint16  char_server_port = 3306;
 std::string char_server_id = "ragnarok";
 std::string char_server_pw = "";
 std::string char_server_db = "ragnarok";
 
-int map_server_port = 3306;
 std::string map_server_ip = "127.0.0.1";
+uint16 map_server_port = 3306;
 std::string map_server_id = "ragnarok";
 std::string map_server_pw = "";
 std::string map_server_db = "ragnarok";
 
-int web_server_port = 3306;
 std::string web_server_ip = "127.0.0.1";
+uint16 web_server_port = 3306;
 std::string web_server_id = "ragnarok";
 std::string web_server_pw = "";
 std::string web_server_db = "ragnarok";
@@ -188,7 +188,7 @@ int inter_config_read(const char* cfgName)
 		else if(!strcmpi(w1,"login_server_ip"))
 			login_server_ip = w2;
 		else if(!strcmpi(w1,"login_server_port"))
-			login_server_port = atoi(w2);
+			login_server_port = (uint16)strtoul( w2, nullptr, 10 );
 		else if(!strcmpi(w1,"login_server_id"))
 			login_server_id = w2;
 		else if(!strcmpi(w1,"login_server_pw"))
@@ -198,7 +198,7 @@ int inter_config_read(const char* cfgName)
 		else if(!strcmpi(w1,"char_server_ip"))
 			char_server_ip = w2;
 		else if(!strcmpi(w1,"char_server_port"))
-			char_server_port = atoi(w2);
+			char_server_port = (uint16)strtoul( w2, nullptr, 10 );
 		else if(!strcmpi(w1,"char_server_id"))
 			char_server_id = w2;
 		else if(!strcmpi(w1,"char_server_pw"))
@@ -208,7 +208,7 @@ int inter_config_read(const char* cfgName)
 		else if(!strcmpi(w1,"map_server_ip"))
 			map_server_ip = w2;
 		else if(!strcmpi(w1,"map_server_port"))
-			map_server_port = atoi(w2);
+			map_server_port = (uint16)strtoul( w2, nullptr, 10 );
 		else if(!strcmpi(w1,"map_server_id"))
 			map_server_id = w2;
 		else if(!strcmpi(w1,"map_server_pw"))
@@ -218,7 +218,7 @@ int inter_config_read(const char* cfgName)
 		else if(!strcmpi(w1,"web_server_ip"))
 			web_server_ip = w2;
 		else if(!strcmpi(w1,"web_server_port"))
-			web_server_port = atoi(w2);
+			web_server_port = (uint16)strtoul( w2, nullptr, 10 );
 		else if(!strcmpi(w1,"web_server_id"))
 			web_server_id = w2;
 		else if(!strcmpi(w1,"web_server_pw"))
@@ -276,7 +276,7 @@ int web_sql_init(void) {
 	ShowInfo("Connecting to the Login DB server.....\n");
 
 	if (SQL_ERROR == Sql_Connect(login_handle, login_server_id.c_str(), login_server_pw.c_str(), login_server_ip.c_str(), login_server_port, login_server_db.c_str())) {
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			login_server_id.c_str(), login_server_ip.c_str(), login_server_port, login_server_db.c_str());
 		Sql_ShowDebug(login_handle);
 		Sql_Free(login_handle);
@@ -293,7 +293,7 @@ int web_sql_init(void) {
 	ShowInfo("Connecting to the Char DB server.....\n");
 
 	if (SQL_ERROR == Sql_Connect(char_handle, char_server_id.c_str(), char_server_pw.c_str(), char_server_ip.c_str(), char_server_port, char_server_db.c_str())) {
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			char_server_id.c_str(), char_server_ip.c_str(), char_server_port, char_server_db.c_str());
 		Sql_ShowDebug(char_handle);
 		Sql_Free(char_handle);
@@ -310,7 +310,7 @@ int web_sql_init(void) {
 	ShowInfo("Connecting to the Map DB server.....\n");
 
 	if (SQL_ERROR == Sql_Connect(map_handle, map_server_id.c_str(), map_server_pw.c_str(), map_server_ip.c_str(), map_server_port, map_server_db.c_str())) {
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			map_server_id.c_str(), map_server_ip.c_str(), map_server_port, map_server_db.c_str());
 		Sql_ShowDebug(map_handle);
 		Sql_Free(map_handle);
@@ -327,7 +327,7 @@ int web_sql_init(void) {
 	ShowInfo("Connecting to the Web DB server.....\n");
 
 	if (SQL_ERROR == Sql_Connect(web_handle, web_server_id.c_str(), web_server_pw.c_str(), web_server_ip.c_str(), web_server_port, web_server_db.c_str())) {
-		ShowError("Couldn't connect with uname='%s',host='%s',port='%d',database='%s'\n",
+		ShowError("Couldn't connect with uname='%s',host='%s',port='%hu',database='%s'\n",
 			web_server_id.c_str(), web_server_ip.c_str(), web_server_port, web_server_db.c_str());
 		Sql_ShowDebug(web_handle);
 		Sql_Free(web_handle);


### PR DESCRIPTION
#### Issues

The login server is unable to process MySQL passwords that exceed 31 characters in length. Should a password be longer than this, it will end up being truncated.

#### Why

The issue is specific to the login server. This is because the Buffer allocated for storing passwords has a maximum capacity of 32 characters. Considering the termination character (null character), it effectively stores only up to 31 characters.

#### Solution

Taking a cue from the approach used in several other projects, I switch the variable type for storing database connection details from char[] to std::string. This change is intended to resolve the truncation issue stemming from inadequate storage space.