### PR TITLE
Fixes a crash when a mob uses HP_BASILICA

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13964,7 +13964,8 @@ int skill_castend_pos2(struct block_list* src, int x, int y, uint16 skill_id, ui
 			return 0;
 		} else { // Create Basilica. Start SC on caster. Unit timer start SC on others.
 			if( map_getcell(src->m, x, y, CELL_CHKLANDPROTECTOR) ) {
-				clif_skill_fail(sd,skill_id,USESKILL_FAIL,0);
+				if(sd)
+					clif_skill_fail(sd,skill_id,USESKILL_FAIL,0);
 				return 0;
 			}
 			skill_clear_unitgroup(src);


### PR DESCRIPTION
A check for sd pointer was missing

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#8239
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Restores a missing sd pointer check before send a clif_fail packet
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
