### PR TITLE
Read this in 2037 if project stay alive

### DIFF
--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -10,6 +10,9 @@
 
 #ifdef WIN32
 #include "winapi.hpp" // GetTickCount()
+#ifdef DEPRECATED_WINDOWS_SUPPORT
+#include <chrono>
+#endif
 #else
 #endif
 
@@ -143,7 +146,19 @@ static t_tick tick(void)
 {
 #if defined(WIN32)
 #ifdef DEPRECATED_WINDOWS_SUPPORT
-	return GetTickCount();
+	if(GetTickCount() < 0x7FFFFFFF && GetTickCount() > 0)
+		return GetTickCount();
+	else {
+			OSVERSIONINFO osvi;
+			osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+			if (GetVersionEx(&osvi) && osvi.dwMajorVersion >= 6) 
+				return GetTickCount64();
+			else {
+				auto now = std::chrono::system_clock::now();
+			    auto duration = now.time_since_epoch();
+				return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+			}
+	}
 #else
 	return GetTickCount64();
 #endif

--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -149,15 +149,9 @@ static t_tick tick(void)
 	if(GetTickCount() < 0x7FFFFFFF && GetTickCount() > 0)
 		return GetTickCount();
 	else {
-			OSVERSIONINFO osvi;
-			osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-			if (GetVersionEx(&osvi) && osvi.dwMajorVersion >= 6) 
-				return GetTickCount64();
-			else {
-				auto now = std::chrono::system_clock::now();
-			    auto duration = now.time_since_epoch();
-				return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-			}
+		auto now = std::chrono::system_clock::now();
+	    auto duration = now.time_since_epoch();
+		return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();	
 	}
 #else
 	return GetTickCount64();


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adjustment on DEPRECATED WINDOWS SUPPORT to avoid Y2K38 bug when UNIX TIME returns a negative number using 32-bit DWORD

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
