### PR TITLE
Moved battle_fix_damage definition to battle.cpp

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -422,6 +422,10 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 	return 0;
 }
 
+int battle_fix_damage(struct block_list* src, struct block_list* target, int64 damage, t_tick walkdelay, uint16 skill_id) {
+	return battle_damage(src, target, damage, walkdelay, 0, skill_id, ATK_DEF, BF_MISC, false, gettick(), false);
+}
+
 /**
  * Does attribute fix modifiers.
  * Added passing of the chars so that the status changes can affect it. [Skotlex]

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -124,9 +124,7 @@ int64 battle_calc_pk_damage(block_list &src, block_list &bl, int64 damage, uint1
 
 int battle_damage(struct block_list *src, struct block_list *target, int64 damage, t_tick delay, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, unsigned short attack_type, bool additional_effects, t_tick tick, bool spdamage);
 int battle_delay_damage (t_tick tick, int amotion, struct block_list *src, struct block_list *target, int attack_type, uint16 skill_id, uint16 skill_lv, int64 damage, enum damage_lv dmg_lv, t_tick ddelay, bool additional_effects, bool spdamage);
-static int battle_fix_damage(struct block_list* src, struct block_list* target, int64 damage, t_tick walkdelay, uint16 skill_id) {
-	return battle_damage(src, target, damage, walkdelay, 0, skill_id, ATK_DEF, BF_MISC, false, gettick(), false);
-}
+int battle_fix_damage(struct block_list* src, struct block_list* target, int64 damage, t_tick walkdelay, uint16 skill_id);
 
 int battle_calc_chorusbonus(map_session_data *sd);
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8291

* **Server Mode**: Both

* **Description of Pull Request**: 
Commit cad5cab976290283bf47738aa8a383891e33b82a introduced reference to gettick in battle.hpp in definition of `battle_fix_damage`. Tools do not have reference to it, so definition of `battle_fix_damage` is moved to battle.cpp to make them compile again.