### PR TITLE
Make the global packet_buffer owned by common

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -47,6 +47,10 @@
 #include "strlib.hpp"
 #include "timer.hpp"
 
+// Reuseable global packet buffer to prevent too many allocations
+// Take socket.cpp::socket_max_client_packet into consideration
+int8 packet_buffer[UINT16_MAX];
+
 /////////////////////////////////////////////////////////////////////
 #if defined(WIN32)
 /////////////////////////////////////////////////////////////////////

--- a/src/common/socket.hpp
+++ b/src/common/socket.hpp
@@ -201,7 +201,7 @@ void send_shortlist_do_sends();
 
 // Reuseable global packet buffer to prevent too many allocations
 // Take socket.cpp::socket_max_client_packet into consideration
-static int8 packet_buffer[UINT16_MAX];
+extern int8 packet_buffer[UINT16_MAX];
 
 template <typename P>
 bool socket_send( int fd, P& packet ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: We're getting some warnings about unused variables. This is because any fiel that includes `socket.hpp` has a definition for the global `packet_buffer`.

This fix makes the global owned by the `socket.cpp` translation unit, and can be accessed via the externed definition.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
