### PR TITLE
Allow use of 'false' in group commands (conf/groups.yml)

### DIFF
--- a/src/map/pc_groups.cpp
+++ b/src/map/pc_groups.cpp
@@ -17,7 +17,7 @@ const std::string PlayerGroupDatabase::getDefaultLocation() {
 	return std::string( conf_path ) + "/groups.yml";
 }
 
-bool PlayerGroupDatabase::parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands ){
+bool PlayerGroupDatabase::parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands, std::vector<std::string>& del_commands ){
 	for( const auto& it : node.children() ){
 		std::string command;
 
@@ -44,12 +44,10 @@ bool PlayerGroupDatabase::parseCommands( const ryml::NodeRef& node, std::vector<
 				commands.push_back( command );
 			}
 		}else{
-			if( !util::vector_exists( commands, command ) ){
-				this->invalidWarning( it, "Group does not have command \"%s\". Please check your data.\n", command.c_str() );
-				return false;
-			}else{
+			if( util::vector_exists( commands, command ) ){
 				util::vector_erase_if_exists( commands, command );
 			}
+			del_commands.push_back( command );
 		}
 	}
 
@@ -115,11 +113,11 @@ uint64 PlayerGroupDatabase::parseBodyNode( const ryml::NodeRef& node ){
 		}
 	}
 
-	if( this->nodeExists( node, "Commands" ) && !this->parseCommands( node["Commands"], group->commands ) ){
+	if( this->nodeExists( node, "Commands" ) && !this->parseCommands( node["Commands"], group->commands, group->del_commands ) ){
 		return 0;
 	}
 
-	if( this->nodeExists( node, "CharCommands" ) && !this->parseCommands( node["CharCommands"], group->char_commands ) ){
+	if( this->nodeExists( node, "CharCommands" ) && !this->parseCommands( node["CharCommands"], group->char_commands, group->del_char_commands ) ){
 		return 0;
 	}
 
@@ -316,13 +314,27 @@ PlayerGroupDatabase player_group_db;
  * @param type enum AtCommanndType { COMMAND_ATCOMMAND = 1, COMMAND_CHARCOMMAND = 2 }
  */
 bool s_player_group::can_use_command( const std::string& command, AtCommandType type ){
-	if( this->has_permission( PC_PERM_USE_ALL_COMMANDS ) ){
-		return true;
-	}
-
 	std::string command_lower = command;
 
 	util::tolower( command_lower );
+
+	if( this->del_commands.size() > 0 || this->del_char_commands.size() > 0 ){
+		switch( type ){
+			case COMMAND_ATCOMMAND:
+				if(util::vector_exists( this->del_commands, command_lower ))
+					return false;
+				break;
+			case COMMAND_CHARCOMMAND:
+				if(util::vector_exists( this->del_char_commands, command_lower ))
+					return false;
+				break;
+		}
+	}
+
+
+	if( this->has_permission( PC_PERM_USE_ALL_COMMANDS ) ){
+		return true;
+	}
 
 	switch( type ){
 		case COMMAND_ATCOMMAND:

--- a/src/map/pc_groups.hpp
+++ b/src/map/pc_groups.hpp
@@ -97,8 +97,6 @@ struct s_player_group{
 	bool log_commands;
 	std::vector<std::string> commands;
 	std::vector<std::string> char_commands;
-	std::vector<std::string> del_commands;
-	std::vector<std::string> del_char_commands;
 	std::bitset<PC_PERM_MAX> permissions;
 	uint32 index;
 
@@ -111,7 +109,7 @@ public:
 class PlayerGroupDatabase : public TypesafeYamlDatabase<uint32, s_player_group>{
 private:
 	std::map<uint32, std::vector<std::string>> inheritance;
-	bool parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands, std::vector<std::string>& del_commands );
+	bool parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands );
 
 public:
 	PlayerGroupDatabase() : TypesafeYamlDatabase( "PLAYER_GROUP_DB", 1 ){

--- a/src/map/pc_groups.hpp
+++ b/src/map/pc_groups.hpp
@@ -97,6 +97,8 @@ struct s_player_group{
 	bool log_commands;
 	std::vector<std::string> commands;
 	std::vector<std::string> char_commands;
+	std::vector<std::string> del_commands;
+	std::vector<std::string> del_char_commands;
 	std::bitset<PC_PERM_MAX> permissions;
 	uint32 index;
 
@@ -109,7 +111,7 @@ public:
 class PlayerGroupDatabase : public TypesafeYamlDatabase<uint32, s_player_group>{
 private:
 	std::map<uint32, std::vector<std::string>> inheritance;
-	bool parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands );
+	bool parseCommands( const ryml::NodeRef& node, std::vector<std::string>& commands, std::vector<std::string>& del_commands );
 
 public:
 	PlayerGroupDatabase() : TypesafeYamlDatabase( "PLAYER_GROUP_DB", 1 ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  When the <code>false</code> option is used, it does not consider inheritance or the <code>all_commands</code> permission, making it  it rather restrictive. It is also common trigger an error, because didn't found the command.

This fix add on <code>pc_groups.cpp</code> and <code>pc_groups.hpp</code> a new variable to store the commands that will be remove from the group.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
