### PR TITLE
Rebalance Arch Mage 20240205

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35945,7 +35945,7 @@ Body:
     Element: Fire
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 5000
     Cooldown: 5000
     FixedCastTime: 1500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35675,7 +35675,7 @@ Body:
     Element: Earth
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 5000
     FixedCastTime: 1500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35732,7 +35732,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 1200

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35894,7 +35894,7 @@ Body:
     Element: Wind
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 3000
     Cooldown: 5000
     FixedCastTime: 1500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35443,7 +35443,7 @@ Body:
     Element: Water
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 5000
     FixedCastTime: 1500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35490,7 +35490,7 @@ Body:
     Element: Dark
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 4000
     FixedCastTime: 1500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36013,7 +36013,7 @@ Body:
         Area: 5
     CastCancel: true
     CastTime: 8000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 6000
     Cooldown: 6000
     FixedCastTime: 2000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35547,7 +35547,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 1200

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36072,11 +36072,11 @@ Body:
     CastCancel: true
     AfterCastActDelay: 300
     Duration1: 300000
-    Cooldown: 300000
+    Cooldown: 60000
     FixedCastTime: 4000
     Requires:
       SpCost: 60
-      ApCost: 150
+      ApCost: 125
     Status: Climax
   - Id: 5233
     Name: AG_ROCK_DOWN

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8081,11 +8081,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW:
-						skillratio += -100 + 350 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW_ATK:
-						skillratio += -100 + 700 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 750 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8063,7 +8063,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ROCK_DOWN:
-						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;
@@ -8089,7 +8089,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:
-						skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 450 + 950 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 150 + 350 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8072,7 +8072,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STORM_CANNON:
-						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8004,7 +8004,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case AG_SOUL_VC_STRIKE:
-						skillratio += -100 + 250 * skill_lv + 3 * sstatus->spl;
+						skillratio += -100 + 300 * skill_lv + 3 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STRANTUM_TREMOR:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Arch Mage
-----------------------------------------------

1. Climax
	- Reduces AP consumption from 150 to 125.
	- Reduces skill cooldown from 300 seconds to 60 seconds.

2. Floral Flare Road
	- Increases global cooldown from 0.25 seconds to 0.75 seconds based on level 5.

3. Tornado Storm
	- Increases global cooldown from 0.25 seconds to 0.75 seconds based on level 5.

4. Stratum Tremor
	- Increases global cooldown from 0.25 seconds to 0.75 seconds based on level 5.

5. Rain of Crystal
	- Increases global cooldown from 0.25 seconds to 0.75 seconds based on level 5.

6. Crimson Arrow
	- Increases base damage from 1750%/3500%Matk to 2000%/3750%Matk based on level 5.

7. Storm Cannon
	- Increases base damage from 6000%/7500%(Climax)Matk to 7750%/9250%(Climax)Matk based on level 5.

8. Rock Down
	- Increases base damage from 6000%/7500%(Climax)Matk to 7750%/9250%(Climax)Matk based on level 5.

9. Frozen Slash
	- Increases base damage from 4900%/6800%(Climax)Matk to 5200%/7100%(Climax)Matk based on level 5.

10. Mystery Illusion
	- Increases global cooldown from 0.5 seconds to 0.75 seconds based on level 5.

11. All Bloom
	- Increases global cooldown from 0.5 seconds to 1 second based on level 5.

11. Violent Quake
	- Increases global cooldown from 0.5 seconds to 1 second based on level 5.

12. Soul Vulcan Strike
	- Increases base damage from 1250%Matk to 1500%Matk per hit based on level 5.

13. Astral Strike
	- Increases global cooldown from 0.5 seconds to 1 second based on level 10. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
