### PR TITLE
Bumping CMake min version

### DIFF
--- a/3rdparty/httplib/CMakeLists.txt
+++ b/3rdparty/httplib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if ( NOT ENABLE_WEB_SERVER )
     return()

--- a/3rdparty/json/CMakeLists.txt
+++ b/3rdparty/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set (JSON_INCLUDE_DIRS
     "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/3rdparty/yaml-cpp/CMakeLists.txt
+++ b/3rdparty/yaml-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 ## start setting
 SET (this_target yaml-cpp)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#8066
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This PR bumps the minimum CMake version of `2.8` to `2.8.12`, so the compiler stops whining about it.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
