### PR TITLE
Rebalance Elemental Master 2024-02-05

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41110,7 +41110,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 2000
     Requires:
       SpCost: 100

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40909,7 +40909,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 10000
     Cooldown: 2000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41152,7 +41152,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 2000
     Requires:
       SpCost: 100

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40948,7 +40948,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41131,7 +41131,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 2000
     Requires:
       SpCost: 100

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41171,11 +41171,11 @@ Body:
     CastCancel: true
     CastTime: 8000
     AfterCastActDelay: 500
-    Cooldown: 5000
+    Cooldown: 2000
     FixedCastTime: 1500
     Requires:
       SpCost: 140
-      ApCost: 30
+      ApCost: 15
   - Id: 5381
     Name: EM_ELEMENTAL_VEIL
     Description: Elemental Veil

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41089,7 +41089,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 2000
     Requires:
       SpCost: 100

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40987,7 +40987,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -41068,7 +41068,7 @@ Body:
     CastTime: 3000
     AfterCastActDelay: 500
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 2000
     Requires:
       SpCost: 100

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7547,7 +7547,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 							if ((skill_id == MG_FIREBOLT && sc->getSCE(SC_FLAMETECHNIC_OPTION)) ||
 								(skill_id == MG_COLDBOLT && sc->getSCE(SC_COLD_FORCE_OPTION)) ||
 								(skill_id == MG_LIGHTNINGBOLT && sc->getSCE(SC_GRACE_BREEZE_OPTION)))
-								skillratio *= 2;
+								skillratio *= 5;
 
 							if (sc->getSCE(SC_SPELLFIST) && mflag & BF_SHORT) {
 								skillratio += (sc->getSCE(SC_SPELLFIST)->val3 * 100) + (sc->getSCE(SC_SPELLFIST)->val1 * 50 - 50) - 100; // val3 = used bolt level, val1 = used spellfist level. [Rytech]

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7867,7 +7867,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 								skillratio += (sd ? sd->status.job_level : 0);
 
 							if (sc->getSCE(SC_DEEP_POISONING_OPTION))
-								skillratio += skillratio * 50 / 100;
+								skillratio += skillratio * 1500 / 100;
 						}
 						break;
 					case NPC_CLOUD_KILL:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8209,10 +8209,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_CONFLAGRATION:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 700 + 1100 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_ARDOR ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8222,10 +8222,12 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_TERRA_DRIVE:
-						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 2400 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_TERREMOTUS ) ){
-							skillratio += 5000 + 250 * skill_lv + 5 * sstatus->spl;
+							skillratio += 7300 + 200 * skill_lv;
+							skillratio += 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7600,7 +7600,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case WZ_EARTHSPIKE:
 						skillratio += 100;
 						if (sc && sc->getSCE(SC_EARTH_CARE_OPTION))
-							skillratio += skillratio * 80 / 100;
+							skillratio += skillratio * 800 / 100;
 						break;
 #endif
 					case HW_NAPALMVULCAN:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8182,10 +8182,12 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case EM_DIAMOND_STORM:
-						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 2400 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_DILUVIO ) ){
-							skillratio += 5000 + 250 * skill_lv  + 5 * sstatus->spl;
+							skillratio += 7300 + 200 * skill_lv;
+							skillratio += 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8203,10 +8203,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_VENOM_SWAMP:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 700 + 1100 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 
 						if( sc && sc->getSCE( SC_SUMMON_ELEMENTAL_SERPENS ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8193,10 +8193,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_LIGHTNING_LAND:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 700 + 1100 * skill_lv;
+						skillratio += 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_PROCELLA ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8242,7 +8242,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case EM_ELEMENTAL_BUSTER_WIND:
 					case EM_ELEMENTAL_BUSTER_GROUND:
 					case EM_ELEMENTAL_BUSTER_POISON:
-						skillratio += -100 + 500 + 2200 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 550 + 2650 * skill_lv;
+						skillratio += 10 * sstatus->spl;
 						if (tstatus->race == RC_FORMLESS || tstatus->race == RC_DRAGON)
 							skillratio += 150 * skill_lv;
 						RE_LVL_DMOD(100);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2202,7 +2202,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_TERRA_DRIVE:
-		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 40 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case MT_RUSH_QUAKE:
 		sc_start( src, bl, SC_RUSH_QUAKE1, 100, skill_lv, skill_get_time( skill_id, skill_lv ) );

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2199,7 +2199,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_CONFLAGRATION:
-		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_TERRA_DRIVE:
 		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 40 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2190,7 +2190,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		status_change_end(bl, SC_SOUNDBLEND);
 		break;
 	case EM_DIAMOND_STORM:
-		sc_start(src, bl, SC_HANDICAPSTATE_FROSTBITE, 40 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_FROSTBITE, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_LIGHTNING_LAND:
 		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2196,7 +2196,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_VENOM_SWAMP:
-		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_CONFLAGRATION:
 		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 3, skill_lv, skill_get_time2(skill_id, skill_lv));

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2193,7 +2193,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src, bl, SC_HANDICAPSTATE_FROSTBITE, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_LIGHTNING_LAND:
-		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_VENOM_SWAMP:
 		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Elemental Master
-------------------------------------

1. Summon Elemental Ardor
	- Reduces skill cooldown from 900 seconds to 60 seconds.
	- Passive mode : Flame Technique, increases damage bonus of Fire Bolt from 100% to 400%.

2. Summon Elemental Diluvio
	- Reduces skill cooldown from 900 seconds to 60 seconds.
	- Passive mode : Cold Force, increases damage bonus of Cold Bolt from 100% to 400%.

3. Summon Elemental Procella
	- Reduces skill cooldown from 900 seconds to 60 seconds.
	- Passive mode : Grace Breeze, increases damage bonus of Lightning Bolt from 100% to 400%.

4. Summon Elemental Terremotus
	- Reduces skill cooldown from 900 seconds to 60 seconds.
	- Passive mode : Earth Care, increases damage bonus of Earth Spike from 80% to 800%.

5. Summon Elemental Serpens
	- Reduces skill cooldown from 900 seconds to 60 seconds.
	- Passive mode : Deep Poisoning, increases damage bonus of Killing Cloud from 50% to 1500%.

6. Conflagration
	- Increases global cooldown from 0.5 seconds to 0.7 seconds.
	- Increases base damage from 3750%/5750%(spirit)Matk to 6200%/7200%(spirit)Matk based on level 5.
	- Reduces the chance of inflicting [blaze] on each hit from 60% to 3%.

7. Diamond Storm
	- Increases base damage from 8150%/14400%(spirit)Matk to 12500%/20800%(spirit)Matk based on level 5.
	- Reduces the chance of inflicting [quench] on each hit from 90% to 5%.

8. Lightning Land
	- Increases global cooldown from 0.5 seconds to 0.7 seconds.
	- Increases base damage from 3750%/5750%(spirit)Matk to 6200%/7200%(spirit)Matk based on level 5.
	- Reduces the chance of inflicting [torrent] on each hit from 60% to 3%.

9. Terra Drive
	- Increases base damage from 8150%/14400%(spirit)Matk to 12500%/20800%(spirit)Matk based on level 5.
	- Reduces the chance of inflicting [concretion] on each hit from 90% to 5%.

10. Venom Swamp
	- Increases global cooldown from 0.5 seconds to 0.7 seconds.
	- Increases base damage from 3750%/5750%(spirit)Matk to 6200%/7200%(spirit)Matk based on level 5.
	- Reduces the chance of inflicting [severe poison] on each hit from 60% to 3%.

11. Elemental Buster
	- Reduces AP consumption from 30 to 15.
	- Reduces skill cooldown from 5 seconds to 2 seconds.
	- Increases base damage from 22500%/24000%(dragon and formless)Matk to 27050%/28550%(dragon and formless)Matk based on level 10. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->