### PR TITLE
Move skill_onskillusage from skill_attack to skill_castend

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2521,7 +2521,7 @@ int skill_onskillusage(map_session_data *sd, struct block_list *bl, uint16 skill
 		sd->state.autocast = 0;
 	}
 
-	// Check for player and pet autobonuses when being attacked by skill_id
+	// Check for player and pet autobonuses when casting skill_id
 	if (sd != nullptr) {
 		// Player
 		if (!sd->autobonus3.empty()) {
@@ -4138,8 +4138,6 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 				}
 				break;
 		}
-		if( sd )
-			skill_onskillusage(sd, bl, skill_id, tick);
 	}
 
 	if (!(flag&2)) {
@@ -7181,7 +7179,7 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		{// consume arrow on last invocation to this skill.
 			battle_consume_ammo(sd, skill_id, skill_lv);
 		}
-
+		skill_onskillusage(sd,bl,skill_id,skill_lv);
 		// perform skill requirement consumption
 		if (!(flag&SKILL_NOCONSUME_REQ))
 			skill_consume_requirement(sd,skill_id,skill_lv,2);


### PR DESCRIPTION
Fixes #8256

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8256 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Move skill_onskillusage from skill_attack to skill_castend_damage_id

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
