### PR TITLE
Corrected CD_ARBITRIUM_ATK area of damage

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37417,27 +37417,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
-    SplashArea:
-      - Level: 1
-        Area: 1
-      - Level: 2
-        Area: 1
-      - Level: 3
-        Area: 1
-      - Level: 4
-        Area: 2
-      - Level: 5
-        Area: 2
-      - Level: 6
-        Area: 2
-      - Level: 7
-        Area: 3
-      - Level: 8
-        Area: 3
-      - Level: 9
-        Area: 3
-      - Level: 10
-        Area: 4
+    SplashArea: 4
     Requires:
       SpCost: 1
   - Id: 5275


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8079

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The splash area should be 9x9 regardless of the skill level according to the description.
`데미지를 입은 대상에게 빛이 폭발하며, 대상 및 주변 9x9 범위내 대상에게 2차 성속성 마법 데미지를 입힌다.`
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
