### PR TITLE
Fixes clif_viewequip_ack packet length

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10450,7 +10450,7 @@ void clif_viewequip_ack( map_session_data* sd, map_session_data* tsd ){
 
 			clif_item_equip( client_index( k ), &p->list[equip], &tsd->inventory.u.items_inventory[k], tsd->inventory_data[k], pc_equippoint( tsd, k ) );
 
-			p->PacketLength = sizeof( p->list[0] );
+			p->PacketLength += sizeof( p->list[0] );
 			equip++;
 		}
 	}


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#8303

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Now correctly increments PACKET_ZC_EQUIPWIN_MICROSCOPE packet length for each EQUIPITEM_INFO element.