### PR TITLE
Rebalance Imperial Guard 2024-02-05

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36847,16 +36847,16 @@ Body:
       Toggleable: true
     Hit: Single
     HitCount: 1
-    GiveAp: 15
     SplashArea: 10
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 500
-    Duration1: 60000
-    Cooldown: 15000
+    AfterCastActDelay: 300
+    Duration1: 40000
+    Cooldown: 25000
     FixedCastTime: 1000
     Requires:
       SpCost: 60
+      ApCost: 35
       Status:
         Guard_Stance: true
     Status: Guardian_S

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37105,7 +37105,7 @@ Body:
     HitCount: 3
     Element: Weapon
     SplashArea: 3
-    GiveAp: 3
+    GiveAp: 5
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37058,7 +37058,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -7
     Element: Weapon
-    GiveAp: 3
+    GiveAp: 5
     SplashArea:
       - Level: 1
         Area: 2

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37018,7 +37018,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -10
-    Element: Holy
+    Element: Neutral
     CastCancel: true
     CastTime: 2000
     Cooldown: 5000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37145,7 +37145,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
-    GiveAp: 4
+    GiveAp: 6
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 150

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7937,6 +7937,9 @@ Body:
     Flags:
       BlEffect: true
       DisplayPc: true
+      NoBanishingBuster: true
+      NoDispell: true
+      NoClearance: true
   - Status: Ultimate_S
     Icon: EFST_ULTIMATE_S
     DurationLookup: IG_ULTIMATE_SACRIFICE

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5565,8 +5565,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IG_OVERSLASH:
-			skillratio += -100 + 160 * skill_lv;
-			skillratio += pc_checkskill(sd, IG_SPEAR_SWORD_M) * 25 * skill_lv;
+			skillratio += -100 + 220 * skill_lv;
+			skillratio += pc_checkskill(sd, IG_SPEAR_SWORD_M) * 50 * skill_lv;
 			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5551,15 +5551,15 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * i / 100;
 			break;
 		case IG_SHIELD_SHOOTING:
-			skillratio += -100 + 650 + 2850 * skill_lv;
-			skillratio += 7 * sstatus->pow;
-			skillratio += skill_lv * 50 * pc_checkskill( sd, IG_SHIELD_MASTERY );
+			skillratio += -100 + 1000 + 3500 * skill_lv;
+			skillratio += 10 * sstatus->pow;
+			skillratio += skill_lv * 150 * pc_checkskill( sd, IG_SHIELD_MASTERY );
 			if (sd) { // Damage affected by the shield's weight and refine. Need official formula. [Rytech]
 				short index = sd->equip_index[EQI_HAND_L];
 
 				if (index >= 0 && sd->inventory_data[index] && sd->inventory_data[index]->type == IT_ARMOR) {
 					skillratio += (sd->inventory_data[index]->weight * 7 / 6) / 10;
-					skillratio += sd->inventory.u.items_inventory[index].refine * 25;
+					skillratio += sd->inventory.u.items_inventory[index].refine * 100;
 				}
 			}
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8114,9 +8114,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case IG_CROSS_RAIN:
 						if( sc && sc->getSCE( SC_HOLY_S ) ){
-							skillratio += -100 + ( 450 + 15 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 650 + 15 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}else{
-							skillratio += -100 + ( 320 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 450 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}
 						skillratio += 7 * sstatus->spl;
 						RE_LVL_DMOD(100);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12600,7 +12600,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			tick = INFINITE_TICK;
 			break;
 		case SC_GUARDIAN_S:
-			val2 = ( status->max_hp / 2 ) * ( 50 * val1 ) / 100 + 15 * status->sta; // Barrier HP
+			val2 = ( status->max_hp * 30 / 100 ) * ( 25 * val1 ) / 100 + 15 * status->sta; // Barrier HP
 			break;
 		case SC_REBOUND_S:
 			val2 = 10 * val1;// Reduced Damage From Devotion


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Imperial Guard
-------------------------------------

1. Attack Stance
	- Reduces fixed casting time from 1 second to 0.5 seconds.
	- Removes 1 second variable casting time.
	- No longer be removed by Dispell or Clearance.

2. Guard Stance
	- Reduces fixed casting time from 1 second to 0.5 seconds.
	- Removes 1 second variable casting time.
	- No longer be removed by Dispell or Clearance.

3. Guardian Shield
	- Reworks AP condition from recovering AP to consuming 35 AP upon using instead.
	- Reduces skill duration from 60 seconds to 40 seconds.
	- Increases skill cooldown from 15 seconds to 25 seconds.
	- Reduces global cooldown from 1 second to 0.3 seconds.
	- Reduces factor weight of MaxHP in skill formula from 50% to 30%.
	- Reduces final durability factor of skill level from 250% to 125% based on level 5. 

4. Cross Rain
	- Increases AP recovery rate from 4 to 6.
	- Increases base damage from 3200+(Spear & Sword Mastery skill level x 100)%/4500+(Spear & Sword Mastery skill level x 150)%(Holy Shield)Matk to 4500+(Spear & Sword Mastery skill level x 100)%/6500+(Spear & Sword Mastery skill level x 150)%(Holy Shield)Matk per hit based on level 10.

5. Holy Shield
	- No longer be removed by Dispell or Clearance.

6. Shield Shooting
	- Increases AP recovery rate from 3 to 5.
	- Increases base damage from 14900+(Shield Mastery skill level x 250)%Atk to 18500+(Shield Mastery skill level x 750)%Atk based on level 5.
	- Increases factor weight of shield refine rate in skill formula from 25 to 100.
	- Increases factor weight of POW in skill formula from 7 to 10.

7. Overslash
	- Increases AP recovery rate from 3 to 5.
	- Increases base damage from 1600+(Spear & Sword Mastery skill level x 250)%Atk to 2200+(Spear & Sword Mastery skill level x 500)%Atk per hit based on level 10.

8. Judgement Cross
   - Changes damage property from holy to neutral. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->