### PR TITLE
* fixes wrong double damage calculation for skills in renewal mode

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7335,11 +7335,13 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		wd.dmg_lv = ATK_FLEE;
 	else if(!(infdef = is_infinite_defense(target, wd.flag))) { //no need for math against plants
 
+#ifndef RENEWAL
 		// First call function with skill_id 0 to get base damage of a normal attack
 		battle_calc_skill_base_damage(&wd, src, target, 0, 0); // base damage
 		wd.basedamage = wd.damage;
 		// Now get actual skill damage
 		if (skill_id != 0)
+#endif
 			battle_calc_skill_base_damage(&wd, src, target, skill_id, skill_lv); // base skill damage
 
 		int64 ratio = 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Skill Damage calculation was doubled in Renewal Mode

* **Server Mode**: Renewal

* **Description of Pull Request**: 

Fixes skill damage calculation in Renewal.
