### PR TITLE
ATKpercent, Base Damage, Occult Impaction, Freezing Trap, Acid Terror, Paladin skills

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4408,7 +4408,6 @@ Body:
     TargetType: Ground
     DamageFlags:
       Splash: true
-      IgnoreFlee: true
     Flags:
       IsTrap: true
       AlterRangeResearchTrap: true
@@ -6461,6 +6460,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       IgnoreAtkCard: true
+      IgnoreDefense: true
       IgnoreFlee: true
     Flags:
       IgnoreAutoGuard: true
@@ -32636,7 +32636,6 @@ Body:
     TargetType: Ground
     DamageFlags:
       Splash: true
-      IgnoreFlee: true
     Flags:
       IsTrap: true
       AlterRangeResearchTrap: true

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7027,27 +7027,6 @@ static unsigned short status_calc_batk(struct block_list *bl, status_change *sc,
 		batk += sc->getSCE(SC_ANGRIFFS_MODUS)->val2;
 	if(sc->getSCE(SC_2011RWC_SCROLL))
 		batk += 30;
-	if(sc->getSCE(SC_INCATKRATE))
-		batk += batk * sc->getSCE(SC_INCATKRATE)->val1/100;
-	if(sc->getSCE(SC_PROVOKE))
-		batk += batk * sc->getSCE(SC_PROVOKE)->val2/100;
-#ifndef RENEWAL
-	if(sc->getSCE(SC_CONCENTRATION))
-		batk += batk * sc->getSCE(SC_CONCENTRATION)->val2/100;
-#endif
-	if(sc->getSCE(SC_SKE))
-		batk += batk * 3;
-	if(sc->getSCE(SC_BLOODLUST))
-		batk += batk * sc->getSCE(SC_BLOODLUST)->val2/100;
-	if(sc->getSCE(SC_JOINTBEAT) && sc->getSCE(SC_JOINTBEAT)->val2&BREAK_WAIST)
-		batk -= batk * 25/100;
-	if(sc->getSCE(SC_CURSE))
-		batk -= batk * 25/100;
-	/* Curse shouldn't effect on this? <- Curse OR Bleeding??
-	if(sc->getSCE(SC_BLEEDING))
-		batk -= batk * 25 / 100; */
-	if(sc->getSCE(SC_FLEET))
-		batk += batk * sc->getSCE(SC_FLEET)->val3/100;
 	if(sc->getSCE(SC__ENERVATION))
 		batk -= batk * sc->getSCE(SC__ENERVATION)->val2 / 100;
 	if( sc->getSCE(SC_ZANGETSU) )
@@ -7122,21 +7101,7 @@ static unsigned short status_calc_watk(struct block_list *bl, status_change *sc,
 				watk += sc->getSCE(SC_NIBELUNGEN)->val2;
 		}
 	}
-	if(sc->getSCE(SC_CONCENTRATION))
-		watk += watk * sc->getSCE(SC_CONCENTRATION)->val2 / 100;
 #endif
-	if(sc->getSCE(SC_INCATKRATE))
-		watk += watk * sc->getSCE(SC_INCATKRATE)->val1/100;
-	if(sc->getSCE(SC_PROVOKE))
-		watk += watk * sc->getSCE(SC_PROVOKE)->val2/100;
-	if(sc->getSCE(SC_SKE))
-		watk += watk * 3;
-	if(sc->getSCE(SC_FLEET))
-		watk += watk * sc->getSCE(SC_FLEET)->val3/100;
-	if(sc->getSCE(SC_CURSE))
-		watk -= watk * 25/100;
-	if(sc->getSCE(SC_STRIPWEAPON) && bl->type != BL_PC)
-		watk -= watk * sc->getSCE(SC_STRIPWEAPON)->val2/100;
 	if(sc->getSCE(SC_FIGHTINGSPIRIT))
 		watk += sc->getSCE(SC_FIGHTINGSPIRIT)->val1;
 	if (sc->getSCE(SC_SHIELDSPELL_ATK))
@@ -12228,7 +12193,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 		case SC_ASH:
 			val2 = 0; // hit % reduc
 			val3 = 0; // def % reduc
-			val4 = 0; // atk flee & reduc
+			val4 = 0; // atk flee % reduc
 			if (!status_bl_has_mode(bl,MD_STATUSIMMUNE)) {
 				val2 = 50;
 				if (status_get_race(bl) == RC_PLANT) // plant type


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8193

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- A handful of skills grant status changes that actually are calculated together into a value "ATKpercent" rather than increasing BATK/WATK, this value is then applied to most weapon skills
  * Pre-re - Damage after skill ratio but before DEF reduction is multiplied with ATKpercent
  * Renewal - Is a linear addition to skill ratio instead (ATKpercent of 200 means +100% to any skill ratio, so 100% becomes 200%, but 500% only becomes 600%)
- Fixed base damage not being calculated correctly for certain skills
- MO_INVESTIGATE is no longer influenced by Spirit Spheres except when you have the WATK_ELEMENT effect (Magnum Break)
- Freezing trap now deals 100% damage on all levels and can miss
- Acid Terror now ignores DEF, but its base attack is reduced by VIT
- Acid Terror skill ratio is now 50%+50%*level
- Acid Terror and Martyr's Reckoning (PA_SACRIFICE) are no longer affected by refine and mastery bonus
- Magnum Break/EDP bonus no longer affects Acid Terror and unit skills
- Fixed damage formula of Shield Boomerang and Rapid Smiting
- Code improvements
- Fixes #8193 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
