### PR TITLE
Rebalance Dragon Knight 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35331,19 +35331,19 @@ Body:
     GiveAp: 2
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 35
         - Level: 2
-          Amount: 45
+          Amount: 40
         - Level: 3
-          Amount: 50
+          Amount: 45
         - Level: 4
-          Amount: 55
+          Amount: 50
         - Level: 5
-          Amount: 60
+          Amount: 55
       Weapon:
         2hSword: true
         2hAxe: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35258,15 +35258,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 36
+          Amount: 27
         - Level: 2
-          Amount: 44
+          Amount: 34
         - Level: 3
-          Amount: 52
+          Amount: 41
         - Level: 4
-          Amount: 60
+          Amount: 48
         - Level: 5
-          Amount: 68
+          Amount: 55
       Weapon:
         2hSword: true
         2hSpear: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35121,6 +35121,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
+      Critical: true
     Range: 2
     Hit: Multi_Hit
     HitCount: 2
@@ -35133,19 +35134,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     CastCancel: true
     AfterCastActDelay: 250
     Cooldown: 700
@@ -35182,6 +35183,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
+      Critical: true
     Range: 2
     Hit: Multi_Hit
     HitCount: 2
@@ -35194,19 +35196,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     Requires:
       SpCost: 1
   - Id: 5210

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5427,7 +5427,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 		case DK_STORMSLASH:
 			skillratio += -100 + 200 + 400 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
-			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 60)
+			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd_chance(60, 100))
 				skillratio *= 2;
 			break;
 		case DK_DRAGONIC_BREATH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5425,9 +5425,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio *= 2;
 			break;
 		case DK_STORMSLASH:
-			skillratio += -100 + 100 + 170 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + 400 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
-			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 30)
+			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 60)
 				skillratio *= 2;
 			break;
 		case DK_DRAGONIC_BREATH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5401,7 +5401,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case DK_HACKANDSLASHER:
 		case DK_HACKANDSLASHER_ATK:
-			skillratio += -100 + 300 + 700 * skill_lv;
+			skillratio += -100 + 200 + 750 * skill_lv;
 			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5412,7 +5412,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_MADNESS_CRUSHER:
-			skillratio += -100 + 400 + 800 * skill_lv + 7 * sstatus->pow;
+			skillratio += -100 + 350 + 1600 * skill_lv + 10 * sstatus->pow;
 			if( sd != nullptr ){
 				int16 index = sd->equip_index[EQI_HAND_R];
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Dragon Knight
---------------------------------

1. [Madness Crusher](https://www.divine-pride.net/database/skill/5211)
	- Reduces SP consumption from 68 to 55 based on level 5.
	- Increases base damage from 4400%Atk to 8350%Atk based on level 5.
	- Increases factor weight of POW in skill formula from 7 to 10.

2. [Storm Slash](https://www.divine-pride.net/database/skill/5213)
	- Increases cooldown from 0.3 seconds to 0.35 seconds.
	- Reduces SP consumption from 60 to 55 based on level 5.
	- Increases base damage from 950%Atk to 2200%Atk per hit based on level 5.
	- Increases the chance to double skill damage while under Giant Growth buff from 30% to 60%.

3. [Hack and Slasher](https://www.divine-pride.net/database/skill/5208)
	- Increases base damage from 7300%Atk to 7700%Atk per hit based on level 10.
	- Reduces area of effect from 9 x 9 cells to 7 x 7 cells based on level 10.
	- Applies critical damage, the critical chance is the user's Cri. 
