### PR TITLE
Frenzy, Super Novice Level Up Buff, Assassin Soul Link

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -9940,7 +9940,7 @@ Body:
     Hit: Single
     HitCount: 1
     Duration1: 300000
-    Duration2: 15000
+    Duration2: 10000
     Requires:
       SpCost: 200
     Status: Berserk
@@ -45857,7 +45857,7 @@ Body:
     Hit: Single
     HitCount: 1
     Duration1: 300000
-    Duration2: 15000
+    Duration2: 10000
     Requires:
       SpCost: 200
     Status: Berserk

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -8107,7 +8107,7 @@ int pc_checkbaselevelup(map_session_data *sd) {
 	if ((sd->class_&MAPID_UPPERMASK) == MAPID_SUPER_NOVICE) {
 		for (const auto &status : status_db) {
 			if (status.second->flag[SCF_SUPERNOVICEANGEL])
-				sc_start(&sd->bl, &sd->bl, status.second->type, 100, 1, skill_get_time(status.second->skill_id, 1));
+				sc_start(&sd->bl, &sd->bl, status.second->type, 100, 1, 120000); //All buffs with super novice flag for 2 minutes
 		}
 		if (sd->state.snovice_dead_flag)
 			sd->state.snovice_dead_flag = 0; //Reenable steelbody resurrection on dead.

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1435,7 +1435,10 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 
 	case AS_SONICBLOW:
 	case HN_MEGA_SONIC_BLOW:
-		sc_start(src,bl,SC_STUN,(2*skill_lv+10),skill_lv,skill_get_time2(skill_id,skill_lv));
+		if (!map_flag_gvg2(bl->m) && !map_getmapflag(bl->m, MF_BATTLEGROUND) && sc->getSCE(SC_SPIRIT)->val2 == SL_ASSASIN)
+			sc_start(src, bl, SC_STUN, (4 * skill_lv + 20), skill_lv, skill_get_time2(skill_id, skill_lv)); //Link gives double stun chance outside GVG/BG
+		else
+			sc_start(src, bl, SC_STUN, (2 * skill_lv + 10), skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 
 	case AS_GRIMTOOTH:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8189, https://github.com/rathena/rathena/issues/8195, https://github.com/rathena/rathena/issues/7663

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed Frenzy HP drain interval being 15 instead 10 seconds in renewal (follow-up to 1a004f0)
- The buffs granted when a Super Novice levels up now all last 120 seconds (fixes #8189)
- Assassin Soul Link now doubles stun chance outside GVG/BG (fixes #8195)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
