### PR TITLE
Mercenary Improvements

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -33068,9 +33068,10 @@ Body:
     Type: Weapon
     TargetType: Attack
     Range: 1
-    Hit: Multi_Hit
-    HitCount: 3
+    Hit: Single
+    HitCount: 1
     Element: Weapon
+    CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 2000
     Duration2: 5000

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -9641,7 +9641,7 @@ Body:
     Hit: Single
     HitCount: 1
     Duration1: 300000
-    Duration2: 15000
+    Duration2: 10000
     Requires:
       SpCost: 200
     Status: Berserk
@@ -32467,9 +32467,9 @@ Body:
     Hit: Single
     HitCount: 1
     Duration1: 300000
-    Duration2: 15000
+    Duration2: 10000
     Requires:
-      SpCost: 100
+      SpCost: 200
     Status: Berserk
   - Id: 8207
     Name: MA_DOUBLE

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -2712,6 +2712,7 @@ Body:
     CalcFlags:
       Flee: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2720,6 +2721,7 @@ Body:
     CalcFlags:
       Watk: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2728,6 +2730,7 @@ Body:
     CalcFlags:
       MaxHp: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2736,6 +2739,7 @@ Body:
     CalcFlags:
       MaxSp: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2744,6 +2748,7 @@ Body:
     CalcFlags:
       Hit: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -46490,9 +46490,10 @@ Body:
     Type: Weapon
     TargetType: Attack
     Range: 1
-    Hit: Multi_Hit
-    HitCount: 3
+    Hit: Single
+    HitCount: 1
     Element: Weapon
+    CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 2000
     Duration2: 4500

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -2822,6 +2822,7 @@ Body:
     CalcFlags:
       Flee: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2830,6 +2831,7 @@ Body:
     CalcFlags:
       Watk: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2838,6 +2840,7 @@ Body:
     CalcFlags:
       MaxHp: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2846,6 +2849,7 @@ Body:
     CalcFlags:
       MaxSp: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
@@ -2854,6 +2858,7 @@ Body:
     CalcFlags:
       Hit: true
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6579,7 +6579,8 @@ void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick, 
 
 	sd = BL_CAST(BL_PC, bl);
 
-	if (!(status_efst_get_bl_type((efst_type)type)&bl->type)) // only send status changes that actually matter to the client
+	// Only send status changes that actually matter to the client
+	if (!(status_efst_get_bl_type(static_cast<efst_type>(type)) & bl->type)) // Check if current bl type is in the returned bitmask
 		return;
 
 	clif_status_change_sub(bl, bl->id, type, flag, tick, val1, val2, val3, ((sd ? (pc_isinvisible(sd) ? SELF : AREA) : AREA_WOS)));

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6579,8 +6579,8 @@ void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick, 
 
 	sd = BL_CAST(BL_PC, bl);
 
-	// Only send status changes that actually matter to the client
-	if (!(status_efst_get_bl_type(static_cast<efst_type>(type)) & bl->type)) // Check if current bl type is in the returned bitmask
+	// Check if current bl type is in the returned bitmask and only send status changes that actually matter to the client
+	if (!(status_efst_get_bl_type(static_cast<efst_type>(type)) & bl->type))
 		return;
 
 	clif_status_change_sub(bl, bl->id, type, flag, tick, val1, val2, val3, ((sd ? (pc_isinvisible(sd) ? SELF : AREA) : AREA_WOS)));

--- a/src/map/mercenary.cpp
+++ b/src/map/mercenary.cpp
@@ -421,7 +421,7 @@ bool mercenary_dead(s_mercenary_data *md) {
 void mercenary_killbonus(s_mercenary_data *md) {
 	std::vector<sc_type> scs = { SC_MERC_FLEEUP, SC_MERC_ATKUP, SC_MERC_HPUP, SC_MERC_SPUP, SC_MERC_HITUP };
 
-	sc_start(&md->bl,&md->bl, util::vector_random(scs), 100, rnd_value(1, 5), 600000);
+	sc_start(&md->bl,&md->bl, util::vector_random(scs), 100, rnd_value(1, 5), 300000); //Bonus lasts for 5 minutes
 }
 
 /**

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3110,7 +3110,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 			}
 
 			// The master or Mercenary can increase the kill count
-			if (sd->md && src && (src->type == BL_PC || src->type == BL_MER) && mob->lv > sd->status.base_level / 2)
+			if (sd->md && src && (src->type == BL_PC || src->type == BL_MER) && mob->lv >= sd->status.base_level / 2)
 				mercenary_kills(sd->md);
 		}
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3109,7 +3109,7 @@ int mob_dead(struct mob_data *md, struct block_list *src, int type)
 					achievement_update_objective(sd, AG_BATTLE, 1, md->mob_id);
 			}
 
-			// The master or Mercenary can increase the kill count
+			// The master or Mercenary can increase the kill count, if the monster level is greater or equal than half the baselevel of the master
 			if (sd->md && src && (src->type == BL_PC || src->type == BL_MER) && mob->lv >= sd->status.base_level / 2)
 				mercenary_kills(sd->md);
 		}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5261,16 +5261,16 @@ void status_calc_regen(struct block_list *bl, struct status_data *status, struct
 			regen->sp = cap_value(val, 1, SHRT_MAX);
 		}
 	} else if( bl->type == BL_MER ) {
-		val = (status->max_hp * status->vit / 10000 + 1) * 6;
+		val = (status->max_hp * status->vit / 10000.0 + 1.0) * 6.0;
 		regen->hp = cap_value(val, 1, SHRT_MAX);
 
-		val = (status->max_sp * (status->int_ + 10) / 750) + 1;
+		val = (status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0;
 		regen->sp = cap_value(val, 1, SHRT_MAX);
 	} else if( bl->type == BL_ELEM ) {
-		val = (status->max_hp * status->vit / 10000 + 1) * 6;
+		val = (status->max_hp * status->vit / 10000.0 + 1.0) * 6.0;
 		regen->hp = cap_value(val, 1, SHRT_MAX);
 
-		val = (status->max_sp * (status->int_ + 10) / 750) + 1;
+		val = (status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0;
 		regen->sp = cap_value(val, 1, SHRT_MAX);
 	}
 }
@@ -15239,7 +15239,7 @@ static int status_natural_heal(struct block_list* bl, va_list args)
 
 	if (flag&(RGN_HP|RGN_SHP|RGN_SSP) && ud && ud->walktimer != INVALID_TIMER) {
 		flag &= ~(RGN_SHP|RGN_SSP);
-		if(!regen->state.walk)
+		if(sd && !regen->state.walk)
 			flag &= ~RGN_HP;
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5261,16 +5261,16 @@ void status_calc_regen(struct block_list *bl, struct status_data *status, struct
 			regen->sp = cap_value(val, 1, SHRT_MAX);
 		}
 	} else if( bl->type == BL_MER ) {
-		val = static_cast<int>((status->max_hp * status->vit / 10000.0 + 1.0) * 6.0);
+		val = static_cast<decltype(val)>((status->max_hp * status->vit / 10000.0 + 1.0) * 6.0);
 		regen->hp = cap_value(val, 1, SHRT_MAX);
 
-		val = static_cast<int>((status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0);
+		val = static_cast<decltype(val)>((status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0);
 		regen->sp = cap_value(val, 1, SHRT_MAX);
 	} else if( bl->type == BL_ELEM ) {
-		val = static_cast<int>((status->max_hp * status->vit / 10000.0 + 1.0) * 6.0);
+		val = static_cast<decltype(val)>((status->max_hp * status->vit / 10000.0 + 1.0) * 6.0);
 		regen->hp = cap_value(val, 1, SHRT_MAX);
 
-		val = static_cast<int>((status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0);
+		val = static_cast<decltype(val)>((status->max_sp * (status->int_ + 10.0) / 750.0) + 1.0);
 		regen->sp = cap_value(val, 1, SHRT_MAX);
 	}
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/8184
https://github.com/rathena/rathena/issues/7663

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (MER_CRASH and Frenzy fixes only apply to pre-renewal)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- When a Mercenary gains a bonus, there will now be an animation
- Mercenary bonuses now last for 5 minutes instead of 10 minutes
- Fixed HP/SP recovery values of Mercenaries (and Elementals)
- Mercenaries now recover HP when walking
- Homunculi no longer recover SP when walking
- Mercenary natural recovery interval is 8s for HP and 6s for SP
- Homunculus natural recovery interval is 2s for HP and 4s for SP
- MER_CRASH now only deals 1 hit and can be cast-cancelled
- Frenzy now drains HP every 10 seconds instead of every 15 in pre-renewal
- Fixed SP cost Mercenary Frenzy (100 -> 200 SP)
- Killing monsters exactly 2 times below you base level now still counts as mercenary kill

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
