### PR TITLE
Rebalance Abyss Chaser 2024-02-05

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -39023,7 +39023,7 @@ Body:
     Hit: Multi_Hit
     HitCount: 2
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
     Cooldown: 350

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38888,7 +38888,7 @@ Body:
     FixedCastTime: 1000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 120
     Status: Abyss_Slayer
   - Id: 5319
     Name: ABC_ABYSS_STRIKE

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38892,22 +38892,23 @@ Body:
     Status: Abyss_Slayer
   - Id: 5319
     Name: ABC_ABYSS_STRIKE
-    Description: Abyss Strike
+    Description: Omega Abyss Strike
     MaxLevel: 10
     Type: Magic
     TargetType: Ground
     Range: 9
     Hit: Single
     HitCount: 1
+    Element: Fire
     CastCancel: true
     CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 100
-    Cooldown: 3000
+    Cooldown: 700
     FixedCastTime: 1000
     Requires:
       SpCost: 125
-      ApCost: 15
+      ApCost: 10
     Unit:
       Id: Dummyskill
       Range: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38857,7 +38857,7 @@ Body:
         Time: 1500
       - Level: 5
         Time: 1000
-    Cooldown: 60000
+    Cooldown: 30000
     Requires:
       SpCost:
         - Level: 1
@@ -41241,7 +41241,7 @@ Body:
       Splash: true
     Range: 1
     Hit: Multi_Hit
-    HitCount: 2
+    HitCount: 5
     SplashArea: 4
     Requires:
       SpCost: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8228,7 +8228,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_FROM_THE_ABYSS_ATK:
-						skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 150 + 650 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case EM_ELEMENTAL_BUSTER_FIRE:
@@ -9751,7 +9752,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 				sd->state.autocast = 0;
 			}
 
-			if( sc->getSCE(SC_ABYSSFORCEWEAPON) && sd->abyssball > 0 && rnd() % 100 < 15 ){
+			if( sc->getSCE(SC_ABYSSFORCEWEAPON) && sd->abyssball > 0 && rnd_chance( 25, 100 ) ){
 				uint16 skill_id = ABC_FROM_THE_ABYSS_ATK;
 				uint16 skill_lv = sc->getSCE(SC_ABYSSFORCEWEAPON)->val1;
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -4172,7 +4172,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 			break;
 		}
 		case ABC_FRENZY_SHOT:
-			if( rnd()%100 < 5 * skill_lv ){
+			if( rnd_chance( 5 * skill_lv, 100 ) ){
 				wd->div_ = 3;
 			}
 			break;
@@ -5685,7 +5685,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:
-			skillratio += -100 + 150 + 600 * skill_lv;
+			skillratio += -100 + 250 + 800 * skill_lv;
 			skillratio += 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8153,9 +8153,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_STRIKE:
-						skillratio += -100 + 2200 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 2650 * skill_lv;
+						skillratio += 10 * sstatus->spl;
 						if (tstatus->race == RC_DEMON || tstatus->race == RC_ANGEL)
-							skillratio += 150 * skill_lv;
+							skillratio += 200 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_SQUARE:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5661,7 +5661,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_ABYSS_DAGGER:
-			skillratio += -100 + 100 + 900 * skill_lv;
+			skillratio += -100 + 350 + 1400 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8160,7 +8160,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_SQUARE:
-						skillratio += -100 + ( 570 + 20 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 750 * skill_lv;
+						skillratio += 40 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) * skill_lv;
+						skillratio += 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case TR_METALIC_FURY:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5670,11 +5670,13 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_CHAIN_REACTION_SHOT:
-			skillratio += -100 + 850 * skill_lv + 15 * sstatus->con;
+			skillratio += -100 + 850 * skill_lv;
+			skillratio += 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_CHAIN_REACTION_SHOT_ATK:
-			skillratio += -100 + 600 + 2350 * skill_lv + 15 * sstatus->con;
+			skillratio += -100 + 800 + 2550 * skill_lv;
+			skillratio += 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5678,8 +5678,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:
-			skillratio += -100 + 250 + 350 * skill_lv;
-			skillratio += 5 * sstatus->pow;
+			skillratio += -100 + 700 + 550 * skill_lv;
+			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Abyss Chaser
----------------------------------

1. Abyss Slayer
   - Reduces AP consumption from 150 to 120.

2. Omega Abyss Strike
   - Reduces fixed casting time from 1.5 seconds to 1 second.
   - Reduces skill cooldown from 3 seconds to 0.7 seconds.
   - Reduces AP consumption from 15 to 10.
   - Changes damage property from neutral to fire.
   - Increases base damage from 22000%/23500%(angel and demon)Matk to 26500%/28500%(angel and demon)Matk based on level 10.

3. Abyss Dagger
   - Increases base damage from 4600%Atk to 7350%Atk based on level 5.

4. Deft Stab
   - Increases base damage from 3750%Atk to 6200%Atk based on level 10.
   - Increases factor weight of POW in skill formula from 5 to 7.

5. From the Abyss
   - Reduces skill cooldown from 60 seconds to 30 seconds.
   - Increases number of hit from 2 hits to 5 hits.
   - Increases base damage from 2600%Matk to 3400%Matk based on level 5.
   - No longer be removed by Dispell or Clearance.
   - Increases the trigger chance of abyss sphere from 15% to 25% based on level 5.

6. Abyss Square
   - Increases base damage from 2850+(Magic Sword Mastery skill level x 100)%Matk to 3750+(Magic Sword Mastery skill level x 200)Matk based on level 5.

7. Chain Reaction Shot
   - Increases base damage of secondary attack from 12350%Atk to 13550%Atk based on level 5.

8. Frenzy Shot
   - Increases AP recovery rate from 1 to 3.
   - Increases base damage from 6150%Atk to 8250%Atk per hit based on level 10. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->