### PR TITLE
Volcano and Min Damage

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1101,6 +1101,7 @@ Body:
     DurationLookup: SA_VOLCANO
     CalcFlags:
       Batk: true
+      Watk: true
     Flags:
       NoSave: true
       NoClearance: true

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1100,7 +1100,7 @@ Body:
     Icon: EFST_GROUNDMAGIC
     DurationLookup: SA_VOLCANO
     CalcFlags:
-      Watk: true
+      Batk: true
     Flags:
       NoSave: true
       NoClearance: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1117,7 +1117,7 @@ Body:
     Icon: EFST_GROUNDMAGIC
     DurationLookup: SA_VOLCANO
     CalcFlags:
-      Watk: true
+      Batk: true
       Matk: true
     Flags:
       NoSave: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1118,6 +1118,7 @@ Body:
     DurationLookup: SA_VOLCANO
     CalcFlags:
       Batk: true
+      Watk: true
       Matk: true
     Flags:
       NoSave: true

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6563,12 +6563,12 @@ static void battle_calc_defense_reduction(struct Damage* wd, struct block_list *
  */
 static void battle_min_damage(struct Damage* wd, struct block_list* src, uint16 skill_id, int64 min) {
 	if (is_attack_right_handed(src, skill_id)) {
-		cap_value(wd->damage, min, INT64_MAX);
-		cap_value(wd->basedamage, min, INT64_MAX);
+		wd->damage = cap_value(wd->damage, min, INT64_MAX);
+		wd->basedamage = cap_value(wd->basedamage, min, INT64_MAX);
 	}
 	if (is_attack_left_handed(src, skill_id)) {
-		cap_value(wd->damage2, min, INT64_MAX);
-		cap_value(wd->basedamage2, min, INT64_MAX);
+		wd->damage2 = cap_value(wd->damage2, min, INT64_MAX);
+		wd->basedamage2 = cap_value(wd->basedamage2, min, INT64_MAX);
 	}
 }
 
@@ -7548,7 +7548,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			if (index >= 0 && sd->inventory_data[index] && sd->inventory_data[index]->type == IT_ARMOR) {
 				//First calculate the random part of the bonus
 				int bonus = (7 * sd->inventory_data[index]->weight) / 100;
-				bonus += pow(skill_lv + sd->inventory.u.items_inventory[index].refine, 2);
+				bonus += static_cast<decltype(bonus)>(pow(skill_lv + sd->inventory.u.items_inventory[index].refine, 2));
 				//Now get a random value between 100 and the random part
 				bonus = max(100, rnd_value(100, bonus));
 				ATK_ADD(wd.damage, wd.damage2, bonus);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7085,6 +7085,8 @@ static unsigned short status_calc_watk(struct block_list *bl, status_change *sc,
 		watk += sc->getSCE(SC_IMPOSITIO)->val2;
 	if(sc->getSCE(SC_WATKFOOD))
 		watk += sc->getSCE(SC_WATKFOOD)->val1;
+	if (sc->getSCE(SC_VOLCANO) && bl->type == BL_MOB)
+		watk += sc->getSCE(SC_VOLCANO)->val2;
 	if(sc->getSCE(SC_MERC_ATKUP))
 		watk += sc->getSCE(SC_MERC_ATKUP)->val2;
 	if(sc->getSCE(SC_WATER_BARRIER))

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7011,6 +7011,8 @@ static unsigned short status_calc_batk(struct block_list *bl, status_change *sc,
 		batk += sc->getSCE(SC_ATKPOTION)->val1;
 	if(sc->getSCE(SC_BATKFOOD))
 		batk += sc->getSCE(SC_BATKFOOD)->val1;
+	if (sc->getSCE(SC_VOLCANO))
+		batk += sc->getSCE(SC_VOLCANO)->val2;
 #ifndef RENEWAL
 	if(sc->getSCE(SC_GATLINGFEVER))
 		batk += sc->getSCE(SC_GATLINGFEVER)->val3;
@@ -7083,8 +7085,6 @@ static unsigned short status_calc_watk(struct block_list *bl, status_change *sc,
 		watk += sc->getSCE(SC_IMPOSITIO)->val2;
 	if(sc->getSCE(SC_WATKFOOD))
 		watk += sc->getSCE(SC_WATKFOOD)->val1;
-	if(sc->getSCE(SC_VOLCANO))
-		watk += sc->getSCE(SC_VOLCANO)->val2;
 	if(sc->getSCE(SC_MERC_ATKUP))
 		watk += sc->getSCE(SC_MERC_ATKUP)->val2;
 	if(sc->getSCE(SC_WATER_BARRIER))
@@ -7303,9 +7303,9 @@ static unsigned short status_calc_matk(struct block_list *bl, status_change *sc,
 		matk += matk * sc->getSCE(SC_MTF_MATK)->val1 / 100;
 	if (sc->getSCE(SC_SHRIMP))
 		matk += matk * sc->getSCE(SC_SHRIMP)->val2 / 100;
+#ifdef RENEWAL
 	if (sc->getSCE(SC_VOLCANO))
 		matk += sc->getSCE(SC_VOLCANO)->val2;
-#ifdef RENEWAL
 	if (sc->getSCE(SC_NIBELUNGEN) && sc->getSCE(SC_NIBELUNGEN)->val2 == RINGNBL_MATKRATE)
 		matk += matk * 20 / 100;
 #endif


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8208 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (MATK fix only applies to pre-re)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Volcano now increases BaseATK instead of WeaponATK for non-monsters
- Fixed a bug that caused Volcano to increase MATK in pre-re (fixes #8208)
- Fixed min damage not being set correctly
- Fixed a compiler warning

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
