### PR TITLE
Fix token auth packet handling

### DIFF
--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -361,7 +361,7 @@ int logclif_parse_reqauth_sso( int fd, login_session_data& sd, char* ip ){
 
 	ShowStatus( "Request for connection (SSO mode) of %s (ip: %s)\n", sd.userid, ip );
 	// Shinryo: For the time being, just use token as password.
-	safestrncpy( sd.passwd, p->token, token_length );
+	safestrncpy( sd.passwd, p->token, token_length + 1 );
 
 	if( login_config.use_md5_passwds ){
 		MD5_String( sd.passwd, sd.passwd );
@@ -369,7 +369,7 @@ int logclif_parse_reqauth_sso( int fd, login_session_data& sd, char* ip ){
 
 	sd.passwdenc = 0;
 
-	RFIFOSKIP( fd, sizeof( *p ) );
+	RFIFOSKIP( fd, p->packetLength );
 
 	int result = login_mmo_auth( &sd, false );
 


### PR DESCRIPTION
It should skip the entire packet

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Follow up to 7999ccb215487db28b4d29f068f8016c4a6671fc
* We weren't copying the whole token
* we also weren't skipping the whole packet

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
