### PR TITLE
Star Crumbs, Spirit Spheres, EDP, Guillotine Fist, Sand Attack, Rapid Smiting, Clashing Spiral

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3775,6 +3775,11 @@ static void battle_calc_attack_masteries(struct Damage* wd, struct block_list *s
 #else
 		if (skill_id == TF_POISON)
 			ATK_ADD(wd->damage, wd->damage2, 15 * skill_lv);
+		if (skill_id == MO_FINGEROFFENSIVE) { //Need to calculate number of Spirit Balls you had before cast
+			ATK_ADD(wd->damage, wd->damage2, (wd->div_ + sd->spiritball) * 3);
+		}
+		else
+			ATK_ADD(wd->damage, wd->damage2, sd->spiritball * 3);
 #endif
 
 		if (skill_id == NJ_SYURIKEN && (skill = pc_checkskill(sd,NJ_TOBIDOUGU)) > 0) { // !TODO: Confirm new mastery formula
@@ -3915,7 +3920,10 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 	map_session_data *sd = BL_CAST(BL_PC, src);
 	map_session_data *tsd = BL_CAST(BL_PC, target);
 
-	uint16 i, bflag = BDMG_NONE;
+	uint16 bflag = BDMG_NONE;
+#ifndef RENEWAL
+	uint16 i;
+#endif
 	std::bitset<NK_MAX> nk = battle_skill_get_damage_properties(skill_id, wd->miscflag);
 
 	switch (skill_id) {	//Calc base damage according to skill
@@ -7533,10 +7541,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			ATK_ADD(wd.damage, wd.damage2, 50 * skill_lv);
 		if (skill_id != MC_CARTREVOLUTION && pc_checkskill(sd, BS_HILTBINDING) > 0)
 			ATK_ADD(wd.damage, wd.damage2, 4);
-		if (skill_id == MO_FINGEROFFENSIVE) { //Need to calculate number of Spirit Balls you had before cast
-			ATK_ADD(wd.damage, wd.damage2, (wd.div_ + sd->spiritball) * 3);
-		} else if (skill_id != MO_INVESTIGATE)
-			ATK_ADD(wd.damage, wd.damage2, ((wd.div_ < 1) ? 1 : wd.div_) * sd->spiritball * 3);
 #endif
 		if (sd && skill_id == PA_SHIELDCHAIN) { //Rapid Smiting has a unique mastery bonus
 			short index = sd->equip_index[EQI_HAND_L];

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2263,7 +2263,7 @@ int64 battle_addmastery(map_session_data *sd,struct block_list *target,int64 dmg
 			damage += damage * 30 / 100;
 	}
 
-	if (type == 0)
+	if(type == 0)
 		weapon = sd->weapontype1;
 	else
 		weapon = sd->weapontype2;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3366,30 +3366,30 @@ static bool attack_ignores_def(struct Damage* wd, struct block_list *src, struct
 static bool battle_skill_stacks_masteries_vvs(uint16 skill_id, int type)
 {
 	switch (skill_id) {
-	case PA_SHIELDCHAIN:
-	case CR_SHIELDBOOMERANG:
-	case AM_ACIDTERROR:
-	case MO_INVESTIGATE:
-	case MO_EXTREMITYFIST:
-	case PA_SACRIFICE:
-	case NPC_DRAGONBREATH:
-	case RK_DRAGONBREATH:
-	case RK_DRAGONBREATH_WATER:
-	case NC_SELFDESTRUCTION:
-	case LG_SHIELDPRESS:
-	case LG_EARTHDRIVE:
-		return false;
-	case CR_GRANDCROSS:
-	case NPC_GRANDDARKNESS:
-		// Grand Cross is influenced by refine bonus but not by atkpercent / masteries / Star Crumbs / Spirit Spheres
-		if (type != 1)
+		case PA_SHIELDCHAIN:
+		case CR_SHIELDBOOMERANG:
+		case AM_ACIDTERROR:
+		case MO_INVESTIGATE:
+		case MO_EXTREMITYFIST:
+		case PA_SACRIFICE:
+		case NPC_DRAGONBREATH:
+		case RK_DRAGONBREATH:
+		case RK_DRAGONBREATH_WATER:
+		case NC_SELFDESTRUCTION:
+		case LG_SHIELDPRESS:
+		case LG_EARTHDRIVE:
 			return false;
-		break;
-	case LK_SPIRALPIERCE:
-		// Spiral Pierce is influenced only by refine bonus and Star Crumbs
-		if (type != 1 && type != 2)
-			return false;
-		break;
+		case CR_GRANDCROSS:
+		case NPC_GRANDDARKNESS:
+			// Grand Cross is influenced by refine bonus but not by atkpercent / masteries / Star Crumbs / Spirit Spheres
+			if (type != 1)
+				return false;
+			break;
+		case LK_SPIRALPIERCE:
+			// Spiral Pierce is influenced only by refine bonus and Star Crumbs
+			if (type != 1 && type != 2)
+				return false;
+			break;
 	}
 
 	return true;
@@ -3404,18 +3404,18 @@ static bool battle_skill_stacks_masteries_vvs(uint16 skill_id, int type)
 static bool battle_skill_stacks_edp_element(uint16 skill_id)
 {
 	switch (skill_id) {
-	case TF_SPRINKLESAND:
-	case AS_SPLASHER:
-	case ASC_METEORASSAULT:
-	case ASC_BREAKER:
-	case AS_VENOMKNIFE:
-	case AM_ACIDTERROR:
-		return false;
-	default:
-		//Unit skills
-		if (skill_get_unit_id(skill_id))
+		case TF_SPRINKLESAND:
+		case AS_SPLASHER:
+		case ASC_METEORASSAULT:
+		case ASC_BREAKER:
+		case AS_VENOMKNIFE:
+		case AM_ACIDTERROR:
 			return false;
-		break;
+		default:
+			//Unit skills
+			if (skill_get_unit_id(skill_id))
+				return false;
+			break;
 	}
 
 	return true;
@@ -3696,21 +3696,21 @@ static int battle_get_spiritball_damage(struct Damage& wd, struct block_list& sr
 	int damage = 0;
 
 	switch (skill_id) {
-	case MO_INVESTIGATE:
+		case MO_INVESTIGATE:
 #ifndef RENEWAL
-	case MO_FINGEROFFENSIVE:
+		case MO_FINGEROFFENSIVE:
 #endif
-		// These skills used as many spheres as they do hits
-		damage = (wd.div_ + sd->spiritball) * 3;
-		break;
-	case MO_EXTREMITYFIST:
-		// These skills store the number of spheres the player had before cast
-		damage = sd->spiritball_old * 3;
-		break;
-	default:
-		// Any skills that do not consume spheres or do not care
-		damage = sd->spiritball * 3;
-		break;
+			// These skills used as many spheres as they do hits
+			damage = (wd.div_ + sd->spiritball) * 3;
+			break;
+		case MO_EXTREMITYFIST:
+			// These skills store the number of spheres the player had before cast
+			damage = sd->spiritball_old * 3;
+			break;
+		default:
+			// Any skills that do not consume spheres or do not care
+			damage = sd->spiritball * 3;
+			break;
 	}
 
 	return damage;
@@ -3791,6 +3791,7 @@ static void battle_calc_element_damage(struct Damage* wd, struct block_list *src
 		// Star Crumb bonus damage
 		ATK_ADD2(wd->damage, wd->damage2, sd->right_weapon.star, sd->left_weapon.star);
 	}
+	// Check if general mastery bonuses apply (above check is only for Star Crumb)
 	if (battle_skill_stacks_masteries_vvs(skill_id, 0)) {
 		// Spirit Sphere bonus damage
 		ATK_ADD(wd->damage, wd->damage2, battle_get_spiritball_damage(*wd, *src, skill_id));

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3831,6 +3831,8 @@ static void battle_calc_attack_masteries(struct Damage* wd, struct block_list *s
 			ATK_ADD(wd->masteryAtk, wd->masteryAtk2, 15 * skill_lv);
 		if (skill_id != MC_CARTREVOLUTION && pc_checkskill(sd, BS_HILTBINDING) > 0)
 			ATK_ADD(wd->masteryAtk, wd->masteryAtk2, 4);
+		if (skill_id != CR_SHIELDBOOMERANG)
+			ATK_ADD2(wd->masteryAtk, wd->masteryAtk2, ((wd->div_ < 1) ? 1 : wd->div_) * sd->right_weapon.star, ((wd->div_ < 1) ? 1 : wd->div_) * sd->left_weapon.star);
 		ATK_ADD(wd->masteryAtk, wd->masteryAtk2, ((wd->div_ < 1) ? 1 : wd->div_) * sd->spiritball * 3);
 #endif
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2455,11 +2455,11 @@ static int battle_calc_base_weapon_attack(struct block_list *src, struct status_
  * This applies to pre-renewal and non-sd in renewal
  *------------------------------------------
  * Pass damage2 as NULL to not calc it.
- * Flag values:
+ * Flag values (see e_base_damage_flag):
  * &1 : Critical hit
  * &2 : Arrow attack
  * &4 : Skill is Magic Crasher
- * &8 : Skip target size adjustment (Extremity Fist?)
+ * &8 : Skip target size adjustment (Weapon Perfection)
  * &16: Arrow attack but BOW, REVOLVER, RIFLE, SHOTGUN, GATLING or GRENADE type weapon not equipped (i.e. shuriken, kunai and venom knives not affected by DEX)
  *
  * Credits:
@@ -4084,7 +4084,6 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 			// Pre-renewal exclusive flags
 			if (is_skill_using_arrow(src, skill_id)) bflag |= BDMG_ARROW;
 			if (skill_id == HW_MAGICCRASHER) bflag |= BDMG_MAGIC;
-			if (skill_id == MO_EXTREMITYFIST) bflag |= BDMG_NOSIZE;
 			if (sc && sc->getSCE(SC_WEAPONPERFECTION)) bflag |= BDMG_NOSIZE;
 			if (is_skill_using_arrow(src, skill_id) && sd) {
 				switch(sd->status.weapon) {
@@ -4634,7 +4633,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 #endif
 			break;
 		case MO_EXTREMITYFIST:
-			skillratio += 100 * (7 + sstatus->sp / 10);			
+			skillratio += 700 + sstatus->sp * 10;
 #ifdef RENEWAL
 			if (wd->miscflag&1)
 				skillratio *= 2; // More than 5 spirit balls active

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -36,7 +36,7 @@ enum e_base_damage_flag : uint16 {
 	BDMG_CRIT	= 0x0001, /// Critical hit damage
 	BDMG_ARROW  = 0x0002, /// Add arrow attack and use ranged damage formula
 	BDMG_MAGIC  = 0x0004, /// Use MATK for base damage (e.g. Magic Crasher)
-	BDMG_NOSIZE = 0x0008, /// Skip target size adjustment (e.g. Weapon Perfection, Extremity Fist)
+	BDMG_NOSIZE = 0x0008, /// Skip target size adjustment (e.g. Weapon Perfection)
 	BDMG_THROW  = 0x0010, /// Arrow attack should use melee damage formula (e.g., shuriken, kunai and venom knives)
 };
 

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -86,8 +86,7 @@ struct Damage {
 #endif
 	int64 damage, /// Right hand damage
 		damage2, /// Left hand damage
-		basedamage, /// Right hand base damage after def reduction
-		basedamage2; /// Left hand base damage after def reduction
+		basedamage; /// Right hand damage that a normal attack would deal
 	enum e_damage_type type; /// Check clif_damage for type
 	short div_; /// Number of hit
 	int amotion,

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -17586,9 +17586,7 @@ bool skill_check_condition_castbegin(map_session_data* sd, uint16 skill_id, uint
 				clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
 				return false;
 			}
-#ifdef RENEWAL
 			sd->spiritball_old = sd->spiritball;
-#endif
 			break;
 		case TK_MISSION:
 			if( (sd->class_&MAPID_UPPERMASK) != MAPID_TAEKWON ) { // Cannot be used by Non-Taekwon classes


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8211

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (changes to the order of damage processing only applies to pre-renewal)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**:

- ATKpercent, Spirit Spheres and other mastery bonuses, now all affect the exactly same skills with some exceptions for refine and Star Crumbs, see battle_skill_stacks_masteries_vvs
- EDP and elemental bonus damage now apply to the exact same list of skills, see battle_skill_stacks_edp_element
- Star Crumbs and Spirit Spheres no longer multiply the damage by number of hits twice
- Star Crumbs, Spirit Spheres and similar mastery bonuses that apply even on MISS are now applied after the attribute table but before EDP and elemental bonus damage in pre-renewal
- Attribute table can now make damage go negative which is weighted against any of the above mastery bonuses and elemental bonus damage before being capped to 0
- EDP and elemental bonus damage no longer apply to the left hand; removed "basedamage2" as it is no longer needed
- Left-hand damage is now always capped to 0 instead of 1
- Fixed Guillotine Fist ignoring size modifiers
- Fixed inaccuracies in Guillotine Fist's damage due to rounding issues
- Fixed bonus damage from Magnum Break when using Guillotine Fist
- Sand Attack is no longer influenced by EDP
- Rapid Smiting now has a fixed 20% hit bonus (it hits at least to 25%)
- Rapid Smiting no longer deals damage on MISS
- Clashing Spiral damage is no longer influenced by ATKpercent and any mastery except Star Crumbs
- Further code improvements / compiler warning fix
- Fixes #8211 
- Fixes #8218 
- Fixes #7750 
- Fixes #1823 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
