### PR TITLE
Fixed a Zeny variable overflow in mails

### DIFF
--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -7,6 +7,7 @@
 #include <common/showmsg.hpp>
 #include <common/strlib.hpp>
 #include <common/timer.hpp>
+#include <common/utilities.hpp>
 
 #include "atcommand.hpp"
 #include "battle.hpp"
@@ -17,6 +18,8 @@
 #include "log.hpp"
 #include "pc.hpp"
 #include "pet.hpp"
+
+using namespace rathena;
 
 void mail_clear(map_session_data *sd)
 {

--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -106,8 +106,14 @@ bool mail_removezeny( map_session_data *sd, bool flag ){
 	if( sd->mail.zeny > 0 ){
 		//Zeny send
 		if( flag ){
+			// To avoid negative values, we need to calculate the fee before the subtraction
+			int Zeny = sd->mail.zeny + (int) ((double)sd->mail.zeny * battle_config.mail_zeny_fee / 100);
+
+			if (Zeny < 0)
+				return false;
+
 			// It's possible that we don't know what the dest_id is, so it will be 0
-			if (pc_payzeny(sd, sd->mail.zeny + sd->mail.zeny * battle_config.mail_zeny_fee / 100, LOG_TYPE_MAIL, sd->mail.dest_id)) {
+			if (pc_payzeny(sd, Zeny, LOG_TYPE_MAIL, sd->mail.dest_id)) {
 				return false;
 			}
 		}else{

--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -109,28 +109,36 @@ bool mail_removezeny( map_session_data *sd, bool flag ){
 	if( sd->mail.zeny > 0 ){
 		//Zeny send
 		if( flag ){
-			int64 fee;
+			int64 zeny = sd->mail.zeny;
 
-			if( util::safe_multiplication( static_cast<decltype(fee)>( sd->mail.zeny ), static_cast<decltype(fee)>( battle_config.mail_zeny_fee ), fee ) ){
-				return false;
-			}
+			if( battle_config.mail_zeny_fee > 0 ){
+				int64 fee;
 
-			if( fee < 0 ){
-				return false;
-			}
+				if( util::safe_multiplication( zeny, static_cast<decltype(fee)>( battle_config.mail_zeny_fee ), fee ) ){
+					return false;
+				}
 
-			fee /= 100;
+				if( fee < 0 ){
+					return false;
+				}
 
-			if( fee > MAX_ZENY ){
-				return false;
+				fee /= 100;
+
+				if( fee > MAX_ZENY ){
+					return false;
+				}
+
+				if( util::safe_addition( zeny, fee, zeny ) ){
+					return false;
+				}
+
+				if( zeny > MAX_ZENY ){
+					return false;
+				}
 			}
 
 			// It's possible that we don't know what the dest_id is, so it will be 0
-			if( pc_payzeny( sd, static_cast<int32>( fee ), LOG_TYPE_MAIL, sd->mail.dest_id ) ){
-				return false;
-			}
-			// It's possible that we don't know what the dest_id is, so it will be 0
-			if( pc_payzeny( sd, static_cast<int32>( fee ), LOG_TYPE_MAIL, sd->mail.dest_id ) ){
+			if( pc_payzeny( sd, static_cast<int32>( zeny ), LOG_TYPE_MAIL, sd->mail.dest_id ) ){
 				return false;
 			}
 		}else{


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
When sending a mail, if the attached Zeny is too high, calculating the handling fee will cause the total Zeny to become negative, resulting in situations where Zeny should be deducted turning into gaining Zeny.
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Fix the Zeny fee calculation, and break the function if Zeny is negative.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
