### PR TITLE
NPC_RUN, Monster Skill Interval

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -26,8 +26,8 @@ min_skill_delay_limit: 100
 
 // This delay is the min 'can't walk delay' of all skills.
 // NOTE: Do not set this too low, if a character starts moving too soon after 
-// doing a skill, the client will not update this, and the player/mob will 
-// appear to "teleport" afterwards.
+// doing a skill, the client will not update this, and the player will appear
+// to "teleport" afterwards. Monsters use AttackMotion instead.
 default_walk_delay: 300
 
 // Completely disable skill delay of the following types (Note 3)

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1919,6 +1919,8 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		// Only use skill if able to walk on next tick and not attempted a skill the last second
 		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL){
 			if (mobskill_use(md, tick, -1)) {
+				// After the monster used an angry skill, it will not attack for aDelay
+				// Setting the delay here because not all monster skill use situations will cause an attack delay
 				md->ud.attackabletime = tick + md->status.adelay;
 				return true;
 			}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1985,7 +1985,6 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	//Follow up if possible.
 	if (!mob_can_reach(md, tbl, md->min_chase)) {
 		mob_unlocktarget(md, tick);
-
 		return true;
 	}
 	// Monsters can use chase skills before starting to walk
@@ -1996,7 +1995,6 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		&& DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME
 		&& DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL) {
 		md->state.skillstate = md->state.aggressive ? MSS_FOLLOW : MSS_RUSH;
-		
 		if (mobskill_use(md, tick, -1))
 			return true;
 	}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1916,8 +1916,8 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	// Monsters in angry state, after having used a normal attack, will always attempt a skill
 	if (md->ud.walktimer == INVALID_TIMER && md->state.skillstate == MSS_ANGRY && md->ud.skill_id == 0)
 	{
-		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL)
-		{ //Only use skill if able to walk on next tick and not attempted a skill the last second
+		// Only use skill if able to walk on next tick and not attempted a skill the last second
+		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL){
 			if (mobskill_use(md, tick, -1)) {
 				md->ud.attackabletime = tick + md->status.adelay;
 				return true;
@@ -1985,21 +1985,24 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	//Follow up if possible.
 	if (!mob_can_reach(md, tbl, md->min_chase)) {
 		mob_unlocktarget(md, tick);
+
+		return true;
 	}
-	else {
-		// Monsters can use chase skills before starting to walk
-		// So we need to change the state and check for a skill here already
-		// Skills during movement are handled in the walktobl routine
-		if (md->ud.walktimer == INVALID_TIMER
-			&& DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME
-			&& DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL) {
-			md->state.skillstate = md->state.aggressive ? MSS_FOLLOW : MSS_RUSH;
-			if (mobskill_use(md, tick, -1))
-				return true;
-		}
-		if(!unit_walktobl(&md->bl, tbl, md->status.rhw.range, 2))
-			mob_unlocktarget(md, tick);
+	// Monsters can use chase skills before starting to walk
+	// So we need to change the state and check for a skill here already
+	// But only use skill if able to walk on next tick and not attempted a skill the last second
+	// Skills during movement are handled in the walktobl routine
+	if (md->ud.walktimer == INVALID_TIMER
+		&& DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME
+		&& DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL) {
+		md->state.skillstate = md->state.aggressive ? MSS_FOLLOW : MSS_RUSH;
+		
+		if (mobskill_use(md, tick, -1))
+			return true;
 	}
+
+	if(!unit_walktobl(&md->bl, tbl, md->status.rhw.range, 2))
+		mob_unlocktarget(md, tick);
 
 	return true;
 }

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -45,8 +45,6 @@ using namespace rathena;
 
 #define ACTIVE_AI_RANGE 2	//Distance added on top of 'AREA_SIZE' at which mobs enter active AI mode.
 
-#define IDLE_SKILL_INTERVAL 10	//Active idle skills should be triggered every 1 second (1000/MIN_MOBTHINKTIME)
-
 const t_tick MOB_MAX_DELAY = 24 * 3600 * 1000;
 #define RUDE_ATTACKED_COUNT 1	//After how many rude-attacks should the skill be used?
 
@@ -1165,6 +1163,7 @@ int mob_spawn (struct mob_data *md)
 	md->dmgtick = tick - 5000;
 	md->last_pcneartime = 0;
 	md->last_canmove = tick;
+	md->last_skillcheck = 0;
 
 	t_tick c = tick - MOB_MAX_DELAY;
 
@@ -1522,7 +1521,7 @@ int mob_unlocktarget(struct mob_data *md, t_tick tick)
 			break;
 		}
 		// Idle skill.
-		if (!(++md->ud.walk_count%IDLE_SKILL_INTERVAL) && mobskill_use(md, tick, -1))
+		if (DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL && mobskill_use(md, tick, -1))
 			break;
 		//Random walk.
 		if (!md->master_id &&
@@ -1563,8 +1562,7 @@ int mob_unlocktarget(struct mob_data *md, t_tick tick)
 int mob_randomwalk(struct mob_data *md,t_tick tick)
 {
 	const int d=7;
-	int i,c,r,rdir,dx,dy,max;
-	int speed;
+	int i,r,rdir,dx,dy,max;
 
 	nullpo_ret(md);
 
@@ -1648,16 +1646,9 @@ int mob_randomwalk(struct mob_data *md,t_tick tick)
 		}
 		return 0;
 	}
-	speed=status_get_speed(&md->bl);
-	for(i=c=0;i<md->ud.walkpath.path_len;i++){	// The next walk start time is calculated.
-		if( direction_diagonal( md->ud.walkpath.path[i] ) )
-			c+=speed*MOVE_DIAGONAL_COST/MOVE_COST;
-		else
-			c+=speed;
-	}
 	md->state.skillstate=MSS_WALK;
 	md->move_fail_count=0;
-	md->next_walktime = tick+rnd()%1000+MIN_RANDOMWALKTIME+c;
+	md->next_walktime = tick+rnd()%1000+MIN_RANDOMWALKTIME + unit_get_walkpath_time(md->bl);
 	return 1;
 }
 
@@ -1940,11 +1931,12 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		return true;
 	}
 
-	//Monsters in berserk state, unable to use normal attacks, will always attempt a skill
-	if(md->ud.walktimer == INVALID_TIMER && (md->state.skillstate == MSS_BERSERK || md->state.skillstate == MSS_ANGRY)) 
+	// Monsters in angry state, unable to use normal attacks, will always attempt a skill
+	// This does not apply to berserk state (i.e. after you hit an angry mob, it will no longer use follow-up skills)
+	if (md->ud.walktimer == INVALID_TIMER && md->state.skillstate == MSS_ANGRY)
 	{
-		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(md->ud.canact_tick, tick) < -MIN_MOBTHINKTIME*IDLE_SKILL_INTERVAL) 
-		{ //Only use skill if able to walk on next tick and not used a skill the last second
+		if (DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME && DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL)
+		{ //Only use skill if able to walk on next tick and not attempted a skill the last second
 			if (mobskill_use(md, tick, -1))
 				return true;
 		}
@@ -1971,7 +1963,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			else {
 				// Use idle skill but keep target for now
 				md->state.skillstate = MSS_IDLE;
-				if (!(++md->ud.walk_count%IDLE_SKILL_INTERVAL))
+				if (DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL)
 					mobskill_use(md, tick, -1);
 			}
 		}
@@ -1986,10 +1978,23 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		return true;
 
 	//Follow up if possible.
-	//Hint: Chase skills are handled in the walktobl routine
-	if(!mob_can_reach(md, tbl, md->min_chase) ||
-		!unit_walktobl(&md->bl, tbl, md->status.rhw.range, 2))
-		mob_unlocktarget(md,tick);
+	if (!mob_can_reach(md, tbl, md->min_chase)) {
+		mob_unlocktarget(md, tick);
+	}
+	else {
+		// Monsters can use chase skills before starting to walk
+		// So we need to change the state and check for a skill here already
+		// Skills during movement are handled in the walktobl routine
+		if (md->ud.walktimer == INVALID_TIMER
+			&& DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME
+			&& DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL) {
+			md->state.skillstate = md->state.aggressive ? MSS_FOLLOW : MSS_RUSH;
+			if (mobskill_use(md, tick, -1))
+				return true;
+		}
+		if(!unit_walktobl(&md->bl, tbl, md->status.rhw.range, 2))
+			mob_unlocktarget(md, tick);
+	}
 
 	return true;
 }
@@ -3752,8 +3757,9 @@ int mobskill_use(struct mob_data *md, t_tick tick, int event, int64 damage)
 	if (!battle_config.mob_skill_rate || md->ud.skilltimer != INVALID_TIMER || ms.empty() || status_has_mode(&md->status,MD_NOCAST))
 		return 0;
 
-	if (event == -1 && DIFF_TICK(md->ud.canact_tick, tick) > 0)
-		return 0; //Skill act delay only affects non-event skills.
+	// Monsters check their non-attack-state skills once per second, but we ignore this for events for now
+	if (event == -1)
+		md->last_skillcheck = tick;
 
 	//Pick a starting position and loop from that.
 	i = battle_config.mob_ai&0x100?rnd()%ms.size():0;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -38,6 +38,9 @@ const t_tick MIN_MOBLINKTIME = 1000;
 //Min time between random walks
 const t_tick MIN_RANDOMWALKTIME = 4000;
 
+// How often a monster will check for using a skill on non-attack states (in ms)
+const t_tick MOB_SKILL_INTERVAL = 1000;
+
 //Distance that slaves should keep from their master.
 #define MOB_SLAVEDISTANCE 2
 
@@ -359,7 +362,7 @@ struct mob_data {
 	int areanpc_id; //Required in OnTouchNPC (to avoid multiple area touchs)
 	int bg_id; // BattleGround System
 
-	t_tick next_walktime,last_thinktime,last_linktime,last_pcneartime,dmgtick,last_canmove;
+	t_tick next_walktime,last_thinktime,last_linktime,last_pcneartime,dmgtick,last_canmove,last_skillcheck;
 	short move_fail_count;
 	short lootitem_count;
 	short min_chase;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13421,8 +13421,12 @@ TIMER_FUNC(skill_castend_id){
 			}
 			}
 		}
-		if (skill_get_state(ud->skill_id) != ST_MOVE_ENABLE)
-			unit_set_walkdelay(src, tick, battle_config.default_walk_delay+skill_get_walkdelay(ud->skill_id, ud->skill_lv), 1);
+		if (skill_get_state(ud->skill_id) != ST_MOVE_ENABLE) {
+			if (src->type == BL_MOB)
+				unit_set_walkdelay(src, tick, max((int)status_get_amotion(src), skill_get_walkdelay(ud->skill_id, ud->skill_lv)), 1);
+			else
+				unit_set_walkdelay(src, tick, battle_config.default_walk_delay + skill_get_walkdelay(ud->skill_id, ud->skill_lv), 1);
+		}
 
 		if(battle_config.skill_log && battle_config.skill_log&src->type)
 			ShowInfo("Type %d, ID %d skill castend id [id =%d, lv=%d, target ID %d]\n",
@@ -13636,7 +13640,10 @@ TIMER_FUNC(skill_castend_pos){
 //				break;
 //			}
 //		}
-		unit_set_walkdelay(src, tick, battle_config.default_walk_delay+skill_get_walkdelay(ud->skill_id, ud->skill_lv), 1);
+		if (src->type == BL_MOB)
+			unit_set_walkdelay(src, tick, max((int)status_get_amotion(src), skill_get_walkdelay(ud->skill_id, ud->skill_lv)), 1);
+		else
+			unit_set_walkdelay(src, tick, battle_config.default_walk_delay + skill_get_walkdelay(ud->skill_id, ud->skill_lv), 1);
 		map_freeblock_lock();
 		skill_castend_pos2(src,ud->skillx,ud->skilly,ud->skill_id,ud->skill_lv,tick,0);
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13426,6 +13426,8 @@ TIMER_FUNC(skill_castend_id){
 			}
 		}
 		if (skill_get_state(ud->skill_id) != ST_MOVE_ENABLE) {
+			// When monsters used a skill they won't walk for amotion, this does not apply to players
+			// This is also important for monster skill usage behavior
 			if (src->type == BL_MOB)
 				unit_set_walkdelay(src, tick, max((int)status_get_amotion(src), skill_get_walkdelay(ud->skill_id, ud->skill_lv)), 1);
 			else
@@ -13644,6 +13646,8 @@ TIMER_FUNC(skill_castend_pos){
 //				break;
 //			}
 //		}
+		// When monsters used a skill they won't walk for amotion, this does not apply to players
+		// This is also important for monster skill usage behavior
 		if (src->type == BL_MOB)
 			unit_set_walkdelay(src, tick, max((int)status_get_amotion(src), skill_get_walkdelay(ud->skill_id, ud->skill_lv)), 1);
 		else

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9934,7 +9934,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if (tbl) {
 				md->state.can_escape = 1;
 				mob_unlocktarget(md, tick);
-				unit_escape(src, tbl, skill_lv > 1 ? skill_lv : AREA_SIZE, 2); // Send distance in skill level > 1
+				t_tick time = unit_escape(src, tbl, skill_lv > 1 ? skill_lv : 7, 2); // Official distance is 7, if level > 1, distance = level
+				if (time) {
+					md->state.skillstate = MSS_WALK; // Need to set state here as it's not set otherwise
+					md->last_thinktime = tick + time; // Set AI to inactive for the duration of this movement
+				}
 			}
 		}
 		break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9934,10 +9934,14 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if (tbl) {
 				md->state.can_escape = 1;
 				mob_unlocktarget(md, tick);
-				t_tick time = unit_escape(src, tbl, skill_lv > 1 ? skill_lv : 7, 2); // Official distance is 7, if level > 1, distance = level
+				// Official distance is 7, if level > 1, distance = level
+				t_tick time = unit_escape(src, tbl, skill_lv > 1 ? skill_lv : 7, 2);
+
 				if (time) {
-					md->state.skillstate = MSS_WALK; // Need to set state here as it's not set otherwise
-					md->last_thinktime = tick + time; // Set AI to inactive for the duration of this movement
+					// Need to set state here as it's not set otherwise
+					md->state.skillstate = MSS_WALK;
+					// Set AI to inactive for the duration of this movement
+					md->last_thinktime = tick + time;
 				}
 			}
 		}

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -182,10 +182,6 @@ enum e_skill_unit_flag : uint8 {
 	UF_MAX,
 };
 
-/// Walk intervals at which chase-skills are attempted to be triggered.
-/// If you change this, make sure it's an odd value (for icewall block behavior).
-#define WALK_SKILL_INTERVAL 5
-
 /// Time that's added to canact delay on castbegin and substracted on castend
 /// This is to prevent hackers from sending a skill packet after cast but before a timer triggers castend
 const t_tick SECURITY_CASTTIME = 100;

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1019,7 +1019,8 @@ t_tick unit_get_walkpath_time(struct block_list& bl)
 	unsigned short speed = status_get_speed(&bl);
 	struct unit_data* ud = unit_bl2ud(&bl);
 
-	for (uint8 i = 0; i < ud->walkpath.path_len; i++) {	// The next walk start time is calculated.
+	// The next walk start time is calculated.
+	for (uint8 i = 0; i < ud->walkpath.path_len; i++) {
 		if (direction_diagonal(ud->walkpath.path[i]))
 			time += speed * MOVE_DIAGONAL_COST / MOVE_COST;
 		else

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2813,7 +2813,8 @@ static int unit_attack_timer_sub(struct block_list* src, int tid, t_tick tick)
 			unit_stop_walking(src,1);
 
 		if(md) {
-			// Berserk skills can replace normal attacks except for the first attack (state not berserk yet)
+			// Berserk skills can replace normal attacks except for the first attack
+			// If this is the first attack, the state is not Berserk yet, so the skill check is skipped
 			if(md->state.skillstate == MSS_BERSERK) {
 				if (mobskill_use(md, tick, -1)) {
 					ud->attackabletime = tick + sstatus->adelay;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -44,7 +44,6 @@ struct unit_data {
 	t_tick canmove_tick;
 	bool immune_attack; ///< Whether the unit is immune to attacks
 	uint8 dir;
-	unsigned char walk_count;
 	unsigned char target_count;
 	struct s_udState {
 		unsigned change_walk_target : 1 ;
@@ -122,7 +121,8 @@ bool unit_can_move(struct block_list *bl);
 int unit_is_walking(struct block_list *bl);
 int unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int type);
 
-int unit_escape(struct block_list *bl, struct block_list *target, short dist, uint8 flag = 0);
+t_tick unit_get_walkpath_time(struct block_list& bl);
+t_tick unit_escape(struct block_list *bl, struct block_list *target, short dist, uint8 flag = 0);
 
 // Instant unit changes
 bool unit_movepos(struct block_list *bl, short dst_x, short dst_y, int easy, bool checkpath);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7941, #1700

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Monsters will now properly run away when using NPC_RUN (fixes #7941)
- Introduced a new function unit_get_walkpath_time that returns the time the unit needs to walk its current walkpath
  * This is now used for NPC_RUN and random walking
- Fixed an issue with mismatching timer warnings when a monster casts NPC_RUN multiple times in row

- Monsters will now always attempt to use non-berserk-state skills once per second (fixes #1700)
  * This completely replaces the "ugly" solution to use a walk_count for idle, walk and chase skills
  * This interval is now a lot more accurate and no longer influenced by external factors such as canact delay
  * This interval is now also used for lazy monsters rather than MIN_MOBTHINKTIME*10 so that MIN_MOBTHINKTIME can be reduced without having to worry about skills being cast more often
  * Angry skills no longer replace the normal attack and now follow the once per second rule; they will always first be attempted at the end of the walk delay after a normal attack
- The special follow-up attack skill monsters use when you move out of their attack range, now is only used when they are in Angry state
  * Also fixed a bug that this was checked every 100ms until the monster used a skill, instead of just once per second

- Monsters now can use chase skills even before they start moving (assuming one second has already passed since last skill check)
- Removed "hack" to make monsters cast chase skills when trapped in icewall
  * This was solved by implementing checking for chase skills before starting to move
  * For truly official behavior you'd need to set MIN_MOBTHINKTIME to 20

- Monsters will now receive an aMotion walk delay after having used a skill
- A monster that could not walk randomly because of walk delay will now walk immediately once the walk delay expires
- Using angry or berserk skills will now set a monster's attack delay

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
