### PR TITLE
Archmage skill corrections

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35597,7 +35597,7 @@ Body:
     Description: Violent Quake Attack
     MaxLevel: 5
     Type: Magic
-    TargetType: Attack
+    TargetType: Ground
     Range: 9
     Hit: Single
     HitCount: 1
@@ -35782,7 +35782,7 @@ Body:
     Description: All Bloom Attack
     MaxLevel: 5
     Type: Magic
-    TargetType: Attack
+    TargetType: Ground
     Range: 9
     Hit: Single
     HitCount: 1
@@ -35802,7 +35802,7 @@ Body:
     Description: All Bloom Attack 2
     MaxLevel: 5
     Type: Magic
-    TargetType: Attack
+    TargetType: Ground
     Range: 9
     Hit: Single
     HitCount: 1
@@ -35873,7 +35873,7 @@ Body:
     Description: Crystal Impact Attack
     MaxLevel: 5
     Type: Magic
-    TargetType: Attack
+    TargetType: Ground
     DamageFlags:
       Splash: true
     Hit: Single
@@ -36052,7 +36052,7 @@ Body:
     Description: Astral Strike Attack
     MaxLevel: 10
     Type: Magic
-    TargetType: Attack
+    TargetType: Ground
     Range: 9
     Hit: Single
     HitCount: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -10125,6 +10125,7 @@ Body:
     FixedCastTime: 700
     CastTimeFlags:
       IgnoreDex: true
+      IgnoreItemBonus: true
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36241,8 +36241,8 @@ Body:
     TargetType: Self
     DamageFlags:
       Splash: true
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: -3
     Element: Water
     SplashArea:
       - Level: 1


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Corrections of several Archmage skills and High wizard skill `HW_MAGICPOWER` :

* `AG_FROZEN_SLASH` : 3 hits is displayed instead of a single hit.
* `TargetType` of 4th ground skills is now `Ground`. `Ground` skills don't trigger `HW_SOULDRAIN`. Skills affected :
  * `AG_VIOLENT_QUAKE_ATK`
  * `AG_ALL_BLOOM_ATK`
  * `AG_ALL_BLOOM_ATK2`
  * `AG_CRYSTAL_IMPACT_ATK`
  * `AG_ASTRAL_STRIKE_ATK`
*  Fixed cast time of `HW_MAGICPOWER` is not affected by item bonus anymore.


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
