### PR TITLE
Rebalance Arch mage 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36197,15 +36197,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 86
+          Amount: 74
         - Level: 2
-          Amount: 88
+          Amount: 78
         - Level: 3
-          Amount: 90
+          Amount: 82
         - Level: 4
-          Amount: 92
+          Amount: 86
         - Level: 5
-          Amount: 94
+          Amount: 90
   - Id: 5236
     Name: AG_CRIMSON_ARROW_ATK
     Description: Crimson Arrow Attack

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36262,15 +36262,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 103
         - Level: 2
-          Amount: 87
+          Amount: 106
         - Level: 3
-          Amount: 90
+          Amount: 109
         - Level: 4
-          Amount: 93
+          Amount: 112
         - Level: 5
-          Amount: 96
+          Amount: 115
   - Id: 5238
     Name: IQ_POWERFUL_FAITH
     Description: Powerful Faith

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35838,15 +35838,15 @@ Body:
     Element: Water
     SplashArea:
       - Level: 1
-        Area: 3
+        Area: 4
       - Level: 2
         Area: 4
       - Level: 3
         Area: 5
       - Level: 4
-        Area: 6
+        Area: 5
       - Level: 5
-        Area: 7
+        Area: 6
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
@@ -35856,15 +35856,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 100
+          Amount: 170
         - Level: 2
-          Amount: 108
+          Amount: 174
         - Level: 3
-          Amount: 116
+          Amount: 178
         - Level: 4
-          Amount: 124
+          Amount: 182
         - Level: 5
-          Amount: 132
+          Amount: 186
     Status: Climax_CryImp
   - Id: 5226
     Name: AG_CRYSTAL_IMPACT_ATK

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36117,15 +36117,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 68
+          Amount: 72
         - Level: 2
-          Amount: 74
+          Amount: 76
         - Level: 3
           Amount: 80
         - Level: 4
-          Amount: 86
+          Amount: 84
         - Level: 5
-          Amount: 92
+          Amount: 88
   - Id: 5234
     Name: AG_STORM_CANNON
     Description: Storm Cannon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35414,20 +35414,20 @@ Body:
     CastTime: 4000
     AfterCastActDelay: 500
     Duration2: 900000
-    Cooldown: 2000
+    Cooldown: 2500
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 108
+          Amount: 170
         - Level: 2
-          Amount: 114
+          Amount: 174
         - Level: 3
-          Amount: 120
+          Amount: 178
         - Level: 4
-          Amount: 126
+          Amount: 182
         - Level: 5
-          Amount: 132
+          Amount: 186
     Status: Climax_Des_Hu
   - Id: 5216
     Name: AG_RAIN_OF_CRYSTAL

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36157,15 +36157,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 78
+          Amount: 79
         - Level: 2
-          Amount: 82
+          Amount: 79
         - Level: 3
-          Amount: 86
+          Amount: 82
         - Level: 4
-          Amount: 90
+          Amount: 85
         - Level: 5
-          Amount: 94
+          Amount: 88
   - Id: 5235
     Name: AG_CRIMSON_ARROW
     Description: Crimson Arrow

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35447,28 +35447,28 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 85
         - Level: 2
-          Amount: 88
+          Amount: 95
         - Level: 3
-          Amount: 92
+          Amount: 105
         - Level: 4
-          Amount: 96
+          Amount: 115
         - Level: 5
-          Amount: 100
+          Amount: 125
     Unit:
       Id: Rain_Of_Crystal
       Range:
         - Level: 1
-          Size: 6
+          Size: 4
         - Level: 2
-          Size: 7
+          Size: 4
         - Level: 3
-          Size: 8
+          Size: 5
         - Level: 4
-          Size: 9
+          Size: 5
         - Level: 5
-          Size: 10
+          Size: 6
       Interval: 500
       Target: Enemy
       Flag:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7930,7 +7930,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STORM_CANNON:
-						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7921,7 +7921,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ROCK_DOWN:
-						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7947,7 +7947,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:
-						skillratio += -100 + 250 + 900 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 150 + 350 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7939,11 +7939,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW:
-						skillratio += -100 + 300 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 350 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW_ATK:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 700 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7833,14 +7833,14 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE:
-						skillratio += -100 + 250 + 2800 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + 2850 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX))
 						{
 							if (sc->getSCE(SC_CLIMAX)->val1 == 3)
-								skillratio *= 3;
+								skillratio += skillratio * 150 / 100;
 							else if (sc->getSCE(SC_CLIMAX)->val1 == 5)
-								skillratio += skillratio * 50 / 100;
+								skillratio += skillratio * 20 / 100;
 						}
 						break;
 					case AG_RAIN_OF_CRYSTAL:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7840,7 +7840,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 							if (sc->getSCE(SC_CLIMAX)->val1 == 3)
 								skillratio += skillratio * 150 / 100;
 							else if (sc->getSCE(SC_CLIMAX)->val1 == 5)
-								skillratio += skillratio * 20 / 100;
+								skillratio -= skillratio * 20 / 100;
 						}
 						break;
 					case AG_RAIN_OF_CRYSTAL:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7969,7 +7969,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				if (skill_id == AG_DESTRUCTIVE_HURRICANE)
 					splash_size = 9; // 19x19
 				else if(skill_id == AG_CRYSTAL_IMPACT)
-					splash_size = AREA_SIZE; // 29x29 - Entire screen.
+					splash_size = 7; // 15x15
 			}
 
 			skill_area_temp[1] = 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Arch Mage
---------------------------------

1. Rain of Crystal
	- Reduces area of effect from 19 x 19 cells to 13 x 13 cells based on level 5.
	- Increases SP consumption from 100 to 125 based on level 5.

2. Crimson Arrow
	- Reduces SP consumption from 94 to 90 based on level 5.
	- Increases base damage of linear damage from 1500%Matk to 1750%Matk based on level 5.
	- Increases base damage of explosion damage from 3000%Matk to 3500%Matk based on level 5.

3. Storm Cannon
	- Reduces SP consumption from 94 to 88 based on level 5.
	- Increases base damage from 4750%/6250%Matk to 6000%/7500%Matk based on level 5.

4. Rock Down
	- Reduces SP consumption from 94 to 88 based on level 5.
	- Increases base damage from 4750%/6250%Matk to 6000%/7500%Matk based on level 5.

5. Frozen Slash
	- Increases SP consumption from 96 to 115 based on level 5.
	- Increases base damage from 4750%/6650%Matk to 4900%/6800%Matk based on level 5.

6. Destructive Hurricane
	- Increases cooldown from 2 seconds to 2.5 seconds.
	- Increases base damage from 14250%Matk to 14850%Matk based on level 5.
	- Reduces damage bonus from Climax level 3 from 200% to 150%.
	- Changes damage modifier from Climax level 5 from 50% increasing to 20% reducing.
	- Increases SP consumption from 132 to 186 based on level 5.

7. Crystal Impact
	- Reduces area of effect from 15 x 15 cells to 13 x 13 cells based on level 5.
	- Reduces area of effect bonus from Climax level 5 from entire screen to 15 x 15 cells.
	- Increases SP consumption from 132 to 186 based on level 5. 
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
