### PR TITLE
Enchant Deadly Poison / Magnum Break Damage Bonus and Durations

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -10233,17 +10233,7 @@ Body:
         Time: 55000
       - Level: 5
         Time: 60000
-    Duration2:
-      - Level: 1
-        Time: 20000
-      - Level: 2
-        Time: 30000
-      - Level: 3
-        Time: 40000
-      - Level: 4
-        Time: 50000
-      - Level: 5
-        Time: 60000
+    Duration2: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1123,6 +1123,8 @@ Body:
       NoClearance: true
   - Status: Watk_Element
     DurationLookup: MS_MAGNUM
+    Flags:
+      NoSave: true
     EndOnStart:
       Watk_Element: true
   - Status: Armor

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -162,6 +162,7 @@ Body:
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
+      Def: true
       Def2: true
       Regen: true
     Opt2:
@@ -252,6 +253,7 @@ Body:
   - Status: Dpoison
     DurationLookup: NPC_POISON
     CalcFlags:
+      Def: true
       Def2: true
       Regen: true
     Opt2:
@@ -1121,6 +1123,8 @@ Body:
       NoClearance: true
   - Status: Watk_Element
     DurationLookup: MS_MAGNUM
+    EndOnStart:
+      Watk_Element: true
   - Status: Armor
     DurationLookup: NPC_DEFENDER
   - Status: Armor_Element_Water

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -10486,11 +10486,11 @@ Body:
       - Level: 1
         Time: 40000
       - Level: 2
-        Time: 45000
+        Time: 60000
       - Level: 3
-        Time: 50000
+        Time: 80000
       - Level: 4
-        Time: 55000
+        Time: 100000
       - Level: 5
         Time: 120000
     Duration2:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -165,6 +165,7 @@ Body:
   - Status: Poison
     DurationLookup: NPC_POISON
     CalcFlags:
+      Def: true
       Def2: true
       Regen: true
     Opt2:
@@ -261,6 +262,7 @@ Body:
   - Status: Dpoison
     DurationLookup: NPC_POISON
     CalcFlags:
+      Def: true
       Def2: true
       Regen: true
     Opt2:
@@ -1139,6 +1141,8 @@ Body:
       NoClearance: true
   - Status: Watk_Element
     DurationLookup: MS_MAGNUM
+    EndOnStart:
+      Watk_Element: true
   - Status: Armor
     DurationLookup: NPC_DEFENDER
   - Status: Armor_Element_Water

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1141,6 +1141,8 @@ Body:
       NoClearance: true
   - Status: Watk_Element
     DurationLookup: MS_MAGNUM
+    Flags:
+      NoSave: true
     EndOnStart:
       Watk_Element: true
   - Status: Armor

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6486,16 +6486,12 @@ static void battle_calc_defense_reduction(struct Damage* wd, struct block_list *
  */
 static void battle_min_damage(struct Damage* wd, struct block_list* src, uint16 skill_id, int64 min) {
 	if (is_attack_right_handed(src, skill_id)) {
-		if (wd->damage < min)
-			wd->damage = min;
-		if (wd->basedamage < min)
-			wd->basedamage = min;
+		cap_value(wd->damage, min, INT64_MAX);
+		cap_value(wd->basedamage, min, INT64_MAX);
 	}
 	if (is_attack_left_handed(src, skill_id)) {
-		if (wd->damage2 < min)
-			wd->damage2 = min;
-		if (wd->basedamage2 < min)
-			wd->basedamage2 = min;
+		cap_value(wd->damage2, min, INT64_MAX);
+		cap_value(wd->basedamage2, min, INT64_MAX);
 	}
 }
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6476,6 +6476,29 @@ static void battle_calc_defense_reduction(struct Damage* wd, struct block_list *
 #endif
 }
 
+
+/**
+ * Cap both damage and basedamage of damage struct to a minimum value
+ * @param wd: Weapon damage structure
+ * @param src: Source of the attack
+ * @param skill_id: Skill ID of the skill used by source
+ * @param min: Minimum value to which damage should be capped
+ */
+static void battle_min_damage(struct Damage* wd, struct block_list* src, uint16 skill_id, int64 min) {
+	if (is_attack_right_handed(src, skill_id)) {
+		if (wd->damage < min)
+			wd->damage = min;
+		if (wd->basedamage < min)
+			wd->basedamage = min;
+	}
+	if (is_attack_left_handed(src, skill_id)) {
+		if (wd->damage2 < min)
+			wd->damage2 = min;
+		if (wd->basedamage2 < min)
+			wd->basedamage2 = min;
+	}
+}
+
 /*====================================
  * Modifiers ignoring DEF
  *------------------------------------
@@ -6500,10 +6523,7 @@ static void battle_calc_attack_post_defense(struct Damage* wd, struct block_list
 
 	//After DEF reduction, damage can be negative, refine bonus works against that value
 	//After refinement bonus was applied, damage is capped to 1, then masteries are applied
-	if (is_attack_right_handed(src, skill_id) && wd->damage < 1) wd->damage = 1;
-	if (is_attack_left_handed(src, skill_id) && wd->damage2 < 1) wd->damage2 = 1;
-	if (is_attack_right_handed(src, skill_id) && wd->basedamage < 1) wd->basedamage = 1;
-	if (is_attack_left_handed(src, skill_id) && wd->basedamage2 < 1) wd->basedamage2 = 1;
+	battle_min_damage(wd, src, skill_id, 1);
 
 	battle_calc_attack_masteries(wd, src, target, skill_id, skill_lv);
 #endif
@@ -6536,10 +6556,7 @@ static void battle_calc_attack_post_defense(struct Damage* wd, struct block_list
 	}
 
 	//Set to min of 1
-	if (is_attack_right_handed(src, skill_id) && wd->damage < 1) wd->damage = 1;
-	if (is_attack_left_handed(src, skill_id) && wd->damage2 < 1) wd->damage2 = 1;
-	if (is_attack_right_handed(src, skill_id) && wd->basedamage < 1) wd->basedamage = 1;
-	if (is_attack_left_handed(src, skill_id) && wd->basedamage2 < 1) wd->basedamage2 = 1;
+	battle_min_damage(wd, src, skill_id, 1);
 
 #ifdef RENEWAL
 	switch (skill_id) {

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -97,7 +97,7 @@ int64 battle_calc_return_damage(struct block_list *bl, struct block_list *src, i
 
 void battle_drain(map_session_data *sd, struct block_list *tbl, int64 rdamage, int64 ldamage, int race, int class_);
 
-int64 battle_attr_fix(struct block_list *src, struct block_list *target, int64 damage,int atk_elem,int def_type, int def_lv);
+int64 battle_attr_fix(struct block_list* src, struct block_list* target, int64 damage, int atk_elem, int def_type, int def_lv, int flag = 0);
 int battle_calc_cardfix(int attack_type, struct block_list *src, struct block_list *target, std::bitset<NK_MAX> nk, int s_ele, int s_ele_, int64 damage, int left, int flag);
 
 // Final calculation Damage

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -75,7 +75,9 @@ struct Damage {
 	int64 statusAtk, statusAtk2, weaponAtk, weaponAtk2, equipAtk, equipAtk2, masteryAtk, masteryAtk2, percentAtk, percentAtk2;
 #endif
 	int64 damage, /// Right hand damage
-		damage2; /// Left hand damage
+		damage2, /// Left hand damage
+		basedamage, /// Right hand base damage after def reduction
+		basedamage2; /// Left hand base damage after def reduction
 	enum e_damage_type type; /// Check clif_damage for type
 	short div_; /// Number of hit
 	int amotion,

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7869,9 +7869,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_nodamage (src,src,skill_id,skill_lv,1);
 		// Initiate 20% of your damage becomes fire element.
 #ifdef RENEWAL
-		sc_start4(src,src,SC_SUB_WEAPONPROPERTY,100,3,20,skill_id,0,skill_get_time2(skill_id, skill_lv));
+		sc_start4(src,src,SC_SUB_WEAPONPROPERTY,100,ELE_FIRE,20,skill_id,0,skill_get_time2(skill_id, skill_lv));
 #else
-		sc_start4(src,src,SC_WATK_ELEMENT,100,3,20,0,0,skill_get_time2(skill_id, skill_lv));
+		sc_start4(src,src,SC_WATK_ELEMENT,100,ELE_FIRE,20,0,0,skill_get_time2(skill_id, skill_lv));
 #endif
 		break;
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4377,6 +4377,28 @@ static int skill_check_unit_range2 (struct block_list *bl, int x, int y, uint16 
 		map_foreachinallarea(npc_isnear_sub,bl->m,x - range,y - range,x + range,y + range,type,skill_id);
 }
 
+/** Apply special cases where skills require HP/SP/AP but do not consume them, then continue with consuming HP/SP/AP
+* @param bl Object from which HP/SP/AP are consumed
+* @param skill_id ID of used skill
+* @param hp Original HP requirement to use skill
+* @param sp Original SP requirement to use skill
+* @param ap Original AP requirement to use skill
+*/
+void skill_consume_hpspap(block_list* bl, uint16 skill_id, int hp, int sp, int ap)
+{
+	nullpo_retv(bl);
+
+	switch (skill_id) {
+		//Skills that require HP but do not consume them
+	case SM_MAGNUM:
+	case MS_MAGNUM:
+		hp = 0;
+		break;
+	}
+
+	status_zap(bl, hp, sp, ap);
+}
+
 /*==========================================
  * Checks that you have the requirements for casting a skill for homunculus/mercenary.
  * Flag:
@@ -4480,7 +4502,7 @@ static int skill_check_condition_mercenary(struct block_list *bl, uint16 skill_i
 		return 1;
 
 	if( sp || hp )
-		status_zap(bl, hp, sp);
+		skill_consume_hpspap(bl, skill_id, hp, sp, 0);
 
 	return 1;
 }
@@ -7924,9 +7946,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case HW_MAGICPOWER:
 	case PF_MEMORIZE:
 	case PA_SACRIFICE:
-#ifndef RENEWAL
-	case ASC_EDP:
-#endif
 	case PF_DOUBLECASTING:
 	case SG_SUN_COMFORT:
 	case SG_MOON_COMFORT:
@@ -8035,14 +8054,16 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		clif_skill_damage(src, bl, tick, status_get_amotion(src), 0, -30000, 1, skill_id, skill_lv, DMG_SINGLE);
 		break;
 
-#ifdef RENEWAL
 	// EDP also give +25% WATK poison pseudo element to user.
 	case ASC_EDP:
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,
 			sc_start(src,bl,type,100,skill_lv,skill_get_time(skill_id,skill_lv)));
-		sc_start4(src,src,SC_SUB_WEAPONPROPERTY,100,5,25,skill_id,0,skill_get_time2(skill_id, skill_lv));
-		break;
+#ifdef RENEWAL
+		sc_start4(src, src, SC_SUB_WEAPONPROPERTY, 100, ELE_POISON, 25, skill_id, 0, skill_get_time(skill_id, skill_lv));
+#else
+		sc_start4(src, src, SC_WATK_ELEMENT, 100, ELE_POISON, 25, 0, 0, skill_get_time(skill_id, skill_lv));
 #endif
+		break;
 
 	case LG_SHIELDSPELL:
 		if (skill_lv == 1)
@@ -18648,7 +18669,7 @@ void skill_consume_requirement(map_session_data *sd, uint16 skill_id, uint16 ski
 			break;
 		}
 		if(require.hp || require.sp || require.ap)
-			status_zap(&sd->bl, require.hp, require.sp, require.ap);
+			skill_consume_hpspap(&sd->bl, skill_id, require.hp, require.sp, require.ap);
 
 		if(require.spiritball > 0) { // Skills that require certain types of spheres to use
 			switch (skill_id) { // Skills that require soul spheres.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8187

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal (Renewal only slightly affected)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

Major pre-renewal damage handling rework on everything regarding the Magnum Break / EDP damage bonus based on in-depth testing (see linked issue).

Notable changes:
- Added missing EDP 25% poison damage bonus (it was already fixed in renewal but applies to pre-re too), that works identical to the 20% fire damage bonus from Magnum Break; both buffs overwrite each other
- Added "basedamage" and "basedamage2" to the damage object - this is the damage on which EDP/Magnum Break is based on; it now considers defense reduction, passive mastery, refine and true sight (there might be more interactions, will continue with this in a follow-up branch, don't want this to blow up too much)
- The EDP/Magnum Break damage bonus now considers spirit sphere damage, but the spirit sphere part is non-elemental; both are added together before they get rounded down
- The EDP/Magnum Break damage bonus can now become negative through attribute table and is dispelled on logout
- The EDP/Magnum Break damage bonus no longer applies when damage is already 0 or lower beforehand
- EDP is now applied after defense, refine and mastery
- Refine bonus now is applied before mastery and between both the damage is capped to 1
- Envenom's fixed damage bonus is now a mastery bonus (was already fixed in renewal but applies to pre-re too) and thus increased by EDP
- Fixed damage interaction between MO_FINGEROFFENSIVE (Throw Spirit Sphere) with Magnum Break, refine and spirit spheres
- Fixed Magnum Break costing HP (created a function that is used for both mercenaries and players, so you don't have to manually code it into their respective functions anymore; can easily add more skills if we find more that require HP/SP/AP but do not consume them)
- Fixed Sonic Blow's damage formula and how the bonus from Sonic Acceleration works
- Poison/DPoison now reduce hard DEF vs. monsters by 25%, but the DEF reduction no longer stacks
- Fixed DPoison's duration (60s base duration on all levels)
- Fixed Enchant Deadly Poison duration in Renewal
- Fixed chance of DPoison to be inflicted
- Fixed negative resistances not increasing the chance of a status change to occur (it's only capped to 0 in renewal)

All damage results in the linked issue that are not striked through are fully verified.
Will continue testing further interactions in the next branch.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
