### PR TITLE
Rebalance Troubadour & Trouvere 2024-02-05

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5790,16 +5790,13 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			}
 			break;
 		case TR_RHYTHMSHOOTING:
-			skillratio += -100 + 450 + 650 * skill_lv;
+			skillratio += -100 + 550 + 950 * skill_lv;
 
 			if (sd && pc_checkskill(sd, TR_STAGE_MANNER) > 0)
 				skillratio += 5 * sstatus->con;
 
 			if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
-				if (skill_lv == 4)
-					skillratio += 830;	// Typo in skill description ?
-				else
-					skillratio += 350 + 100 * skill_lv;
+				skillratio += 300 + 100 * skill_lv;
 				skillratio += 2 * sstatus->con;
 			}
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8151,10 +8151,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case TR_METALIC_FURY:
-						skillratio += -100 + 2600 * skill_lv;
+						skillratio += -100 + 3850 * skill_lv;
 						// !Todo: skill affected by SPL (without SC_SOUNDBLEND) as well?
 						if (tsc && tsc->getSCE(SC_SOUNDBLEND)) {
-							skillratio += 1000 * skill_lv;
+							skillratio += 800 * skill_lv;
 							skillratio += 2 * pc_checkskill(sd, TR_STAGE_MANNER) * sstatus->spl;
 						}
 						RE_LVL_DMOD(100);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Troubadour & Trouvere
-----------------------------------

1. Rhythm Shooting
	- Increases base damage from 3700%/4550%(sound brand)Atk to 5300%/6100%(sound brand)Atk per hit based on level 5.

2. Metallic Fury
	- Increases base damage from 13000%/18000%(sound brand)Matk to 19250%/23250%(sound brand)Matk based on level 5.
	- Changes sound effect. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
