### PR TITLE
Updated/Simplified Damage Bonus Stacking

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4408,6 +4408,7 @@ Body:
     TargetType: Ground
     DamageFlags:
       Splash: true
+      IgnoreAtkCard: true
     Flags:
       IsTrap: true
       AlterRangeResearchTrap: true
@@ -5184,6 +5185,8 @@ Body:
     MaxLevel: 1
     Type: Weapon
     TargetType: Attack
+    DamageFlags:
+      IgnoreAtkCard: true
     Flags:
       IsQuest: true
     Range: 1
@@ -14295,6 +14298,7 @@ Body:
     TargetType: Ground
     DamageFlags:
       Splash: true
+      IgnoreAtkCard: true
       IgnoreFlee: true
     Flags:
       AlterRangeSnakeEye: true
@@ -14510,6 +14514,8 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Self
+    DamageFlags:
+      IgnoreAtkCard: true
     Hit: Single
     HitCount: 1
     Element: Weapon
@@ -17180,6 +17186,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
+      IgnoreAtkCard: true
     Flags:
       IsQuest: true
     Range: -1
@@ -32584,6 +32591,7 @@ Body:
     TargetType: Ground
     DamageFlags:
       Splash: true
+      IgnoreAtkCard: true
     Flags:
       IsTrap: true
       AlterRangeResearchTrap: true

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3359,7 +3359,6 @@ static bool attack_ignores_def(struct Damage* wd, struct block_list *src, struct
 /**
  * This function lists which skills are unaffected by refine bonus, masteries, Star Crumbs and Spirit Spheres
  * This function is also used to determine if atkpercent applies
- * @param src: Source of the attack
  * @param skill_id: Skill being used
  * @param chk_flag: The bonus that is currently being checked for, see e_bonus_chk_flag
  * @return true = bonus applies; false = bonus does not apply


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8250

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Freezing Trap, Sand Attack, Gunslinger Mine, Flip Tatami and Excruciating Palm no longer are affected by +% dmg cards
- The skills that ignore +% dmg cards are now exactly those skills that also ignore EDP and the EDP/Magnum Break elemental damage bonus
- Non-players are now always affected by ATKpercent
- Simplified the code accordingly
- Fixes #8250

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
