### PR TITLE
Rebalance Meister 2024-02-05

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -42378,7 +42378,7 @@ Body:
       - Level: 10
         Area: 3
     CastCancel: true
-    AfterCastActDelay: 250
+    AfterCastActDelay: 700
     Cooldown: 500
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38191,7 +38191,7 @@ Body:
         Area: 3
     GiveAp: 3
     CastCancel: true
-    AfterCastActDelay: 250
+    AfterCastActDelay: 700
     Duration1:
       - Level: 1
         Time: 10000

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -8747,6 +8747,10 @@ Body:
     DurationLookup: MT_RUSH_QUAKE
     CalcFlags:
       All: true
+    Flags:
+      NoDispell: true
+      NoBanishingBuster: true
+      NoClearance: true
   - Status: G_LIFEPOTION
     Icon: EFST_G_LIFEPOTION
     Flags:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5620,10 +5620,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_MIGHTY_SMASH:
-			skillratio += -100 + 25 + 180 * skill_lv;
+			skillratio += -100 + 80 + 240 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			if (sc && sc->getSCE(SC_AXE_STOMP)) {
-				skillratio += 25;
+				skillratio += 20;
 				skillratio += 5 * sstatus->pow;
 			}
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5639,7 +5639,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_SPARK_BLASTER:
-			skillratio += -100 + 250 + 900 * skill_lv;
+			skillratio += -100 + 600 + 1400 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5644,7 +5644,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_TRIPLE_LASER:
-			skillratio += -100 + 550 + 900 * skill_lv;
+			skillratio += -100 + 650 + 1150 * skill_lv;
 			skillratio += 12 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5616,7 +5616,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_AXE_STOMP:
-			skillratio += -100 + 450 + 1150 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 450 + 1150 * skill_lv;
+			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_MIGHTY_SMASH:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5616,7 +5616,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_AXE_STOMP:
-			skillratio += -100 + 400 + 950 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 450 + 1150 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_MIGHTY_SMASH:


### PR DESCRIPTION
* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

* **Server Mode**: renewal

* **Description of Pull Request**: 

Meister
--------------------------

1. Axe Stomp
	- Increases global cooldown from 0.25 seconds to 0.7 seconds based on level 5.
	- Increases base damage from 5150%Atk to 6200%Atk per hit based on level 5.

2. Mighty Smash
	- Increases global cooldown from 0.25 seconds to 0.7 seconds based on level 10.
	- Increases base damage from 1825%/1850%(Axe Stomp)Atk to 2480%/2500%(Axe Stomp)Atk per hit based on level 10.

3. Spark Blaster
	- Increases base damage from 9250%Atk to 14600%Atk based on level 10.

4. Triple Laser
	- Increases base damage from 5050%Atk to 6400%Atk per hit based on level 5.

5. Rush Quake
	- Buff no longer be removed by Dispell or Clearance. 
