### PR TITLE
Rebalance Troubadour & Trouvere 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40335,7 +40335,7 @@ Body:
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 350
-    Cooldown: 1150
+    Cooldown: 350
     FixedCastTime: 1000
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40378,10 +40378,11 @@ Body:
       - Level: 4
         Area: 3
       - Level: 5
-        Area: 3
+        Area: 4
     GiveAp: 2
     CastCancel: true
-    Cooldown: 300
+    AfterCastActDelay: 500
+    Cooldown: 400
     Requires:
       SpCost:
         - Level: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8039,12 +8039,13 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += -100 + ( 570 + 20 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
-					case TR_METALIC_FURY: {
-							int area = skill_get_splash(skill_id, skill_lv);
-							int count = map_forcountinarea(skill_check_bl_sc,target->m,target->x - area,target->y - area,target->x + area,target->y + area,5,BL_MOB,SC_SOUNDBLEND);
-							skillratio += -100 + (2200 + 300 * count) * skill_lv + 5 * sstatus->spl;
-							RE_LVL_DMOD(100);
-						}
+					case TR_METALIC_FURY:
+						skillratio += -100 + 2600 * skill_lv;
+						if (tsc && tsc->getSCE(SC_SOUNDBLEND))
+							skillratio += 1000 * skill_lv;
+						if (sd)
+							skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
+						RE_LVL_DMOD(100);
 						break;
 					case TR_SOUNDBLEND:
 						skillratio += -100 + 120 * skill_lv + 5 * sstatus->spl;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8047,8 +8047,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						// !Todo: skill affected by SPL (without SC_SOUNDBLEND) as well?
 						if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
 							skillratio += 1000 * skill_lv;
-							if (sd)
-								skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
+							skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
 						}
 						RE_LVL_DMOD(100);
 						break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5734,13 +5734,15 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			}
 			break;
 		case TR_RHYTHMSHOOTING:
-			skillratio += -100 + 200 + 120 * skill_lv;
+			skillratio += -100 + 450 + 650 * skill_lv;
 
 			if (sd && pc_checkskill(sd, TR_STAGE_MANNER) > 0)
-				skillratio += 3 * sstatus->con;
+				skillratio += 5 * sstatus->con;
 
-			if (tsc && tsc->getSCE(SC_SOUNDBLEND))
-				skillratio += 100 + 100 * skill_lv;
+			if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
+				skillratio += 350 + 100 * skill_lv;
+				skillratio += 2 * sstatus->con;
+			}
 
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_MYSTIC_SYMPHONY)) {

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5740,7 +5740,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += 5 * sstatus->con;
 
 			if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
-				skillratio += 350 + 100 * skill_lv;
+				if (skill_lv == 4)
+					skillratio += 830;	// Typo in skill description ?
+				else
+					skillratio += 350 + 100 * skill_lv;
 				skillratio += 2 * sstatus->con;
 			}
 
@@ -8041,10 +8044,12 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case TR_METALIC_FURY:
 						skillratio += -100 + 2600 * skill_lv;
-						if (tsc && tsc->getSCE(SC_SOUNDBLEND))
+						// !Todo: skill affected by SPL (without SC_SOUNDBLEND) as well?
+						if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
 							skillratio += 1000 * skill_lv;
-						if (sd)
-							skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
+							if (sd)
+								skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
+						}
 						RE_LVL_DMOD(100);
 						break;
 					case TR_SOUNDBLEND:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2183,7 +2183,6 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		[[fallthrough]];
 	case WM_METALICSOUND:
 	case WM_REVERBERATION:
-	case TR_RHYTHMSHOOTING:
 	case TR_METALIC_FURY:
 		status_change_end(bl, SC_SOUNDBLEND);
 		break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2183,7 +2183,6 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		[[fallthrough]];
 	case WM_METALICSOUND:
 	case WM_REVERBERATION:
-	case TR_METALIC_FURY:
 		status_change_end(bl, SC_SOUNDBLEND);
 		break;
 	case EM_DIAMOND_STORM:
@@ -5680,6 +5679,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 	case BO_EXPLOSIVE_POWDER:
 	case BO_MAYHEMIC_THORNS:
 	case NPC_WIDECRITICALWOUND:
+	case TR_METALIC_FURY:
 		if( flag&1 ) {//Recursive invocation
 			int sflag = skill_area_temp[0] & 0xFFF;
 			int heal = 0;
@@ -5894,24 +5894,6 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 				return 0;
 			}
 		}
-		break;
-	case TR_METALIC_FURY:
-	{
-		if (flag & 1) {
-			clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
-			skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag);
-		} else {
-			int area = skill_get_splash(skill_id, skill_lv);
-			int count = map_forcountinarea(skill_check_bl_sc,bl->m,bl->x - area,bl->y - area,bl->x + area,bl->y + area,5,BL_MOB,SC_SOUNDBLEND);
-			if (count > 0){
-				map_foreachinarea(skill_area_sub, bl->m, bl->x - area, bl->y - area, bl->x + area, bl->y + area, BL_CHAR,
-					src, skill_id, skill_lv, tick, flag | BCT_ENEMY | SD_SPLASH | 1, skill_castend_damage_id);
-			} else{
-				clif_skill_nodamage(src, bl, skill_id, skill_lv, 1);
-				skill_attack(skill_get_type(skill_id), src, src, bl, skill_id, skill_lv, tick, flag);
-			}
-		}
-	}
 		break;
 
 	//Place units around target


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Troubadour & Trouvere
---------------------------------

1. [Rhythm Shooting](https://www.divine-pride.net/database/skill/5355)
	- Increases cooldown from 0.15 seconds to 0.35 seconds.
	- Increases base damage from 800%/1400%Atk to 3700%/4550%Atk per hit based on level 5.
	- Increases factor weight of CON in skill formula from 3 to 5 (7 on targets marked with sound brand).

2. [Metallic Fury](https://www.divine-pride.net/database/skill/5356)
	- Reworks skill to dealing damage to surrounding enemies around the target (9 x 9 cells based on level 5).
	- Increases cooldown from 0.3 seconds to 0.4 seconds.
	- Increases global cool time from 0.3 seconds to 0.5 seconds.
	- No longer remove sound brand debuff from target. (doesn't mention it changelog but it works)
	- Increases base damage from 11000%Matk to 13000%/18000%(targets marked with sound brand)Matk based on level 5.
	- Increases factor weight of SPL in skill formula (on targets marked with sound brand) from 1.5x of Stage Manner skill level to 2x of Stage Manner skill level. 


Additionally
-----------------------------
Rhythm Shooting
- No longer remove sound brand debuff from target. (from skill description)
