### PR TITLE
Venom Splasher, Venom Knife

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4998,7 +4998,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       NoDamage: true
-      IgnoreElement: true
+      IgnoreAtkCard: true
       IgnoreFlee: true
     Range: 1
     Hit: Single
@@ -5013,26 +5013,47 @@ Body:
     CastTime: 1000
     Duration1:
       - Level: 1
-        Time: 5000
+        Time: 11000
       - Level: 2
-        Time: 5500
+        Time: 10000
       - Level: 3
-        Time: 6000
+        Time: 9000
       - Level: 4
-        Time: 6500
+        Time: 8000
       - Level: 5
         Time: 7000
       - Level: 6
-        Time: 7500
+        Time: 6000
       - Level: 7
-        Time: 8000
+        Time: 5000
       - Level: 8
-        Time: 8500
+        Time: 4000
       - Level: 9
-        Time: 9000
+        Time: 3000
       - Level: 10
-        Time: 9500
+        Time: 2000
     Duration2: 60000
+    Cooldown:
+      - Level: 1
+        Time: 7500
+      - Level: 2
+        Time: 8000
+      - Level: 3
+        Time: 8500
+      - Level: 4
+        Time: 9000
+      - Level: 5
+        Time: 9500
+      - Level: 6
+        Time: 10000
+      - Level: 7
+        Time: 10500
+      - Level: 8
+        Time: 11000
+      - Level: 9
+        Time: 11500
+      - Level: 10
+        Time: 12000
     Requires:
       SpCost:
         - Level: 1
@@ -16942,32 +16963,13 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2:
-      - Level: 1
-        Time: 15000
-      - Level: 2
-        Time: 20000
-      - Level: 3
-        Time: 25000
-      - Level: 4
-        Time: 30000
-      - Level: 5
-        Time: 35000
-      - Level: 6
-        Time: 40000
-      - Level: 7
-        Time: 45000
-      - Level: 8
-        Time: 50000
-      - Level: 9
-        Time: 55000
-      - Level: 10
-        Time: 60000
+    Duration2: 60000
     Requires:
       SpCost: 15
       Ammo:
         Dagger: true
       AmmoAmount: 1
+    Status: Poison
   - Id: 1005
     Name: RG_CLOSECONFINE
     Description: Close Confine

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5243,7 +5243,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       NoDamage: true
-      IgnoreElement: true
+      IgnoreAtkCard: true
       IgnoreFlee: true
     Range: 1
     Hit: Single
@@ -5277,7 +5277,7 @@ Body:
         Time: 3000
       - Level: 10
         Time: 2000
-    Duration2: 20000
+    Duration2: 18000
     Cooldown:
       - Level: 1
         Time: 7500
@@ -18507,32 +18507,13 @@ Body:
       Skill:
         Plagiarism: true
         Reproduce: true
-    Duration2:
-      - Level: 1
-        Time: 15000
-      - Level: 2
-        Time: 20000
-      - Level: 3
-        Time: 25000
-      - Level: 4
-        Time: 30000
-      - Level: 5
-        Time: 35000
-      - Level: 6
-        Time: 40000
-      - Level: 7
-        Time: 45000
-      - Level: 8
-        Time: 50000
-      - Level: 9
-        Time: 55000
-      - Level: 10
-        Time: 60000
+    Duration2: 18000
     Requires:
       SpCost: 35
       Ammo:
         Dagger: true
       AmmoAmount: 1
+    Status: Poison
   - Id: 1005
     Name: RG_CLOSECONFINE
     Description: Close Confine

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1422,15 +1422,13 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		break;
 
 	case AS_VENOMKNIFE:
-		if (sd) //Poison chance must be that of Envenom. [Skotlex]
-			skill_lv = pc_checkskill(sd, TF_POISON);
-		[[fallthrough]];
-	case TF_POISON:
 	case AS_SPLASHER:
-		if(!sc_start2(src,bl,SC_POISON,(4*skill_lv+10),skill_lv,src->id,skill_get_time2(skill_id,skill_lv))
-			&& sd && skill_id==TF_POISON
-		)
-			clif_skill_fail(sd,skill_id,USESKILL_FAIL_LEVEL,0);
+		sc_start2(src, bl, SC_POISON, 100, skill_lv, src->id, skill_get_time2(skill_id, skill_lv));
+		break;
+
+	case TF_POISON:
+		if (!sc_start2(src, bl, SC_POISON, (4 * skill_lv + 10), skill_lv, src->id, skill_get_time2(skill_id, skill_lv)) && sd)
+			clif_skill_fail(sd, skill_id, USESKILL_FAIL_LEVEL, 0);
 		break;
 
 	case AS_SONICBLOW:
@@ -10254,9 +10252,6 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		}
 		clif_skill_nodamage(src,bl,skill_id,skill_lv,
 			sc_start4(src,bl,type,100,skill_lv,skill_id,src->id,skill_get_time(skill_id,skill_lv),1000));
-#ifndef RENEWAL
-		if (sd) skill_blockpc_start (sd, skill_id, skill_get_time(skill_id, skill_lv)+3000);
-#endif
 		break;
 
 	case PF_MINDBREAKER:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8221

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (some things were already working on renewal)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 
 
- Venom Splasher now ignores +% damage cards, but no longer ignores weapon element
- Venom Splasher now uses the correct durations and cooldowns in pre-re (was already correct in renewal)
- Both skills now correctly use default poison duration
- Venom Splasher and Venom Knife now have a poison chance of 100%
- Fixes #8221

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
