### PR TITLE
Correct some conditions

### DIFF
--- a/db/re/achievement_db.yml
+++ b/db/re/achievement_db.yml
@@ -2049,21 +2049,21 @@ Body:
   - Id: 200032
     Group: Goal_Level
     Name: The start of another adventure!
-    Condition: " BaseLevel == 100 "
+    Condition: " BaseLevel >= 100 "
     Rewards:
       Item: Rebeginer_Box_100
     Score: 10
   - Id: 200033
     Group: Goal_Level
     Name: With a new mind!(1)
-    Condition: " BaseLevel == 170 && (Class >= JOB_RUNE_KNIGHT && Class <= JOB_GUILLOTINE_CROSS_T) "
+    Condition: " BaseLevel >= 170 && (Class >= JOB_RUNE_KNIGHT && Class <= JOB_GUILLOTINE_CROSS_T) "
     Rewards:
       Item: Costume_Ticket
     Score: 50
   - Id: 200034
     Group: Goal_Level
     Name: With a new mind!(2)
-    Condition: " BaseLevel == 170 && (Class >= JOB_ROYAL_GUARD && Class <= JOB_SHADOW_CHASER_T) "
+    Condition: " BaseLevel >= 170 && (Class >= JOB_ROYAL_GUARD && Class <= JOB_SHADOW_CHASER_T) "
     Rewards:
       Item: Costume_Ticket
     Score: 50


### PR DESCRIPTION
Correct comparations in conditions for some base level achievements to work with the multi level check of achievements.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

https://github.com/rathena/rathena/pull/5425

Server Mode: Renewal

Description of Pull Request: On multi level configuration, the base level achievements like "Reach baselevel 100" is skiped if you level up from 99 to 101 for example.

the corrections allows the achievements to be completed even if you skip said level. This issue is specially notorious in low rates servers like x3 where you can do this specific level up via some eden goup quest rewards.


