### PR TITLE
Rebalance Abyss chaser 20221221

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38742,19 +38742,19 @@ Body:
       - Level: 4
         Time: 900
       - Level: 5
-        Time: 300
+        Time: 400
     Requires:
       SpCost:
         - Level: 1
-          Amount: 48
-        - Level: 2
-          Amount: 52
-        - Level: 3
-          Amount: 56
-        - Level: 4
           Amount: 60
-        - Level: 5
+        - Level: 2
           Amount: 64
+        - Level: 3
+          Amount: 68
+        - Level: 4
+          Amount: 72
+        - Level: 5
+          Amount: 76
       Weapon:
         Dagger: true
         1hSword: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38951,7 +38951,7 @@ Body:
       Splash: true
     Range: 2
     Hit: Multi_Hit
-    HitCount: -5
+    HitCount: 5
     Element: Weapon
     SplashArea:
       - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38977,27 +38977,7 @@ Body:
     GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown:
-      - Level: 1
-        Time: 2000
-      - Level: 2
-        Time: 1900
-      - Level: 3
-        Time: 1700
-      - Level: 4
-        Time: 1500
-      - Level: 5
-        Time: 1300
-      - Level: 6
-        Time: 1100
-      - Level: 7
-        Time: 900
-      - Level: 8
-        Time: 700
-      - Level: 9
-        Time: 500
-      - Level: 10
-        Time: 700 # TODO: unknown cooldown for others levels
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38997,29 +38997,29 @@ Body:
       - Level: 9
         Time: 500
       - Level: 10
-        Time: 300
+        Time: 700 # TODO: unknown cooldown for others levels
     Requires:
       SpCost:
         - Level: 1
-          Amount: 35
+          Amount: 45
         - Level: 2
-          Amount: 38
+          Amount: 48
         - Level: 3
-          Amount: 41
+          Amount: 51
         - Level: 4
-          Amount: 44
+          Amount: 54
         - Level: 5
-          Amount: 47
+          Amount: 57
         - Level: 6
-          Amount: 50
+          Amount: 60
         - Level: 7
-          Amount: 53
+          Amount: 63
         - Level: 8
-          Amount: 56
+          Amount: 66
         - Level: 9
-          Amount: 59
+          Amount: 69
         - Level: 10
-          Amount: 62
+          Amount: 72
   - Id: 5321
     Name: ABC_ABYSS_SQUARE
     Description: Abyss Square

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39066,54 +39066,34 @@ Body:
       Critical: true
     Range: 9
     Hit: Multi_Hit
-    HitCount: 1
+    HitCount: 2
     Element: Weapon
     GiveAp: 1
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown:
-      - Level: 1
-        Time: 2000
-      - Level: 2
-        Time: 1800
-      - Level: 3
-        Time: 1600
-      - Level: 4
-        Time: 1400
-      - Level: 5
-        Time: 1200
-      - Level: 6
-        Time: 1000
-      - Level: 7
-        Time: 800
-      - Level: 8
-        Time: 600
-      - Level: 9
-        Time: 400
-      - Level: 10
-        Time: 200
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1
-          Amount: 37
-        - Level: 2
-          Amount: 39
-        - Level: 3
-          Amount: 41
-        - Level: 4
-          Amount: 43
-        - Level: 5
-          Amount: 45
-        - Level: 6
           Amount: 47
-        - Level: 7
+        - Level: 2
           Amount: 49
-        - Level: 8
+        - Level: 3
           Amount: 51
-        - Level: 9
+        - Level: 4
           Amount: 53
-        - Level: 10
+        - Level: 5
           Amount: 55
+        - Level: 6
+          Amount: 57
+        - Level: 7
+          Amount: 59
+        - Level: 8
+          Amount: 61
+        - Level: 9
+          Amount: 63
+        - Level: 10
+          Amount: 65
       Weapon:
         Bow: true
       Ammo:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5625,7 +5625,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:
-			skillratio += -100 + 400 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 150 + 600 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKRUSH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5605,7 +5605,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_ABYSS_DAGGER:
-			skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 100 + 900 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_UNLUCKY_RUSH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5621,7 +5621,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:
-			skillratio += -100 + 350 + 550 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + 350 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4146,10 +4146,6 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 				if (status_get_lv(src) > 29 && rnd() % 100 < 10 * status_get_lv(src) / 30)
 					skill_addtimerskill(src, tick + dmg.amotion + skill_get_delay(skill_id, skill_lv), bl->id, 0, 0, skill_id, skill_lv, attack_type, flag|2);
 				break;
-			case ABC_DEFT_STAB:
-				if (skill_area_temp[1] == bl->id && rnd()%100 < 4 * skill_lv)// Need official autocast chance. [Rytech]
-					skill_addtimerskill(src, tick + dmg.amotion, bl->id, 0, 0, skill_id, skill_lv, BF_WEAPON, 2);
-				break;
 		}
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8018

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Abyss Chaser
---------------------------------

1. [Abyss Dagger](https://www.divine-pride.net/database/skill/5314)
	- Increases cooldown from 0.3 seconds to 0.4 seconds.
	- Increases SP consumption from 64 to 76 based on level 5.
	- Increases base damage from 2600%Atk to 4600%Atk based on level 5.

2. [Deft Stab](https://www.divine-pride.net/database/skill/5320)
	- Removes a chance to trigger the skill one more time.
	- Increases SP consumption from 62 to 72 based on level 10.
	- Increases cooldown from 0.3 seconds to 0.7 seconds.
	- Reduces base damage from 5850%Atk to 3750%Atk based on level 10.
	- Changes damage logic from 5 split hits to 5 cumulative hits.

3. [Frenzy Shot](https://www.divine-pride.net/database/skill/5322)
	- Increases cooldown from 0.2 seconds to 0.35 seconds.
	- Increases SP consumption from 55 to 65 based on level 10.
	- Increases number of hit from 1 hit to 2 hits.
	- Increases base damage from 4000%Atk to 6150%Atk based on level 10.
	- Increases factor weight of CON in skill formula from 5 to 15. 
