### PR TITLE
Rebalance Hyper Novice 2024-02-05

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5859,7 +5859,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_DOUBLEBOWLINGBASH:
-			skillratio += -100 + 200 + 300 * skill_lv;
+			skillratio += -100 + 250 + 400 * skill_lv;
 			skillratio += pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8281,7 +8281,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case HN_HELLS_DRIVE:
-						skillratio += -100 + 1500 + 700 * skill_lv;
+						skillratio += -100 + 1700 + 900 * skill_lv;
 						skillratio += pc_checkskill(sd, HN_SELFSTUDY_SOCERY) * 4 * skill_lv;
 						skillratio += 5 * sstatus->spl;
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5845,7 +5845,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_SHIELD_CHAIN_RUSH:
-			skillratio += -100 + 700 + 500 * skill_lv;
+			skillratio += -100 + 850 + 1050 * skill_lv;
 			skillratio += pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5828,7 +5828,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 50000;
 			break;
 		case HN_SPIRAL_PIERCE_MAX:
-			skillratio += -100 + 700 + 800 * skill_lv;
+			skillratio += -100 + 1000 + 1500 * skill_lv;
 			skillratio += pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			switch (status_get_size(target)){

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1846,7 +1846,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			switch (skill_id) {
 				case HN_SHIELD_CHAIN_RUSH:
 				case HN_DOUBLEBOWLINGBASH:
-					damage += damage * 70 / 100; 
+					damage += damage * 120 / 100; 
 					break;
 				case HN_MEGA_SONIC_BLOW:
 				case HN_SPIRAL_PIERCE_MAX:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Hyper Novice
-------------------------------------

1. Double Bowling Bash
	- Increases base damage from 3200+(Self Study Tactics skill level x 30)%Atk to 4250+(Self Study Tactics skill level x 30)%Atk per hit based on level 10.

2. Shield Chain Rush
	- Increases base damage from 5700+(Self Study Tactics skill level x 30)%Atk to 11350+(Self Study Tactics skill level x 30)%Atk based on level 10.

3. Spiral Pierce Max
	- Increases base damage from 8700+(Self Study Tactics skill level x 30)%Atk x size correction to 16000+(Self Study Tactics skill level x 30)%Atk x size correction based on level 10.

4. Breaking Limit
	- Increases damage bonus of Double Bowling Bash and Shield Chain Rush from 70% to 120%.

5. Hell's Drive
	- Increases base damage from 8500+(Self Study Sorcery skill level x 30)%Atk to 10700+(Self Study Sorcery skill level x 30)%Matk based on level 10. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->