### PR TITLE
Rebalance Cardinal 20240205

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37535,15 +37535,16 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -10
-    Element: Holy
+    Element: Neutral
     CastCancel: true
     CastTime: 3000
+    AfterCastActDelay: 500
     Duration1: 12000
     Cooldown: 5000
     FixedCastTime: 2000
     Requires:
       SpCost: 150
-      ApCost: 30
+      ApCost: 20
     Unit:
       Id: Pneumaticus_Procella
       Range:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8134,9 +8134,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_FRAMEN:
-						skillratio += -100 + (950 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1300 * skill_lv;
+						skillratio += 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS) * skill_lv;
+						skillratio += 5 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DEMON)
-							skillratio += 100 * skill_lv;
+							skillratio += 50 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE_CLIMAX:// Is this affected by BaseLV and SPL too??? [Rytech]


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Cardinal
---------------------------

1. Framen
	- Increases base damage from 4750+(Fidus Animus skill level x 25)%/5250+(Fidus Animus skill level x 25)%(demon and undead)Matk to 6500+(Fidus Animus skill level x 25)%/6750+(Fidus Animus skill level x 25)%(demon and undead)Matk based on level 5.

2. Pneumaticus Procella
	- Reduces AP consumption from 30 to 20.
	- Changes damage property from holy to neutral.
	- Addes global cooldown by 0.5 seconds.
	- Changes sound effect. 
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
