### PR TITLE
Synchronize Damage Feature

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -130,9 +130,18 @@ equip_self_break_rate: 100
 // This affects the behaviour of skills like acid terror and meltdown
 equip_skill_break_rate: 100
 
-// Do weapon attacks have a attack speed delay before actual damage is applied? (Note 1)
-// NOTE: The official setting is yes, even thought it degrades performance a bit.
+// Should damage have a delay before it is applied? (Note 1)
+// Some skills might not have a delay by default regardless of this setting.
+// The official setting is yes, even thought it degrades performance a bit.
 delay_battle_damage: yes
+
+// Should the damage timing be synchronized between the client and server? (Note 1)
+// This is not official behavior, but it removes the position lag after being hit.
+// This setting only affects normal monster attacks and takes priority over "delay_battle_damage".
+// Many skills show their damage immediately, so setting "delay_battle_damage" to "no" at the same
+// time might improve the experience further, but will not work for all skills.
+// Tired of Dark Illusion hitting you 5 seconds too late? Then turn this on.
+synchronize_damage: no
 
 // Are arrows/ammo consumed when used on a bow/gun?
 // 0 = No

--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -136,7 +136,7 @@ equip_skill_break_rate: 100
 delay_battle_damage: yes
 
 // Should the damage timing be synchronized between the client and server? (Note 1)
-// This is not official behavior, but it removes the position lag after being hit.
+// This is not official behavior, but it should remove the position lag after being hit by a monster.
 // This setting only affects normal monster attacks and takes priority over "delay_battle_damage".
 // Many skills show their damage immediately, so setting "delay_battle_damage" to "no" at the same
 // time might improve the experience further, but will not work for all skills.

--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -169,3 +169,9 @@ macro_detection_punishment: 0
 // Amount of time in minutes that the punishment type is active for. Use 0 for infinite.
 // Official: 0
 macro_detection_punishment_time: 0
+
+// Should the damage timing be synchronized between the client and server?
+// This is not official behavior, but it removes the position lag after being hit.
+// Right now it only works for being hit by normal monster attacks.
+// Tired of Dark Illusion hitting you 5 seconds too late? Then turn this on. (Note 1)
+synchronize_damage: no

--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -169,10 +169,3 @@ macro_detection_punishment: 0
 // Amount of time in minutes that the punishment type is active for. Use 0 for infinite.
 // Official: 0
 macro_detection_punishment_time: 0
-
-// Should the damage timing be synchronized between the client and server?
-// This is not official behavior, but it removes the position lag after being hit.
-// This setting only affects normal monster attacks, unless you set "delay_battle_damage" in battle.conf to "no".
-// If you do, most skills will also be in-sync as skills usually show their damage immediately.
-// Tired of Dark Illusion hitting you 5 seconds too late? Then turn this on. (Note 1)
-synchronize_damage: no

--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -172,6 +172,7 @@ macro_detection_punishment_time: 0
 
 // Should the damage timing be synchronized between the client and server?
 // This is not official behavior, but it removes the position lag after being hit.
-// Right now it only works for being hit by normal monster attacks.
+// This setting only affects normal monster attacks, unless you set "delay_battle_damage" in battle.conf to "no".
+// If you do, most skills will also be in-sync as skills usually show their damage immediately.
 // Tired of Dark Illusion hitting you 5 seconds too late? Then turn this on. (Note 1)
 synchronize_damage: no

--- a/db/import-tmpl/mob_db.yml
+++ b/db/import-tmpl/mob_db.yml
@@ -78,7 +78,7 @@
 
 Header:
   Type: MOB_DB
-  Version: 3
+  Version: 4
 
 #Body:
 # eAthena Dev Team

--- a/db/import-tmpl/mob_db.yml
+++ b/db/import-tmpl/mob_db.yml
@@ -56,6 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
+#   ClientAttackMotion      Client attack speed. (Default: 432)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/import-tmpl/mob_db.yml
+++ b/db/import-tmpl/mob_db.yml
@@ -56,7 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
-#   ClientAttackMotion      Client attack speed. (Default: 432)
+#   ClientAttackMotion      Client attack speed. (Default: AttackMotion)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/mob_db.yml
+++ b/db/mob_db.yml
@@ -56,6 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
+#   ClientAttackMotion      Client attack speed. (Default: 432)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/mob_db.yml
+++ b/db/mob_db.yml
@@ -56,7 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
-#   ClientAttackMotion      Client attack speed. (Default: 432)
+#   ClientAttackMotion      Client attack speed. (Default: AttackMotion)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/mob_db.yml
+++ b/db/mob_db.yml
@@ -78,7 +78,7 @@
 
 Header:
   Type: MOB_DB
-  Version: 3
+  Version: 4
 
 Footer:
   Imports:

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -56,7 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
-#   ClientAttackMotion      Client attack speed. (Default: 432)
+#   ClientAttackMotion      Client attack speed. (Default: AttackMotion)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -219,7 +219,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -264,7 +264,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -367,7 +367,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 1
     Modes:
       Detector: true
@@ -413,7 +413,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -506,6 +506,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -640,7 +641,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -686,7 +687,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -727,6 +728,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 05
     Drops:
@@ -1058,7 +1060,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1274,6 +1276,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -1460,6 +1463,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1506,7 +1510,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
-    ClientAttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -1647,7 +1651,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
-    ClientAttackMotion: 456
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -1859,7 +1863,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
-    ClientAttackMotion: 1008
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
     Drops:
@@ -1952,6 +1956,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 07
     Modes:
@@ -2172,6 +2177,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2215,7 +2221,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 701
     AttackMotion: 1
-    ClientAttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 1
     Modes:
       Detector: true
@@ -2261,7 +2267,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2305,7 +2311,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2351,7 +2357,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 768
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2398,7 +2404,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2447,6 +2453,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2495,6 +2502,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2590,7 +2598,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2635,7 +2643,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
-    ClientAttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2682,7 +2690,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
-    ClientAttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2733,7 +2741,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -2789,7 +2797,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1260
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -2835,7 +2843,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -3248,7 +3256,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -3542,7 +3550,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3588,7 +3596,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3638,7 +3646,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3688,7 +3696,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3738,7 +3746,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3788,7 +3796,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3838,7 +3846,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 2208
+    ClientAttackMotion: 2016
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3888,7 +3896,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3938,7 +3946,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3991,7 +3999,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 07
     Class: Boss
@@ -4047,7 +4055,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
-    ClientAttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -4105,7 +4113,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 600
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -4528,7 +4536,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 768
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -4948,7 +4956,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
-    ClientAttackMotion: 180
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -4994,7 +5002,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 252
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -6628,7 +6636,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
-    ClientAttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -7783,7 +7791,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -8534,6 +8542,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -8570,6 +8579,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -8611,6 +8621,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -8655,6 +8666,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Drops:
       - Item: Sparkling_Dust
@@ -8688,7 +8700,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -8726,7 +8738,7 @@ Body:
     WalkSpeed: 20
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
   - Id: 1188
     AegisName: BON_GUN
@@ -8753,7 +8765,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -9242,7 +9254,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1252
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 476
     Ai: 13
     Class: Boss
@@ -9338,7 +9350,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 13
     Drops:
@@ -9961,7 +9973,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10009,7 +10021,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -10198,6 +10210,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -10242,6 +10255,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -10592,6 +10606,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -10636,6 +10651,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 768
     DamageMotion: 1
     Modes:
       Detector: true
@@ -10682,6 +10698,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1220
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 01
     Modes:
@@ -10724,6 +10741,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -10809,6 +10827,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -10855,6 +10874,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -10897,6 +10917,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -10939,6 +10960,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -10986,6 +11008,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -11033,6 +11056,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -11079,6 +11103,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -11122,6 +11147,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -11212,7 +11238,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1260
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -11448,7 +11474,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
-    ClientAttackMotion: 1296
+    ClientAttackMotion: 1224
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -11496,7 +11522,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -12744,7 +12770,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 502
     AttackMotion: 2304
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12889,7 +12915,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1264
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -12934,7 +12960,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
-    ClientAttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 21
     Modes:
@@ -13290,6 +13316,7 @@ Body:
     WalkSpeed: 265
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 624
     DamageMotion: 384
     Ai: 05
     Class: Guardian
@@ -13400,7 +13427,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
-    ClientAttackMotion: 216
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -13448,7 +13475,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13496,7 +13523,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 600
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 1728
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -13646,7 +13673,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -13793,7 +13820,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -13843,7 +13870,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
-    ClientAttackMotion: 1248
+    ClientAttackMotion: 1056
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13991,7 +14018,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
-    ClientAttackMotion: 5472
+    ClientAttackMotion: 5280
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -14040,7 +14067,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -14190,7 +14217,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1260
     AttackMotion: 230
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -14238,7 +14265,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 120
+    ClientAttackMotion: 360
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -14287,7 +14314,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 1008
-    ClientAttackMotion: 2688
+    ClientAttackMotion: 2496
     DamageMotion: 840
     Ai: 21
     Drops:
@@ -14383,7 +14410,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 1728
     DamageMotion: 780
     Ai: 21
     Drops:
@@ -14538,7 +14565,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 21
     Drops:
@@ -14684,7 +14711,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -14781,7 +14808,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1296
+    ClientAttackMotion: 1200
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -16472,7 +16499,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -16684,7 +16711,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1460
     AttackMotion: 960
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -17155,7 +17182,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -17812,7 +17839,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
   - Id: 1395
@@ -17828,7 +17855,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -17867,7 +17894,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -17906,7 +17933,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -17945,7 +17972,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -18105,7 +18132,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -18250,7 +18277,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -18499,7 +18526,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -18796,7 +18823,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -18849,6 +18876,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
   - Id: 1420
@@ -18873,6 +18901,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
   - Id: 1421
@@ -18900,6 +18929,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -18929,6 +18959,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -18957,6 +18988,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
   - Id: 1424
@@ -18984,6 +19016,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1425
@@ -19009,6 +19042,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 04
   - Id: 1426
@@ -19035,6 +19069,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 04
   - Id: 1427
@@ -19060,6 +19095,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -19086,6 +19122,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
   - Id: 1429
@@ -19111,6 +19148,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -19138,6 +19176,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 04
     Modes:
@@ -19165,6 +19204,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 04
     Modes:
@@ -19193,6 +19233,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 04
   - Id: 1433
@@ -19219,6 +19260,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -19245,6 +19287,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
   - Id: 1435
@@ -19271,6 +19314,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 04
   - Id: 1436
@@ -19297,6 +19341,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 04
   - Id: 1437
@@ -19323,6 +19368,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1364
     AttackMotion: 864
+    ClientAttackMotion: 312
     DamageMotion: 432
     Ai: 04
   - Id: 1438
@@ -19350,6 +19396,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 528
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 04
   - Id: 1439
@@ -19377,6 +19424,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 04
   - Id: 1440
@@ -19403,6 +19451,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 288
     DamageMotion: 1000
     Ai: 04
   - Id: 1441
@@ -19429,6 +19478,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 04
   - Id: 1442
@@ -19455,6 +19505,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 04
   - Id: 1443
@@ -19481,6 +19532,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
+    ClientAttackMotion: 1224
     DamageMotion: 432
     Ai: 04
   - Id: 1444
@@ -19506,6 +19558,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 672
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
   - Id: 1445
@@ -19532,6 +19585,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 04
   - Id: 1446
@@ -19557,6 +19611,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 770
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
   - Id: 1447
@@ -19584,6 +19639,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 704
     AttackMotion: 504
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Class: Boss
@@ -19611,6 +19667,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 04
     Modes:
@@ -19641,6 +19698,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 900
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -19667,6 +19725,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -19696,6 +19755,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 916
     AttackMotion: 816
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 04
   - Id: 1452
@@ -19723,6 +19783,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 04
   - Id: 1453
@@ -19750,6 +19811,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -19778,6 +19840,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 04
     Modes:
@@ -19807,6 +19870,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 04
   - Id: 1456
@@ -19833,6 +19897,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
     Class: Boss
@@ -19859,6 +19924,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -19886,6 +19952,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 840
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 04
   - Id: 1459
@@ -19911,6 +19978,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 04
     Modes:
@@ -19937,6 +20005,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 04
   - Id: 1461
@@ -19964,6 +20033,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 04
   - Id: 1462
@@ -19990,6 +20060,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
   - Id: 1463
@@ -20016,6 +20087,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2852
     AttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 840
     Ai: 04
   - Id: 1464
@@ -20042,6 +20114,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 976
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
   - Id: 1465
@@ -20068,6 +20141,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 620
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 04
   - Id: 1466
@@ -20094,6 +20168,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1420
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 528
     Ai: 04
   - Id: 1467
@@ -20121,6 +20196,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 04
   - Id: 1468
@@ -20146,6 +20222,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1516
     AttackMotion: 816
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 04
   - Id: 1469
@@ -20171,6 +20248,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
   - Id: 1470
@@ -20196,6 +20274,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1780
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
   - Id: 1471
@@ -20221,6 +20300,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
   - Id: 1472
@@ -20246,6 +20326,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 04
   - Id: 1473
@@ -20272,6 +20353,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 04
   - Id: 1474
@@ -20298,6 +20380,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
   - Id: 1475
@@ -20324,6 +20407,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 04
   - Id: 1476
@@ -20350,6 +20434,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 04
   - Id: 1477
@@ -20377,6 +20462,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -20406,6 +20492,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 04
   - Id: 1479
@@ -20433,6 +20520,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1848
     AttackMotion: 500
+    ClientAttackMotion: 864
     DamageMotion: 576
     Ai: 04
   - Id: 1480
@@ -20459,6 +20547,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 04
   - Id: 1481
@@ -20484,6 +20573,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 1000
     Ai: 04
   - Id: 1482
@@ -20512,6 +20602,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 792
+    ClientAttackMotion: 1920
     DamageMotion: 384
     Ai: 04
   - Id: 1483
@@ -20538,6 +20629,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
+    ClientAttackMotion: 900
     DamageMotion: 540
     Ai: 04
     Modes:
@@ -20566,6 +20658,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
+    ClientAttackMotion: 960
     DamageMotion: 600
     Ai: 04
   - Id: 1485
@@ -20593,6 +20686,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -20622,6 +20716,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 816
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -20650,6 +20745,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Class: Boss
@@ -20677,6 +20773,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 900
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 04
   - Id: 1489
@@ -20704,6 +20801,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 04
   - Id: 1490
@@ -20731,6 +20829,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 04
     Modes:
@@ -20759,6 +20858,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -20792,7 +20892,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -21193,6 +21293,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -21298,6 +21399,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 847
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -21341,7 +21443,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21688,7 +21790,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
-    ClientAttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -21733,7 +21835,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1257
     AttackMotion: 528
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -21868,6 +21970,7 @@ Body:
     WalkSpeed: 445
     AttackDelay: 106
     AttackMotion: 1056
+    ClientAttackMotion: 624
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -21955,7 +22058,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -22083,6 +22186,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 520
     AttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Ai: 17
   - Id: 1522
@@ -22110,6 +22214,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
   - Id: 1523
@@ -22138,6 +22243,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 05
   - Id: 1524
@@ -22164,6 +22270,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 318
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 04
   - Id: 1525
@@ -22189,6 +22296,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
   - Id: 1526
@@ -22215,6 +22323,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 13
     Modes:
@@ -22243,6 +22352,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 17
   - Id: 1528
@@ -22269,6 +22379,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
   - Id: 1529
@@ -22297,6 +22408,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -22324,6 +22436,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -22352,6 +22465,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 840
+    ClientAttackMotion: 624
     DamageMotion: 432
     Ai: 05
   - Id: 1532
@@ -22378,6 +22492,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
   - Id: 1533
@@ -22406,6 +22521,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 09
   - Id: 1534
@@ -22432,6 +22548,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
   - Id: 1535
@@ -22458,6 +22575,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1320
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 09
   - Id: 1536
@@ -22484,6 +22602,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
   - Id: 1537
@@ -22510,6 +22629,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
   - Id: 1538
@@ -22536,6 +22656,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 3074
     AttackMotion: 1874
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 13
   - Id: 1539
@@ -22563,6 +22684,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 1056
     DamageMotion: 240
     Ai: 21
   - Id: 1540
@@ -22588,6 +22710,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
   - Id: 1541
@@ -22614,6 +22737,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 816
     DamageMotion: 384
     Ai: 10
   - Id: 1542
@@ -22641,6 +22765,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -22668,6 +22793,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 2012
     AttackMotion: 1728
+    ClientAttackMotion: 576
     DamageMotion: 672
     Ai: 04
   - Id: 1544
@@ -22694,6 +22820,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1638
     AttackMotion: 2016
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 01
   - Id: 1545
@@ -22720,6 +22847,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1546
@@ -22746,6 +22874,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1547
@@ -22772,6 +22901,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1548
@@ -22799,6 +22929,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
   - Id: 1549
@@ -22825,6 +22956,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2190
     AttackMotion: 2040
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 09
   - Id: 1550
@@ -22853,6 +22985,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 05
   - Id: 1551
@@ -22878,6 +23011,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 468
     DamageMotion: 528
     Ai: 17
   - Id: 1552
@@ -22905,6 +23039,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -22932,6 +23067,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
   - Id: 1554
@@ -22958,6 +23094,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -22986,6 +23123,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 10
   - Id: 1556
@@ -23014,6 +23152,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1148
     AttackMotion: 1728
+    ClientAttackMotion: 624
     DamageMotion: 864
     Ai: 01
   - Id: 1557
@@ -23040,6 +23179,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 2416
     AttackMotion: 2016
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 05
   - Id: 1558
@@ -23067,6 +23207,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
   - Id: 1559
@@ -23092,6 +23233,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 09
     Modes:
@@ -23123,6 +23265,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 21
   - Id: 1561
@@ -23148,6 +23291,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
   - Id: 1562
@@ -23174,6 +23318,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
   - Id: 1563
@@ -23201,6 +23346,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1439
     AttackMotion: 1920
+    ClientAttackMotion: 624
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -23230,6 +23376,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -23260,6 +23407,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 756
+    ClientAttackMotion: 540
     DamageMotion: 360
     Ai: 17
   - Id: 1566
@@ -23287,6 +23435,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
   - Id: 1567
@@ -23314,6 +23463,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -23341,6 +23491,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -23369,6 +23520,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
   - Id: 1570
@@ -23394,6 +23546,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 09
   - Id: 1571
@@ -23420,6 +23573,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1680
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
   - Id: 1572
@@ -23444,6 +23598,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 1573
@@ -23470,6 +23625,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
   - Id: 1574
@@ -23496,6 +23652,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 09
   - Id: 1575
@@ -23522,6 +23679,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1432
     AttackMotion: 432
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 10
   - Id: 1576
@@ -23548,6 +23706,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1220
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -23574,6 +23733,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1172
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 420
     Ai: 05
   - Id: 1578
@@ -23600,6 +23760,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1888
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 13
   - Id: 1579
@@ -23625,6 +23786,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 10
   - Id: 1580
@@ -23651,6 +23813,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 850
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -23680,6 +23843,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
+    ClientAttackMotion: 600
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -23711,7 +23875,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 1056
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -23908,7 +24072,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 720
     Ai: 02
     Drops:
@@ -24002,7 +24166,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -24046,6 +24210,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
   - Id: 1590
@@ -24072,6 +24237,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
   - Id: 1591
@@ -24098,6 +24264,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Class: Guardian
@@ -24130,6 +24297,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 03
     Class: Boss
@@ -24169,6 +24337,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Class: Guardian
@@ -24203,6 +24372,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
   - Id: 1595
@@ -24228,6 +24398,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
   - Id: 1596
@@ -24255,6 +24426,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 13
     Modes:
@@ -24284,6 +24456,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -24312,6 +24485,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1732
     AttackMotion: 1332
+    ClientAttackMotion: 468
     DamageMotion: 540
     Ai: 20
     Modes:
@@ -24339,6 +24513,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -24368,6 +24543,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1200
     DamageMotion: 528
     Ai: 21
   - Id: 1601
@@ -24395,6 +24571,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 483
+    ClientAttackMotion: 720
     DamageMotion: 528
     Ai: 21
   - Id: 1602
@@ -24422,6 +24599,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 21
   - Id: 1603
@@ -24447,6 +24625,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
   - Id: 1604
@@ -24474,6 +24653,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -24503,6 +24683,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
+    ClientAttackMotion: 5280
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -24532,6 +24713,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1607
@@ -24558,6 +24740,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
   - Id: 1608
@@ -24584,6 +24767,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -24616,6 +24800,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 600
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 504
     Ai: 02
     Class: Guardian
@@ -24657,6 +24842,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -24691,6 +24877,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 09
     Class: Boss
@@ -24728,6 +24915,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 720
     Ai: 04
     Class: Boss
@@ -25294,6 +25482,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1152
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
   - Id: 1625
@@ -25322,6 +25511,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -25352,6 +25542,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Class: Boss
@@ -25393,7 +25584,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 140
     AttackMotion: 864
-    ClientAttackMotion: 384
+    ClientAttackMotion: 420
     DamageMotion: 430
     Ai: 04
     Modes:
@@ -25515,7 +25706,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -25574,6 +25765,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 04
     Drops:
@@ -26006,6 +26198,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26040,6 +26233,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26075,6 +26269,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26109,6 +26304,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26143,6 +26339,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26177,6 +26374,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26212,6 +26410,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26270,6 +26469,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26329,6 +26529,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26387,6 +26588,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26445,6 +26647,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26503,6 +26706,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26853,6 +27057,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26908,6 +27113,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26939,6 +27145,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26969,6 +27176,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27000,6 +27208,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27030,6 +27239,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27735,7 +27945,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
-    ClientAttackMotion: 288
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27871,6 +28081,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
   - Id: 1684
@@ -27898,6 +28109,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1080
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 04
   - Id: 1685
@@ -28138,7 +28350,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -28159,7 +28371,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Modes:
@@ -28200,6 +28412,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28550,7 +28763,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
-    ClientAttackMotion: 240
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -29049,6 +29262,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 115
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 420
     Ai: 20
     Class: Boss
@@ -29087,6 +29301,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -29125,6 +29340,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -29163,6 +29379,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -29568,7 +29785,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 24
     AttackMotion: 1
-    ClientAttackMotion: 24
+    ClientAttackMotion: 0
     DamageMotion: 1
     Drops:
       - Item: Elunium
@@ -29614,6 +29831,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 01
     Drops:
@@ -29651,6 +29869,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1008
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
   - Id: 1724
@@ -29677,6 +29896,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
   - Id: 1725
@@ -29700,6 +29920,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 1726
@@ -29725,6 +29946,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 02
   - Id: 1727
@@ -29749,6 +29971,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 312
     DamageMotion: 576
     Ai: 02
   - Id: 1728
@@ -29774,6 +29997,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 02
   - Id: 1729
@@ -29799,6 +30023,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 02
     Modes:
@@ -29827,6 +30052,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 02
     Modes:
@@ -29858,6 +30084,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -30000,7 +30227,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
-    ClientAttackMotion: 240
+    ClientAttackMotion: 2112
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -30148,7 +30375,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
-    ClientAttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30187,6 +30414,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 480
+    ClientAttackMotion: 2112
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -30219,6 +30447,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1296
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -30249,6 +30478,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 04
   - Id: 1742
@@ -30274,6 +30504,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1078
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -30303,6 +30534,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
   - Id: 1744
@@ -30329,6 +30561,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Ai: 04
   - Id: 1745
@@ -30356,6 +30589,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 05
     Modes:
@@ -30388,6 +30622,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 04
     Drops:
@@ -30416,6 +30651,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1748
@@ -30440,6 +30676,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1749
@@ -30466,6 +30703,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1720
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -30495,6 +30733,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -30777,6 +31016,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
     Class: Boss
@@ -30804,6 +31044,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 04
   - Id: 1758
@@ -30830,6 +31071,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
   - Id: 1759
@@ -30856,6 +31098,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 04
   - Id: 1760
@@ -30882,6 +31125,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
   - Id: 1761
@@ -30908,6 +31152,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -30939,6 +31184,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 480
     AttackMotion: 576
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -30971,6 +31217,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -31002,6 +31249,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -31109,7 +31357,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 17
     Class: Guardian
@@ -31897,7 +32145,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -31944,6 +32192,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 600
+    ClientAttackMotion: 480
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -31998,6 +32247,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -32028,6 +32278,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -32058,6 +32309,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 20
     Drops:
@@ -32087,7 +32339,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     Ai: 10
     Drops:
       - Item: Ice_Piece
@@ -32130,6 +32382,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -32164,6 +32417,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Class: Boss
@@ -32217,6 +32471,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 21
   - Id: 1794
@@ -32243,6 +32498,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 412
     AttackMotion: 840
+    ClientAttackMotion: 600
     DamageMotion: 300
     Ai: 20
   - Id: 1795
@@ -32270,6 +32526,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Class: Boss
@@ -32361,7 +32618,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
-    ClientAttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -32426,6 +32683,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32459,6 +32717,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32493,6 +32752,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32526,6 +32786,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32559,6 +32820,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Class: Boss
@@ -32592,6 +32854,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32625,6 +32888,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32658,6 +32922,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32692,6 +32957,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32725,6 +32991,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32758,6 +33025,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32791,6 +33059,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32821,6 +33090,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -32850,6 +33120,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Modes:
       IgnoreMagic: true
@@ -32892,6 +33163,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -32934,6 +33206,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -32953,7 +33226,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackDelay: 1320
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 300
     Modes:
       IgnoreMagic: true
@@ -33031,6 +33304,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 936
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -33070,6 +33344,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -33099,6 +33374,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
     Drops:
@@ -33127,6 +33403,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -33156,6 +33433,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -33185,6 +33463,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -33217,6 +33496,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -33248,6 +33528,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -33277,6 +33558,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -33305,6 +33587,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -33334,6 +33617,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -33363,6 +33647,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -33646,6 +33931,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33674,6 +33960,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33704,7 +33991,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
-    ClientAttackMotion: 336
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -33941,6 +34228,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -33976,6 +34264,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -34012,6 +34301,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -34048,6 +34338,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 09
     Modes:
@@ -34144,6 +34435,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -34173,6 +34465,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -34202,6 +34495,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34231,6 +34525,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -34261,6 +34556,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 21
   - Id: 1852
@@ -34287,6 +34583,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 312
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34314,6 +34611,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34344,6 +34642,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 02
     Drops:
@@ -34388,6 +34687,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -34434,6 +34734,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1560
     AttackMotion: 360
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -34481,6 +34782,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -34526,6 +34828,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2208
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -34571,6 +34874,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -34616,6 +34920,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -34663,6 +34968,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 360
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -34709,6 +35015,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -34754,6 +35061,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Drops:
@@ -34969,6 +35277,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -35144,6 +35453,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 252
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -35172,6 +35482,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 100
     AttackMotion: 576
+    ClientAttackMotion: 252
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -35296,6 +35607,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1446
     AttackMotion: 1296
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -35312,6 +35624,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -35349,6 +35662,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 2016
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -35695,6 +36009,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1536
     AttackMotion: 504
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
   - Id: 1887
@@ -35722,6 +36037,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -35757,6 +36073,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -35789,6 +36106,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 312
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -35824,6 +36142,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 864
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 20
   - Id: 1891
@@ -35851,6 +36170,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -35879,6 +36199,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -35909,6 +36230,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 21
   - Id: 1894
@@ -35967,6 +36289,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
   - Id: 1896
@@ -35994,6 +36317,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
   - Id: 1897
@@ -36020,6 +36344,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -36041,6 +36366,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -36131,6 +36457,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -36226,7 +36553,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1906
@@ -36250,6 +36577,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36277,7 +36605,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1908
@@ -36298,7 +36626,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1909
@@ -36369,7 +36697,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36395,7 +36723,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36421,7 +36749,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36447,7 +36775,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36473,7 +36801,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36542,6 +36870,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36594,7 +36923,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 540
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36640,7 +36969,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 540
-    ClientAttackMotion: 360
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36684,7 +37013,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 540
-    ClientAttackMotion: 216
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36730,7 +37059,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 540
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36772,6 +37101,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36800,6 +37130,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36828,6 +37159,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36856,6 +37188,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36883,6 +37216,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -36919,6 +37253,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Ai: 09
     Modes:
@@ -36952,6 +37287,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -36987,7 +37323,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 384
+    ClientAttackMotion: 216
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37123,7 +37459,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 1152
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -37145,7 +37481,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -37172,7 +37508,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -37199,7 +37535,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -37233,6 +37569,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
   - Id: 1938
@@ -37574,6 +37911,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37603,6 +37941,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
   - Id: 1949
@@ -37672,6 +38011,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -37708,6 +38048,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -37744,6 +38085,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -37780,6 +38122,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 25
     Class: Boss
     Modes:
@@ -37893,7 +38236,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 140
     AttackMotion: 540
-    ClientAttackMotion: 540
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -37938,6 +38281,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 432
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -37964,6 +38308,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 2864
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -37990,6 +38335,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 1024
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -38016,6 +38362,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 2864
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -38041,6 +38388,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 02
   - Id: 1963
@@ -38070,6 +38418,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 21
   - Id: 1964
@@ -38094,6 +38443,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Class: Boss
     Drops:
@@ -38128,6 +38478,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Class: Boss
   - Id: 1966
@@ -38156,6 +38507,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Class: Boss
   - Id: 1967
@@ -38185,6 +38537,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 288
     Class: Boss
   - Id: 1968
@@ -38213,6 +38566,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Class: Boss
     Drops:
@@ -38259,6 +38613,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Class: Boss
     Drops:
@@ -38304,6 +38659,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Class: Boss
     Drops:
@@ -38349,6 +38705,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Class: Boss
     Drops:
@@ -38394,6 +38751,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
+    ClientAttackMotion: 288
     DamageMotion: 864
     Class: Boss
     Drops:
@@ -38435,6 +38793,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Class: Boss
     Drops:
@@ -38569,7 +38928,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -38804,6 +39163,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 21
   - Id: 1982
@@ -38832,6 +39192,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 09
   - Id: 1983
@@ -38860,6 +39221,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
   - Id: 1984
@@ -38889,6 +39251,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
   - Id: 1985
@@ -39472,6 +39835,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
   - Id: 1998
@@ -39501,6 +39865,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 400
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
   - Id: 1999
@@ -39871,6 +40236,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
   - Id: 2009
@@ -39900,6 +40266,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 414
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -39932,6 +40299,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
+    ClientAttackMotion: 1728
     DamageMotion: 780
     Class: Boss
 #  - Id: 2011
@@ -40057,7 +40425,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 24
     AttackMotion: 1
-    ClientAttackMotion: 24
+    ClientAttackMotion: 0
     DamageMotion: 1
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -40550,6 +40918,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -40594,6 +40963,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 21
     Modes:
@@ -40695,6 +41065,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -40724,6 +41095,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -41021,6 +41393,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 960
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41051,6 +41424,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41081,6 +41455,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41111,6 +41486,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41141,6 +41517,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41171,6 +41548,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 400
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -41224,6 +41602,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 480
     DamageMotion: 540
     Ai: 04
     Modes:
@@ -41415,6 +41794,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 648
     DamageMotion: 480
     Class: Boss
 #  - Id: 2058
@@ -41820,7 +42200,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -42011,6 +42391,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -42040,6 +42421,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 20
     Modes:
@@ -42069,6 +42451,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1306
     AttackMotion: 1056
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -42143,6 +42526,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Class: Guardian
   - Id: 2082
@@ -42170,5 +42554,6 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 20

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -219,7 +219,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 336
+    ClientAttackMotion: 648
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -1510,7 +1510,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
-    ClientAttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -4956,7 +4956,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
-    ClientAttackMotion: 216
+    ClientAttackMotion: 180
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -5002,7 +5002,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 216
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -6636,7 +6636,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
-    ClientAttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -11522,7 +11522,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -13427,7 +13427,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
-    ClientAttackMotion: 336
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -14265,7 +14265,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -16499,7 +16499,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
-    ClientAttackMotion: 540
+    ClientAttackMotion: 1440
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -18823,7 +18823,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
-    ClientAttackMotion: 288
+    ClientAttackMotion: 1440
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -25584,7 +25584,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 140
     AttackMotion: 864
-    ClientAttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 430
     Ai: 04
     Modes:
@@ -27945,7 +27945,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28371,7 +28371,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
-    ClientAttackMotion: 756
+    ClientAttackMotion: 2304
     DamageMotion: 511
     Ai: 02
     Modes:
@@ -28763,7 +28763,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
-    ClientAttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30227,7 +30227,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -33991,7 +33991,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
-    ClientAttackMotion: 288
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -36801,7 +36801,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36923,7 +36923,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 540
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36969,7 +36969,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 540
-    ClientAttackMotion: 336
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -37013,7 +37013,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 540
-    ClientAttackMotion: 336
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -37059,7 +37059,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 540
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -37323,7 +37323,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 216
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37459,7 +37459,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -38928,7 +38928,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
-    ClientAttackMotion: 300
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -41426,7 +41426,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 1000
@@ -41457,7 +41457,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 1000
@@ -41488,7 +41488,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 1000
@@ -41519,7 +41519,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 1000
@@ -42200,7 +42200,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 420
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Modes:

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -219,7 +219,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 576
+    ClientAttackMotion: 792
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -264,7 +264,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 144
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -413,7 +413,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 360
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -640,7 +640,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 528
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -686,7 +686,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1058,7 +1058,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 576
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1460,7 +1460,6 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
-    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1802,7 +1801,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 384
+    ClientAttackMotion: 600
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -2173,7 +2172,6 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 864
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2263,7 +2261,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 144
+    ClientAttackMotion: 288
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2353,7 +2351,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 480
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2400,7 +2398,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 576
+    ClientAttackMotion: 864
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2449,7 +2447,6 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2498,7 +2495,6 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2594,7 +2590,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 432
+    ClientAttackMotion: 576
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2639,7 +2635,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
-    ClientAttackMotion: 360
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2686,7 +2682,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
-    ClientAttackMotion: 432
+    ClientAttackMotion: 504
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2737,7 +2733,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 288
+    ClientAttackMotion: 648
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -2793,7 +2789,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1092
+    ClientAttackMotion: 1260
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -3546,7 +3542,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
-    ClientAttackMotion: 528
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -4051,7 +4047,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
-    ClientAttackMotion: 480
+    ClientAttackMotion: 780
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -4440,7 +4436,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 144
+    ClientAttackMotion: 180
     DamageMotion: 384
     Ai: 07
     Modes:
@@ -4532,7 +4528,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 768
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -4577,7 +4573,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 768
-    ClientAttackMotion: 288
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -5188,7 +5184,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 144
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 09
     Drops:
@@ -7393,7 +7389,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 868
     AttackMotion: 768
-    ClientAttackMotion: 288
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -7645,7 +7641,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
-    ClientAttackMotion: 2652
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -7787,7 +7783,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 432
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -8692,7 +8688,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 1536
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -8730,7 +8726,7 @@ Body:
     WalkSpeed: 20
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 1
   - Id: 1188
     AegisName: BON_GUN
@@ -9389,7 +9385,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
-    ClientAttackMotion: 288
+    ClientAttackMotion: 900
     DamageMotion: 540
     Ai: 13
     Modes:
@@ -9438,7 +9434,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
-    ClientAttackMotion: 288
+    ClientAttackMotion: 960
     DamageMotion: 600
     Ai: 13
     Drops:
@@ -9725,7 +9721,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
-    ClientAttackMotion: 336
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -9965,7 +9961,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 192
+    ClientAttackMotion: 432
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10013,7 +10009,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 360
+    ClientAttackMotion: 504
     DamageMotion: 1000
     Ai: 09
     Drops:

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -78,7 +78,7 @@
 
 Header:
   Type: MOB_DB
-  Version: 3
+  Version: 4
 
 Body:
   - Id: 1001

--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -56,6 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
+#   ClientAttackMotion      Client attack speed. (Default: 432)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)
@@ -105,6 +106,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 09
     Modes:
@@ -150,6 +152,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -216,6 +219,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -260,6 +264,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -318,6 +323,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -361,6 +367,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       Detector: true
@@ -406,6 +413,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -452,6 +460,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -544,6 +553,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -584,6 +594,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -629,6 +640,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -674,6 +686,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -810,6 +823,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 01
     Modes:
@@ -856,6 +870,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -899,6 +914,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -1042,6 +1058,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1087,6 +1104,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1048
     AttackMotion: 48
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -1132,6 +1150,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -1176,6 +1195,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1301,6 +1321,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 09
     Modes:
@@ -1347,6 +1368,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -1392,6 +1414,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1437,6 +1460,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1483,6 +1507,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -1528,6 +1553,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -1573,6 +1599,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -1621,6 +1648,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 456
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -1668,6 +1696,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -1715,6 +1744,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -1772,6 +1802,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -1829,6 +1860,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 1008
     DamageMotion: 396
     Ai: 17
     Drops:
@@ -1875,6 +1907,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -1993,6 +2026,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -2039,6 +2073,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -2087,6 +2122,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -2137,6 +2173,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 864
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2180,6 +2217,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 701
     AttackMotion: 1
+    ClientAttackMotion: 480
     DamageMotion: 1
     Modes:
       Detector: true
@@ -2225,6 +2263,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2268,6 +2307,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2313,6 +2353,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 480
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2359,6 +2400,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2407,6 +2449,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2455,6 +2498,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2504,6 +2548,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 01
     Drops:
@@ -2549,6 +2594,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2593,6 +2639,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2639,6 +2686,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2689,6 +2737,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 288
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -2744,6 +2793,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -2789,6 +2839,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 816
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -2835,6 +2886,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -2878,6 +2930,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Drops:
@@ -2923,6 +2976,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2492
     AttackMotion: 792
+    ClientAttackMotion: 696
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -2969,6 +3023,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -3014,6 +3069,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Ai: 17
     Drops:
@@ -3059,6 +3115,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 48
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -3104,6 +3161,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 10
     Drops:
@@ -3148,6 +3206,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1968
     AttackMotion: 768
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -3193,6 +3252,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -3240,6 +3300,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1754
     AttackMotion: 554
+    ClientAttackMotion: 360
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3286,6 +3347,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1700
     AttackMotion: 1000
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 04
     Modes:
@@ -3334,6 +3396,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 992
     AttackMotion: 792
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 01
     Drops:
@@ -3375,6 +3438,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 468
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -3439,6 +3503,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -3481,6 +3546,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3526,6 +3592,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3575,6 +3642,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3624,6 +3692,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3673,6 +3742,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3722,6 +3792,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3771,6 +3842,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 2208
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3820,6 +3892,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3869,6 +3942,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3921,6 +3995,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 07
     Class: Boss
@@ -3976,6 +4051,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -4033,6 +4109,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -4079,6 +4156,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1236
     AttackMotion: 336
+    ClientAttackMotion: 168
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -4125,6 +4203,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -4171,6 +4250,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -4218,6 +4298,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1048
     AttackMotion: 648
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -4264,6 +4345,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -4310,6 +4392,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2048
     AttackMotion: 648
+    ClientAttackMotion: 312
     DamageMotion: 648
     Ai: 17
     Modes:
@@ -4357,6 +4440,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 07
     Modes:
@@ -4404,6 +4488,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -4447,6 +4532,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 1536
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -4491,6 +4577,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -4536,6 +4623,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -4581,6 +4669,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 09
     Modes:
@@ -4628,6 +4717,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 21
     Modes:
@@ -4675,6 +4765,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
     Drops:
@@ -4722,6 +4813,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1604
     AttackMotion: 840
+    ClientAttackMotion: 216
     DamageMotion: 756
     Ai: 17
     Drops:
@@ -4765,6 +4857,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -4810,6 +4903,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -4858,6 +4952,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 180
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -4903,6 +4998,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -4949,6 +5045,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1680
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -4995,6 +5092,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -5043,6 +5141,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -5089,6 +5188,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 09
     Drops:
@@ -5137,6 +5237,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 620
     AttackMotion: 420
+    ClientAttackMotion: 108
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -5189,6 +5290,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -5234,6 +5336,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1004
     AttackMotion: 504
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -5282,6 +5385,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 872
     AttackMotion: 1344
+    ClientAttackMotion: 408
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -5338,6 +5442,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -5384,6 +5489,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -5430,6 +5536,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1432
     AttackMotion: 432
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -5476,6 +5583,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 720
+    ClientAttackMotion: 324
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -5522,6 +5630,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1220
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -5570,6 +5679,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1848
     AttackMotion: 1296
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -5618,6 +5728,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -5666,6 +5777,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1320
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 09
     Drops:
@@ -5714,6 +5826,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
     Drops:
@@ -5762,6 +5875,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
     Drops:
@@ -5810,6 +5924,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 3074
     AttackMotion: 1874
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 13
     Drops:
@@ -5855,6 +5970,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 720
     Ai: 01
     Drops:
@@ -5901,6 +6017,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -5947,6 +6064,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1888
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 13
     Drops:
@@ -5993,6 +6111,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -6037,6 +6156,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1364
     AttackMotion: 864
+    ClientAttackMotion: 312
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -6084,6 +6204,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 528
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 21
     Drops:
@@ -6132,6 +6253,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6178,6 +6300,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6224,6 +6347,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6366,6 +6490,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1560
     AttackMotion: 360
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -6413,6 +6538,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 09
     Modes:
@@ -6460,6 +6586,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 840
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 09
     Drops:
@@ -6505,6 +6632,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -6548,6 +6676,7 @@ Body:
     WalkSpeed: 800
     AttackDelay: 1201
     AttackMotion: 1
+    ClientAttackMotion: 240
     DamageMotion: 1
     Drops:
       - Item: Tendon
@@ -6590,6 +6719,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 09
     Modes:
@@ -6637,6 +6767,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 468
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -6683,6 +6814,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -6727,6 +6859,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -6773,6 +6906,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 864
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -6829,6 +6963,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1720
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -6878,6 +7013,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -6926,6 +7062,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -6981,6 +7118,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -7029,6 +7167,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -7075,6 +7214,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2852
     AttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 840
     Ai: 04
     Drops:
@@ -7113,6 +7253,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 976
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -7157,6 +7298,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 620
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 09
     Drops:
@@ -7203,6 +7345,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1420
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 528
     Ai: 09
     Drops:
@@ -7250,6 +7393,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -7305,6 +7449,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2544
     AttackMotion: 1344
+    ClientAttackMotion: 432
     DamageMotion: 1152
     Ai: 17
     Drops:
@@ -7350,6 +7495,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 1020
+    ClientAttackMotion: 324
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -7405,6 +7551,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -7452,6 +7599,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2208
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -7497,6 +7645,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 2652
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -7544,6 +7693,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -7589,6 +7739,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1516
     AttackMotion: 816
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -7636,6 +7787,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -7682,6 +7834,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -7726,6 +7879,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 312
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -7816,6 +7970,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -7861,6 +8016,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2112
     AttackMotion: 912
+    ClientAttackMotion: 324
     DamageMotion: 576
     Ai: 17
     Modes:
@@ -8037,6 +8193,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1688
     AttackMotion: 1188
+    ClientAttackMotion: 720
     DamageMotion: 612
     Ai: 17
     Modes:
@@ -8083,6 +8240,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1744
     AttackMotion: 1044
+    ClientAttackMotion: 252
     DamageMotion: 684
     Ai: 17
     Drops:
@@ -8125,6 +8283,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -8172,6 +8331,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 02
     Drops:
@@ -8215,6 +8375,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1780
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -8260,6 +8421,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Ai: 09
     Modes:
@@ -8301,6 +8463,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -8529,6 +8692,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
+    ClientAttackMotion: 1152
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -8566,6 +8730,7 @@ Body:
     WalkSpeed: 20
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 288
     DamageMotion: 1
   - Id: 1188
     AegisName: BON_GUN
@@ -8592,6 +8757,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -8640,6 +8806,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -8688,6 +8855,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1248
     AttackMotion: 500
+    ClientAttackMotion: 624
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -8743,6 +8911,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -8789,6 +8958,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -8835,6 +9005,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -8882,6 +9053,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 09
     Modes:
@@ -8931,6 +9103,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -8978,6 +9151,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1848
     AttackMotion: 500
+    ClientAttackMotion: 864
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -9024,6 +9198,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 13
     Drops:
@@ -9071,6 +9246,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1252
+    ClientAttackMotion: 384
     DamageMotion: 476
     Ai: 13
     Class: Boss
@@ -9117,6 +9293,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -9165,6 +9342,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
+    ClientAttackMotion: 2112
     DamageMotion: 768
     Ai: 13
     Drops:
@@ -9211,6 +9389,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
+    ClientAttackMotion: 288
     DamageMotion: 540
     Ai: 13
     Modes:
@@ -9259,6 +9438,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
+    ClientAttackMotion: 288
     DamageMotion: 600
     Ai: 13
     Drops:
@@ -9302,6 +9482,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -9351,6 +9532,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 816
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -9399,6 +9581,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -9446,6 +9629,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 900
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 21
     Drops:
@@ -9493,6 +9677,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -9540,6 +9725,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -9587,6 +9773,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -9679,6 +9866,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 09
     Modes:
@@ -9727,6 +9915,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 384
     DamageMotion: 1000
     Ai: 09
     Modes:
@@ -9776,6 +9965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 192
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -9823,6 +10013,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 360
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -9869,6 +10060,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 288
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -9915,6 +10107,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -9963,6 +10156,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10975,6 +11169,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -11021,6 +11216,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1260
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -11067,6 +11263,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 01
     Drops:
@@ -11113,6 +11310,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 01
     Drops:
@@ -11158,6 +11356,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 17
     Drops:
@@ -11201,6 +11400,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 01
     Modes:
@@ -11252,6 +11452,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
+    ClientAttackMotion: 1296
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -11299,6 +11500,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -11344,6 +11546,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 672
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -11393,6 +11596,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 468
     AttackMotion: 468
+    ClientAttackMotion: 252
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -11452,6 +11656,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 312
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -11507,6 +11712,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -11551,6 +11757,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -11597,6 +11804,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 776
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -11642,6 +11850,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 700
     AttackMotion: 648
+    ClientAttackMotion: 396
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -11685,6 +11894,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 770
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -11732,6 +11942,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1172
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 420
     Ai: 05
     Drops:
@@ -11779,6 +11990,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 704
     AttackMotion: 504
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -11826,6 +12038,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 21
     Modes:
@@ -11870,6 +12083,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -11918,6 +12132,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 900
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -11964,6 +12179,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -12013,6 +12229,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 916
     AttackMotion: 816
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -12058,6 +12275,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1036
     AttackMotion: 936
+    ClientAttackMotion: 108
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -12103,6 +12321,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 17
     Drops:
@@ -12146,6 +12365,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1078
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -12191,6 +12411,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -12237,6 +12458,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12283,6 +12505,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -12329,6 +12552,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1100
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12372,6 +12596,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 408
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -12431,6 +12656,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -12477,6 +12703,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -12521,6 +12748,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 502
     AttackMotion: 2304
+    ClientAttackMotion: 2304
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12568,6 +12796,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 05
     Modes:
@@ -12614,6 +12843,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 816
     DamageMotion: 384
     Ai: 10
     Drops:
@@ -12663,6 +12893,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -12707,6 +12938,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 660
     DamageMotion: 624
     Ai: 21
     Modes:
@@ -12755,6 +12987,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 324
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -12800,6 +13033,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 936
+    ClientAttackMotion: 504
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -12849,6 +13083,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 05
     Drops:
@@ -12895,6 +13130,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -13119,6 +13355,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1024
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -13167,6 +13404,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -13214,6 +13452,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 816
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13261,6 +13500,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 600
+    ClientAttackMotion: 1920
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -13310,6 +13550,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 21
     Modes:
@@ -13359,6 +13600,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -13408,6 +13650,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 2496
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -13458,6 +13701,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -13505,6 +13749,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -13552,6 +13797,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -13601,6 +13847,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 1248
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13648,6 +13895,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -13697,6 +13945,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -13746,6 +13995,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
+    ClientAttackMotion: 5472
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -13794,6 +14044,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -13843,6 +14094,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 21
     Modes:
@@ -13892,6 +14144,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -13941,6 +14194,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1260
     AttackMotion: 230
+    ClientAttackMotion: 1344
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -13988,6 +14242,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -14036,6 +14291,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 1008
+    ClientAttackMotion: 2688
     DamageMotion: 840
     Ai: 21
     Drops:
@@ -14083,6 +14339,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1000
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 21
     Drops:
@@ -14130,6 +14387,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
+    ClientAttackMotion: 1920
     DamageMotion: 780
     Ai: 21
     Drops:
@@ -14177,6 +14435,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -14225,6 +14484,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -14282,6 +14542,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 672
     DamageMotion: 580
     Ai: 21
     Drops:
@@ -14329,6 +14590,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 483
+    ClientAttackMotion: 720
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -14378,6 +14640,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -14425,6 +14688,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1440
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -14473,6 +14737,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 04
     Drops:
@@ -14520,6 +14785,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1296
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -14567,6 +14833,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -14614,6 +14881,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 768
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -14662,6 +14930,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 862
     AttackMotion: 534
+    ClientAttackMotion: 360
     DamageMotion: 312
     Ai: 21
     Modes:
@@ -14711,6 +14980,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Drops:
@@ -14758,6 +15028,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1132
     AttackMotion: 583
+    ClientAttackMotion: 432
     DamageMotion: 532
     Ai: 04
     Drops:
@@ -16205,6 +16476,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 1440
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -16238,6 +16510,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1840
     AttackMotion: 1440
+    ClientAttackMotion: 720
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -16286,6 +16559,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2190
     AttackMotion: 2040
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 09
     Drops:
@@ -16330,6 +16604,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1732
     AttackMotion: 1332
+    ClientAttackMotion: 468
     DamageMotion: 540
     Ai: 20
     Modes:
@@ -16370,6 +16645,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -16412,6 +16688,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1460
     AttackMotion: 960
+    ClientAttackMotion: 2496
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -16454,6 +16731,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1306
     AttackMotion: 1056
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -16503,6 +16781,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16545,6 +16824,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1380
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 03
     Drops:
@@ -16593,6 +16873,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1446
     AttackMotion: 1296
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -16649,6 +16930,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 850
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -16697,6 +16979,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1160
     AttackMotion: 960
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16739,6 +17022,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 470
     Ai: 04
     Modes:
@@ -16785,6 +17069,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16831,6 +17116,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 672
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -16873,6 +17159,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 816
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -16921,6 +17208,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1300
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16959,6 +17247,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1492
     AttackMotion: 1092
+    ClientAttackMotion: 840
     DamageMotion: 192
     Ai: 04
     Drops:
@@ -16997,6 +17286,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 864
     DamageMotion: 180
     Ai: 04
     Modes:
@@ -17041,6 +17331,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -17083,6 +17374,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 13
     Drops:
@@ -17123,6 +17415,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1024
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 13
     Drops:
@@ -17163,6 +17456,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1350
     AttackMotion: 1200
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -17209,6 +17503,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -17252,6 +17547,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -17300,6 +17596,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -17354,6 +17651,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1356
     AttackMotion: 1056
+    ClientAttackMotion: 240
     DamageMotion: 540
     Ai: 05
     Drops:
@@ -17400,6 +17698,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1430
     AttackMotion: 1080
+    ClientAttackMotion: 480
     DamageMotion: 1080
     Ai: 07
     Drops:
@@ -17446,6 +17745,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 2416
     AttackMotion: 2016
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -17490,6 +17790,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
   - Id: 1394
@@ -17515,6 +17816,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 04
   - Id: 1395
@@ -17530,6 +17832,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 25
     Class: Boss
     Modes:
@@ -17568,6 +17871,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 25
     Class: Boss
     Modes:
@@ -17606,6 +17910,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 25
     Class: Boss
     Modes:
@@ -17644,6 +17949,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 25
     Class: Boss
     Modes:
@@ -17696,6 +18002,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -17752,6 +18059,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1638
     AttackMotion: 2016
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -17801,6 +18109,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
+    ClientAttackMotion: 2304
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -17848,6 +18157,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1148
     AttackMotion: 1728
+    ClientAttackMotion: 624
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -17896,6 +18206,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 05
     Drops:
@@ -17943,6 +18254,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
+    ClientAttackMotion: 2112
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -17992,6 +18304,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1439
     AttackMotion: 1920
+    ClientAttackMotion: 624
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -18040,6 +18353,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 2012
     AttackMotion: 1728
+    ClientAttackMotion: 576
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -18094,6 +18408,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 13
     Modes:
@@ -18141,6 +18456,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 647
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -18187,6 +18503,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -18238,6 +18555,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 840
+    ClientAttackMotion: 624
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -18286,6 +18604,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 756
+    ClientAttackMotion: 540
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -18340,6 +18659,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 318
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -18385,6 +18705,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -18434,6 +18755,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 780
     AttackMotion: 1008
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -18478,6 +18800,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
+    ClientAttackMotion: 1632
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -20473,6 +20796,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
+    ClientAttackMotion: 1344
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -20528,6 +20852,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 950
     AttackMotion: 2520
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -20574,6 +20899,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1247
     AttackMotion: 768
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 03
     Modes:
@@ -20618,6 +20944,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2413
     AttackMotion: 1248
+    ClientAttackMotion: 96
     DamageMotion: 768
     Ai: 04
     Drops:
@@ -20671,6 +20998,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1543
     AttackMotion: 1632
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -20718,6 +21046,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 857
     AttackMotion: 1056
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -20764,6 +21093,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 912
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -20810,6 +21140,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -20923,6 +21254,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 917
     AttackMotion: 1584
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21013,6 +21345,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
+    ClientAttackMotion: 1632
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21061,6 +21394,7 @@ Body:
     WalkSpeed: 147
     AttackDelay: 516
     AttackMotion: 768
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -21110,6 +21444,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 914
     AttackMotion: 1344
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -21157,6 +21492,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -21200,6 +21536,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -21246,6 +21583,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 741
     AttackMotion: 1536
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -21295,6 +21633,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 854
     AttackMotion: 2016
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -21353,6 +21692,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
+    ClientAttackMotion: 1320
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -21397,6 +21737,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1257
     AttackMotion: 528
+    ClientAttackMotion: 1056
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -21441,6 +21782,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 600
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 504
     Ai: 02
     Drops:
@@ -21485,6 +21827,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -21571,6 +21914,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1120
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 04
     Modes:
@@ -21615,6 +21959,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -21661,6 +22006,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 21
     Drops:
@@ -21704,6 +22050,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1152
     AttackMotion: 672
+    ClientAttackMotion: 432
     DamageMotion: 672
     Ai: 01
     Drops:
@@ -23368,6 +23715,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 1056
+    ClientAttackMotion: 1056
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -23416,6 +23764,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 288
+    ClientAttackMotion: 384
     DamageMotion: 144
     Ai: 21
     Class: Boss
@@ -23473,6 +23822,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 13
     Modes:
@@ -23517,6 +23867,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -23561,6 +23912,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 720
     Ai: 02
     Drops:
@@ -23607,6 +23959,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -23653,6 +24006,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -24416,6 +24770,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -24463,6 +24818,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -24510,6 +24866,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 720
     AttackMotion: 864
+    ClientAttackMotion: 624
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -24555,6 +24912,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 960
     AttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 300
     Ai: 17
     Drops:
@@ -24603,6 +24961,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -24650,6 +25009,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 420
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 21
     Modes:
@@ -24698,6 +25058,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -24744,6 +25105,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -24785,6 +25147,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -24828,6 +25191,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 20
     Drops:
@@ -24877,6 +25241,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 128
     AttackMotion: 1104
+    ClientAttackMotion: 480
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -25032,6 +25397,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 140
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 430
     Ai: 04
     Modes:
@@ -25071,6 +25437,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 140
     AttackMotion: 960
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -25112,6 +25479,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 336
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -25151,6 +25519,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -25254,6 +25623,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 540
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -25301,6 +25671,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 336
     AttackMotion: 840
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -25345,6 +25716,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Modes:
@@ -25395,6 +25767,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Modes:
@@ -25445,6 +25818,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -25492,6 +25866,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -25539,6 +25914,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -25586,6 +25962,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -26188,6 +26565,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26235,6 +26613,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26283,6 +26662,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26330,6 +26710,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26378,6 +26759,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26425,6 +26807,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26682,6 +27065,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -26717,6 +27101,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -26754,6 +27139,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -26789,6 +27175,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -26825,6 +27212,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 580
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -26868,6 +27256,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -26901,6 +27290,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -26948,6 +27338,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -26995,6 +27386,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27042,6 +27434,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27086,6 +27479,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1368
     AttackMotion: 1344
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -27119,6 +27513,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27152,6 +27547,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27199,6 +27595,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27246,6 +27643,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27293,6 +27691,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27340,6 +27739,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27381,6 +27781,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 360
+    ClientAttackMotion: 240
     DamageMotion: 864
     Ai: 04
     Class: Boss
@@ -27429,6 +27830,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1536
     AttackMotion: 1056
+    ClientAttackMotion: 336
     DamageMotion: 1152
     Ai: 04
     Drops:
@@ -27530,6 +27932,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 504
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -27587,6 +27990,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27631,6 +28035,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 720
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -27678,6 +28083,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 10
     Class: Boss
@@ -27736,6 +28142,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -27756,6 +28163,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 2496
     DamageMotion: 511
     Ai: 02
     Modes:
@@ -27839,6 +28247,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -27884,6 +28293,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -27925,6 +28335,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -27966,6 +28377,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28007,6 +28419,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28048,6 +28461,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28092,6 +28506,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 176
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 21
     Drops:
@@ -28139,6 +28554,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28187,6 +28603,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28236,6 +28653,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 420
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28283,6 +28701,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 360
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28332,6 +28751,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 576
     AttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28381,6 +28801,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -28428,6 +28849,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -28475,6 +28897,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -28522,6 +28945,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -28570,6 +28994,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 115
     AttackMotion: 816
+    ClientAttackMotion: 672
     DamageMotion: 504
     Ai: 21
     Class: Boss
@@ -28778,6 +29203,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 09
     Drops:
@@ -28824,6 +29250,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -28870,6 +29297,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28908,6 +29336,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -28954,6 +29383,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -28998,6 +29428,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 252
     AttackMotion: 816
+    ClientAttackMotion: 528
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -29039,6 +29470,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 432
     AttackMotion: 936
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -29096,6 +29528,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -29139,6 +29572,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 24
     AttackMotion: 1
+    ClientAttackMotion: 24
     DamageMotion: 1
     Drops:
       - Item: Elunium
@@ -29480,6 +29914,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 1152
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -29511,6 +29946,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1152
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -29568,6 +30004,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -29617,6 +30054,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -29666,6 +30104,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 17
     Drops:
@@ -29713,6 +30152,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30093,6 +30533,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -30147,6 +30588,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 20
     Modes:
@@ -30195,6 +30637,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 576
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -30242,6 +30685,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -30290,6 +30734,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -30594,6 +31039,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -30628,6 +31074,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 312
     DamageMotion: 384
     Ai: 17
     Class: Guardian
@@ -30666,6 +31113,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 1056
     DamageMotion: 384
     Ai: 17
     Class: Guardian
@@ -30708,6 +31156,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1344
     AttackMotion: 2880
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -30762,6 +31211,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -30807,6 +31257,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -30854,6 +31305,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30898,6 +31350,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -30943,6 +31396,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 960
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -30992,6 +31446,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 20
     Drops:
@@ -31037,6 +31492,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 660
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -31084,6 +31540,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 432
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 02
     Drops:
@@ -31125,6 +31582,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
     Drops:
@@ -31169,6 +31627,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 370
+    ClientAttackMotion: 300
     DamageMotion: 270
     Ai: 20
     Modes:
@@ -31213,6 +31672,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 432
     AttackMotion: 840
+    ClientAttackMotion: 660
     DamageMotion: 216
     Ai: 21
     Class: Boss
@@ -31267,6 +31727,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 672
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -31311,6 +31772,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 864
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 336
     Ai: 10
     Drops:
@@ -31355,6 +31817,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 412
     AttackMotion: 840
+    ClientAttackMotion: 600
     DamageMotion: 300
     Ai: 07
     Drops:
@@ -31396,6 +31859,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Class: Boss
@@ -31437,6 +31901,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -31626,6 +32091,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
+    ClientAttackMotion: 1344
     Ai: 10
     Drops:
       - Item: Ice_Piece
@@ -31855,6 +32321,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -31898,6 +32365,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 864
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -32489,6 +32957,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackDelay: 1320
+    ClientAttackMotion: 648
     DamageMotion: 300
     Modes:
       IgnoreMagic: true
@@ -33026,6 +33495,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33075,6 +33545,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 212
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -33132,6 +33603,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33236,6 +33708,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -33274,6 +33747,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Modes:
@@ -33321,6 +33795,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1548
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -33370,6 +33845,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -33415,6 +33891,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Class: Guardian
@@ -34315,6 +34792,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -34357,6 +34835,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 21
     Drops:
@@ -34402,6 +34881,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -34449,6 +34929,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -34523,6 +35004,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 972
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 432
     Ai: 09
     Modes:
@@ -34563,6 +35045,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 1320
+    ClientAttackMotion: 780
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -34611,6 +35094,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 1152
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -34723,6 +35207,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 212
     AttackMotion: 504
+    ClientAttackMotion: 252
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -34780,6 +35265,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 1152
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -34910,6 +35396,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -34939,6 +35426,7 @@ Body:
     WalkSpeed: 320
     AttackDelay: 2304
     AttackMotion: 840
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 01
     Drops:
@@ -34981,6 +35469,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1728
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -35024,6 +35513,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1536
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -35067,6 +35557,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -35110,6 +35601,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1536
     AttackMotion: 504
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -35155,6 +35647,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 864
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -35445,6 +35938,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 07
     Class: Boss
@@ -35712,6 +36206,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 13
   - Id: 1905
@@ -35735,6 +36230,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1906
@@ -35785,6 +36281,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1908
@@ -35805,6 +36302,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1909
@@ -35823,6 +36321,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35848,6 +36347,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35873,6 +36373,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35898,6 +36399,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35923,6 +36425,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35948,6 +36451,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -35973,6 +36477,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36009,6 +36514,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36092,6 +36598,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 540
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36137,6 +36644,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36180,6 +36688,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 540
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36225,6 +36734,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 540
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36481,6 +36991,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -36526,6 +37037,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -36554,6 +37066,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -36576,6 +37089,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Class: Guardian
@@ -36613,6 +37127,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -36634,6 +37149,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -36660,6 +37176,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -36686,6 +37203,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Guardian
     Modes:
@@ -37335,6 +37853,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 504
     Ai: 21
     Class: Boss
@@ -37378,6 +37897,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 140
     AttackMotion: 540
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -37957,6 +38477,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 20
     Modes:
@@ -38007,6 +38528,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 336
     AttackMotion: 840
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -38051,6 +38573,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -38098,6 +38621,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 20
     Drops:
@@ -38142,6 +38666,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1840
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 384
     Ai: 20
     Drops:
@@ -38190,6 +38715,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 580
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -38235,6 +38761,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -38392,6 +38919,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
   - Id: 1986
@@ -38423,6 +38951,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Drops:
@@ -38470,6 +38999,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -38521,6 +39051,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 10
     Drops:
@@ -38567,6 +39098,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 400
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -38615,6 +39147,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 660
+    ClientAttackMotion: 300
     DamageMotion: 588
     Ai: 21
     Class: Boss
@@ -38662,6 +39195,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 780
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -38709,6 +39243,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 624
+    ClientAttackMotion: 192
     DamageMotion: 300
     Ai: 03
     Drops:
@@ -38758,6 +39293,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 400
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -38804,6 +39340,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 08
     Modes:
@@ -38855,6 +39392,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 700
     AttackMotion: 600
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -38998,6 +39536,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -39480,6 +40019,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 420
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -39521,6 +40061,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 24
     AttackMotion: 1
+    ClientAttackMotion: 24
     DamageMotion: 1
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -39553,6 +40094,7 @@ Body:
     WalkSpeed: 290
     AttackDelay: 1426
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -39592,6 +40134,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 504
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -39630,6 +40173,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 792
     AttackMotion: 540
+    ClientAttackMotion: 420
     DamageMotion: 420
     Ai: 20
     Drops:
@@ -39667,6 +40211,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 420
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -39708,6 +40253,7 @@ Body:
     WalkSpeed: 290
     AttackDelay: 504
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -39747,6 +40293,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 576
     AttackMotion: 660
+    ClientAttackMotion: 300
     DamageMotion: 420
     Ai: 13
     Drops:
@@ -39782,6 +40329,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 360
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -39818,6 +40366,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1596
     AttackMotion: 1620
+    ClientAttackMotion: 576
     DamageMotion: 864
     Ai: 21
     Class: Boss
@@ -39871,6 +40420,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 09
     Modes:
@@ -39920,6 +40470,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 480
     DamageMotion: 540
     Ai: 20
     Drops:
@@ -41129,6 +41680,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -41182,6 +41734,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -41226,6 +41779,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 04
     Drops:
@@ -41270,6 +41824,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -41316,6 +41871,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1248
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -41356,6 +41912,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 960
     AttackMotion: 1440
+    ClientAttackMotion: 300
     DamageMotion: 960
     Ai: 03
     Drops:
@@ -41396,6 +41953,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 528
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 07
     Drops:

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -56,7 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
-#   ClientAttackMotion      Client attack speed. (Default: 432)
+#   ClientAttackMotion      Client attack speed. (Default: AttackMotion)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -222,7 +222,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 576
+    ClientAttackMotion: 792
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -271,7 +271,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 144
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -429,7 +429,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 360
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -661,7 +661,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 528
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -707,7 +707,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1090,7 +1090,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 576
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1507,7 +1507,6 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
-    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1855,7 +1854,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 384
+    ClientAttackMotion: 600
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -2235,7 +2234,6 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 864
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2325,7 +2323,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 144
+    ClientAttackMotion: 288
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2420,7 +2418,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 480
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2470,7 +2468,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 576
+    ClientAttackMotion: 864
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2520,7 +2518,6 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2570,7 +2567,6 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2666,7 +2662,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 432
+    ClientAttackMotion: 576
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2713,7 +2709,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
-    ClientAttackMotion: 360
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2760,7 +2756,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
-    ClientAttackMotion: 432
+    ClientAttackMotion: 504
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2811,7 +2807,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 288
+    ClientAttackMotion: 648
     DamageMotion: 300
     DamageTaken: 10
     Ai: 21
@@ -2868,7 +2864,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1092
+    ClientAttackMotion: 1260
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -3654,7 +3650,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
-    ClientAttackMotion: 528
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -4116,7 +4112,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
-    ClientAttackMotion: 480
+    ClientAttackMotion: 780
     DamageMotion: 648
     DamageTaken: 10
     Ai: 21
@@ -4519,7 +4515,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 144
+    ClientAttackMotion: 180
     DamageMotion: 384
     Ai: 07
     Modes:
@@ -4614,7 +4610,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 768
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -4657,7 +4653,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 720
-    ClientAttackMotion: 288
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -5296,7 +5292,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 144
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 19
     Drops:
@@ -7564,7 +7560,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 868
     AttackMotion: 768
-    ClientAttackMotion: 288
+    ClientAttackMotion: 576
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -7829,7 +7825,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
-    ClientAttackMotion: 2652
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 05
     Drops:
@@ -7973,7 +7969,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 432
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -8897,7 +8893,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 1536
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -9587,7 +9583,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
-    ClientAttackMotion: 288
+    ClientAttackMotion: 900
     DamageMotion: 540
     Ai: 13
     Modes:
@@ -9637,7 +9633,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
-    ClientAttackMotion: 288
+    ClientAttackMotion: 960
     DamageMotion: 600
     Ai: 13
     Drops:
@@ -9940,7 +9936,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
-    ClientAttackMotion: 336
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -10187,7 +10183,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 192
+    ClientAttackMotion: 432
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10235,7 +10231,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
-    ClientAttackMotion: 360
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 19
     Drops:
@@ -80406,7 +80402,6 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 360
-    ClientAttackMotion: 360
     DamageMotion: 360
     Drops:
       - Item: White_Slim_Potion

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -222,7 +222,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 336
+    ClientAttackMotion: 648
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -1555,7 +1555,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
-    ClientAttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -5051,7 +5051,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
-    ClientAttackMotion: 216
+    ClientAttackMotion: 180
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -5100,7 +5100,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 216
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -6786,7 +6786,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
-    ClientAttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -11753,7 +11753,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -13708,7 +13708,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
-    ClientAttackMotion: 336
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -14550,7 +14550,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -16584,7 +16584,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
-    ClientAttackMotion: 540
+    ClientAttackMotion: 1440
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -18982,7 +18982,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
-    ClientAttackMotion: 288
+    ClientAttackMotion: 1440
     DamageMotion: 420
     DamageTaken: 10
     Ai: 21
@@ -25908,7 +25908,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
-    ClientAttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -28356,7 +28356,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28791,7 +28791,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
-    ClientAttackMotion: 756
+    ClientAttackMotion: 2304
     DamageMotion: 511
     Ai: 02
     Class: Boss
@@ -29185,7 +29185,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
-    ClientAttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30674,7 +30674,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -34576,7 +34576,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
-    ClientAttackMotion: 288
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -37440,7 +37440,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37574,7 +37574,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -37620,7 +37620,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 648
-    ClientAttackMotion: 336
+    ClientAttackMotion: 360
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -37664,7 +37664,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 432
-    ClientAttackMotion: 336
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -37710,7 +37710,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
-    ClientAttackMotion: 336
+    ClientAttackMotion: 432
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -37987,7 +37987,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 216
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -38122,7 +38122,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Class: Boss
@@ -39565,7 +39565,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
-    ClientAttackMotion: 300
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -40605,7 +40605,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 384
-    ClientAttackMotion: 336
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 01
     Class: Boss
@@ -42189,7 +42189,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 500
@@ -42219,7 +42219,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 500
@@ -42249,7 +42249,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 500
@@ -42279,7 +42279,7 @@ Body:
     AttackMotion: 1020
     ClientAttackMotion: 288
     DamageMotion: 360
-    Ai: 10
+    Ai: 06
     Drops:
       - Item: Steel
         Rate: 500
@@ -43201,7 +43201,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 420
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -43955,7 +43955,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 240
+    ClientAttackMotion: 0
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43991,7 +43991,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 480
+    ClientAttackMotion: 0
     DamageMotion: 480
     Modes:
       Detector: true
@@ -46749,7 +46749,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
-    ClientAttackMotion: 480
+    ClientAttackMotion: 420
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46800,7 +46800,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 588
     AttackMotion: 768
-    ClientAttackMotion: 420
+    ClientAttackMotion: 1056
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -46947,7 +46947,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 240
+    ClientAttackMotion: 0
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46983,7 +46983,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 480
+    ClientAttackMotion: 0
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -54052,7 +54052,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
-    ClientAttackMotion: 480
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -55489,7 +55489,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 288
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55534,7 +55534,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 288
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55626,7 +55626,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 288
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55718,7 +55718,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 864
     AttackMotion: 400
-    ClientAttackMotion: 288
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55810,7 +55810,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 288
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55994,7 +55994,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 336
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -56040,7 +56040,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 336
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -59038,7 +59038,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1276
     AttackMotion: 792
-    ClientAttackMotion: 720
+    ClientAttackMotion: 1152
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -59719,7 +59719,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -75874,7 +75874,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 1728
     DamageMotion: 660
     Ai: 09
     Drops:
@@ -75922,7 +75922,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
-    ClientAttackMotion: 720
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -77510,7 +77510,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 1296
-    ClientAttackMotion: 1224
+    ClientAttackMotion: 468
     DamageMotion: 432
     Ai: 05
     Modes:
@@ -78712,7 +78712,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -79212,7 +79212,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1
     Class: Event
     Modes:
@@ -80135,7 +80135,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 460
-    ClientAttackMotion: 336
+    ClientAttackMotion: 540
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -80171,7 +80171,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 750
     AttackMotion: 510
-    ClientAttackMotion: 336
+    ClientAttackMotion: 420
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -80907,7 +80907,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 2016
-    ClientAttackMotion: 420
+    ClientAttackMotion: 1824
     DamageMotion: 672
     Ai: 26
     Class: Boss
@@ -81001,7 +81001,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 1056
-    ClientAttackMotion: 288
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -81048,7 +81048,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 816
-    ClientAttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -82551,7 +82551,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
-    ClientAttackMotion: 288
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82703,7 +82703,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 240
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82755,7 +82755,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 288
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -84373,7 +84373,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
-    ClientAttackMotion: 288
+    ClientAttackMotion: 1728
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -87795,7 +87795,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 864
-    ClientAttackMotion: 336
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -88343,7 +88343,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2112
     AttackMotion: 1152
-    ClientAttackMotion: 720
+    ClientAttackMotion: 1920
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -89179,7 +89179,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 336
+    ClientAttackMotion: 648
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -89277,7 +89277,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 216
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -89603,7 +89603,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 864
     AttackMotion: 1056
-    ClientAttackMotion: 360
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -93328,7 +93328,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 420
+    ClientAttackMotion: 576
     DamageMotion: 600
     Ai: 04
     Drops:
@@ -93376,7 +93376,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 600
-    ClientAttackMotion: 300
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 04
     Drops:
@@ -93612,7 +93612,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1826
     AttackMotion: 816
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 19
     Modes:
@@ -94053,7 +94053,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
-    ClientAttackMotion: 336
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -96270,7 +96270,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 632
     AttackMotion: 518
-    ClientAttackMotion: 720
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -96320,7 +96320,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
-    ClientAttackMotion: 936
+    ClientAttackMotion: 900
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -99114,7 +99114,7 @@ Body:
   - Id: 20543
     AegisName: MD_ED_M_SCIENCE
     Name: MD_ED_M_SCIENCE
-    ClientAttackMotion: 1872
+    ClientAttackMotion: 1584
 #  - Id: 20544
 #    AegisName: MINERAL_R_MJ
 #  - Id: 20545
@@ -100985,7 +100985,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1200
     AttackMotion: 1200
-    ClientAttackMotion: 216
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -103583,7 +103583,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 1155
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -103675,7 +103675,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1070
     AttackMotion: 1512
-    ClientAttackMotion: 468
+    ClientAttackMotion: 936
     DamageMotion: 485
     Ai: 04
     Drops:
@@ -103723,7 +103723,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 708
     AttackMotion: 1225
-    ClientAttackMotion: 384
+    ClientAttackMotion: 504
     DamageMotion: 675
     Ai: 04
     Drops:
@@ -103817,7 +103817,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 335
     AttackMotion: 1250
-    ClientAttackMotion: 192
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -103865,7 +103865,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 276
     AttackMotion: 672
-    ClientAttackMotion: 108
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -103913,7 +103913,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 168
     AttackMotion: 1154
-    ClientAttackMotion: 432
+    ClientAttackMotion: 528
     DamageMotion: 865
     Ai: 04
     Drops:
@@ -103961,7 +103961,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 480
     AttackMotion: 960
-    ClientAttackMotion: 360
+    ClientAttackMotion: 480
     DamageMotion: 970
     Ai: 04
     Drops:
@@ -104007,7 +104007,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 422
     AttackMotion: 870
-    ClientAttackMotion: 480
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -104374,7 +104374,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 0
+    ClientAttackMotion: 600
     DamageMotion: 300
     Ai: 20
   - Id: 20851
@@ -105256,7 +105256,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1332
     AttackMotion: 2664
-    ClientAttackMotion: 528
+    ClientAttackMotion: 936
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -105698,7 +105698,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 510
     AttackMotion: 1020
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 720
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -107571,7 +107571,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 576
-    ClientAttackMotion: 216
+    ClientAttackMotion: 360
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -107697,7 +107697,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 792
     AttackMotion: 792
-    ClientAttackMotion: 216
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -108018,7 +108018,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 736
     AttackMotion: 1104
-    ClientAttackMotion: 576
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -108053,7 +108053,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
-    ClientAttackMotion: 480
+    ClientAttackMotion: 672
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -108192,7 +108192,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 540
     AttackMotion: 1080
-    ClientAttackMotion: 720
+    ClientAttackMotion: 660
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -108238,7 +108238,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 216
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -108620,7 +108620,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 792
-    ClientAttackMotion: 96
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -108712,7 +108712,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 144
+    ClientAttackMotion: 96
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -108799,7 +108799,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1848
     AttackMotion: 1296
-    ClientAttackMotion: 480
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -108893,7 +108893,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1768
     AttackMotion: 768
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 21
     Drops:

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -1,5 +1,5 @@
 # This file is a part of rAthena.
-#   Copyright(C) 2021 rAthena Development Team
+#   Copyright(C) 2024 rAthena Development Team
 #   https://rathena.org - https://github.com/rathena
 #
 # This program is free software: you can redistribute it and/or modify
@@ -56,6 +56,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
+#   ClientAttackMotion      Client attack speed. (Default: 432)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)
@@ -107,6 +108,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 19
     Modes:
@@ -153,6 +155,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -219,6 +222,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -267,6 +271,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -327,6 +332,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -375,6 +381,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       Detector: true
@@ -422,6 +429,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -469,6 +477,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -562,6 +571,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -605,6 +615,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -650,6 +661,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -695,6 +707,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -836,6 +849,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 01
     Modes:
@@ -884,6 +898,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -929,6 +944,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -1074,6 +1090,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1120,6 +1137,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1048
     AttackMotion: 48
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -1168,6 +1186,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -1215,6 +1234,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1341,6 +1361,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 19
     Modes:
@@ -1389,6 +1410,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -1437,6 +1459,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1484,6 +1507,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1528,6 +1552,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -1575,6 +1600,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -1622,6 +1648,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -1671,6 +1698,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 456
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -1718,6 +1746,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -1766,6 +1795,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     DamageTaken: 10
     Ai: 21
@@ -1825,6 +1855,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -1885,6 +1916,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 1008
     DamageMotion: 396
     Ai: 17
     Drops:
@@ -1930,6 +1962,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -2052,6 +2085,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -2099,6 +2133,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -2145,6 +2180,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -2199,6 +2235,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 864
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2240,6 +2277,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 701
     AttackMotion: 1
+    ClientAttackMotion: 480
     DamageMotion: 1
     Modes:
       Detector: true
@@ -2287,6 +2325,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2334,6 +2373,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2380,6 +2420,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 480
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2429,6 +2470,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2478,6 +2520,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2527,6 +2570,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 768
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2575,6 +2619,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 01
     Drops:
@@ -2621,6 +2666,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2667,6 +2713,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2713,6 +2760,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2763,6 +2811,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 288
     DamageMotion: 300
     DamageTaken: 10
     Ai: 21
@@ -2819,6 +2868,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -2866,6 +2916,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 816
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -2913,6 +2964,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -2958,6 +3010,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Drops:
@@ -3005,6 +3058,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2492
     AttackMotion: 792
+    ClientAttackMotion: 696
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -3052,6 +3106,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -3099,6 +3154,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Ai: 17
     Drops:
@@ -3146,6 +3202,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 48
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -3194,6 +3251,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 10
     Drops:
@@ -3241,6 +3299,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1968
     AttackMotion: 768
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -3288,6 +3347,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -3335,6 +3395,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1754
     AttackMotion: 554
+    ClientAttackMotion: 360
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3382,6 +3443,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1700
     AttackMotion: 1000
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 04
     Modes:
@@ -3431,6 +3493,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 992
     AttackMotion: 792
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 01
     Drops:
@@ -3476,6 +3539,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 468
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -3542,6 +3606,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -3589,6 +3654,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3628,6 +3694,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3671,6 +3738,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3714,6 +3782,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3757,6 +3826,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3800,6 +3870,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1152
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3844,6 +3915,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 2208
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3887,6 +3959,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3930,6 +4003,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3982,6 +4056,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     DamageTaken: 10
     Ai: 07
@@ -4041,6 +4116,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 648
     DamageTaken: 10
     Ai: 21
@@ -4099,6 +4175,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -4148,6 +4225,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1236
     AttackMotion: 336
+    ClientAttackMotion: 168
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -4196,6 +4274,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -4244,6 +4323,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -4292,6 +4372,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1048
     AttackMotion: 648
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -4340,6 +4421,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -4387,6 +4469,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2048
     AttackMotion: 648
+    ClientAttackMotion: 312
     DamageMotion: 648
     Ai: 17
     Modes:
@@ -4436,6 +4519,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 07
     Modes:
@@ -4485,6 +4569,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -4529,6 +4614,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 1536
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -4571,6 +4657,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -4618,6 +4705,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -4665,6 +4753,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 19
     Modes:
@@ -4716,6 +4805,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 21
     Modes:
@@ -4765,6 +4855,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
     Drops:
@@ -4811,6 +4902,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1604
     AttackMotion: 840
+    ClientAttackMotion: 216
     DamageMotion: 756
     Ai: 17
     Drops:
@@ -4857,6 +4949,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -4904,6 +4997,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -4953,6 +5047,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 180
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -5001,6 +5096,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -5048,6 +5144,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1680
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -5097,6 +5194,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -5146,6 +5244,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -5197,6 +5296,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 144
     DamageMotion: 384
     Ai: 19
     Drops:
@@ -5245,6 +5345,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 620
     AttackMotion: 420
+    ClientAttackMotion: 108
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -5297,6 +5398,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -5344,6 +5446,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1004
     AttackMotion: 504
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -5392,6 +5495,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 872
     AttackMotion: 1344
+    ClientAttackMotion: 408
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -5450,6 +5554,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -5497,6 +5602,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -5545,6 +5651,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1432
     AttackMotion: 432
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -5592,6 +5699,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 720
+    ClientAttackMotion: 324
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -5639,6 +5747,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1220
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -5687,6 +5796,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1848
     AttackMotion: 1296
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -5738,6 +5848,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -5787,6 +5898,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1320
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 19
     Drops:
@@ -5836,6 +5948,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
     Drops:
@@ -5885,6 +5998,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
     Drops:
@@ -5934,6 +6048,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 3074
     AttackMotion: 1874
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 13
     Drops:
@@ -5981,6 +6096,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 720
     Ai: 01
     Drops:
@@ -6028,6 +6144,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -6077,6 +6194,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1888
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 13
     Drops:
@@ -6124,6 +6242,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -6173,6 +6292,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1364
     AttackMotion: 864
+    ClientAttackMotion: 312
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -6220,6 +6340,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 528
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 21
     Drops:
@@ -6269,6 +6390,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6318,6 +6440,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6367,6 +6490,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -6414,6 +6538,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Class: Boss
@@ -6461,6 +6586,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Class: Boss
@@ -6509,6 +6635,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 02
     Modes:
@@ -6557,6 +6684,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 19
     Modes:
@@ -6606,6 +6734,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 840
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 19
     Drops:
@@ -6653,6 +6782,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -6698,6 +6828,7 @@ Body:
     WalkSpeed: 800
     AttackDelay: 1201
     AttackMotion: 1
+    ClientAttackMotion: 240
     DamageMotion: 1
     Drops:
       - Item: Tendon
@@ -6740,6 +6871,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 19
     Modes:
@@ -6790,6 +6922,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 468
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -6837,6 +6970,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -6884,6 +7018,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 19
     Drops:
@@ -6928,6 +7063,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 864
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -6986,6 +7122,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1720
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -7035,6 +7172,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -7083,6 +7221,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -7141,6 +7280,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -7190,6 +7330,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -7237,6 +7378,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2852
     AttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 840
     Ai: 04
     Drops:
@@ -7276,6 +7418,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 976
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -7323,6 +7466,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -7371,6 +7515,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -7419,6 +7564,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -7477,6 +7623,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2544
     AttackMotion: 1344
+    ClientAttackMotion: 432
     DamageMotion: 1152
     Ai: 17
     Drops:
@@ -7525,6 +7672,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 1020
+    ClientAttackMotion: 324
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -7583,6 +7731,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -7632,6 +7781,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2208
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -7679,6 +7829,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 2652
     DamageMotion: 240
     Ai: 05
     Drops:
@@ -7726,6 +7877,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -7773,6 +7925,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1516
     AttackMotion: 816
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -7820,6 +7973,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -7867,6 +8021,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -7913,6 +8068,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 312
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -8005,6 +8161,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -8052,6 +8209,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2112
     AttackMotion: 912
+    ClientAttackMotion: 324
     DamageMotion: 576
     Ai: 17
     Modes:
@@ -8229,6 +8387,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1688
     AttackMotion: 1188
+    ClientAttackMotion: 720
     DamageMotion: 612
     Ai: 17
     Modes:
@@ -8276,6 +8435,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1744
     AttackMotion: 1044
+    ClientAttackMotion: 252
     DamageMotion: 684
     Ai: 17
     Drops:
@@ -8321,6 +8481,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -8370,6 +8531,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 02
     Drops:
@@ -8415,6 +8577,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1780
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -8464,6 +8627,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Ai: 19
     Modes:
@@ -8509,6 +8673,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -8732,6 +8897,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
+    ClientAttackMotion: 1152
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -8777,6 +8943,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -8827,6 +8994,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -8877,6 +9045,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1248
     AttackMotion: 500
+    ClientAttackMotion: 624
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -8934,6 +9103,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -8979,6 +9149,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -9026,6 +9197,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -9072,6 +9244,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 19
     Modes:
@@ -9123,6 +9296,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -9170,6 +9344,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1848
     AttackMotion: 500
+    ClientAttackMotion: 864
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -9217,6 +9392,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 13
     Drops:
@@ -9264,6 +9440,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1252
+    ClientAttackMotion: 384
     DamageMotion: 476
     Ai: 13
     Modes:
@@ -9315,6 +9492,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 1000
     Ai: 19
     Drops:
@@ -9361,6 +9539,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
+    ClientAttackMotion: 2112
     DamageMotion: 768
     Ai: 13
     Drops:
@@ -9408,6 +9587,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
+    ClientAttackMotion: 288
     DamageMotion: 540
     Ai: 13
     Modes:
@@ -9457,6 +9637,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
+    ClientAttackMotion: 288
     DamageMotion: 600
     Ai: 13
     Drops:
@@ -9504,6 +9685,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -9558,6 +9740,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 816
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -9610,6 +9793,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -9659,6 +9843,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 900
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 21
     Drops:
@@ -9706,6 +9891,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -9754,6 +9940,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -9804,6 +9991,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 19
     Drops:
@@ -9899,6 +10087,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 19
     Modes:
@@ -9945,6 +10134,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 384
     DamageMotion: 1000
     Ai: 19
     Modes:
@@ -9997,6 +10187,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 192
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10044,6 +10235,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 19
     Drops:
@@ -10093,6 +10285,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 288
     DamageMotion: 528
     Ai: 19
     Drops:
@@ -10143,6 +10336,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -10197,6 +10391,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -11198,6 +11393,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -11245,6 +11441,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1260
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -11292,6 +11489,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -11339,6 +11537,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -11386,6 +11585,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 17
     Drops:
@@ -11429,6 +11629,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 01
     Class: Boss
@@ -11482,6 +11683,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
+    ClientAttackMotion: 1296
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -11529,6 +11731,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -11576,6 +11779,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 672
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -11625,6 +11829,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 468
     AttackMotion: 468
+    ClientAttackMotion: 252
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -11685,6 +11890,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 312
     DamageMotion: 336
     DamageTaken: 10
     Ai: 21
@@ -11741,6 +11947,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -11788,6 +11995,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -11836,6 +12044,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 776
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -11883,6 +12092,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 700
     AttackMotion: 648
+    ClientAttackMotion: 396
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -11928,6 +12138,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 770
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -11977,6 +12188,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1172
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 420
     Ai: 05
     Drops:
@@ -12024,6 +12236,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 704
     AttackMotion: 504
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -12073,6 +12286,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 21
     Modes:
@@ -12118,6 +12332,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -12166,6 +12381,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 900
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -12214,6 +12430,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -12263,6 +12480,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 916
     AttackMotion: 816
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -12310,6 +12528,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1036
     AttackMotion: 936
+    ClientAttackMotion: 108
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -12356,6 +12575,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 17
     Drops:
@@ -12403,6 +12623,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1078
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -12452,6 +12673,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -12501,6 +12723,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12550,6 +12773,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -12597,6 +12821,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1100
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12641,6 +12866,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 408
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -12701,6 +12927,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -12748,6 +12975,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -12793,6 +13021,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 502
     AttackMotion: 1999
+    ClientAttackMotion: 2304
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -12840,6 +13069,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 05
     Modes:
@@ -12887,6 +13117,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 816
     DamageMotion: 384
     Ai: 10
     Drops:
@@ -12935,6 +13166,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -12983,6 +13215,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 660
     DamageMotion: 624
     Ai: 21
     Modes:
@@ -13031,6 +13264,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 324
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -13080,6 +13314,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 936
+    ClientAttackMotion: 504
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -13129,6 +13364,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 05
     Drops:
@@ -13175,6 +13411,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -13399,6 +13636,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1024
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -13447,6 +13685,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -13495,6 +13734,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 816
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13542,6 +13782,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 600
+    ClientAttackMotion: 1920
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -13591,6 +13832,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 21
     Modes:
@@ -13640,6 +13882,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -13689,6 +13932,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 2496
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -13739,6 +13983,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -13787,6 +14032,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -13834,6 +14080,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -13883,6 +14130,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 1248
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13930,6 +14178,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -13979,6 +14228,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -14029,6 +14279,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
+    ClientAttackMotion: 5472
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -14078,6 +14329,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -14127,6 +14379,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 21
     Modes:
@@ -14176,6 +14429,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -14225,6 +14479,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1260
     AttackMotion: 230
+    ClientAttackMotion: 1344
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -14272,6 +14527,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -14320,6 +14576,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 1008
+    ClientAttackMotion: 2688
     DamageMotion: 840
     Ai: 21
     Drops:
@@ -14367,6 +14624,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1000
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 21
     Drops:
@@ -14414,6 +14672,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
+    ClientAttackMotion: 1920
     DamageMotion: 780
     Ai: 21
     Drops:
@@ -14462,6 +14721,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -14510,6 +14770,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 500
     DamageTaken: 10
     Ai: 21
@@ -14568,6 +14829,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 672
     DamageMotion: 580
     Ai: 21
     Drops:
@@ -14615,6 +14877,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 483
+    ClientAttackMotion: 720
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -14664,6 +14927,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 504
     Ai: 21
     Drops:
@@ -14711,6 +14975,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1440
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -14760,6 +15025,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 19
     Drops:
@@ -14807,6 +15073,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1296
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -14854,6 +15121,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 540
     DamageMotion: 672
     Ai: 21
     Drops:
@@ -14901,6 +15169,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 768
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -14950,6 +15219,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 862
     AttackMotion: 534
+    ClientAttackMotion: 360
     DamageMotion: 312
     Ai: 21
     Modes:
@@ -14995,6 +15265,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Drops:
@@ -15042,6 +15313,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1132
     AttackMotion: 583
+    ClientAttackMotion: 432
     DamageMotion: 532
     Ai: 19
     Drops:
@@ -16289,6 +16561,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 1440
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -16323,6 +16596,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1840
     AttackMotion: 1440
+    ClientAttackMotion: 720
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -16372,6 +16646,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2190
     AttackMotion: 2040
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 19
     Drops:
@@ -16419,6 +16694,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1732
     AttackMotion: 1332
+    ClientAttackMotion: 468
     DamageMotion: 540
     Ai: 20
     Modes:
@@ -16460,6 +16736,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -16505,6 +16782,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1460
     AttackMotion: 960
+    ClientAttackMotion: 2496
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -16548,6 +16826,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1306
     AttackMotion: 1056
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -16598,6 +16877,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16645,6 +16925,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1380
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 03
     Drops:
@@ -16692,6 +16973,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1446
     AttackMotion: 1296
+    ClientAttackMotion: 768
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -16750,6 +17032,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 850
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -16799,6 +17082,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 720
     AttackMotion: 864
+    ClientAttackMotion: 540
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -16842,6 +17126,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 470
     Ai: 04
     Modes:
@@ -16891,6 +17176,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -16940,6 +17226,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 672
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -16983,6 +17270,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 816
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -17032,6 +17320,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1300
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -17071,6 +17360,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1492
     AttackMotion: 1092
+    ClientAttackMotion: 840
     DamageMotion: 192
     Ai: 04
     Drops:
@@ -17112,6 +17402,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 864
     DamageMotion: 180
     Ai: 04
     Modes:
@@ -17159,6 +17450,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -17202,6 +17494,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 13
     Drops:
@@ -17247,6 +17540,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1024
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 13
     Drops:
@@ -17294,6 +17588,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1350
     AttackMotion: 1200
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -17342,6 +17637,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1264
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -17386,6 +17682,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -17433,6 +17730,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -17489,6 +17787,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1356
     AttackMotion: 1056
+    ClientAttackMotion: 240
     DamageMotion: 540
     Ai: 05
     Drops:
@@ -17537,6 +17836,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1430
     AttackMotion: 1080
+    ClientAttackMotion: 480
     DamageMotion: 1080
     Ai: 07
     Drops:
@@ -17584,6 +17884,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 2416
     AttackMotion: 2016
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -17627,6 +17928,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
   - Id: 1394
@@ -17652,6 +17954,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 04
   - Id: 1395
@@ -17667,6 +17970,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 01
     Class: Boss
     Modes:
@@ -17705,6 +18009,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 01
     Class: Boss
     Modes:
@@ -17743,6 +18048,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 01
     Class: Boss
     Modes:
@@ -17781,6 +18087,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 1152
     Ai: 01
     Class: Boss
     Modes:
@@ -17833,6 +18140,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -17890,6 +18198,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1638
     AttackMotion: 2016
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -17939,6 +18248,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
+    ClientAttackMotion: 2304
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -17987,6 +18297,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1148
     AttackMotion: 1728
+    ClientAttackMotion: 624
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -18035,6 +18346,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 05
     Drops:
@@ -18083,6 +18395,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
+    ClientAttackMotion: 2112
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -18133,6 +18446,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1439
     AttackMotion: 1920
+    ClientAttackMotion: 624
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -18183,6 +18497,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 2012
     AttackMotion: 1728
+    ClientAttackMotion: 576
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -18238,6 +18553,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 13
     Modes:
@@ -18289,6 +18605,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1247
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -18335,6 +18652,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -18391,6 +18709,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 840
+    ClientAttackMotion: 624
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -18439,6 +18758,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 756
+    ClientAttackMotion: 540
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -18495,6 +18815,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 318
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -18539,6 +18860,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -18590,6 +18912,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 780
     AttackMotion: 1008
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -18636,6 +18959,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
+    ClientAttackMotion: 1632
     DamageMotion: 420
     DamageTaken: 10
     Ai: 21
@@ -20711,6 +21035,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
+    ClientAttackMotion: 1344
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -20769,6 +21094,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 950
     AttackMotion: 2520
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -20814,6 +21140,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1247
     AttackMotion: 768
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 03
     Modes:
@@ -20859,6 +21186,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2413
     AttackMotion: 1248
+    ClientAttackMotion: 96
     DamageMotion: 768
     Ai: 04
     Drops:
@@ -20913,6 +21241,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1543
     AttackMotion: 1632
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -20960,6 +21289,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 857
     AttackMotion: 1056
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -21007,6 +21337,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 912
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -21054,6 +21385,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -21167,6 +21499,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 917
     AttackMotion: 1584
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21261,6 +21594,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
+    ClientAttackMotion: 1632
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21310,6 +21644,7 @@ Body:
     WalkSpeed: 147
     AttackDelay: 516
     AttackMotion: 768
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -21359,6 +21694,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 914
     AttackMotion: 1344
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -21406,6 +21742,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -21449,6 +21786,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -21497,6 +21835,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 741
     AttackMotion: 1536
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -21547,6 +21886,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 854
     AttackMotion: 2016
+    ClientAttackMotion: 720
     DamageMotion: 480
     DamageTaken: 10
     Ai: 10
@@ -21606,6 +21946,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
+    ClientAttackMotion: 1320
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -21654,6 +21995,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1257
     AttackMotion: 528
+    ClientAttackMotion: 1056
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -21698,6 +22040,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 600
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 504
     Ai: 02
     Drops:
@@ -21742,6 +22085,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -21828,6 +22172,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1120
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 04
     Modes:
@@ -21873,6 +22218,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -21924,6 +22270,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 04
     Drops:
@@ -21966,6 +22313,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1152
     AttackMotion: 672
+    ClientAttackMotion: 432
     DamageMotion: 672
     Ai: 01
     Drops:
@@ -23684,6 +24032,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 1056
+    ClientAttackMotion: 1056
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -23733,6 +24082,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 288
+    ClientAttackMotion: 384
     DamageMotion: 144
     DamageTaken: 10
     Ai: 21
@@ -23791,6 +24141,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 13
     Modes:
@@ -23833,6 +24184,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 676
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -23865,6 +24217,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 720
     Ai: 02
     Drops:
@@ -23912,6 +24265,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -23959,6 +24313,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -24719,6 +25074,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -24766,6 +25122,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -24813,6 +25170,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 720
     AttackMotion: 864
+    ClientAttackMotion: 624
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -24858,6 +25216,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 960
     AttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 300
     Ai: 17
     Drops:
@@ -24906,6 +25265,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -24953,6 +25313,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 420
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 21
     Modes:
@@ -25002,6 +25363,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -25050,6 +25412,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -25097,6 +25460,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -25146,6 +25510,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 20
     Drops:
@@ -25195,6 +25560,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 128
     AttackMotion: 1104
+    ClientAttackMotion: 480
     DamageMotion: 240
     DamageTaken: 10
     Ai: 21
@@ -25355,6 +25721,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -25393,6 +25760,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1400
     AttackMotion: 960
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -25434,6 +25802,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 336
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -25473,6 +25842,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -25580,6 +25950,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 540
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -25629,6 +26000,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 336
     AttackMotion: 840
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -25675,6 +26047,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 19
     Modes:
@@ -25727,6 +26100,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 19
     Modes:
@@ -25779,6 +26153,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -25829,6 +26204,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -25879,6 +26255,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -25929,6 +26306,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -26569,6 +26947,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26619,6 +26998,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26669,6 +27049,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26719,6 +27100,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26769,6 +27151,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -26819,6 +27202,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27092,6 +27476,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -27127,6 +27512,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -27164,6 +27550,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -27199,6 +27586,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -27235,6 +27623,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 580
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -27278,6 +27667,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27311,6 +27701,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27358,6 +27749,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27405,6 +27797,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27452,6 +27845,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -27495,6 +27889,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1368
     AttackMotion: 1344
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -27529,6 +27924,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27562,6 +27958,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27609,6 +28006,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27656,6 +28054,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27703,6 +28102,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27750,6 +28150,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -27793,6 +28194,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 360
+    ClientAttackMotion: 240
     DamageMotion: 864
     Ai: 04
     Class: Boss
@@ -27842,6 +28244,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1536
     AttackMotion: 1056
+    ClientAttackMotion: 336
     DamageMotion: 1152
     Ai: 04
     Drops:
@@ -27943,6 +28346,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 504
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -28002,6 +28406,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -28050,6 +28455,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -28098,6 +28504,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 384
     DamageMotion: 360
     DamageTaken: 10
     Ai: 10
@@ -28155,6 +28562,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -28175,6 +28583,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 2496
     DamageMotion: 511
     Ai: 02
     Class: Boss
@@ -28252,6 +28661,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -28299,6 +28709,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 1296
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -28344,6 +28755,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28387,6 +28799,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 1296
     DamageMotion: 1000
     Ai: 04
     Drops:
@@ -28428,6 +28841,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -28471,6 +28885,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 1296
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28513,6 +28928,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 176
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 21
     Drops:
@@ -28560,6 +28976,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28608,6 +29025,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28657,6 +29075,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 420
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28704,6 +29123,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 360
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28754,6 +29174,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 576
     AttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -28806,6 +29227,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -28855,6 +29277,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -28904,6 +29327,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -28953,6 +29377,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -29003,6 +29428,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 115
     AttackMotion: 816
+    ClientAttackMotion: 672
     DamageMotion: 504
     DamageTaken: 10
     Ai: 21
@@ -29213,6 +29639,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 19
     Drops:
@@ -29260,6 +29687,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -29307,6 +29735,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -29346,6 +29775,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 19
     Drops:
@@ -29393,6 +29823,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -29440,6 +29871,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 252
     AttackMotion: 816
+    ClientAttackMotion: 528
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -29481,6 +29913,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 432
     AttackMotion: 936
+    ClientAttackMotion: 240
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -29540,6 +29973,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -29586,6 +30020,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 24
+    ClientAttackMotion: 24
     Drops:
       - Item: Elunium
         Rate: 3
@@ -29925,6 +30360,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 1152
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -29956,6 +30392,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1152
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -30014,6 +30451,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -30063,6 +30501,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -30113,6 +30552,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 17
     Drops:
@@ -30160,6 +30600,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30557,6 +30998,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -30613,6 +31055,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 20
     Modes:
@@ -30662,6 +31105,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 576
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -30709,6 +31153,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -30757,6 +31202,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -31068,6 +31514,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -31103,6 +31550,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 312
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -31140,6 +31588,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 1056
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -31183,6 +31632,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1344
     AttackMotion: 2880
+    ClientAttackMotion: 288
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -31241,6 +31691,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -31290,6 +31741,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -31339,6 +31791,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -31388,6 +31841,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -31437,6 +31891,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 960
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -31488,6 +31943,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 20
     Drops:
@@ -31533,6 +31989,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 660
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -31580,6 +32037,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 432
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 02
     Drops:
@@ -31625,6 +32083,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
     Drops:
@@ -31672,6 +32131,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 370
+    ClientAttackMotion: 300
     DamageMotion: 270
     Ai: 20
     Modes:
@@ -31722,6 +32182,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 432
     AttackMotion: 840
+    ClientAttackMotion: 660
     DamageMotion: 216
     DamageTaken: 10
     Ai: 21
@@ -31780,6 +32241,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 672
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -31827,6 +32289,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 864
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 336
     Ai: 10
     Drops:
@@ -31874,6 +32337,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 600
     DamageMotion: 1000
     Ai: 07
     Drops:
@@ -31921,6 +32385,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Class: Boss
@@ -31965,6 +32430,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -32159,6 +32625,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
+    ClientAttackMotion: 1344
     Ai: 10
     Drops:
       - Item: Ice_Piece
@@ -32400,6 +32867,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -32447,6 +32915,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 864
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -33054,6 +33523,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 250
     AttackDelay: 1320
+    ClientAttackMotion: 648
     DamageMotion: 300
     Ai: 01
     Class: Boss
@@ -33609,6 +34079,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33658,6 +34129,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 212
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -33716,6 +34188,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33820,6 +34293,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -33857,6 +34331,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 26
     Modes:
@@ -33906,6 +34381,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1548
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -33956,6 +34432,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -34000,6 +34477,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 01
     Class: Boss
@@ -34889,6 +35367,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -34936,6 +35415,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 26
     Drops:
@@ -34984,6 +35464,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 19
     Modes:
@@ -35031,6 +35512,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 20
     Modes:
@@ -35107,6 +35589,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 972
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -35150,6 +35633,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 1320
+    ClientAttackMotion: 780
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -35198,6 +35682,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -35313,6 +35798,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 212
     AttackMotion: 504
+    ClientAttackMotion: 252
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -35370,6 +35856,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 1152
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 21
     Class: Event
@@ -35506,6 +35993,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -35537,6 +36025,7 @@ Body:
     WalkSpeed: 320
     AttackDelay: 2304
     AttackMotion: 840
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 01
     Drops:
@@ -35585,6 +36074,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1728
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -35633,6 +36123,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1536
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -35681,6 +36172,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -35728,6 +36220,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1536
     AttackMotion: 504
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -35776,6 +36269,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 864
+    ClientAttackMotion: 648
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -36075,6 +36569,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Class: Event
@@ -36349,6 +36844,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 13
     Class: Boss
@@ -36373,6 +36869,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1906
@@ -36423,6 +36920,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1908
@@ -36443,6 +36941,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Boss
   - Id: 1909
@@ -36461,6 +36960,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36486,6 +36986,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36511,6 +37012,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36536,6 +37038,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36561,6 +37064,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36586,6 +37090,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36611,6 +37116,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36645,6 +37151,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 312
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36742,6 +37249,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36787,6 +37295,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -36830,6 +37339,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 432
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -36875,6 +37385,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -37144,6 +37655,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37189,6 +37701,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37217,6 +37730,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -37239,6 +37753,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Class: Boss
@@ -37275,6 +37790,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Class: Boss
@@ -37296,6 +37812,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37321,6 +37838,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37346,6 +37864,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 96
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37966,6 +38485,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 504
     Ai: 21
     Class: Boss
@@ -38013,6 +38533,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 140
     AttackMotion: 540
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -38591,6 +39112,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 20
     Modes:
@@ -38640,6 +39162,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 336
     AttackMotion: 840
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -38687,6 +39210,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -38734,6 +39258,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 20
     Drops:
@@ -38782,6 +39307,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1840
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 384
     Ai: 20
     Drops:
@@ -38830,6 +39356,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 580
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -38879,6 +39406,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -39034,6 +39562,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
   - Id: 1986
@@ -39065,6 +39594,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Drops:
@@ -39114,6 +39644,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -39165,6 +39696,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 10
     Drops:
@@ -39215,6 +39747,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 400
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -39264,6 +39797,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 660
+    ClientAttackMotion: 300
     DamageMotion: 588
     Ai: 21
     Class: Boss
@@ -39314,6 +39848,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 780
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -39364,6 +39899,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 624
+    ClientAttackMotion: 192
     DamageMotion: 300
     Ai: 03
     Drops:
@@ -39413,6 +39949,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 400
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -39463,6 +40000,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 08
     Modes:
@@ -39514,6 +40052,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 700
     AttackMotion: 600
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -39660,6 +40199,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -39704,6 +40244,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 01
     Class: Boss
@@ -39731,6 +40272,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 01
     Class: Boss
@@ -40163,6 +40705,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 420
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -40205,6 +40748,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackDelay: 24
+    ClientAttackMotion: 24
     Drops:
       - Item: Piece_Of_Egg_Shell
         Rate: 2500
@@ -40240,6 +40784,7 @@ Body:
     WalkSpeed: 290
     AttackDelay: 1426
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -40287,6 +40832,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 504
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -40330,6 +40876,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 792
     AttackMotion: 540
+    ClientAttackMotion: 420
     DamageMotion: 420
     Ai: 20
     Drops:
@@ -40373,6 +40920,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 420
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -40420,6 +40968,7 @@ Body:
     WalkSpeed: 290
     AttackDelay: 504
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
     Drops:
@@ -40465,6 +41014,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 576
     AttackMotion: 660
+    ClientAttackMotion: 300
     DamageMotion: 420
     Ai: 13
     Drops:
@@ -40504,6 +41054,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 360
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -40544,6 +41095,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1596
     AttackMotion: 1620
+    ClientAttackMotion: 576
     DamageMotion: 864
     Ai: 21
     Class: Boss
@@ -40594,6 +41146,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 19
     Modes:
@@ -40645,6 +41198,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 480
     DamageMotion: 540
     Ai: 20
     Drops:
@@ -41014,6 +41568,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       Detector: true
@@ -42090,6 +42645,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 240
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -42147,6 +42703,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -42194,6 +42751,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 04
     Drops:
@@ -42241,6 +42799,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -42291,6 +42850,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1248
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -42335,6 +42895,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 960
     AttackMotion: 1440
+    ClientAttackMotion: 300
     DamageMotion: 960
     Ai: 03
     Drops:
@@ -42378,6 +42939,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 528
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -42419,6 +42981,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Ai: 21
     Class: Boss
@@ -42554,6 +43117,7 @@ Body:
     WalkSpeed: 177
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 1152
     DamageMotion: 288
     Class: Boss
   - Id: 2080
@@ -42583,6 +43147,7 @@ Body:
     WalkSpeed: 177
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 1152
     DamageMotion: 288
     Class: Boss
     Modes:
@@ -42687,6 +43252,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 03
     Modes:
@@ -42737,6 +43303,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 336
     AttackMotion: 360
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 03
     Modes:
@@ -42786,6 +43353,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -42837,6 +43405,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 588
     AttackMotion: 768
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -42890,6 +43459,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 864
     AttackMotion: 1000
+    ClientAttackMotion: 300
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -42942,6 +43512,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Modes:
       Detector: true
@@ -42977,6 +43548,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43012,6 +43584,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43047,6 +43620,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43086,6 +43660,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 360
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 600
     Ai: 04
     Modes:
@@ -43135,6 +43710,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -44639,6 +45215,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -44689,6 +45266,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 864
     AttackMotion: 1056
+    ClientAttackMotion: 360
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -44734,6 +45312,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -44777,6 +45356,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 384
     AttackMotion: 792
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -44808,6 +45388,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 192
     AttackMotion: 192
+    ClientAttackMotion: 192
     DamageMotion: 576
     Modes:
       IgnoreMagic: true
@@ -44841,6 +45422,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 300
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -44880,6 +45462,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 576
     AttackMotion: 1140
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -44908,6 +45491,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 768
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -44930,6 +45514,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 1248
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45215,6 +45800,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 360
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -45262,6 +45848,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -45305,6 +45892,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -45346,6 +45934,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 2304
+    ClientAttackMotion: 1080
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -45391,6 +45980,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 576
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -45436,6 +46026,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -45610,6 +46201,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -45660,6 +46252,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 336
     AttackMotion: 360
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -45710,6 +46303,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 420
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -45760,6 +46354,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 588
     AttackMotion: 768
+    ClientAttackMotion: 1248
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -45811,6 +46406,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 864
     AttackMotion: 1000
+    ClientAttackMotion: 300
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -45868,6 +46464,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -45904,6 +46501,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -45939,6 +46537,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -45974,6 +46573,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46969,6 +47569,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 384
     AttackMotion: 720
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 10
     Class: Boss
@@ -47007,6 +47608,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 576
     AttackMotion: 2160
+    ClientAttackMotion: 2160
     DamageMotion: 504
     Ai: 20
     Class: Boss
@@ -47048,6 +47650,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 432
     AttackMotion: 720
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 10
     Class: Boss
@@ -47090,6 +47693,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 576
     AttackMotion: 1584
+    ClientAttackMotion: 252
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -47197,6 +47801,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 768
     AttackMotion: 1224
+    ClientAttackMotion: 420
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -47245,6 +47850,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 720
     Ai: 21
     Class: Boss
@@ -47293,6 +47899,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1536
     AttackMotion: 1296
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 02
     Drops:
@@ -47355,6 +47962,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 792
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -47405,6 +48013,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -47463,6 +48072,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1008
     AttackMotion: 936
+    ClientAttackMotion: 936
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -47510,6 +48120,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 792
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -47584,6 +48195,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 576
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 240
     Ai: 10
     Class: Boss
@@ -47650,6 +48262,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 432
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -47737,6 +48350,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 02
     Drops:
@@ -48142,6 +48756,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48191,6 +48806,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48240,6 +48856,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -48290,6 +48907,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48339,6 +48957,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Modes:
@@ -48390,6 +49009,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48439,6 +49059,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -49326,6 +49947,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 2688
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -49380,6 +50002,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 1380
+    ClientAttackMotion: 324
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -49437,6 +50060,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1600
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -49484,6 +50108,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1344
     AttackMotion: 2592
+    ClientAttackMotion: 432
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -49540,6 +50165,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 880
     AttackMotion: 1224
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -49588,6 +50214,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 900
     AttackMotion: 792
+    ClientAttackMotion: 504
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -49645,6 +50272,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -49693,6 +50321,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 900
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -49749,6 +50378,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1576
     AttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -51144,6 +51774,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1568
     AttackMotion: 432
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51187,6 +51818,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1424
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51230,6 +51862,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 280
     AttackMotion: 720
+    ClientAttackMotion: 720
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51279,6 +51912,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1664
     AttackMotion: 336
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -51326,6 +51960,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1064
     AttackMotion: 936
+    ClientAttackMotion: 936
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51367,6 +52002,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 496
     AttackMotion: 504
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51408,6 +52044,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 424
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51449,6 +52086,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1328
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -51587,6 +52225,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1424
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -52628,6 +53267,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 128
     AttackMotion: 1104
+    ClientAttackMotion: 2208
     DamageMotion: 240
     Ai: 02
     Class: Boss
@@ -52679,6 +53319,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -52728,6 +53369,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 720
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -52827,6 +53469,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -52904,6 +53547,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -52985,6 +53629,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 720
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -53067,6 +53712,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 854
     AttackMotion: 2016
+    ClientAttackMotion: 1260
     DamageMotion: 480
     DamageTaken: 10
     Ai: 10
@@ -53126,6 +53772,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 1056
+    ClientAttackMotion: 1056
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53169,6 +53816,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53214,6 +53862,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 720
+    ClientAttackMotion: 720
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -53259,6 +53908,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 960
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53303,6 +53953,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 1728
+    ClientAttackMotion: 1728
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53346,6 +53997,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 150
     AttackMotion: 3456
+    ClientAttackMotion: 3456
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53389,6 +54041,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 150
     AttackMotion: 4032
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53432,6 +54085,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 100
     AttackMotion: 2304
+    ClientAttackMotion: 2304
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53475,6 +54129,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 480
     AttackMotion: 1536
+    ClientAttackMotion: 1536
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53719,6 +54374,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 1824
     DamageMotion: 420
     Ai: 01
     Modes:
@@ -53763,6 +54419,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 768
     DamageMotion: 420
     Ai: 01
     Modes:
@@ -53842,6 +54499,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -53978,6 +54636,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2208
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -54018,6 +54677,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -54060,6 +54720,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -54105,6 +54766,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 360
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -54229,6 +54891,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54273,6 +54936,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54318,6 +54982,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54363,6 +55028,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54408,6 +55074,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54453,6 +55120,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54498,6 +55166,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54543,6 +55212,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54588,6 +55258,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54633,6 +55304,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54678,6 +55350,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54723,6 +55396,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54768,6 +55442,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55340,6 +56015,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -55391,6 +56067,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -55440,6 +56117,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55480,6 +56158,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55520,6 +56199,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55560,6 +56240,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55600,6 +56281,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55640,6 +56322,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -55680,6 +56363,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -56516,6 +57200,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 350
     AttackMotion: 864
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -56563,6 +57248,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 350
     AttackMotion: 768
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -56609,6 +57295,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 576
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -56659,6 +57346,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 312
     AttackMotion: 1200
+    ClientAttackMotion: 300
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -57148,6 +57836,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -57197,6 +57886,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57247,6 +57937,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57282,6 +57973,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackDelay: 384
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -57321,6 +58013,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57372,6 +58065,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57423,6 +58117,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57474,6 +58169,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -57619,6 +58315,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 150
     AttackDelay: 24
+    ClientAttackMotion: 24
     Modes:
       Detector: true
       IgnoreMagic: true
@@ -57662,6 +58359,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -57707,6 +58405,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1276
     AttackMotion: 792
+    ClientAttackMotion: 1344
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -57754,6 +58453,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1384
     AttackMotion: 792
+    ClientAttackMotion: 960
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -57801,6 +58501,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1452
     AttackMotion: 792
+    ClientAttackMotion: 960
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -57949,6 +58650,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -57984,6 +58686,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58021,6 +58724,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58056,6 +58760,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58091,6 +58796,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 950
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58126,6 +58832,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 648
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58161,6 +58868,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58196,6 +58904,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58231,6 +58940,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58266,6 +58976,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58301,6 +59012,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58336,6 +59048,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58371,6 +59084,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58406,6 +59120,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -58443,6 +59158,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 720
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -74024,6 +74740,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 1056
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -74073,6 +74790,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -74120,6 +74838,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 1344
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -74169,6 +74888,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 1920
     DamageMotion: 660
     Ai: 09
     Drops:
@@ -74216,6 +74936,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 2304
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -74265,6 +74986,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 2496
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -74343,6 +75065,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 2496
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -74839,6 +75562,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 800
     AttackMotion: 750
+    ClientAttackMotion: 300
     DamageMotion: 300
   - Id: 2938
     AegisName: MM_MAGIC_SEAL
@@ -74867,6 +75591,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1000
     AttackMotion: 1000
+    ClientAttackMotion: 936
     DamageMotion: 1000
   - Id: 2939
     AegisName: MM_EVIL_SHADOW1
@@ -74895,6 +75620,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 864
     DamageMotion: 500
     Ai: 10
     Modes:
@@ -74931,6 +75657,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 600
     Ai: 10
     Modes:
@@ -74967,6 +75694,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1800
     AttackMotion: 780
+    ClientAttackMotion: 1632
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -75003,6 +75731,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 240
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -75037,6 +75766,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackMotion: 1000
+    ClientAttackMotion: 384
     Class: Battlefield
     Modes:
       Detector: true
@@ -75477,6 +76207,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 420
+    ClientAttackMotion: 864
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -75511,6 +76242,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackMotion: 1000
+    ClientAttackMotion: 384
     Class: Battlefield
     Modes:
       Detector: true
@@ -75625,6 +76357,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 917
     AttackMotion: 1584
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -75722,6 +76455,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 03
     Modes:
@@ -75763,6 +76497,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 1296
+    ClientAttackMotion: 468
     DamageMotion: 432
     Ai: 05
     Modes:
@@ -75794,6 +76529,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 864
     DamageMotion: 432
     Ai: 03
     Modes:
@@ -75837,6 +76573,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -75888,6 +76625,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 741
     AttackMotion: 1536
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -75935,6 +76673,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 09
     Modes:
@@ -75982,6 +76721,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 20
     Modes:
@@ -76028,6 +76768,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 1056
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -76114,6 +76855,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2612
     AttackMotion: 824
+    ClientAttackMotion: 336
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76145,6 +76887,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 384
+    ClientAttackMotion: 960
     DamageMotion: 288
     Ai: 10
     Class: Boss
@@ -76185,6 +76928,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 2700
     AttackMotion: 384
+    ClientAttackMotion: 780
     DamageMotion: 288
     Ai: 10
     Class: Boss
@@ -76230,6 +76974,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 2612
     AttackMotion: 824
+    ClientAttackMotion: 456
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76262,6 +77007,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2612
     AttackMotion: 824
+    ClientAttackMotion: 192
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76294,6 +77040,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 824
+    ClientAttackMotion: 672
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76326,6 +77073,7 @@ Body:
     WalkSpeed: 600
     AttackDelay: 300
     AttackMotion: 824
+    ClientAttackMotion: 384
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76358,6 +77106,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 824
+    ClientAttackMotion: 480
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76390,6 +77139,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 824
+    ClientAttackMotion: 288
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76451,6 +77201,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 2000
     AttackMotion: 824
+    ClientAttackMotion: 384
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -76485,6 +77236,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 504
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76531,6 +77283,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 252
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76577,6 +77330,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76623,6 +77377,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 864
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76669,6 +77424,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 180
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76715,6 +77471,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 432
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76761,6 +77518,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 768
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76807,6 +77565,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 480
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76853,6 +77612,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 696
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -76901,6 +77661,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -76937,6 +77698,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 648
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -76972,6 +77734,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1540
     AttackMotion: 720
+    ClientAttackMotion: 324
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -77009,6 +77772,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 1632
     DamageMotion: 396
     Ai: 04
     Drops:
@@ -77048,6 +77812,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 4608
     DamageMotion: 288
     Modes:
       IgnoreMagic: true
@@ -77079,6 +77844,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 480
     DamageMotion: 768
     Ai: 25
     Drops:
@@ -77150,6 +77916,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 864
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -77427,6 +78194,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 240
     DamageMotion: 1
     Class: Event
     Modes:
@@ -77547,6 +78315,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 676
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -77592,6 +78361,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 1248
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -77637,6 +78407,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 672
+    ClientAttackMotion: 144
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -77682,6 +78453,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 1248
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -77728,6 +78500,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 2592
+    ClientAttackMotion: 2592
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -77775,6 +78548,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 100
     AttackMotion: 576
+    ClientAttackMotion: 1152
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -78187,6 +78961,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 420
     DamageMotion: 768
     Ai: 21
     Class: Boss
@@ -78219,6 +78994,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 360
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -78326,6 +79102,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 460
+    ClientAttackMotion: 540
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -78361,6 +79138,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 750
     AttackMotion: 510
+    ClientAttackMotion: 420
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -78677,6 +79455,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2592
+    ClientAttackMotion: 2592
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -78721,6 +79500,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2592
+    ClientAttackMotion: 2592
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -79088,6 +79868,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 2016
+    ClientAttackMotion: 2016
     DamageMotion: 672
     Ai: 26
     Class: Boss
@@ -79136,6 +79917,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 676
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -79180,6 +79962,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 1056
+    ClientAttackMotion: 1056
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -79226,6 +80009,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 816
+    ClientAttackMotion: 816
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -79270,6 +80054,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -79361,6 +80146,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 768
     Ai: 10
     Modes:
@@ -79399,6 +80185,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 1536
     DamageMotion: 384
     Ai: 10
     Modes:
@@ -79437,6 +80224,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 660
     Ai: 10
     Modes:
@@ -79475,6 +80263,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -79617,6 +80406,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 360
     Drops:
       - Item: White_Slim_Potion
@@ -80034,6 +80824,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 500
+    ClientAttackMotion: 1344
     DamageMotion: 300
     Ai: 10
     Class: Boss
@@ -80285,6 +81076,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 1152
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -80328,6 +81120,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 1248
     DamageMotion: 360
     Ai: 07
     Modes:
@@ -80367,6 +81160,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 7680
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -80409,6 +81203,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -80645,6 +81440,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -80696,6 +81492,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -80745,6 +81542,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -80794,6 +81592,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -80845,6 +81644,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -80896,6 +81696,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81446,6 +82247,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81497,6 +82299,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81548,6 +82351,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81599,6 +82403,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81650,6 +82455,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81701,6 +82507,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81752,6 +82559,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82382,6 +83190,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 720
+    ClientAttackMotion: 720
     DamageMotion: 360
     Ai: 10
     Modes:
@@ -82428,6 +83237,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 660
     Ai: 02
     Modes:
@@ -82478,6 +83288,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 1920
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -82528,6 +83339,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2400
     AttackMotion: 500
+    ClientAttackMotion: 2304
     DamageMotion: 400
     Ai: 10
     Modes:
@@ -82577,6 +83389,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 600
     Ai: 10
     Modes:
@@ -82622,6 +83435,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 1152
     DamageMotion: 500
     Ai: 10
     Modes:
@@ -82659,6 +83473,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 3000
     AttackMotion: 600
+    ClientAttackMotion: 1152
     DamageMotion: 550
     Ai: 01
     Class: Battlefield
@@ -82692,6 +83507,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -82743,6 +83559,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2050
     AttackMotion: 500
+    ClientAttackMotion: 456
     DamageMotion: 660
     Ai: 10
     Modes:
@@ -82775,6 +83592,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 2155
     AttackMotion: 960
+    ClientAttackMotion: 912
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -85376,7 +86194,7 @@ Body:
         StealProtected: true
   - Id: 3431
     AegisName: MIN_G_RODA_FROG
-    Name: Roda Frog 
+    Name: Roda Frog
     Level: 100
     Hp: 100000
     Attack: 632
@@ -85405,7 +86223,7 @@ Body:
       Aggressive: true
   - Id: 3432
     AegisName: MIN_G_WOLF
-    Name: Wolf 
+    Name: Wolf
     Level: 100
     Hp: 100000
     Attack: 647
@@ -85699,6 +86517,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -85742,6 +86561,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1604
     AttackMotion: 1344
+    ClientAttackMotion: 1344
     DamageMotion: 2016
     Ai: 17
     Drops:
@@ -85789,6 +86609,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 1344
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -85832,6 +86653,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -85872,6 +86694,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1440
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -85912,6 +86735,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -85950,6 +86774,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 1536
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -85990,6 +86815,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 1536
     DamageMotion: 480
     Ai: 04
   - Id: 3450
@@ -86020,6 +86846,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2000
     AttackMotion: 1536
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -86074,6 +86901,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 600
     DamageMotion: 500
     Ai: 04
     Modes:
@@ -86123,6 +86951,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 768
     AttackMotion: 2784
+    ClientAttackMotion: 2784
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -86175,6 +87004,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
   - Id: 3455
@@ -86197,6 +87027,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -86265,6 +87096,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 960
     AttackMotion: 1632
+    ClientAttackMotion: 1632
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -86322,6 +87154,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -86368,6 +87201,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2112
     AttackMotion: 1152
+    ClientAttackMotion: 2112
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -87049,6 +87883,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 72
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -87093,6 +87928,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Drops:
@@ -87138,6 +87974,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -87185,6 +88022,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 792
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -87234,6 +88072,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -87281,6 +88120,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -87322,6 +88162,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -87368,6 +88209,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 864
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -87413,6 +88255,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 960
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -87460,6 +88303,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -87507,6 +88351,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 72
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -87553,6 +88398,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -87600,6 +88446,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 864
     AttackMotion: 1056
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -87684,7 +88531,7 @@ Body:
       - Item: Black_Mask
         Rate: 3000
       - Item: Silver_Bracelet
-        Rate: 3000  
+        Rate: 3000
       - Item: Center_Potion_B
         Rate: 100
       - Item: White_Potion_B
@@ -88664,6 +89511,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -88723,6 +89571,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 780
+    ClientAttackMotion: 1152
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -88944,6 +89793,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 1268
+    ClientAttackMotion: 1440
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -89001,6 +89851,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
   - Id: 3630
@@ -89030,6 +89881,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -89061,6 +89913,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 1620
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -89109,6 +89962,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 1152
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -89158,6 +90012,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 672
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -89220,6 +90075,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 09
     Modes:
@@ -90589,6 +91445,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 864
     DamageMotion: 180
     Ai: 04
     Modes:
@@ -90620,6 +91477,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1024
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 13
 #  - Id: 3671
@@ -90781,6 +91639,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 900
     AttackMotion: 770
+    ClientAttackMotion: 420
     DamageMotion: 550
     Ai: 04
     Drops:
@@ -90826,6 +91685,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1200
     AttackMotion: 672
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -90871,6 +91731,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 800
     AttackMotion: 420
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -90916,6 +91777,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 750
     AttackMotion: 400
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 01
     Modes:
@@ -90965,6 +91827,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1100
     AttackMotion: 650
+    ClientAttackMotion: 528
     DamageMotion: 500
     Ai: 04
     Drops:
@@ -91013,6 +91876,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 900
     AttackMotion: 1000
+    ClientAttackMotion: 1152
     DamageMotion: 500
     DamageTaken: 10
     Ai: 04
@@ -91056,6 +91920,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -91083,6 +91948,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 504
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -91114,6 +91980,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 900
     AttackMotion: 770
+    ClientAttackMotion: 420
     DamageMotion: 550
     Ai: 04
   - Id: 3745
@@ -91141,6 +92008,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1200
     AttackMotion: 672
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
   - Id: 3746
@@ -91168,6 +92036,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 800
     AttackMotion: 420
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
   - Id: 3747
@@ -91199,6 +92068,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2050
     AttackMotion: 500
+    ClientAttackMotion: 420
     DamageMotion: 660
     Ai: 04
     Drops:
@@ -91246,6 +92116,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 600
     Ai: 04
     Drops:
@@ -91293,6 +92164,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 04
     Drops:
@@ -91340,6 +92212,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 19
     Drops:
@@ -91385,6 +92258,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -91432,6 +92306,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 924
     AttackMotion: 912
+    ClientAttackMotion: 912
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -91475,6 +92350,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 456
     DamageMotion: 504
     Ai: 19
     Drops:
@@ -91524,6 +92400,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1826
     AttackMotion: 816
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 19
     Modes:
@@ -91565,6 +92442,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackMotion: 1
+    ClientAttackMotion: 768
     Drops:
       - Item: Alchol
         Rate: 50
@@ -91609,6 +92487,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 19
     Class: Boss
@@ -91663,6 +92542,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     Ai: 19
     Class: Boss
@@ -91719,6 +92599,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 19
     Class: Boss
@@ -91774,6 +92655,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -91819,6 +92701,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -91864,6 +92747,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -91909,6 +92793,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 912
     AttackMotion: 2112
+    ClientAttackMotion: 360
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -91956,6 +92841,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -92003,6 +92889,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 768
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -92050,6 +92937,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1450
     AttackMotion: 864
+    ClientAttackMotion: 864
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -92224,6 +93112,7 @@ Body:
     WalkSpeed: 440
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Modes:
@@ -92265,6 +93154,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 370
+    ClientAttackMotion: 300
     DamageMotion: 270
     Ai: 20
     Modes:
@@ -92310,6 +93200,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 660
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -92353,6 +93244,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
     Drops:
@@ -92395,6 +93287,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
+    ClientAttackMotion: 1344
     Drops:
       - Item: Frozen_PieceOfRock
         Rate: 200
@@ -92448,6 +93341,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 432
     AttackMotion: 840
+    ClientAttackMotion: 660
     DamageMotion: 216
     Ai: 21
     Class: Boss
@@ -92490,6 +93384,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 96
     DamageMotion: 500
     Modes:
       NORANDOMWALK: true
@@ -92517,6 +93412,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 96
     DamageMotion: 500
     Modes:
       NORANDOMWALK: true
@@ -92557,6 +93453,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 504
     Ai: 21
     Drops:
@@ -92606,6 +93503,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 483
+    ClientAttackMotion: 720
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -92655,6 +93553,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 540
     DamageMotion: 672
     Ai: 21
     Drops:
@@ -92704,6 +93603,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1440
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -92753,6 +93653,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1296
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -92802,6 +93703,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -94063,6 +94965,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 300
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Modes:
       NoRandomWalk: true
@@ -94095,6 +94998,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 660
     DamageMotion: 624
     Ai: 07
     Drops:
@@ -94144,6 +95048,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 632
     AttackMotion: 518
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -94193,6 +95098,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 900
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -94240,6 +95146,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 288
+    ClientAttackMotion: 384
     DamageMotion: 144
     Ai: 21
     Class: Boss
@@ -94292,6 +95199,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2413
     AttackMotion: 1248
+    ClientAttackMotion: 96
     DamageMotion: 768
     Ai: 04
     Drops:
@@ -94341,6 +95249,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 857
     AttackMotion: 1056
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 05
     Drops:
@@ -94390,6 +95299,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 912
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -94439,6 +95349,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 288
+    ClientAttackMotion: 288
     DamageMotion: 144
     Ai: 21
     Class: Boss
@@ -94688,6 +95599,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 128
     AttackMotion: 1004
+    ClientAttackMotion: 960
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -94771,6 +95683,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -94913,6 +95826,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 872
     AttackMotion: 1044
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -94953,6 +95867,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 872
     AttackMotion: 1044
+    ClientAttackMotion: 540
     DamageMotion: 432
     Class: Boss
     Ai: 21
@@ -96370,6 +97285,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 144
+    ClientAttackMotion: 528
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -96932,6 +97848,7 @@ Body:
   - Id: 20543
     AegisName: MD_ED_M_SCIENCE
     Name: MD_ED_M_SCIENCE
+    ClientAttackMotion: 1872
 #  - Id: 20544
 #    AegisName: MINERAL_R_MJ
 #  - Id: 20545
@@ -98717,6 +99634,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 432
     DamageMotion: 1152
     Ai: 04
     Drops:
@@ -98765,6 +99683,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1200
     AttackMotion: 1200
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -98813,6 +99732,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 624
     AttackMotion: 624
+    ClientAttackMotion: 192
     DamageMotion: 144
     Ai: 04
     Drops:
@@ -98861,6 +99781,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 540
     Ai: 04
     Drops:
@@ -100220,6 +101141,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 96
     DamageMotion: 1
     Ai: 06
     Class: Battlefield
@@ -100519,6 +101441,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 522
     AttackMotion: 1044
+    ClientAttackMotion: 756
     DamageMotion: 684
     Ai: 04
     Drops:
@@ -100563,6 +101486,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -101261,6 +102185,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 550
     AttackMotion: 1056
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -101306,6 +102231,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 1155
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -101351,6 +102277,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 480
     AttackMotion: 970
+    ClientAttackMotion: 768
     DamageMotion: 770
     Ai: 04
     Drops:
@@ -101396,6 +102323,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1070
     AttackMotion: 1512
+    ClientAttackMotion: 936
     DamageMotion: 485
     Ai: 04
     Drops:
@@ -101443,6 +102371,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 708
     AttackMotion: 1225
+    ClientAttackMotion: 504
     DamageMotion: 675
     Ai: 04
     Drops:
@@ -101488,6 +102417,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 168
     AttackMotion: 965
+    ClientAttackMotion: 576
     DamageMotion: 578
     Ai: 04
     Drops:
@@ -101535,6 +102465,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 335
     AttackMotion: 1250
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -101582,6 +102513,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 276
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -101629,6 +102561,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 168
     AttackMotion: 1154
+    ClientAttackMotion: 528
     DamageMotion: 865
     Ai: 04
     Drops:
@@ -101676,6 +102609,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 970
     Ai: 04
     Drops:
@@ -101721,6 +102655,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 422
     AttackMotion: 870
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -101923,6 +102858,7 @@ Body:
     WalkSpeed: 210
     AttackDelay: 360
     AttackMotion: 1250
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -102028,6 +102964,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 300
     Ai: 20
   - Id: 20849
@@ -102053,6 +102990,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 300
     Ai: 20
   - Id: 20850
@@ -102078,6 +103016,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 840
     DamageMotion: 300
     Ai: 20
   - Id: 20851
@@ -102103,6 +103042,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 1080
     DamageMotion: 300
     Ai: 20
 #  - Id: 20856
@@ -102262,6 +103202,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 700
     AttackMotion: 1152  # TODO
+    ClientAttackMotion: 384
     DamageMotion: 300
     Ai: 04
     Drops:
@@ -102311,6 +103252,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -102360,6 +103302,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -102409,6 +103352,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -102458,6 +103402,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -102507,6 +103452,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 540
     AttackMotion: 1080
+    ClientAttackMotion: 480
     DamageMotion: 768
     Ai: 04
     Drops:
@@ -102556,6 +103502,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 900
     AttackMotion: 1800
+    ClientAttackMotion: 792
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -102605,6 +103552,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 3072
+    ClientAttackMotion: 1920
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -102652,6 +103600,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1440
     AttackMotion: 2880
+    ClientAttackMotion: 864
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -102849,6 +103798,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 924
     AttackMotion: 1848
+    ClientAttackMotion: 1176
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -102898,6 +103848,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 674
     AttackMotion: 1248
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -102947,6 +103898,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1332
     AttackMotion: 2664
+    ClientAttackMotion: 936
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -102996,6 +103948,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 672
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -103043,6 +103996,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 1536
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -103090,6 +104044,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 672
     AttackMotion: 1344
+    ClientAttackMotion: 1056
     DamageMotion: 768
     DamageTaken: 10
     Ai: 21
@@ -103137,6 +104092,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 238
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -103184,6 +104140,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -103233,6 +104190,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 336
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -103282,6 +104240,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 624
     AttackMotion: 1248
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -103331,6 +104290,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -103380,6 +104340,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 510
     AttackMotion: 1020
+    ClientAttackMotion: 720
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -103429,6 +104390,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 792
     AttackMotion: 1584
+    ClientAttackMotion: 1152
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -103478,6 +104440,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 768
     AttackMotion: 1536
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -103527,6 +104490,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 517
     AttackMotion: 1134
+    ClientAttackMotion: 864
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -104737,6 +105701,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 04
   - Id: 21293
@@ -104762,6 +105727,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 252
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
   - Id: 21294
@@ -104787,6 +105753,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 04
   - Id: 21295
@@ -104816,6 +105783,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 936
     Ai: 04
     Drops:
@@ -104859,6 +105827,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 432
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1512
     Ai: 10
     Drops:
@@ -104900,6 +105869,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 936
     AttackMotion: 1872
+    ClientAttackMotion: 1872
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -104943,6 +105913,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 571
     AttackMotion: 1152
+    ClientAttackMotion: 648
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -104988,6 +105959,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 792
     AttackMotion: 1584
+    ClientAttackMotion: 648
     DamageMotion: 504
     Ai: 02
     Drops:
@@ -105031,6 +106003,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -105080,6 +106053,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 420
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -105132,6 +106106,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 760
     AttackMotion: 1080
+    ClientAttackMotion: 792
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -105173,6 +106148,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -105214,6 +106190,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 360
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -105255,6 +106232,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 506
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 504
     Ai: 07
     Drops:
@@ -105298,6 +106276,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 1512
     Ai: 04
     Drops:
@@ -105337,6 +106316,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 792
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -105374,6 +106354,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
   - Id: 21309
@@ -105401,6 +106382,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 648
     AttackMotion: 648
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
   - Id: 21310
@@ -105428,6 +106410,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 648
     AttackMotion: 648
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 04
   - Id: 21311
@@ -105455,6 +106438,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 648
     AttackMotion: 648
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 04
   - Id: 21312
@@ -105482,6 +106466,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 432
+    ClientAttackMotion: 1152
     DamageMotion: 360
     Ai: 04
   - Id: 21313
@@ -105509,6 +106494,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 04
   - Id: 21314
@@ -105536,6 +106522,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 1440
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -105580,6 +106567,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 736
     AttackMotion: 1104
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -105614,6 +106602,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 1440
+    ClientAttackMotion: 2880
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -105648,6 +106637,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 736
     AttackMotion: 1104
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -105682,6 +106672,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 672
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -105715,6 +106706,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 05
   - Id: 21320
@@ -105819,6 +106811,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 540
     AttackMotion: 1080
+    ClientAttackMotion: 660
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -105864,6 +106857,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -106145,6 +107139,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -106192,6 +107187,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1288
     AttackMotion: 648
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -106239,6 +107235,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -106282,6 +107279,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -106329,6 +107327,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 96
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -106367,6 +107366,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 768
     DamageMotion: 1
     Ai: 06
     Drops:
@@ -106414,6 +107414,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1848
     AttackMotion: 1296
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -106461,6 +107462,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -106506,6 +107508,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -106553,6 +107556,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 864
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 480
     Ai: 21
     Drops:

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -222,7 +222,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 03
     Modes:
@@ -271,7 +271,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -381,7 +381,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 1
     Modes:
       Detector: true
@@ -429,7 +429,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 03
     Drops:
@@ -523,6 +523,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -661,7 +662,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -707,7 +708,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -755,6 +756,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 05
     Drops:
@@ -1090,7 +1092,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -1314,6 +1316,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -1507,6 +1510,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -1551,7 +1555,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
-    ClientAttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -1697,7 +1701,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
-    ClientAttackMotion: 456
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -1915,7 +1919,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
-    ClientAttackMotion: 1008
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
     Drops:
@@ -2009,6 +2013,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 07
     Modes:
@@ -2234,6 +2239,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -2275,7 +2281,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 701
     AttackMotion: 1
-    ClientAttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 1
     Modes:
       Detector: true
@@ -2323,7 +2329,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2371,7 +2377,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
-    ClientAttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -2418,7 +2424,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 768
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2468,7 +2474,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -2518,6 +2524,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 07
     Modes:
@@ -2567,6 +2574,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -2662,7 +2670,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -2709,7 +2717,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
-    ClientAttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -2756,7 +2764,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
-    ClientAttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -2807,7 +2815,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 300
     DamageTaken: 10
     Ai: 21
@@ -2864,7 +2872,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1260
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -2912,7 +2920,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -3343,7 +3351,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -3650,7 +3658,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -3690,7 +3698,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3734,7 +3742,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3778,7 +3786,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3822,7 +3830,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3866,7 +3874,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3911,7 +3919,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 2208
+    ClientAttackMotion: 2016
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3955,7 +3963,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -3999,7 +4007,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -4052,7 +4060,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 720
     DamageMotion: 480
     DamageTaken: 10
     Ai: 07
@@ -4112,7 +4120,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
-    ClientAttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     DamageTaken: 10
     Ai: 21
@@ -4171,7 +4179,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 600
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -4610,7 +4618,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 768
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -5043,7 +5051,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
-    ClientAttackMotion: 180
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -5092,7 +5100,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 252
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -6778,7 +6786,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
-    ClientAttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -7969,7 +7977,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -8738,6 +8746,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 0
     DamageMotion: 1
     Class: Event
     Modes:
@@ -8775,6 +8784,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -8814,6 +8824,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -8857,6 +8868,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Drops:
       - Item: Sparkling_Dust
@@ -8893,7 +8905,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -8939,7 +8951,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -9436,7 +9448,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1252
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 476
     Ai: 13
     Modes:
@@ -9535,7 +9547,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 13
     Drops:
@@ -10183,7 +10195,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -10231,7 +10243,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
-    ClientAttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 19
     Drops:
@@ -10436,6 +10448,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -10480,6 +10493,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -10829,6 +10843,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -10872,6 +10887,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 768
     DamageMotion: 1
     Modes:
       Detector: true
@@ -10918,6 +10934,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1220
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 288
     Ai: 01
     Modes:
@@ -10954,6 +10971,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -11037,6 +11055,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -11082,6 +11101,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -11123,6 +11143,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 672
     DamageMotion: 1
     Drops:
       - Item: Phracon
@@ -11163,6 +11184,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -11210,6 +11232,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -11257,6 +11280,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -11302,6 +11326,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -11344,6 +11369,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -11437,7 +11463,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
-    ClientAttackMotion: 1260
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -11679,7 +11705,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
-    ClientAttackMotion: 1296
+    ClientAttackMotion: 1224
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -11727,7 +11753,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -13017,7 +13043,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 502
     AttackMotion: 1999
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -13162,7 +13188,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1264
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -13211,7 +13237,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
-    ClientAttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 21
     Modes:
@@ -13567,6 +13593,7 @@ Body:
     WalkSpeed: 265
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 624
     DamageMotion: 384
     Ai: 12
     Class: Guardian
@@ -13681,7 +13708,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
-    ClientAttackMotion: 216
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -13730,7 +13757,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -13778,7 +13805,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 600
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 1728
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -13928,7 +13955,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -14076,7 +14103,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -14126,7 +14153,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
-    ClientAttackMotion: 1248
+    ClientAttackMotion: 1056
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -14275,7 +14302,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
-    ClientAttackMotion: 5472
+    ClientAttackMotion: 5280
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -14325,7 +14352,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -14475,7 +14502,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1260
     AttackMotion: 230
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -14523,7 +14550,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1276
     AttackMotion: 576
-    ClientAttackMotion: 120
+    ClientAttackMotion: 360
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -14572,7 +14599,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 1008
-    ClientAttackMotion: 2688
+    ClientAttackMotion: 2496
     DamageMotion: 840
     Ai: 21
     Drops:
@@ -14668,7 +14695,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 1728
     DamageMotion: 780
     Ai: 21
     Drops:
@@ -14825,7 +14852,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 21
     Drops:
@@ -14971,7 +14998,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -15069,7 +15096,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1296
+    ClientAttackMotion: 1200
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -16557,7 +16584,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1000
     AttackMotion: 900
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 540
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -16778,7 +16805,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1460
     AttackMotion: 960
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -17266,7 +17293,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -17950,7 +17977,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
   - Id: 1395
@@ -17966,7 +17993,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -18005,7 +18032,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -18044,7 +18071,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -18083,7 +18110,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -18244,7 +18271,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -18391,7 +18418,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -18648,7 +18675,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -18955,7 +18982,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 288
     DamageMotion: 420
     DamageTaken: 10
     Ai: 21
@@ -19011,6 +19038,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
   - Id: 1420
@@ -19038,6 +19066,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 576
     Ai: 04
   - Id: 1421
@@ -19065,6 +19094,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -19094,6 +19124,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -19123,6 +19154,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
   - Id: 1424
@@ -19152,6 +19184,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1425
@@ -19179,6 +19212,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 04
   - Id: 1426
@@ -19206,6 +19240,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 04
   - Id: 1427
@@ -19233,6 +19268,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -19262,6 +19298,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
   - Id: 1429
@@ -19289,6 +19326,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -19318,6 +19356,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1468
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 04
     Modes:
@@ -19347,6 +19386,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 04
     Modes:
@@ -19376,6 +19416,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 04
   - Id: 1433
@@ -19403,6 +19444,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -19432,6 +19474,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
   - Id: 1435
@@ -19459,6 +19502,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 04
   - Id: 1436
@@ -19486,6 +19530,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 04
   - Id: 1437
@@ -19513,6 +19558,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1364
     AttackMotion: 864
+    ClientAttackMotion: 312
     DamageMotion: 432
     Ai: 04
   - Id: 1438
@@ -19540,6 +19586,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 528
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 04
   - Id: 1439
@@ -19567,6 +19614,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 04
   - Id: 1440
@@ -19594,6 +19642,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 288
     DamageMotion: 1000
     Ai: 04
   - Id: 1441
@@ -19621,6 +19670,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 04
   - Id: 1442
@@ -19648,6 +19698,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 04
   - Id: 1443
@@ -19675,6 +19726,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1296
+    ClientAttackMotion: 1224
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -19705,6 +19757,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 672
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
   - Id: 1445
@@ -19732,6 +19785,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 04
   - Id: 1446
@@ -19758,6 +19812,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 770
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
   - Id: 1447
@@ -19785,6 +19840,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 704
     AttackMotion: 504
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 04
     Class: Boss
@@ -19813,6 +19869,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 04
     Modes:
@@ -19843,6 +19900,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 900
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -19871,6 +19929,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -19900,6 +19959,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 916
     AttackMotion: 816
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 04
   - Id: 1452
@@ -19927,6 +19987,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 04
   - Id: 1453
@@ -19954,6 +20015,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -19982,6 +20044,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 04
     Modes:
@@ -20011,6 +20074,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 04
   - Id: 1456
@@ -20037,6 +20101,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 04
     Class: Boss
@@ -20064,6 +20129,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -20093,6 +20159,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 840
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 04
   - Id: 1459
@@ -20120,6 +20187,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 04
     Modes:
@@ -20149,6 +20217,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 360
     Ai: 04
   - Id: 1461
@@ -20176,6 +20245,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 04
   - Id: 1462
@@ -20203,6 +20273,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
   - Id: 1463
@@ -20230,6 +20301,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2852
     AttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 840
     Ai: 04
   - Id: 1464
@@ -20257,6 +20329,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 976
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
   - Id: 1465
@@ -20284,6 +20357,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 620
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 04
   - Id: 1466
@@ -20311,6 +20385,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1420
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 528
     Ai: 04
   - Id: 1467
@@ -20338,6 +20413,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 04
   - Id: 1468
@@ -20365,6 +20441,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1516
     AttackMotion: 816
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 04
   - Id: 1469
@@ -20392,6 +20469,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
   - Id: 1470
@@ -20419,6 +20497,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1780
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
   - Id: 1471
@@ -20446,6 +20525,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 840
     AttackMotion: 540
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
   - Id: 1472
@@ -20473,6 +20553,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 04
   - Id: 1473
@@ -20500,6 +20581,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 04
   - Id: 1474
@@ -20526,6 +20608,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
   - Id: 1475
@@ -20553,6 +20636,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 04
   - Id: 1476
@@ -20580,6 +20664,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 04
   - Id: 1477
@@ -20608,6 +20693,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -20637,6 +20723,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 04
   - Id: 1479
@@ -20664,6 +20751,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1848
     AttackMotion: 500
+    ClientAttackMotion: 864
     DamageMotion: 576
     Ai: 04
   - Id: 1480
@@ -20691,6 +20779,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 04
   - Id: 1481
@@ -20718,6 +20807,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 1152
     DamageMotion: 1000
     Ai: 04
   - Id: 1482
@@ -20746,6 +20836,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 792
+    ClientAttackMotion: 1920
     DamageMotion: 384
     Ai: 04
   - Id: 1483
@@ -20773,6 +20864,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1790
     AttackMotion: 1440
+    ClientAttackMotion: 900
     DamageMotion: 540
     Ai: 04
     Modes:
@@ -20802,6 +20894,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1744
     AttackMotion: 1344
+    ClientAttackMotion: 960
     DamageMotion: 600
     Ai: 04
   - Id: 1485
@@ -20829,6 +20922,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -20858,6 +20952,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 816
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 240
     Ai: 04
     Class: Boss
@@ -20886,6 +20981,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Class: Boss
@@ -20914,6 +21010,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 900
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 04
   - Id: 1489
@@ -20941,6 +21038,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 04
   - Id: 1490
@@ -20969,6 +21067,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 04
     Modes:
@@ -20998,6 +21097,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -21031,7 +21131,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 576
     DamageTaken: 10
     Ai: 21
@@ -21438,6 +21538,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -21545,6 +21646,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 847
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -21590,7 +21692,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -21942,7 +22044,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
-    ClientAttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -21991,7 +22093,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1257
     AttackMotion: 528
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -22126,6 +22228,7 @@ Body:
     WalkSpeed: 445
     AttackDelay: 106
     AttackMotion: 1056
+    ClientAttackMotion: 624
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -22214,7 +22317,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -22355,6 +22458,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 520
     AttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Ai: 17
   - Id: 1522
@@ -22382,6 +22486,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
   - Id: 1523
@@ -22410,6 +22515,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 05
   - Id: 1524
@@ -22437,6 +22543,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 318
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 04
   - Id: 1525
@@ -22464,6 +22571,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
   - Id: 1526
@@ -22491,6 +22599,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 13
     Modes:
@@ -22520,6 +22629,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 384
     Ai: 17
   - Id: 1528
@@ -22547,6 +22657,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
   - Id: 1529
@@ -22575,6 +22686,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -22603,6 +22715,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -22632,6 +22745,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 840
+    ClientAttackMotion: 624
     DamageMotion: 432
     Ai: 05
   - Id: 1532
@@ -22659,6 +22773,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
   - Id: 1533
@@ -22687,6 +22802,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 19
   - Id: 1534
@@ -22714,6 +22830,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
   - Id: 1535
@@ -22741,6 +22858,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1320
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 19
   - Id: 1536
@@ -22768,6 +22886,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
   - Id: 1537
@@ -22795,6 +22914,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 13
   - Id: 1538
@@ -22822,6 +22942,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 3074
     AttackMotion: 1874
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 13
   - Id: 1539
@@ -22849,6 +22970,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 1056
     DamageMotion: 240
     Ai: 21
   - Id: 1540
@@ -22876,6 +22998,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
   - Id: 1541
@@ -22903,6 +23026,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 816
     DamageMotion: 384
     Ai: 10
   - Id: 1542
@@ -22930,6 +23054,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 874
     AttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -22958,6 +23083,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 2012
     AttackMotion: 1728
+    ClientAttackMotion: 576
     DamageMotion: 672
     Ai: 04
   - Id: 1544
@@ -22985,6 +23111,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1638
     AttackMotion: 2016
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 01
   - Id: 1545
@@ -23012,6 +23139,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1546
@@ -23039,6 +23167,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1547
@@ -23066,6 +23195,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
   - Id: 1548
@@ -23093,6 +23223,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
   - Id: 1549
@@ -23120,6 +23251,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2190
     AttackMotion: 2040
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 19
   - Id: 1550
@@ -23148,6 +23280,7 @@ Body:
     WalkSpeed: 410
     AttackDelay: 400
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 05
   - Id: 1551
@@ -23175,6 +23308,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 468
     DamageMotion: 528
     Ai: 17
   - Id: 1552
@@ -23203,6 +23337,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -23232,6 +23367,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
   - Id: 1554
@@ -23259,6 +23395,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -23288,6 +23425,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 10
   - Id: 1556
@@ -23316,6 +23454,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1148
     AttackMotion: 1728
+    ClientAttackMotion: 624
     DamageMotion: 864
     Ai: 01
   - Id: 1557
@@ -23343,6 +23482,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 2416
     AttackMotion: 2016
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 05
   - Id: 1558
@@ -23370,6 +23510,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
   - Id: 1559
@@ -23397,6 +23538,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 19
     Modes:
@@ -23428,6 +23570,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1003
     AttackMotion: 1152
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 21
   - Id: 1561
@@ -23454,6 +23597,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
   - Id: 1562
@@ -23481,6 +23625,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 04
   - Id: 1563
@@ -23508,6 +23653,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1439
     AttackMotion: 1920
+    ClientAttackMotion: 624
     DamageMotion: 672
     Ai: 04
     Modes:
@@ -23538,6 +23684,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -23568,6 +23715,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 756
+    ClientAttackMotion: 540
     DamageMotion: 360
     Ai: 17
   - Id: 1566
@@ -23595,6 +23743,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
   - Id: 1567
@@ -23622,6 +23771,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -23651,6 +23801,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -23679,6 +23830,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
   - Id: 1570
@@ -23706,6 +23858,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 19
   - Id: 1571
@@ -23733,6 +23886,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1680
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
   - Id: 1572
@@ -23756,6 +23910,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 1573
@@ -23783,6 +23938,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
   - Id: 1574
@@ -23807,6 +23963,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 19
   - Id: 1575
@@ -23834,6 +23991,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1432
     AttackMotion: 432
+    ClientAttackMotion: 180
     DamageMotion: 576
     Ai: 10
   - Id: 1576
@@ -23861,6 +24019,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1220
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -23888,6 +24047,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1172
     AttackMotion: 672
+    ClientAttackMotion: 528
     DamageMotion: 420
     Ai: 05
   - Id: 1578
@@ -23915,6 +24075,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1888
     AttackMotion: 1152
+    ClientAttackMotion: 552
     DamageMotion: 828
     Ai: 13
   - Id: 1579
@@ -23941,6 +24102,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 10
   - Id: 1580
@@ -23968,6 +24130,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 850
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -23997,6 +24160,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
+    ClientAttackMotion: 600
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -24028,7 +24192,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 1056
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -24213,7 +24377,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 720
     Ai: 02
     Drops:
@@ -24309,7 +24473,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -24355,6 +24519,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
   - Id: 1590
@@ -24382,6 +24547,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
   - Id: 1591
@@ -24408,6 +24574,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 04
     Class: Boss
@@ -24438,6 +24605,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 04
     Class: Boss
@@ -24474,6 +24642,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Class: Boss
@@ -24505,6 +24674,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
   - Id: 1595
@@ -24532,6 +24702,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
   - Id: 1596
@@ -24559,6 +24730,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 512
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 13
     Modes:
@@ -24588,6 +24760,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -24617,6 +24790,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1732
     AttackMotion: 1332
+    ClientAttackMotion: 468
     DamageMotion: 540
     Ai: 20
     Modes:
@@ -24646,6 +24820,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2536
     AttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -24675,6 +24850,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1200
     DamageMotion: 528
     Ai: 21
   - Id: 1601
@@ -24702,6 +24878,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 483
+    ClientAttackMotion: 720
     DamageMotion: 528
     Ai: 21
   - Id: 1602
@@ -24729,6 +24906,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 21
   - Id: 1603
@@ -24754,6 +24932,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
   - Id: 1604
@@ -24781,6 +24960,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -24810,6 +24990,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1024
     AttackMotion: 768
+    ClientAttackMotion: 5280
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -24839,6 +25020,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1607
@@ -24865,6 +25047,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
   - Id: 1608
@@ -24890,6 +25073,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 13
     Modes:
@@ -24920,6 +25104,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 600
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 504
     Ai: 02
     Class: Boss
@@ -24959,6 +25144,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -24995,6 +25181,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1720
     AttackMotion: 500
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 19
     Class: Boss
@@ -25032,6 +25219,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 720
     Ai: 04
     Class: Boss
@@ -25614,6 +25802,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1152
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
   - Id: 1625
@@ -25643,6 +25832,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -25674,6 +25864,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Class: Boss
@@ -25717,7 +25908,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
-    ClientAttackMotion: 384
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -25838,7 +26029,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -25898,6 +26089,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 21
     Drops:
@@ -26351,6 +26543,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26388,6 +26581,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26426,6 +26620,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26464,6 +26659,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26502,6 +26698,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26540,6 +26737,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26579,6 +26777,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26639,6 +26838,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26700,6 +26900,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26761,6 +26962,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26822,6 +27024,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -26883,6 +27086,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -27250,6 +27454,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -27309,6 +27514,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27342,6 +27548,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27375,6 +27582,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27408,6 +27616,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -27441,6 +27650,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -28146,7 +28356,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
-    ClientAttackMotion: 288
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -28285,6 +28495,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
   - Id: 1684
@@ -28312,6 +28523,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1080
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 04
   - Id: 1685
@@ -28558,7 +28770,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -28579,7 +28791,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Class: Boss
@@ -28613,6 +28825,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 1536
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -28972,7 +29185,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
-    ClientAttackMotion: 240
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -29484,6 +29697,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 115
     AttackMotion: 288
+    ClientAttackMotion: 192
     DamageMotion: 420
     Ai: 20
     Class: Boss
@@ -29522,6 +29736,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -29560,6 +29775,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -29598,6 +29814,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 160
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -30016,7 +30233,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 24
-    ClientAttackMotion: 24
+    ClientAttackMotion: 0
     Drops:
       - Item: Elunium
         Rate: 3
@@ -30061,6 +30278,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 01
     Drops:
@@ -30098,6 +30316,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1008
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 26
   - Id: 1724
@@ -30124,6 +30343,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1536
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 27
   - Id: 1725
@@ -30146,6 +30366,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -30174,6 +30395,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 02
   - Id: 1727
@@ -30198,6 +30420,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 312
     DamageMotion: 576
     Ai: 02
   - Id: 1728
@@ -30225,6 +30448,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 02
   - Id: 1729
@@ -30250,6 +30474,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 02
     Modes:
@@ -30279,6 +30504,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 02
     Modes:
@@ -30308,6 +30534,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -30447,7 +30674,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
-    ClientAttackMotion: 240
+    ClientAttackMotion: 2112
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -30596,7 +30823,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
-    ClientAttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -30636,6 +30863,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1080
     AttackMotion: 480
+    ClientAttackMotion: 2112
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -30669,6 +30897,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -30702,6 +30931,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -30732,6 +30962,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1078
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -30761,6 +30992,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -30791,6 +31023,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Ai: 04
   - Id: 1745
@@ -30818,6 +31051,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 05
     Modes:
@@ -30851,6 +31085,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 04
     Drops:
@@ -30883,6 +31118,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1748
@@ -30909,6 +31145,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
   - Id: 1749
@@ -30936,6 +31173,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1720
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -30960,6 +31198,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -31246,6 +31485,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
     Class: Boss
@@ -31274,6 +31514,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 04
   - Id: 1758
@@ -31301,6 +31542,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
   - Id: 1759
@@ -31328,6 +31570,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 04
   - Id: 1760
@@ -31355,6 +31598,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 108
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
   - Id: 1761
@@ -31382,6 +31626,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -31414,6 +31659,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 480
     AttackMotion: 576
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -31446,6 +31692,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -31477,6 +31724,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 780
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -31584,7 +31832,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -32426,7 +32674,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -32475,6 +32723,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 600
+    ClientAttackMotion: 480
     DamageMotion: 240
     DamageTaken: 10
     Ai: 21
@@ -32531,6 +32780,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -32562,6 +32812,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -32593,6 +32844,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 20
     Drops:
@@ -32621,7 +32873,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     Ai: 10
     Drops:
       - Item: Ice_Piece
@@ -32666,6 +32918,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -32701,6 +32954,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Class: Boss
@@ -32761,6 +33015,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 21
   - Id: 1794
@@ -32788,6 +33043,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 412
     AttackMotion: 840
+    ClientAttackMotion: 600
     DamageMotion: 300
     Ai: 20
   - Id: 1795
@@ -32815,6 +33071,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 04
     Class: Boss
@@ -32911,7 +33168,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 432
-    ClientAttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -32970,6 +33227,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33003,6 +33261,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33037,6 +33296,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33070,6 +33330,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33103,6 +33364,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33136,6 +33398,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33163,6 +33426,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33195,6 +33459,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33228,6 +33493,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33261,6 +33527,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33294,6 +33561,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
     Class: Boss
@@ -33327,6 +33595,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33362,6 +33631,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -33397,6 +33667,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -33440,6 +33711,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -33491,6 +33763,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 120
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -33519,7 +33792,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 250
     AttackDelay: 1320
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 300
     Ai: 01
     Class: Boss
@@ -33600,6 +33873,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 936
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -33646,6 +33920,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Drops:
       - Item: Piece_Of_Cogwheel
@@ -33676,6 +33951,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1504
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
     Drops:
@@ -33704,6 +33980,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -33734,6 +34011,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1120
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 13
     Drops:
@@ -33764,6 +34042,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -33796,6 +34075,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -33827,6 +34107,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -33856,6 +34137,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 01
     Drops:
@@ -33886,6 +34168,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -33915,6 +34198,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -33943,6 +34227,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Class: Boss
@@ -34231,6 +34516,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -34259,6 +34545,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -34289,7 +34576,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1472
     AttackMotion: 384
-    ClientAttackMotion: 336
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -34519,6 +34806,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Class: Boss
@@ -34553,6 +34841,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Class: Boss
@@ -34590,6 +34879,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 09
     Class: Boss
@@ -34627,6 +34917,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 09
     Class: Boss
@@ -34722,6 +35013,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -34751,6 +35043,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -34780,6 +35073,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34809,6 +35103,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -34844,6 +35139,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 560
+    ClientAttackMotion: 576
     DamageMotion: 580
     Ai: 21
   - Id: 1852
@@ -34870,6 +35166,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 312
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34897,6 +35194,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -34927,6 +35225,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 02
     Drops:
@@ -34967,6 +35266,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -35012,6 +35312,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1560
     AttackMotion: 360
+    ClientAttackMotion: 192
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -35059,6 +35360,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -35102,6 +35404,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2208
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -35144,6 +35447,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -35189,6 +35493,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -35236,6 +35541,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 360
     DamageMotion: 1000
     Ai: 09
     Drops:
@@ -35282,6 +35588,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -35327,6 +35634,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Drops:
@@ -35554,6 +35862,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 24
     Modes:
@@ -35735,6 +36044,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 252
     DamageMotion: 360
     Ai: 26
     Class: Boss
@@ -35763,6 +36073,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 100
     AttackMotion: 576
+    ClientAttackMotion: 252
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -35889,6 +36200,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1446
     AttackMotion: 1296
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -35914,6 +36226,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -35947,6 +36260,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 2016
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -36322,6 +36636,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1536
     AttackMotion: 504
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
   - Id: 1887
@@ -36349,6 +36664,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 540
     DamageMotion: 528
     Ai: 21
     Class: Boss
@@ -36385,6 +36701,7 @@ Body:
     WalkSpeed: 450
     AttackDelay: 879
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Class: Boss
@@ -36418,6 +36735,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 312
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -36453,6 +36771,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 864
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -36481,6 +36800,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -36509,6 +36829,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 747
     AttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -36539,6 +36860,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 21
   - Id: 1894
@@ -36615,6 +36937,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
   - Id: 1896
@@ -36642,6 +36965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 20
   - Id: 1897
@@ -36669,6 +36993,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -36690,6 +37015,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -36775,6 +37101,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 03
     Modes:
@@ -36865,7 +37192,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1906
@@ -36889,6 +37216,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -36916,7 +37244,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1908
@@ -36937,7 +37265,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Boss
   - Id: 1909
@@ -37008,7 +37336,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37034,7 +37362,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37060,7 +37388,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37086,7 +37414,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37112,7 +37440,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 288
     DamageMotion: 384
     Class: Guardian
     Modes:
@@ -37192,6 +37520,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 312
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -37245,7 +37574,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -37291,7 +37620,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 648
-    ClientAttackMotion: 360
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -37335,7 +37664,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 432
-    ClientAttackMotion: 216
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -37381,7 +37710,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -37424,6 +37753,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 312
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 24
     Class: Boss
@@ -37453,6 +37783,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 312
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 24
     Class: Boss
@@ -37482,6 +37813,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 212
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 24
     Class: Boss
@@ -37511,6 +37843,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 24
     Class: Boss
@@ -37533,6 +37866,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 01
     Modes:
@@ -37573,6 +37907,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Ai: 01
     Modes:
@@ -37613,6 +37948,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 01
     Modes:
@@ -37651,7 +37987,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 384
+    ClientAttackMotion: 216
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -37786,7 +38122,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 1152
     DamageMotion: 360
     Ai: 13
     Class: Boss
@@ -37808,7 +38144,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37834,7 +38170,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37860,7 +38196,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 576
     Class: Boss
     Modes:
@@ -37893,6 +38229,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
   - Id: 1938
@@ -38189,6 +38526,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 24
     Class: Boss
@@ -38218,6 +38556,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
   - Id: 1949
@@ -38289,6 +38628,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -38325,6 +38665,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -38361,6 +38702,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -38397,6 +38739,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 190
+    ClientAttackMotion: 960
     Ai: 01
     Class: Boss
     Modes:
@@ -38529,7 +38872,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 140
     AttackMotion: 540
-    ClientAttackMotion: 540
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -38574,6 +38917,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 432
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 27
     Class: Boss
@@ -38600,6 +38944,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 2864
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 27
     Class: Boss
@@ -38626,6 +38971,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 1024
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 27
     Class: Boss
@@ -38652,6 +38998,7 @@ Body:
     ElementLevel: 4
     AttackDelay: 2864
     AttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 10
     Class: Boss
@@ -38677,6 +39024,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 01
     Class: Boss
@@ -38712,6 +39060,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1728
     AttackMotion: 816
+    ClientAttackMotion: 240
     DamageMotion: 1188
     Ai: 21
   - Id: 1964
@@ -38736,6 +39085,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Drops:
       - Item: Blue_Potion
@@ -38768,6 +39118,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 964
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
   - Id: 1966
     AegisName: M_DOPPELGANGER
@@ -38794,6 +39145,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Class: Boss
   - Id: 1967
@@ -38822,6 +39174,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 288
     Class: Boss
   - Id: 1968
@@ -38850,6 +39203,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Drops:
       - Item: Fin
@@ -38895,6 +39249,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Drops:
       - Item: Mistic_Frozen
@@ -38937,6 +39292,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Drops:
       - Item: Mistic_Frozen
@@ -38981,6 +39337,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Modes:
       IgnoreMagic: true
@@ -39027,6 +39384,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2280
     AttackMotion: 1080
+    ClientAttackMotion: 288
     DamageMotion: 864
     Drops:
       - Item: Single_Cell
@@ -39064,6 +39422,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Modes:
       IgnoreMagic: true
@@ -39206,7 +39565,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 648
     AttackMotion: 480
-    ClientAttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -39450,6 +39809,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 21
   - Id: 1982
@@ -39478,6 +39838,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 620
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 19
   - Id: 1983
@@ -39505,6 +39866,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
   - Id: 1984
@@ -39533,6 +39895,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
   - Id: 1985
@@ -40135,6 +40498,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
   - Id: 1998
@@ -40164,6 +40528,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 400
     AttackMotion: 780
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 13
   - Id: 1999
@@ -40240,7 +40605,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Class: Boss
@@ -40268,7 +40633,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 300
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 01
     Class: Boss
@@ -40299,6 +40664,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1120
     AttackMotion: 552
+    ClientAttackMotion: 756
     DamageMotion: 511
     Ai: 02
     Drops:
@@ -40333,6 +40699,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Drops:
@@ -40374,6 +40741,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -40414,6 +40782,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -40450,6 +40819,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -40486,6 +40856,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 608
     AttackMotion: 1440
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -40528,6 +40899,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Class: Boss
@@ -40558,6 +40930,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 414
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Class: Boss
@@ -40591,6 +40964,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1100
     AttackMotion: 960
+    ClientAttackMotion: 1728
     DamageMotion: 780
     Ai: 24
   - Id: 2011
@@ -40618,6 +40992,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -40658,6 +41033,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -40744,7 +41120,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackDelay: 24
-    ClientAttackMotion: 24
+    ClientAttackMotion: 0
     Drops:
       - Item: Piece_Of_Egg_Shell
         Rate: 2500
@@ -41235,6 +41611,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1248
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 01
     Class: Boss
@@ -41287,6 +41664,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -41332,6 +41710,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 24
     Modes:
@@ -41433,6 +41812,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -41460,6 +41840,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -41490,6 +41871,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 13
   - Id: 2033
@@ -41511,6 +41893,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 960
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -41543,6 +41926,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Modes:
       NoRandomWalk: true
@@ -41564,7 +41948,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       Detector: true
@@ -41591,6 +41975,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 13
     Drops:
@@ -41625,6 +42010,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Modes:
       NoRandomWalk: true
@@ -41652,6 +42038,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Modes:
       NoRandomWalk: true
@@ -41680,6 +42067,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -41709,6 +42097,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 816
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -41737,6 +42126,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1152
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 240
     Ai: 21
     Class: Boss
@@ -41767,6 +42157,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 960
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41796,6 +42187,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41825,6 +42217,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41854,6 +42247,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41883,6 +42277,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 504
     AttackMotion: 1020
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -41913,6 +42308,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 400
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -41941,6 +42337,7 @@ Body:
     WalkSpeed: 290
     AttackDelay: 1426
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -41970,6 +42367,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 480
     DamageMotion: 540
     Ai: 04
     Modes:
@@ -42001,6 +42399,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 504
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -42060,6 +42459,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 408
     DamageMotion: 480
     DamageTaken: 10
     Ai: 01
@@ -42234,6 +42634,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 09
   - Id: 2058
@@ -42261,6 +42662,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Modes:
       NoRandomWalk: true
@@ -42289,6 +42691,7 @@ Body:
     WalkSpeed: 147
     AttackDelay: 516
     AttackMotion: 768
+    ClientAttackMotion: 360
     DamageMotion: 384
     Modes:
       NoRandomWalk: true
@@ -42318,6 +42721,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 502
     AttackMotion: 1999
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Modes:
       NoRandomWalk: true
@@ -42570,6 +42974,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 21
     Class: Event
@@ -42605,6 +43010,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 420
     DamageMotion: 576
     Class: Event
     Drops:
@@ -42795,7 +43201,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
-    ClientAttackMotion: 288
+    ClientAttackMotion: 420
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -43028,6 +43434,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -43057,6 +43464,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 20
     Modes:
@@ -43086,6 +43494,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1306
     AttackMotion: 1056
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -43113,7 +43522,7 @@ Body:
     WalkSpeed: 177
     AttackDelay: 1152
     AttackMotion: 1152
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 288
     Class: Boss
   - Id: 2080
@@ -43143,7 +43552,7 @@ Body:
     WalkSpeed: 177
     AttackDelay: 1864
     AttackMotion: 864
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 288
     Class: Boss
     Modes:
@@ -43189,6 +43598,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 600
     Class: Guardian
   - Id: 2082
@@ -43216,6 +43626,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 20
   - Id: 2083
@@ -43508,7 +43919,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43544,7 +43955,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 240
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43580,7 +43991,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 480
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43616,7 +44027,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 480
     Modes:
       Detector: true
@@ -43760,6 +44171,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     Ai: 21
     Class: Boss
@@ -43818,6 +44230,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 872
     AttackMotion: 1344
+    ClientAttackMotion: 408
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -43876,6 +44289,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -43934,6 +44348,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 1290
     AttackMotion: 1140
+    ClientAttackMotion: 780
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -43992,6 +44407,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -44050,6 +44466,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 300
     Ai: 21
     Class: Boss
@@ -44108,6 +44525,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -44165,6 +44583,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1446
     AttackMotion: 1296
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -44222,6 +44641,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 408
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -44273,6 +44693,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 432
     AttackMotion: 840
+    ClientAttackMotion: 660
     DamageMotion: 216
     Ai: 21
     Class: Boss
@@ -44332,6 +44753,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 588
     AttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -44390,6 +44812,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 1000
+    ClientAttackMotion: 624
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -44448,6 +44871,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 504
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -44507,6 +44931,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -44566,6 +44991,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1344
     AttackMotion: 2880
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -44624,6 +45050,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -44682,6 +45109,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 212
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -44741,6 +45169,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -44799,6 +45228,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -44854,6 +45284,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -45063,6 +45494,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -45090,6 +45522,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -45118,6 +45551,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -45146,6 +45580,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 08
     Modes:
@@ -45176,6 +45611,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 08
     Modes:
@@ -45384,7 +45820,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 192
     AttackMotion: 192
-    ClientAttackMotion: 192
+    ClientAttackMotion: 0
     DamageMotion: 576
     Modes:
       IgnoreMagic: true
@@ -45510,7 +45946,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
-    ClientAttackMotion: 1248
+    ClientAttackMotion: 1056
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45533,6 +45969,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 768
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45555,6 +45992,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 1056
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45577,6 +46015,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 768
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45599,6 +46038,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 576
+    ClientAttackMotion: 1056
     DamageMotion: 1248
     Ai: 25
     Class: Boss
@@ -45634,6 +46074,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 24
     Modes:
@@ -45665,6 +46106,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 588
     AttackMotion: 768
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 24
     Modes:
@@ -45694,6 +46136,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1596
     AttackMotion: 1620
+    ClientAttackMotion: 576
     DamageMotion: 864
     Ai: 21
     Class: Boss
@@ -45707,6 +46150,7 @@ Body:
     Race: Formless
     Element: Neutral
     ElementLevel: 1
+    ClientAttackMotion: 960
     Ai: 02
   - Id: 2148
     AegisName: E_BLUE_PLANT
@@ -45718,6 +46162,7 @@ Body:
     Race: Formless
     Element: Neutral
     ElementLevel: 1
+    ClientAttackMotion: 960
     Ai: 02
   - Id: 2149
     AegisName: E_SAVAGE_BABE
@@ -45729,6 +46174,7 @@ Body:
     Race: Formless
     Element: Neutral
     ElementLevel: 1
+    ClientAttackMotion: 312
     Ai: 02
   - Id: 2150
     AegisName: WATERMELON
@@ -46022,7 +46468,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 576
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -46077,6 +46523,7 @@ Body:
     Element: Fire
     ElementLevel: 3
     WalkSpeed: 250
+    ClientAttackMotion: 1080
     Ai: 21
   - Id: 2158
     AegisName: S_HORNET
@@ -46103,6 +46550,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -46133,6 +46581,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 340
     Ai: 01
     Modes:
@@ -46163,6 +46612,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 01
     Modes:
@@ -46299,7 +46749,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
-    ClientAttackMotion: 420
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46350,7 +46800,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 588
     AttackMotion: 768
-    ClientAttackMotion: 1248
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -46460,7 +46910,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46497,7 +46947,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 240
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46533,7 +46983,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 480
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46569,7 +47019,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 96
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 480
     Drops:
       - Item: Piece_Of_Egg_Shell
@@ -46609,6 +47059,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46639,6 +47090,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 588
     AttackMotion: 768
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -46669,6 +47121,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46699,6 +47152,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 336
     AttackMotion: 360
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46732,6 +47186,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Ai: 20
     Class: Boss
@@ -46781,6 +47236,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 468
     DamageMotion: 528
     Ai: 20
     Class: Boss
@@ -46830,6 +47286,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 992
     AttackMotion: 792
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -46877,6 +47334,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1248
     AttackMotion: 48
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -46928,6 +47386,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 468
     DamageMotion: 384
     Ai: 20
     Class: Boss
@@ -46980,6 +47439,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 20
     Class: Boss
@@ -47029,6 +47489,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Ai: 20
     Class: Boss
@@ -47078,6 +47539,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1968
     AttackMotion: 768
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 20
     Class: Boss
@@ -47127,6 +47589,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1272
     AttackMotion: 72
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -47176,6 +47639,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 900
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 20
     Class: Boss
@@ -47227,6 +47691,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 20
     Class: Boss
@@ -47276,6 +47741,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 2012
     AttackMotion: 1728
+    ClientAttackMotion: 576
     DamageMotion: 672
     Ai: 20
     Class: Boss
@@ -47322,6 +47788,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -47375,6 +47842,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -47426,6 +47894,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -47476,6 +47945,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -47527,6 +47997,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -47604,7 +48075,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 576
     AttackMotion: 2160
-    ClientAttackMotion: 2160
+    ClientAttackMotion: 2016
     DamageMotion: 504
     Ai: 20
     Class: Boss
@@ -47737,6 +48208,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1776
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 20
     Modes:
@@ -47767,6 +48239,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 108
     DamageMotion: 384
     Ai: 20
     Class: Boss
@@ -48068,7 +48541,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1008
     AttackMotion: 936
-    ClientAttackMotion: 936
+    ClientAttackMotion: 792
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -48258,7 +48731,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 432
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -48298,6 +48771,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 01
     Modes:
@@ -48387,6 +48861,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 02
     Modes:
@@ -48438,6 +48913,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 468
     AttackMotion: 468
+    ClientAttackMotion: 252
     DamageMotion: 288
     Ai: 02
     Class: Boss
@@ -48489,6 +48965,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 02
   - Id: 2214
@@ -48518,6 +48995,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 02
   - Id: 2215
@@ -48546,6 +49024,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 02
     Class: Boss
@@ -48575,6 +49054,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 02
     Class: Boss
@@ -48604,6 +49084,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 02
   - Id: 2218
@@ -48628,6 +49109,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 144
     DamageMotion: 540
     Ai: 02
     Modes:
@@ -48667,6 +49149,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 252
     DamageMotion: 540
     Ai: 02
     Modes:
@@ -48707,6 +49190,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 02
     Modes:
@@ -48752,7 +49236,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48802,7 +49286,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48852,7 +49336,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -48903,7 +49387,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -48953,7 +49437,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Modes:
@@ -49005,7 +49489,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -49055,7 +49539,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -49104,6 +49588,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49140,6 +49625,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49176,6 +49662,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49213,6 +49700,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49249,6 +49737,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49285,6 +49774,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49321,6 +49811,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49359,6 +49850,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -49418,6 +49910,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49478,6 +49971,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49535,6 +50029,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49593,6 +50088,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49651,6 +50147,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49707,6 +50204,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 76
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -49753,6 +50251,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 200
     AttackMotion: 420
+    ClientAttackMotion: 216
     DamageMotion: 288
     Ai: 21
   - Id: 2243
@@ -49780,6 +50279,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 200
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 21
   - Id: 2244
@@ -49808,6 +50308,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 200
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
   - Id: 2245
@@ -49864,6 +50365,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 912
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -49912,6 +50414,7 @@ Body:
     WalkSpeed: 445
     AttackDelay: 106
     AttackMotion: 1056
+    ClientAttackMotion: 624
     DamageMotion: 576
     Ai: 02
     Drops:
@@ -49943,7 +50446,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 2688
+    ClientAttackMotion: 2496
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -50413,6 +50916,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2258
@@ -50434,6 +50938,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2259
@@ -50455,6 +50960,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2260
@@ -50476,6 +50982,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2261
@@ -50497,6 +51004,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 02
   - Id: 2262
@@ -50518,6 +51026,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 02
   - Id: 2263
@@ -50539,6 +51048,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2264
@@ -50561,6 +51071,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
   - Id: 2265
@@ -50583,6 +51094,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
   - Id: 2266
@@ -50605,6 +51117,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2267
@@ -50627,6 +51140,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2268
@@ -50649,6 +51163,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2269
@@ -50671,6 +51186,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2270
@@ -50693,6 +51209,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2271
@@ -50715,6 +51232,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2272
@@ -50737,6 +51255,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2273
@@ -50759,6 +51278,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2274
@@ -50781,6 +51301,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2275
@@ -50803,6 +51324,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2276
@@ -50824,6 +51346,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 02
   - Id: 2277
@@ -50852,6 +51375,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1600
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -50880,6 +51404,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 880
     AttackMotion: 1224
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -50909,6 +51434,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -50937,6 +51463,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1576
     AttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -50968,6 +51495,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 19
     Modes:
@@ -51015,6 +51543,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 21
     Modes:
@@ -51062,6 +51591,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1252
+    ClientAttackMotion: 288
     DamageMotion: 476
     Ai: 13
     Modes:
@@ -51109,6 +51639,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -51154,6 +51685,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -51199,6 +51731,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1228
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Modes:
@@ -51244,6 +51777,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -51318,6 +51852,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 02
   - Id: 2290
@@ -51339,6 +51874,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 02
   - Id: 2291
@@ -51360,6 +51896,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2292
@@ -51381,6 +51918,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
   - Id: 2293
@@ -51402,6 +51940,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
   - Id: 2294
@@ -51423,6 +51962,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 02
   - Id: 2295
@@ -51444,6 +51984,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 02
   - Id: 2296
@@ -51465,6 +52006,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
   - Id: 2297
@@ -51486,6 +52028,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 648
     DamageMotion: 480
     Ai: 02
   - Id: 2298
@@ -51507,6 +52050,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 02
   - Id: 2299
@@ -51528,6 +52072,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 02
   - Id: 2300
@@ -51549,6 +52094,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2301
@@ -51568,6 +52114,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2302
@@ -51589,6 +52136,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2303
@@ -51610,6 +52158,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 624
     DamageMotion: 480
     Ai: 02
   - Id: 2304
@@ -51633,6 +52182,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 300
     DamageMotion: 480
     Ai: 02
   - Id: 2305
@@ -51654,6 +52204,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 02
   - Id: 2306
@@ -51683,6 +52234,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 02
     Class: Boss
@@ -51726,6 +52278,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 400
     AttackMotion: 672
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 02
   - Id: 2308
@@ -51742,6 +52295,7 @@ Body:
     Race: Formless
     Element: Holy
     ElementLevel: 1
+    ClientAttackMotion: 2112
     Class: Boss
   - Id: 2309
     AegisName: BUNGISNGIS
@@ -51770,7 +52324,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1568
     AttackMotion: 432
-    ClientAttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51814,7 +52368,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1424
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51858,7 +52412,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 280
     AttackMotion: 720
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51908,7 +52462,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1664
     AttackMotion: 336
-    ClientAttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -51956,7 +52510,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1064
     AttackMotion: 936
-    ClientAttackMotion: 936
+    ClientAttackMotion: 792
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -51998,7 +52552,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 496
     AttackMotion: 504
-    ClientAttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -52040,7 +52594,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 424
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -52126,6 +52680,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 1080
+    ClientAttackMotion: 936
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -52170,6 +52725,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 920
     AttackMotion: 1080
+    ClientAttackMotion: 936
     DamageMotion: 360
     Class: Boss
     Modes:
@@ -52221,7 +52777,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1424
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -52274,6 +52830,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 440
     AttackMotion: 672
+    ClientAttackMotion: 2808
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -52305,6 +52862,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 440
     AttackMotion: 672
+    ClientAttackMotion: 2808
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -52338,6 +52896,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 440
     AttackMotion: 672
+    ClientAttackMotion: 2808
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -52368,6 +52927,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 13
     Class: Boss
@@ -52405,6 +52965,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -52442,6 +53003,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 21
   - Id: 2326
@@ -52470,6 +53032,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1430
     AttackMotion: 1080
+    ClientAttackMotion: 480
     DamageMotion: 1080
     Ai: 21
   - Id: 2327
@@ -52497,6 +53060,7 @@ Body:
     Element: Dark
     ElementLevel: 2
     WalkSpeed: 1000
+    ClientAttackMotion: 936
     Class: Boss
     Modes:
       IgnoreMagic: true
@@ -52538,6 +53102,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 420
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -52562,6 +53127,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
+    ClientAttackMotion: 432
     DamageMotion: 1
   - Id: 2330
     AegisName: BUWAYA_SLAVE
@@ -52589,6 +53155,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -52612,6 +53179,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 384
     AttackMotion: 720
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 10
     Class: Battlefield
@@ -52647,6 +53215,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1424
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -52669,6 +53238,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 432
     DamageMotion: 1
     Class: Boss
     Modes:
@@ -52701,6 +53271,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 424
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 360
     Ai: 02
   - Id: 2335
@@ -52797,6 +53368,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackMotion: 1000
+    ClientAttackMotion: 768
     Ai: 10
     Class: Battlefield
     Modes:
@@ -52831,6 +53403,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 280
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -52861,6 +53434,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1664
     AttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -52890,6 +53464,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 496
     AttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -52923,6 +53498,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -52979,6 +53555,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 864
     DamageMotion: 180
     Ai: 21
   - Id: 2343
@@ -53007,6 +53584,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackMotion: 2000
+    ClientAttackMotion: 768
     Ai: 10
     Class: Battlefield
     Modes:
@@ -53041,6 +53619,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 288
     DamageMotion: 180
     Ai: 02
   - Id: 2345
@@ -53070,6 +53649,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 1920
     DamageMotion: 180
     Ai: 21
   - Id: 2346
@@ -53098,6 +53678,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 180
     Ai: 21
   - Id: 2347
@@ -53126,6 +53707,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 408
     DamageMotion: 180
     Ai: 21
   - Id: 2348
@@ -53155,6 +53737,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 864
     DamageMotion: 180
     Ai: 21
   - Id: 2349
@@ -53183,6 +53766,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 1440
     DamageMotion: 180
     Ai: 21
   - Id: 2350
@@ -53211,6 +53795,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 288
     DamageMotion: 180
     Ai: 21
   - Id: 2351
@@ -53239,6 +53824,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1080
     AttackMotion: 780
+    ClientAttackMotion: 336
     DamageMotion: 180
     Ai: 21
   - Id: 2352
@@ -53263,7 +53849,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 128
     AttackMotion: 1104
-    ClientAttackMotion: 2208
+    ClientAttackMotion: 2016
     DamageMotion: 240
     Ai: 02
     Class: Boss
@@ -53315,7 +53901,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 864
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -53365,7 +53951,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1772
     AttackMotion: 72
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -53416,6 +54002,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53465,7 +54052,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -53511,6 +54098,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 21
     Modes:
@@ -53543,7 +54131,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53592,6 +54180,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53625,7 +54214,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -53675,6 +54264,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -53708,7 +54298,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 854
     AttackMotion: 2016
-    ClientAttackMotion: 1260
+    ClientAttackMotion: 1140
     DamageMotion: 480
     DamageTaken: 10
     Ai: 10
@@ -53768,7 +54358,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 1056
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53812,7 +54402,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53858,7 +54448,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 720
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -53904,7 +54494,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 960
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53949,7 +54539,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 1728
-    ClientAttackMotion: 1728
+    ClientAttackMotion: 1536
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -53993,7 +54583,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 150
     AttackMotion: 3456
-    ClientAttackMotion: 3456
+    ClientAttackMotion: 3264
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -54081,7 +54671,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 100
     AttackMotion: 2304
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2112
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -54125,7 +54715,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 480
     AttackMotion: 1536
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -54244,6 +54834,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2036
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 02
     Class: Boss
@@ -54272,6 +54863,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2076
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 02
     Class: Boss
@@ -54298,6 +54890,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 252
     AttackMotion: 816
+    ClientAttackMotion: 528
     DamageMotion: 480
     Ai: 02
     Modes:
@@ -54344,6 +54937,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -54370,7 +54964,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 1824
+    ClientAttackMotion: 1632
     DamageMotion: 420
     Ai: 01
     Modes:
@@ -54415,7 +55009,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 420
     Ai: 01
     Modes:
@@ -54542,6 +55136,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2402
@@ -54572,6 +55167,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Modes:
       IgnoreMagic: true
@@ -54603,6 +55199,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Modes:
       IgnoreMelee: true
@@ -54790,6 +55387,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 672
     Class: Boss
     Modes:
       NoRandomWalk: true
@@ -54806,6 +55404,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 0
     Class: Boss
     Modes:
       NoRandomWalk: true
@@ -54822,6 +55421,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 240
     Class: Boss
     Modes:
       NoRandomWalk: true
@@ -54838,6 +55438,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 0
     Class: Boss
     Modes:
       NoRandomWalk: true
@@ -54854,6 +55455,7 @@ Body:
     Element: Fire
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 672
     Class: Boss
     Modes:
       NoRandomWalk: true
@@ -54887,7 +55489,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54932,7 +55534,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -54978,7 +55580,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55024,7 +55626,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55070,7 +55672,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 864
     AttackMotion: 400
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55116,7 +55718,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 864
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55162,7 +55764,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55208,7 +55810,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55254,7 +55856,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55300,7 +55902,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55346,7 +55948,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55392,7 +55994,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55438,7 +56040,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 400
-    ClientAttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55481,6 +56083,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55523,6 +56126,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55566,6 +56170,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55609,6 +56214,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55652,6 +56258,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55695,6 +56302,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 864
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
   - Id: 2434
@@ -55723,6 +56331,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55766,6 +56375,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55809,6 +56419,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55852,6 +56463,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55895,6 +56507,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55938,6 +56551,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -55981,6 +56595,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
   - Id: 2441
@@ -56011,7 +56626,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -56063,7 +56678,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Class: Boss
@@ -56394,6 +57009,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -56435,6 +57051,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 288
     Ai: 01
     Modes:
@@ -56812,6 +57429,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -56852,6 +57470,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -56895,6 +57514,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -56937,6 +57557,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 09
     Modes:
@@ -56979,6 +57600,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -57021,6 +57643,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 05
     Modes:
@@ -57067,6 +57690,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 720
     DamageMotion: 1000
     Ai: 21
     Class: Boss
@@ -57109,6 +57733,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 350
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 21
     Class: Boss
@@ -57152,6 +57777,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 828
     AttackMotion: 528
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 21
     Class: Boss
@@ -57391,6 +58017,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -57439,6 +58066,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -57485,6 +58113,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -57527,6 +58156,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -57569,6 +58199,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -57614,6 +58245,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 600
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -57669,6 +58301,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 480
+    ClientAttackMotion: 216
     DamageMotion: 120
     Ai: 21
   - Id: 2485
@@ -57698,6 +58331,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Class: Boss
@@ -58211,6 +58845,7 @@ Body:
     Element: Ghost
     ElementLevel: 4
     WalkSpeed: 1000
+    ClientAttackMotion: 768
     Ai: 10
     Class: Boss
     Modes:
@@ -58243,6 +58878,7 @@ Body:
     Element: Ghost
     ElementLevel: 4
     WalkSpeed: 1000
+    ClientAttackMotion: 768
     Ai: 10
     Class: Boss
     Modes:
@@ -58278,6 +58914,7 @@ Body:
     ElementLevel: 4
     WalkSpeed: 1000
     AttackDelay: 3000
+    ClientAttackMotion: 768
     Ai: 10
     Class: Boss
     Modes:
@@ -58311,7 +58948,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 150
     AttackDelay: 24
-    ClientAttackMotion: 24
+    ClientAttackMotion: 0
     Modes:
       Detector: true
       IgnoreMagic: true
@@ -58401,7 +59038,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1276
     AttackMotion: 792
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 720
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -58449,7 +59086,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1384
     AttackMotion: 792
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -58497,7 +59134,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1452
     AttackMotion: 792
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -58545,6 +59182,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 792
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 17
     Modes:
@@ -58595,6 +59233,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 972
     AttackMotion: 792
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -58646,7 +59285,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58682,7 +59321,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58720,7 +59359,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58756,7 +59395,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58792,7 +59431,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 950
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58828,7 +59467,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 648
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58864,7 +59503,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58900,7 +59539,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58936,7 +59575,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -58972,7 +59611,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -59008,7 +59647,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -59044,7 +59683,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -59116,7 +59755,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 768
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -59154,7 +59793,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 720
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -59192,6 +59831,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -59240,6 +59880,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1400
     AttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 10
     Modes:
@@ -59269,6 +59910,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 10
     Modes:
@@ -59299,6 +59941,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -59329,6 +59972,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 950
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -59358,6 +60002,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1084
     AttackMotion: 2304
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 02
   - Id: 2570
@@ -59385,6 +60030,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 02
   - Id: 2571
@@ -59412,6 +60058,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 576
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 02
   - Id: 2572
@@ -59438,6 +60085,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1604
     AttackMotion: 840
+    ClientAttackMotion: 216
     DamageMotion: 756
     Ai: 02
   - Id: 2573
@@ -59463,6 +60111,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2574
@@ -59490,6 +60139,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1257
     AttackMotion: 528
+    ClientAttackMotion: 864
     DamageMotion: 432
     Ai: 02
   - Id: 2575
@@ -59516,6 +60166,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 02
   - Id: 2576
@@ -59539,6 +60190,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 02
   - Id: 2577
@@ -59565,6 +60217,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 02
   - Id: 2578
@@ -59592,6 +60245,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
   - Id: 2579
@@ -59619,6 +60273,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 741
     AttackMotion: 1536
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 02
   - Id: 2580
@@ -59646,6 +60301,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1700
     AttackMotion: 1000
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 02
   - Id: 2581
@@ -59673,6 +60329,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 890
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2582
@@ -59698,6 +60355,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 02
   - Id: 2583
@@ -59725,6 +60383,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 02
   - Id: 2584
@@ -59752,6 +60411,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 02
   - Id: 2585
@@ -59779,6 +60439,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1400
     AttackMotion: 960
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 02
   - Id: 2586
@@ -59806,6 +60467,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 776
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 02
   - Id: 2587
@@ -59833,6 +60495,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 720
     AttackMotion: 864
+    ClientAttackMotion: 624
     DamageMotion: 504
     Ai: 02
   - Id: 2588
@@ -59860,6 +60523,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 960
     AttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 300
     Ai: 02
   - Id: 2589
@@ -59887,6 +60551,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2590
@@ -59914,6 +60579,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 540
     Ai: 02
   - Id: 2591
@@ -59941,6 +60607,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 02
   - Id: 2592
@@ -59968,6 +60635,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1536
     AttackMotion: 1296
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 02
   - Id: 2593
@@ -59995,6 +60663,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 432
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 02
   - Id: 2594
@@ -60022,6 +60691,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 660
     DamageMotion: 420
     Ai: 02
   - Id: 2595
@@ -60048,6 +60718,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1688
     AttackMotion: 1188
+    ClientAttackMotion: 720
     DamageMotion: 612
     Ai: 02
   - Id: 2596
@@ -60075,6 +60746,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 02
   - Id: 2597
@@ -60102,6 +60774,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
   - Id: 2598
@@ -60129,6 +60802,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 420
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 02
   - Id: 2599
@@ -60156,6 +60830,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 432
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 360
     Ai: 02
   - Id: 2600
@@ -60183,6 +60858,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 02
   - Id: 2601
@@ -60209,6 +60885,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 02
   - Id: 2602
@@ -60236,6 +60913,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 780
     AttackMotion: 1008
+    ClientAttackMotion: 288
     DamageMotion: 420
     Ai: 02
   - Id: 2603
@@ -60265,6 +60943,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -60312,6 +60991,7 @@ Body:
     WalkSpeed: 420
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 13
     Drops:
@@ -60359,6 +61039,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -60404,6 +61085,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -60449,6 +61131,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 580
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -60495,6 +61178,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -60541,6 +61225,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1054
     AttackMotion: 54
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 07
     Drops:
@@ -60587,6 +61272,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1048
     AttackMotion: 48
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -60634,6 +61320,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -60681,6 +61368,7 @@ Body:
     WalkSpeed: 320
     AttackDelay: 2304
     AttackMotion: 840
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 01
     Drops:
@@ -60728,6 +61416,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -60775,6 +61464,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -60824,6 +61514,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -60871,6 +61562,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 864
+    ClientAttackMotion: 840
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -60918,6 +61610,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 637
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -60969,6 +61662,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 720
     DamageMotion: 504
     Ai: 09
     Modes:
@@ -61012,6 +61706,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -61054,6 +61749,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 21
     Modes:
@@ -61101,6 +61797,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1356
     AttackMotion: 1056
+    ClientAttackMotion: 240
     DamageMotion: 540
     Ai: 05
     Drops:
@@ -61149,6 +61846,7 @@ Body:
     WalkSpeed: 127
     AttackDelay: 1356
     AttackMotion: 1056
+    ClientAttackMotion: 240
     DamageMotion: 540
     Ai: 05
     Drops:
@@ -61197,6 +61895,7 @@ Body:
     WalkSpeed: 204
     AttackDelay: 1356
     AttackMotion: 1056
+    ClientAttackMotion: 240
     DamageMotion: 540
     Ai: 05
     Drops:
@@ -61245,6 +61944,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -61292,6 +61992,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 1020
+    ClientAttackMotion: 600
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -61339,6 +62040,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1536
     AttackMotion: 600
+    ClientAttackMotion: 420
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -61388,6 +62090,7 @@ Body:
     WalkSpeed: 187
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -61435,6 +62138,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1632
     AttackMotion: 432
+    ClientAttackMotion: 420
     DamageMotion: 540
     Ai: 17
     Drops:
@@ -61482,6 +62186,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 420
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 21
     Modes:
@@ -61531,6 +62236,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 500
     AttackMotion: 1440
+    ClientAttackMotion: 300
     DamageMotion: 960
     Ai: 03
     Drops:
@@ -61574,6 +62280,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 496
     AttackMotion: 504
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -61611,6 +62318,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 02
     Modes:
@@ -61660,6 +62368,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 02
     Modes:
@@ -61709,6 +62418,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 288
+    ClientAttackMotion: 720
     DamageMotion: 768
     Ai: 02
     Modes:
@@ -61759,6 +62469,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -61806,6 +62517,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 600
     DamageMotion: 504
     Ai: 20
     Drops:
@@ -61853,6 +62565,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1000
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Drops:
@@ -61898,6 +62611,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1744
     AttackMotion: 1044
+    ClientAttackMotion: 252
     DamageMotion: 684
     Ai: 17
     Drops:
@@ -61943,6 +62657,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 500
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 13
     Modes:
@@ -61991,6 +62706,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -62038,6 +62754,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 1956
     AttackMotion: 756
+    ClientAttackMotion: 288
     DamageMotion: 528
     Ai: 09
     Drops:
@@ -62086,6 +62803,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 07
     Modes:
@@ -62135,6 +62853,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 936
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 432
     Ai: 02
     Drops:
@@ -62181,6 +62900,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -62227,6 +62947,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1688
     AttackMotion: 1188
+    ClientAttackMotion: 720
     DamageMotion: 612
     Ai: 17
     Modes:
@@ -62274,6 +62995,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -62321,6 +63043,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1452
     AttackMotion: 483
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 17
     Drops:
@@ -62370,6 +63093,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -62417,6 +63141,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -62464,6 +63189,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 576
     AttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -62513,6 +63239,7 @@ Body:
     WalkSpeed: 187
     AttackDelay: 2112
     AttackMotion: 912
+    ClientAttackMotion: 324
     DamageMotion: 576
     Ai: 17
     Modes:
@@ -62562,6 +63289,7 @@ Body:
     WalkSpeed: 264
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 660
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -62609,6 +63337,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -62655,6 +63384,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -62702,6 +63432,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1350
     AttackMotion: 1200
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -62750,6 +63481,7 @@ Body:
     WalkSpeed: 146
     AttackDelay: 1350
     AttackMotion: 1200
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -62798,6 +63530,7 @@ Body:
     WalkSpeed: 228
     AttackDelay: 720
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 20
     Modes:
@@ -62848,6 +63581,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -62896,6 +63630,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -62944,6 +63679,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -62991,6 +63727,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 432
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 02
     Drops:
@@ -63036,6 +63773,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -63083,6 +63821,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 09
     Drops:
@@ -63130,6 +63869,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 1152
+    ClientAttackMotion: 2112
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -63178,6 +63918,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 420
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -63224,6 +63965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 468
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -63271,6 +64013,7 @@ Body:
     WalkSpeed: 216
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -63318,6 +64061,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1132
     AttackMotion: 583
+    ClientAttackMotion: 432
     DamageMotion: 532
     Ai: 04
     Drops:
@@ -63365,6 +64109,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 792
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -63414,6 +64159,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 17
     Modes:
@@ -63464,6 +64210,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1624
     AttackMotion: 624
+    ClientAttackMotion: 312
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -63511,6 +64258,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -63558,6 +64306,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -63605,6 +64354,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 500
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -63652,6 +64402,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -63700,6 +64451,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 360
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -63744,6 +64496,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 600
     DamageMotion: 1000
     Ai: 07
     Drops:
@@ -63788,6 +64541,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -63830,6 +64584,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -63873,6 +64628,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 540
     Ai: 01
     Modes:
@@ -63922,6 +64678,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -63969,6 +64726,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 864
     AttackMotion: 500
+    ClientAttackMotion: 468
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -64017,6 +64775,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1247
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 17
     Drops:
@@ -64063,6 +64822,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 500
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -64113,6 +64873,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 360
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -64163,6 +64924,7 @@ Body:
     WalkSpeed: 90
     AttackDelay: 360
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -64212,6 +64974,7 @@ Body:
     WalkSpeed: 480
     AttackDelay: 1516
     AttackMotion: 816
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -64259,6 +65022,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1536
     AttackMotion: 1056
+    ClientAttackMotion: 336
     DamageMotion: 1152
     Ai: 04
     Drops:
@@ -64306,6 +65070,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 768
     AttackMotion: 1224
+    ClientAttackMotion: 420
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -64353,6 +65118,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -64400,6 +65166,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -64448,6 +65215,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -64497,6 +65265,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 768
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -64544,6 +65313,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -64591,6 +65361,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -64635,6 +65406,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64679,6 +65451,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64723,6 +65496,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64767,6 +65541,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64814,6 +65589,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 02
     Modes:
@@ -64862,6 +65638,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64909,6 +65686,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -64956,6 +65734,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -65003,6 +65782,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1148
     AttackMotion: 1728
+    ClientAttackMotion: 624
     DamageMotion: 864
     Ai: 01
     Drops:
@@ -65050,6 +65830,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -65097,6 +65878,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 1296
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -65142,6 +65924,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 1008
+    ClientAttackMotion: 576
     DamageMotion: 324
     Ai: 01
     Drops:
@@ -65189,6 +65972,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 960
     AttackMotion: 336
+    ClientAttackMotion: 240
     DamageMotion: 300
     Ai: 17
     Drops:
@@ -65236,6 +66020,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 864
     Ai: 04
     Drops:
@@ -65283,6 +66068,7 @@ Body:
     WalkSpeed: 348
     AttackDelay: 1426
     AttackMotion: 600
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -65330,6 +66116,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 700
     AttackMotion: 600
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -65377,6 +66164,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Drops:
@@ -65424,6 +66212,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2544
     AttackMotion: 1344
+    ClientAttackMotion: 432
     DamageMotion: 1152
     Ai: 17
     Drops:
@@ -65469,6 +66258,7 @@ Body:
     WalkSpeed: 187
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -65517,6 +66307,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2468
     AttackMotion: 768
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -65565,6 +66356,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 832
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -65612,6 +66404,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -65658,6 +66451,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -65703,6 +66497,7 @@ Body:
     WalkSpeed: 123
     AttackDelay: 976
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -65750,6 +66545,7 @@ Body:
     WalkSpeed: 480
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 288
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -65797,6 +66593,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 768
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -65846,6 +66643,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -65893,6 +66691,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2852
     AttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 840
     Ai: 04
     Drops:
@@ -65932,6 +66731,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2420
     AttackMotion: 720
+    ClientAttackMotion: 288
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -65977,6 +66777,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1050
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Drops:
@@ -66025,6 +66826,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -66073,6 +66875,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 500
     AttackMotion: 1440
+    ClientAttackMotion: 528
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -66120,6 +66923,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -66159,6 +66963,7 @@ Body:
     WalkSpeed: 82
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -66198,6 +67003,7 @@ Body:
     WalkSpeed: 132
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -66237,6 +67043,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 151
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -66276,6 +67083,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 500
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -66326,6 +67134,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1816
     AttackMotion: 576
+    ClientAttackMotion: 720
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -66369,6 +67178,7 @@ Body:
     WalkSpeed: 75
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 04
     Modes:
@@ -66415,6 +67225,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 10
     Drops:
@@ -66462,6 +67273,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 1320
+    ClientAttackMotion: 780
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -66508,6 +67320,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 1248
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 17
     Drops:
@@ -66555,6 +67368,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 672
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 360
     Ai: 10
     Drops:
@@ -66600,6 +67414,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -66645,6 +67460,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1772
     AttackMotion: 72
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -66691,6 +67507,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 01
     Drops:
@@ -66739,6 +67556,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 500
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -66785,6 +67603,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -66831,6 +67650,7 @@ Body:
     WalkSpeed: 82
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 21
     Class: Boss
@@ -66876,6 +67696,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1400
     AttackMotion: 960
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -66917,6 +67738,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1938
     AttackMotion: 2112
+    ClientAttackMotion: 1920
     DamageMotion: 768
     Ai: 17
     Modes:
@@ -66967,6 +67789,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -67014,6 +67837,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -67061,6 +67885,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1360
     AttackMotion: 960
+    ClientAttackMotion: 576
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -67108,6 +67933,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -67155,6 +67981,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 576
     AttackMotion: 1140
+    ClientAttackMotion: 240
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -67195,6 +68022,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -67239,6 +68067,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 972
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -67283,6 +68112,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1708
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -67332,6 +68162,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -67379,6 +68210,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -67426,6 +68258,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 500
     AttackMotion: 816
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -67473,6 +68306,7 @@ Body:
     WalkSpeed: 145
     AttackDelay: 472
     AttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -67513,6 +68347,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 1720
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -67562,6 +68397,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -67609,6 +68445,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1480
     AttackMotion: 480
+    ClientAttackMotion: 240
     DamageMotion: 1056
     Ai: 09
     Modes:
@@ -67659,6 +68496,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -67706,6 +68544,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1540
     AttackMotion: 840
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 09
     Drops:
@@ -67752,6 +68591,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1528
     AttackMotion: 660
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 09
     Modes:
@@ -67801,6 +68641,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 10
     Drops:
@@ -67848,6 +68689,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 280
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -67894,6 +68736,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 1728
     DamageMotion: 780
     Ai: 21
     Drops:
@@ -67942,6 +68785,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 192
     DamageMotion: 432
     Ai: 02
     Modes:
@@ -67991,6 +68835,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 1472
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 02
     Drops:
@@ -68026,6 +68871,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Drops:
@@ -68071,6 +68917,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Drops:
@@ -68118,6 +68965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -68165,6 +69013,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1000
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 08
     Modes:
@@ -68217,6 +69066,7 @@ Body:
     WalkSpeed: 93
     AttackDelay: 747
     AttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -68267,6 +69117,7 @@ Body:
     WalkSpeed: 492
     AttackDelay: 400
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -68309,6 +69160,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -68356,6 +69208,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 300
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -68395,6 +69248,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1120
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 04
     Modes:
@@ -68439,6 +69293,7 @@ Body:
     WalkSpeed: 172
     AttackDelay: 1728
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 03
     Drops:
@@ -68486,6 +69341,7 @@ Body:
     WalkSpeed: 210
     AttackDelay: 1260
     AttackMotion: 230
+    ClientAttackMotion: 1152
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -68533,6 +69389,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 864
+    ClientAttackMotion: 720
     DamageMotion: 720
     Ai: 02
     Drops:
@@ -68580,6 +69437,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 500
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -68624,6 +69482,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 432
     AttackMotion: 400
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 09
     Modes:
@@ -68670,6 +69529,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1008
     AttackMotion: 1008
+    ClientAttackMotion: 504
     DamageMotion: 384
     Ai: 05
     Drops:
@@ -68717,6 +69577,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1028
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 13
     Drops:
@@ -68764,6 +69625,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1548
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -68811,6 +69673,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 500
     AttackMotion: 768
+    ClientAttackMotion: 240
     DamageMotion: 576
     Ai: 03
     Modes:
@@ -68856,6 +69719,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 800
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -68904,6 +69768,7 @@ Body:
     WalkSpeed: 116
     AttackDelay: 1638
     AttackMotion: 2016
+    ClientAttackMotion: 432
     DamageMotion: 576
     Ai: 01
     Drops:
@@ -68951,6 +69816,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1384
     AttackMotion: 768
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 09
     Modes:
@@ -69002,6 +69868,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -69049,6 +69916,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 720
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -69097,6 +69965,7 @@ Body:
     WalkSpeed: 445
     AttackDelay: 106
     AttackMotion: 1056
+    ClientAttackMotion: 624
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -69138,6 +70007,7 @@ Body:
     WalkSpeed: 187
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
     Drops:
@@ -69184,6 +70054,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 288
     Ai: 17
     Drops:
@@ -69231,6 +70102,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 890
     AttackMotion: 1320
+    ClientAttackMotion: 1080
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -69276,6 +70148,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -69325,6 +70198,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -69377,6 +70251,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 03
     Modes:
@@ -69424,6 +70299,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 17
     Modes:
@@ -69475,6 +70351,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 960
     AttackMotion: 528
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -69524,6 +70401,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 720
     Ai: 01
     Drops:
@@ -69571,6 +70449,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 504
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -69614,6 +70493,7 @@ Body:
     WalkSpeed: 127
     AttackDelay: 504
     AttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -69657,6 +70537,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 21
     Drops:
@@ -69704,6 +70585,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 470
     Ai: 04
     Modes:
@@ -69751,6 +70633,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 500
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 470
     Ai: 04
     Modes:
@@ -69798,6 +70681,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -69845,6 +70729,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 816
     DamageMotion: 384
     Ai: 10
     Drops:
@@ -69892,6 +70777,7 @@ Body:
     WalkSpeed: 198
     AttackDelay: 1460
     AttackMotion: 960
+    ClientAttackMotion: 2304
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -69935,6 +70821,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1460
     AttackMotion: 960
+    ClientAttackMotion: 2304
     DamageMotion: 432
     Ai: 03
     Drops:
@@ -69978,6 +70865,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
     Drops:
@@ -70025,6 +70913,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -70072,6 +70961,7 @@ Body:
     WalkSpeed: 75
     AttackDelay: 1120
     AttackMotion: 620
+    ClientAttackMotion: 384
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -70119,6 +71009,7 @@ Body:
     WalkSpeed: 198
     AttackDelay: 1380
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 03
     Drops:
@@ -70164,6 +71055,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1380
     AttackMotion: 1080
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 03
     Drops:
@@ -70210,6 +71102,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -70255,6 +71148,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1528
     AttackMotion: 528
+    ClientAttackMotion: 240
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -70299,6 +71193,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 21
     Modes:
@@ -70345,6 +71240,7 @@ Body:
     WalkSpeed: 264
     AttackDelay: 768
     AttackMotion: 1776
+    ClientAttackMotion: 912
     DamageMotion: 648
     Ai: 21
     Modes:
@@ -70391,6 +71287,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1292
     AttackMotion: 792
+    ClientAttackMotion: 648
     DamageMotion: 340
     Ai: 21
     Modes:
@@ -70440,6 +71337,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 500
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -70487,6 +71385,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -70534,6 +71433,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -70577,6 +71477,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1308
     AttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -70620,6 +71521,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -70667,6 +71569,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -70714,6 +71617,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 07
     Class: Boss
@@ -70756,6 +71660,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 04
     Drops:
@@ -70803,6 +71708,7 @@ Body:
     WalkSpeed: 204
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 540
     DamageMotion: 672
     Ai: 21
     Drops:
@@ -70850,6 +71756,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 540
     DamageMotion: 672
     Ai: 21
     Drops:
@@ -70897,6 +71804,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -70943,6 +71851,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 01
     Modes:
@@ -70994,6 +71903,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 420
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -71040,6 +71950,7 @@ Body:
     WalkSpeed: 480
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -71088,6 +71999,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -71137,6 +72049,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 500
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -71180,6 +72093,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2276
     AttackMotion: 576
+    ClientAttackMotion: 168
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -71223,6 +72137,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -71267,6 +72182,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -71316,6 +72232,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -71363,6 +72280,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 504
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -71410,6 +72328,7 @@ Body:
     WalkSpeed: 127
     AttackDelay: 950
     AttackMotion: 2520
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -71457,6 +72376,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 864
     AttackMotion: 576
+    ClientAttackMotion: 504
     DamageMotion: 336
     Ai: 10
     Drops:
@@ -71500,6 +72420,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -71547,6 +72468,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 500
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -71586,6 +72508,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 09
     Drops:
@@ -71633,6 +72556,7 @@ Body:
     WalkSpeed: 131
     AttackDelay: 862
     AttackMotion: 534
+    ClientAttackMotion: 360
     DamageMotion: 312
     Ai: 21
     Modes:
@@ -71678,6 +72602,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 576
     AttackMotion: 960
+    ClientAttackMotion: 420
     DamageMotion: 504
     Ai: 03
     Drops:
@@ -71725,6 +72650,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 360
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 600
     Ai: 04
     Modes:
@@ -71774,6 +72700,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 500
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -71823,6 +72750,7 @@ Body:
     WalkSpeed: 147
     AttackDelay: 516
     AttackMotion: 768
+    ClientAttackMotion: 360
     DamageMotion: 384
     Ai: 04
     Modes:
@@ -71872,6 +72800,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 576
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -71919,6 +72848,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 980
     AttackMotion: 600
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -71968,6 +72898,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 01
     Modes:
@@ -72016,6 +72947,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 900
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 01
     Modes:
@@ -72065,6 +72997,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 01
     Modes:
@@ -72115,6 +73048,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 176
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 21
     Drops:
@@ -72162,6 +73096,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 176
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 21
     Drops:
@@ -72209,6 +73144,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 176
     AttackMotion: 912
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 21
     Drops:
@@ -72256,6 +73192,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 1252
+    ClientAttackMotion: 288
     DamageMotion: 476
     Ai: 13
     Drops:
@@ -72303,6 +73240,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 600
     AttackMotion: 840
+    ClientAttackMotion: 480
     DamageMotion: 504
     Ai: 02
     Drops:
@@ -72342,6 +73280,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 840
     Ai: 01
     Modes:
@@ -72391,6 +73330,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1248
     AttackMotion: 48
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -72438,6 +73378,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1036
     AttackMotion: 936
+    ClientAttackMotion: 108
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -72485,6 +73426,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -72526,6 +73468,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -72568,6 +73511,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -72614,6 +73558,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 504
     DamageMotion: 1008
     Ai: 17
     Drops:
@@ -72661,6 +73606,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1092
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -72708,6 +73654,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 792
+    ClientAttackMotion: 432
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -72753,6 +73700,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -72802,6 +73750,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 1000
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -72851,6 +73800,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1500
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -72896,6 +73846,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1152
     AttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 20
     Drops:
@@ -72940,6 +73891,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -72989,6 +73941,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1078
     AttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -73037,6 +73990,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1604
     AttackMotion: 840
+    ClientAttackMotion: 216
     DamageMotion: 756
     Ai: 17
     Drops:
@@ -73084,6 +74038,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1568
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -73124,6 +74079,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 140
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -73171,6 +74127,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -73218,6 +74175,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 480
     DamageMotion: 540
     Ai: 20
     Drops:
@@ -73263,6 +74221,7 @@ Body:
     WalkSpeed: 108
     AttackDelay: 472
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 288
     Ai: 13
     Modes:
@@ -73312,6 +74271,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Drops:
@@ -73359,6 +74319,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 840
+    ClientAttackMotion: 288
     DamageMotion: 900
     Ai: 21
     Drops:
@@ -73406,6 +74367,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -73455,6 +74417,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 676
     AttackMotion: 504
+    ClientAttackMotion: 432
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -73502,6 +74465,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 2304
+    ClientAttackMotion: 1080
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -73547,6 +74511,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 504
     Ai: 21
     Drops:
@@ -73594,6 +74559,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 468
+    ClientAttackMotion: 216
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -73641,6 +74607,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -73688,6 +74655,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 1792
     AttackMotion: 792
+    ClientAttackMotion: 576
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -73735,6 +74703,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -73782,6 +74751,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -73829,6 +74799,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 1440
+    ClientAttackMotion: 720
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -73878,6 +74849,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 504
     AttackMotion: 624
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 04
     Modes:
@@ -73923,6 +74895,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 864
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -73963,6 +74936,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 864
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -74003,6 +74977,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 500
     AttackMotion: 500
+    ClientAttackMotion: 660
     DamageMotion: 864
     Ai: 21
     Drops:
@@ -74050,6 +75025,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -74093,6 +75069,7 @@ Body:
     WalkSpeed: 112
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -74136,6 +75113,7 @@ Body:
     WalkSpeed: 360
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 180
     DamageMotion: 384
     Ai: 01
     Modes:
@@ -74186,6 +75164,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 168
     AttackMotion: 480
+    ClientAttackMotion: 480
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -74232,6 +75211,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Drops:
@@ -74279,6 +75259,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2048
     AttackMotion: 648
+    ClientAttackMotion: 312
     DamageMotion: 648
     Ai: 17
     Modes:
@@ -74328,6 +75309,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 360
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -74375,6 +75357,7 @@ Body:
     WalkSpeed: 240
     AttackDelay: 1100
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -74418,6 +75401,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 1440
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 600
     Ai: 17
     Drops:
@@ -74465,6 +75449,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 500
     AttackMotion: 480
+    ClientAttackMotion: 2112
     DamageMotion: 504
     Ai: 13
     Modes:
@@ -74514,6 +75499,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 540
     DamageMotion: 768
     Ai: 21
     Drops:
@@ -74561,6 +75547,7 @@ Body:
     WalkSpeed: 225
     AttackDelay: 768
     AttackMotion: 360
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 20
     Drops:
@@ -74608,6 +75595,7 @@ Body:
     WalkSpeed: 216
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -74655,6 +75643,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 09
     Drops:
@@ -74701,6 +75690,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -74736,7 +75726,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1092
     AttackMotion: 792
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 17
     Drops:
@@ -74834,7 +75824,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1072
     AttackMotion: 672
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 384
     Ai: 17
     Drops:
@@ -74884,7 +75874,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 1152
     DamageMotion: 660
     Ai: 09
     Drops:
@@ -74932,7 +75922,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -74982,7 +75972,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -75029,6 +76019,7 @@ Body:
     WalkSpeed: 195
     AttackDelay: 1345
     AttackMotion: 824
+    ClientAttackMotion: 2304
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -75061,7 +76052,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1345
     AttackMotion: 824
-    ClientAttackMotion: 2496
+    ClientAttackMotion: 2304
     DamageMotion: 440
     Ai: 21
     Class: Boss
@@ -75107,6 +76098,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1372
     AttackMotion: 672
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 09
     Drops:
@@ -75143,6 +76135,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 01
     Drops:
@@ -75179,6 +76172,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 972
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 470
     Ai: 04
     Drops:
@@ -75213,6 +76207,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
     Drops:
@@ -75247,6 +76242,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 917
     AttackMotion: 1584
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -75281,6 +76277,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 1296
     DamageMotion: 1000
     Ai: 04
     Drops:
@@ -75315,6 +76312,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 576
     AttackMotion: 420
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 20
     Class: Boss
@@ -75348,6 +76346,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 384
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -75380,6 +76379,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -75412,6 +76412,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1072
     AttackMotion: 1056
+    ClientAttackMotion: 864
     DamageMotion: 384
     Ai: 21
     Class: Boss
@@ -75447,6 +76448,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 312
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -75482,6 +76484,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 480
     AttackMotion: 840
+    ClientAttackMotion: 624
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -75506,6 +76509,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1220
     AttackMotion: 1080
+    ClientAttackMotion: 336
     DamageMotion: 648
     Class: Event
     Modes:
@@ -75616,7 +76620,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 600
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 500
     Ai: 10
     Modes:
@@ -75653,7 +76657,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 600
     Ai: 10
     Modes:
@@ -75690,7 +76694,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1800
     AttackMotion: 780
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -75805,6 +76809,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 624
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -75839,6 +76844,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 914
     AttackMotion: 1344
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -75875,6 +76881,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 920
     AttackMotion: 720
+    ClientAttackMotion: 360
     DamageMotion: 200
     Ai: 04
     Modes:
@@ -75913,6 +76920,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 972
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -75951,6 +76959,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Modes:
@@ -75987,6 +76996,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1768
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 192
     Ai: 04
     Drops:
@@ -76021,6 +77031,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 1848
     AttackMotion: 500
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -76057,6 +77068,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2457
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -76093,6 +77105,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 528
     AttackMotion: 1000
+    ClientAttackMotion: 240
     DamageMotion: 396
     Ai: 04
     Drops:
@@ -76129,6 +77142,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1155
     AttackMotion: 1152
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -76165,6 +77179,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 735
     AttackMotion: 384
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -76203,7 +77218,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 420
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -76267,6 +77282,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 672
     AttackMotion: 420
+    ClientAttackMotion: 672
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -76402,6 +77418,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 720
     AttackMotion: 720
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 01
     Class: Boss
@@ -76493,7 +77510,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1296
     AttackMotion: 1296
-    ClientAttackMotion: 468
+    ClientAttackMotion: 1224
     DamageMotion: 432
     Ai: 05
     Modes:
@@ -76818,6 +77835,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 768
     AttackMotion: 1056
+    ClientAttackMotion: 360
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -76883,7 +77901,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 300
     AttackMotion: 384
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 288
     Ai: 10
     Class: Boss
@@ -76970,7 +77988,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 2612
     AttackMotion: 824
-    ClientAttackMotion: 456
+    ClientAttackMotion: 408
     DamageMotion: 440
     Ai: 10
     Class: Boss
@@ -77326,7 +78344,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 864
     AttackMotion: 400
-    ClientAttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -77373,7 +78391,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 400
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 150
     Ai: 10
     Modes:
@@ -77657,7 +78675,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 1148
     AttackMotion: 648
-    ClientAttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -77694,7 +78712,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1672
     AttackMotion: 720
-    ClientAttackMotion: 648
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -77768,7 +78786,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1608
     AttackMotion: 816
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 396
     Ai: 04
     Drops:
@@ -77808,7 +78826,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
-    ClientAttackMotion: 4608
+    ClientAttackMotion: 4416
     DamageMotion: 288
     Modes:
       IgnoreMagic: true
@@ -77840,7 +78858,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 768
     Ai: 25
     Drops:
@@ -77912,7 +78930,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 900
     AttackMotion: 864
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 10
     Class: Boss
@@ -77971,6 +78989,7 @@ Body:
     Element: Ghost
     ElementLevel: 4
     WalkSpeed: 1000
+    ClientAttackMotion: 768
     Class: Boss
     Modes:
       Aggressive: true
@@ -78006,6 +79025,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -78039,6 +79059,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 10
     Class: Boss
@@ -78072,6 +79093,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 10
     Class: Boss
@@ -78190,7 +79212,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 240
+    ClientAttackMotion: 480
     DamageMotion: 1
     Class: Event
     Modes:
@@ -78496,7 +79518,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 2592
-    ClientAttackMotion: 2592
+    ClientAttackMotion: 2400
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -78544,7 +79566,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 100
     AttackMotion: 576
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -78619,6 +79641,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1332
     AttackMotion: 288
+    ClientAttackMotion: 312
     DamageMotion: 384
     Ai: 25
     Modes:
@@ -78639,6 +79662,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1332
     AttackMotion: 288
+    ClientAttackMotion: 864
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78658,6 +79682,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 420
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78677,6 +79702,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 192
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78692,6 +79718,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 384
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78711,6 +79738,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 240
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78730,6 +79758,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 360
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78749,6 +79778,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 360
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78768,6 +79798,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 360
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78783,6 +79814,7 @@ Body:
     WalkSpeed: 160
     AttackDelay: 1025
     AttackMotion: 720
+    ClientAttackMotion: 288
     Ai: 25
     Modes:
       NoRandomWalk: true
@@ -78810,6 +79842,7 @@ Body:
     WalkSpeed: 230
     AttackDelay: 1415
     AttackMotion: 792
+    ClientAttackMotion: 768
     Ai: 24
     Class: Battlefield
     Modes:
@@ -78844,6 +79877,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 800
     AttackMotion: 750
+    ClientAttackMotion: 576
     DamageMotion: 300
   - Id: 3088
     AegisName: MM_BRINARANEA_BABY
@@ -78871,6 +79905,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1000
     AttackMotion: 1000
+    ClientAttackMotion: 420
     DamageMotion: 1000
     Ai: 04
     Modes:
@@ -78900,6 +79935,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 540
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -78929,6 +79965,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 288
     DamageMotion: 600
     Ai: 21
     Class: Boss
@@ -79098,7 +80135,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 460
-    ClientAttackMotion: 540
+    ClientAttackMotion: 336
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -79134,7 +80171,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 750
     AttackMotion: 510
-    ClientAttackMotion: 420
+    ClientAttackMotion: 336
     DamageMotion: 500
     Ai: 21
     Class: Boss
@@ -79167,6 +80204,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 2000
     AttackMotion: 750
+    ClientAttackMotion: 336
     DamageMotion: 750
     Ai: 10
     Class: Boss
@@ -79198,6 +80236,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 500
     AttackMotion: 510
+    ClientAttackMotion: 336
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -79349,6 +80388,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 576
     AttackMotion: 480
+    ClientAttackMotion: 336
     DamageMotion: 432
     Ai: 10
     Class: Boss
@@ -79384,6 +80424,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1536
     AttackMotion: 648
+    ClientAttackMotion: 336
     DamageMotion: 300
     Ai: 10
     Class: Boss
@@ -79451,7 +80492,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2592
-    ClientAttackMotion: 2592
+    ClientAttackMotion: 2400
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -79496,7 +80537,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2592
-    ClientAttackMotion: 2592
+    ClientAttackMotion: 2400
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -79805,6 +80846,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2400
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 09
   - Id: 3123
@@ -79835,6 +80877,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 2400
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 09
   - Id: 3124
@@ -79864,7 +80907,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 2016
-    ClientAttackMotion: 2016
+    ClientAttackMotion: 420
     DamageMotion: 672
     Ai: 26
     Class: Boss
@@ -79958,7 +81001,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 676
     AttackMotion: 1056
-    ClientAttackMotion: 1056
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -80005,7 +81048,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 816
-    ClientAttackMotion: 816
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 10
     Drops:
@@ -80050,7 +81093,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 576
-    ClientAttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -80142,7 +81185,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1020
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 768
     Ai: 10
     Modes:
@@ -80181,7 +81224,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 1072
     AttackMotion: 672
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 384
     Ai: 10
     Modes:
@@ -80220,7 +81263,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 660
     Ai: 10
     Modes:
@@ -80259,7 +81302,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
-    ClientAttackMotion: 480
+    ClientAttackMotion: 288
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -80300,6 +81343,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
+    ClientAttackMotion: 576
     DamageMotion: 768
     Ai: 10
     Modes:
@@ -80338,6 +81382,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
+    ClientAttackMotion: 576
     DamageMotion: 768
     Ai: 10
     Modes:
@@ -80368,6 +81413,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 800
     AttackMotion: 2112
+    ClientAttackMotion: 420
     DamageMotion: 768
     Modes:
       IgnoreMagic: true
@@ -80402,6 +81448,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 500
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Drops:
       - Item: White_Slim_Potion
@@ -80436,6 +81483,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 1
+    ClientAttackMotion: 288
     DamageMotion: 1
     Ai: 25
   - Id: 3170
@@ -80454,6 +81502,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 76
     AttackMotion: 1
+    ClientAttackMotion: 288
     DamageMotion: 1
     Ai: 25
 #  - Id: 3171
@@ -80491,6 +81540,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 2416
     AttackMotion: 2016
+    ClientAttackMotion: 1008
     DamageMotion: 432
     Ai: 05
     Drops:
@@ -80538,6 +81588,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 540
+    ClientAttackMotion: 240
     DamageMotion: 432
     Ai: 04
     Modes:
@@ -80583,6 +81634,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 432
     AttackMotion: 540
+    ClientAttackMotion: 300
     DamageMotion: 432
     Ai: 17
     Modes:
@@ -80630,6 +81682,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 528
     DamageMotion: 300
     Ai: 09
     Drops:
@@ -80671,6 +81724,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 168
     AttackMotion: 768
+    ClientAttackMotion: 528
     DamageMotion: 360
     Ai: 17
     Modes:
@@ -80712,6 +81766,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1596
     AttackMotion: 1620
+    ClientAttackMotion: 576
     DamageMotion: 864
     Ai: 17
     Modes:
@@ -80756,6 +81811,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 168
     AttackMotion: 1008
+    ClientAttackMotion: 864
     DamageMotion: 300
     Ai: 01
     Class: Boss
@@ -80819,7 +81875,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 800
     AttackMotion: 500
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 300
     Ai: 10
     Class: Boss
@@ -80863,6 +81919,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1000
     AttackMotion: 750
+    ClientAttackMotion: 1056
     DamageMotion: 600
     Ai: 04
     Class: Boss
@@ -80900,6 +81957,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1000
     AttackMotion: 750
+    ClientAttackMotion: 1056
     DamageMotion: 600
     Ai: 04
     Class: Boss
@@ -80936,6 +81994,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1250
     AttackMotion: 750
+    ClientAttackMotion: 1056
     DamageMotion: 600
     Ai: 04
     Class: Boss
@@ -80968,6 +82027,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 384
     DamageMotion: 500
     Ai: 04
     Class: Boss
@@ -81003,6 +82063,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 384
     DamageMotion: 500
     Ai: 04
     Class: Boss
@@ -81036,6 +82097,7 @@ Body:
     WalkSpeed: 330
     AttackDelay: 1250
     AttackMotion: 800
+    ClientAttackMotion: 384
     DamageMotion: 800
     Ai: 04
     Class: Boss
@@ -81071,7 +82133,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -81115,7 +82177,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 624
-    ClientAttackMotion: 1248
+    ClientAttackMotion: 1056
     DamageMotion: 360
     Ai: 07
     Modes:
@@ -81155,7 +82217,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1280
     AttackMotion: 1080
-    ClientAttackMotion: 7680
+    ClientAttackMotion: 7488
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -81198,7 +82260,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 21
     Drops:
@@ -81252,6 +82314,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 100
+    ClientAttackMotion: 192
     Ai: 25
     Class: Boss
     Modes:
@@ -81293,6 +82356,7 @@ Body:
     Element: Neutral
     ElementLevel: 1
     WalkSpeed: 200
+    ClientAttackMotion: 192
     Ai: 25
     Class: Boss
     Modes:
@@ -81435,7 +82499,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81487,7 +82551,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81537,7 +82601,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81587,7 +82651,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81639,7 +82703,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81691,7 +82755,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81739,6 +82803,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81770,6 +82835,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81801,6 +82867,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81832,6 +82899,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81863,6 +82931,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81894,6 +82963,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81926,6 +82996,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -81978,6 +83049,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82031,6 +83103,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82084,6 +83157,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 240
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82137,6 +83211,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82189,6 +83264,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82242,7 +83318,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82294,7 +83370,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82346,7 +83422,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82398,7 +83474,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82450,7 +83526,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82502,7 +83578,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82554,7 +83630,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
-    ClientAttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82604,6 +83680,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82635,6 +83712,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82666,6 +83744,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82697,6 +83776,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82728,6 +83808,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82759,6 +83840,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82790,6 +83872,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82822,6 +83905,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82874,6 +83958,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82926,6 +84011,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 576
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -82978,6 +84064,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -83030,6 +84117,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -83082,6 +84170,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -83134,6 +84223,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -83185,7 +84275,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 720
-    ClientAttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 10
     Modes:
@@ -83232,7 +84322,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1500
     AttackMotion: 500
-    ClientAttackMotion: 576
+    ClientAttackMotion: 384
     DamageMotion: 660
     Ai: 02
     Modes:
@@ -83283,7 +84373,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1552
     AttackMotion: 1152
-    ClientAttackMotion: 1920
+    ClientAttackMotion: 288
     DamageMotion: 336
     Ai: 10
     Modes:
@@ -83334,7 +84424,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2400
     AttackMotion: 500
-    ClientAttackMotion: 2304
+    ClientAttackMotion: 2160
     DamageMotion: 400
     Ai: 10
     Modes:
@@ -83384,7 +84474,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 600
     Ai: 10
     Modes:
@@ -83430,7 +84520,7 @@ Body:
     WalkSpeed: 135
     AttackDelay: 1500
     AttackMotion: 600
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 500
     Ai: 10
     Modes:
@@ -83468,7 +84558,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 3000
     AttackMotion: 600
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 550
     Ai: 01
     Class: Battlefield
@@ -83502,7 +84592,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1250
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 350
     Ai: 10
     Class: Boss
@@ -83554,7 +84644,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2050
     AttackMotion: 500
-    ClientAttackMotion: 456
+    ClientAttackMotion: 408
     DamageMotion: 660
     Ai: 10
     Modes:
@@ -83587,7 +84677,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 2155
     AttackMotion: 960
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 480
     Ai: 10
     Modes:
@@ -83873,6 +84963,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Modes:
@@ -83921,6 +85012,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 01
     Modes:
@@ -83969,6 +85061,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -84018,6 +85111,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 988
     AttackMotion: 288
+    ClientAttackMotion: 240
     DamageMotion: 168
     Ai: 01
     Modes:
@@ -84067,6 +85161,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1148
     AttackMotion: 648
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 03
     Modes:
@@ -84116,6 +85211,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 432
     Ai: 01
     Modes:
@@ -84165,6 +85261,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 01
     Modes:
@@ -84214,6 +85311,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Modes:
@@ -84262,6 +85360,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 480
     DamageMotion: 420
     Ai: 17
     Modes:
@@ -84311,6 +85410,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1156
     AttackMotion: 456
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 17
     Modes:
@@ -84360,6 +85460,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Modes:
@@ -84408,6 +85509,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1048
     AttackMotion: 48
+    ClientAttackMotion: 288
     DamageMotion: 192
     Ai: 17
     Modes:
@@ -84457,6 +85559,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 03
     Modes:
@@ -84506,6 +85609,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 01
     Modes:
@@ -84554,6 +85658,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1576
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 17
     Modes:
@@ -84603,6 +85708,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -84651,6 +85757,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1960
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 384
     Ai: 01
     Modes:
@@ -84699,6 +85806,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 480
     DamageMotion: 576
     Ai: 03
     Modes:
@@ -84746,6 +85854,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -84795,6 +85904,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 07
     Modes:
@@ -84844,6 +85954,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1288
     AttackMotion: 288
+    ClientAttackMotion: 180
     DamageMotion: 384
     Ai: 07
     Modes:
@@ -84895,6 +86006,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1608
     AttackMotion: 816
+    ClientAttackMotion: 912
     DamageMotion: 396
     Ai: 17
     Modes:
@@ -84944,6 +86056,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1564
     AttackMotion: 864
+    ClientAttackMotion: 384
     DamageMotion: 576
     Ai: 19
     Modes:
@@ -84992,6 +86105,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1076
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 01
     Modes:
@@ -85041,6 +86155,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1708
     AttackMotion: 1008
+    ClientAttackMotion: 432
     DamageMotion: 540
     Ai: 07
     Modes:
@@ -85090,6 +86205,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Modes:
@@ -85139,6 +86255,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 900
+    ClientAttackMotion: 252
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -85188,6 +86305,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 862
     AttackMotion: 534
+    ClientAttackMotion: 360
     DamageMotion: 312
     Ai: 21
     Modes:
@@ -85234,6 +86352,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 02
     Modes:
@@ -85283,6 +86402,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1132
     AttackMotion: 583
+    ClientAttackMotion: 432
     DamageMotion: 532
     Ai: 19
     Modes:
@@ -85332,6 +86452,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1430
     AttackMotion: 1080
+    ClientAttackMotion: 480
     DamageMotion: 1080
     Ai: 07
     Modes:
@@ -85382,6 +86503,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1612
     AttackMotion: 622
+    ClientAttackMotion: 576
     DamageMotion: 583
     Ai: 19
     Modes:
@@ -85431,6 +86553,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1100
     AttackMotion: 900
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 17
     Modes:
@@ -85476,6 +86599,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2492
     AttackMotion: 792
+    ClientAttackMotion: 696
     DamageMotion: 432
     Ai: 01
     Modes:
@@ -85527,6 +86651,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 21
     Modes:
@@ -85574,6 +86699,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 10
     Modes:
@@ -85619,6 +86745,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 950
     AttackMotion: 2520
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -85668,6 +86795,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1236
     AttackMotion: 336
+    ClientAttackMotion: 168
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -85718,6 +86846,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1048
     AttackMotion: 648
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 21
     Modes:
@@ -85768,6 +86897,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1080
     AttackMotion: 648
+    ClientAttackMotion: 600
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -85818,6 +86948,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 21
     Modes:
@@ -85867,6 +86998,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 772
     AttackMotion: 672
+    ClientAttackMotion: 384
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -85918,6 +87050,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 872
     AttackMotion: 1344
+    ClientAttackMotion: 408
     DamageMotion: 432
     DamageTaken: 10
     Ai: 21
@@ -85977,6 +87110,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1072
     AttackMotion: 672
+    ClientAttackMotion: 192
     DamageMotion: 384
     DamageTaken: 10
     Ai: 21
@@ -86036,6 +87170,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 1020
+    ClientAttackMotion: 324
     DamageMotion: 288
     DamageTaken: 10
     Ai: 21
@@ -86097,6 +87232,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1678
     AttackMotion: 780
+    ClientAttackMotion: 660
     DamageMotion: 648
     DamageTaken: 10
     Ai: 21
@@ -86156,6 +87292,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 288
+    ClientAttackMotion: 384
     DamageMotion: 144
     DamageTaken: 10
     Ai: 21
@@ -86211,6 +87348,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2016
     AttackMotion: 816
+    ClientAttackMotion: 336
     DamageMotion: 288
     Ai: 02
     Modes:
@@ -86241,6 +87379,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1054
     AttackMotion: 504
+    ClientAttackMotion: 216
     DamageMotion: 432
     Ai: 02
     Modes:
@@ -86271,6 +87410,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1864
     AttackMotion: 864
+    ClientAttackMotion: 768
     DamageMotion: 540
     Ai: 02
     Modes:
@@ -86299,6 +87439,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1456
     AttackMotion: 456
+    ClientAttackMotion: 264
     DamageMotion: 336
     Ai: 02
     Modes:
@@ -86329,6 +87470,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Modes:
@@ -86357,6 +87499,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1260
     AttackMotion: 192
+    ClientAttackMotion: 1092
     DamageMotion: 192
     Ai: 17
     Modes:
@@ -86387,6 +87530,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1772
     AttackMotion: 120
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 21
     Modes:
@@ -86417,6 +87561,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1672
     AttackMotion: 720
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 04
     Modes:
@@ -86447,6 +87592,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 1000
     Ai: 04
     Modes:
@@ -86477,6 +87623,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 21
     Modes:
@@ -86556,7 +87703,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1604
     AttackMotion: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 2016
     Ai: 17
     Drops:
@@ -86604,7 +87751,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 576
     AttackMotion: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -86648,7 +87795,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1152
     AttackMotion: 864
-    ClientAttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -86769,7 +87916,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1536
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -86810,7 +87957,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1152
     AttackMotion: 1536
-    ClientAttackMotion: 1536
+    ClientAttackMotion: 1344
     DamageMotion: 480
     Ai: 04
   - Id: 3450
@@ -86946,7 +88093,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 768
     AttackMotion: 2784
-    ClientAttackMotion: 2784
+    ClientAttackMotion: 2592
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -86999,7 +88146,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1268
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
   - Id: 3455
@@ -87022,7 +88169,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -87091,7 +88238,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 960
     AttackMotion: 1632
-    ClientAttackMotion: 1632
+    ClientAttackMotion: 1440
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -87196,7 +88343,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 2112
     AttackMotion: 1152
-    ClientAttackMotion: 2112
+    ClientAttackMotion: 720
     DamageMotion: 672
     Ai: 21
     Class: Boss
@@ -87239,6 +88386,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 09
   - Id: 3477
@@ -87268,6 +88416,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 600
     DamageMotion: 500
     Ai: 09
     Drops:
@@ -87313,6 +88462,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 676
     AttackMotion: 648
+    ClientAttackMotion: 432
     DamageMotion: 432
     Ai: 09
     Class: Boss
@@ -87347,6 +88497,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 09
     Drops:
@@ -87395,6 +88546,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 624
     DamageMotion: 420
     Ai: 09
     Drops:
@@ -87444,6 +88596,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 600
+    ClientAttackMotion: 672
     DamageMotion: 500
     Ai: 09
     Drops:
@@ -87492,6 +88645,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 288
     DamageMotion: 600
     Ai: 09
     Drops:
@@ -87540,6 +88694,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1800
     AttackMotion: 780
+    ClientAttackMotion: 1440
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -87583,6 +88738,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 960
     AttackMotion: 1632
+    ClientAttackMotion: 912
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -87611,6 +88767,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 624
     DamageMotion: 420
     Ai: 09
 #  - Id: 3486
@@ -87640,6 +88797,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 500
     AttackMotion: 840
+    ClientAttackMotion: 600
     DamageMotion: 300
     Ai: 04
     Drops:
@@ -87685,6 +88843,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1000
     AttackMotion: 1100
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -87730,6 +88889,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1500
     AttackMotion: 1500
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -87777,6 +88937,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -87827,6 +88988,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 0
     AttackMotion: 0
+    ClientAttackMotion: 2496
     DamageMotion: 0
     Ai: 01
     Class: Guardian
@@ -88017,7 +89179,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1292
     AttackMotion: 792
-    ClientAttackMotion: 792
+    ClientAttackMotion: 336
     DamageMotion: 216
     Ai: 01
     Modes:
@@ -88115,7 +89277,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 252
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 03
     Drops:
@@ -88157,7 +89319,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 01
     Drops:
@@ -88441,7 +89603,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 864
     AttackMotion: 1056
-    ClientAttackMotion: 672
+    ClientAttackMotion: 360
     DamageMotion: 576
     Ai: 04
     Modes:
@@ -88489,6 +89651,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 72
     DamageMotion: 480
     Ai: 02
 #  - Id: 3509
@@ -88520,6 +89683,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1200
     AttackMotion: 1200
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -88560,6 +89724,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -88602,6 +89767,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -88644,6 +89810,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -88688,6 +89855,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1100
     AttackMotion: 1100
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -88730,6 +89898,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
+    ClientAttackMotion: 1152
     Ai: 10
     Modes:
       IgnoreMagic: true
@@ -88763,6 +89932,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 768
     DamageMotion: 144
     Ai: 20
     Class: Boss
@@ -88811,6 +89981,7 @@ Body:
     WalkSpeed: 210
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
   - Id: 3518
@@ -88840,6 +90011,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1100
     AttackMotion: 1100
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 09
     Drops:
@@ -88880,6 +90052,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -88922,6 +90095,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 432
+    ClientAttackMotion: 576
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -88964,6 +90138,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 824
     AttackMotion: 432
+    ClientAttackMotion: 336
     DamageMotion: 360
     Ai: 21
     Modes:
@@ -89008,6 +90183,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1100
     AttackMotion: 1100
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 20
     Class: Boss
@@ -89050,6 +90226,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
+    ClientAttackMotion: 1152
     Ai: 10
     Modes:
       IgnoreMagic: true
@@ -89083,6 +90260,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 768
     DamageMotion: 144
     Ai: 20
     Class: Boss
@@ -89131,6 +90309,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 861
     AttackMotion: 660
+    ClientAttackMotion: 600
     DamageMotion: 144
     Ai: 04
   - Id: 3526
@@ -89160,6 +90339,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 432
     AttackMotion: 840
+    ClientAttackMotion: 660
     DamageMotion: 216
     DamageTaken: 10
     Ai: 21
@@ -89207,6 +90387,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
   - Id: 3528
@@ -89236,6 +90417,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
 #  - Id: 3529
@@ -89345,6 +90527,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
   - Id: 3570
@@ -89374,6 +90557,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 864
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
 #  - Id: 3571
@@ -89506,7 +90690,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -89566,7 +90750,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 780
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -89606,6 +90790,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1296
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -89631,6 +90816,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1296
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -89656,6 +90842,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 1296
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -89691,6 +90878,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 1296
     AttackMotion: 1902
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -89738,6 +90926,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -89788,7 +90977,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 432
     AttackMotion: 1268
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 1248
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -89876,7 +91065,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
-    ClientAttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -89908,7 +91097,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 772
     AttackMotion: 672
-    ClientAttackMotion: 1620
+    ClientAttackMotion: 1260
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -89957,7 +91146,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 772
     AttackMotion: 672
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 768
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -90007,7 +91196,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 772
     AttackMotion: 672
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 360
     DamageTaken: 10
     Ai: 21
@@ -90102,6 +91291,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90149,6 +91339,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90196,6 +91387,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90243,6 +91435,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90290,6 +91483,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90337,6 +91531,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 2228
     AttackMotion: 528
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -90384,6 +91579,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90431,6 +91627,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90478,6 +91675,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90525,6 +91723,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90572,6 +91771,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90619,6 +91819,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 432
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -90664,6 +91865,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90709,6 +91911,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90754,6 +91957,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90799,6 +92003,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90844,6 +92049,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90889,6 +92095,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -90943,6 +92150,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -91001,6 +92209,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 2612
     AttackMotion: 912
+    ClientAttackMotion: 576
     DamageMotion: 288
     Ai: 21
     Class: Boss
@@ -91058,6 +92267,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -91107,6 +92317,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1816
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 20
     Modes:
@@ -91156,6 +92367,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -91203,6 +92415,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1180
     AttackMotion: 480
+    ClientAttackMotion: 192
     DamageMotion: 648
     Ai: 21
     Drops:
@@ -91250,6 +92463,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -91297,6 +92511,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 04
     Drops:
@@ -91344,6 +92559,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 19
     Drops:
@@ -91391,6 +92607,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1276
     AttackMotion: 576
+    ClientAttackMotion: 288
     DamageMotion: 384
     Ai: 19
     Drops:
@@ -91871,7 +93088,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 900
     AttackMotion: 1000
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 500
     DamageTaken: 10
     Ai: 04
@@ -91915,7 +93132,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Modes:
       IgnoreMagic: true
@@ -92111,7 +93328,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 576
+    ClientAttackMotion: 420
     DamageMotion: 600
     Ai: 04
     Drops:
@@ -92159,7 +93376,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1500
     AttackMotion: 600
-    ClientAttackMotion: 432
+    ClientAttackMotion: 300
     DamageMotion: 500
     Ai: 04
     Drops:
@@ -92253,7 +93470,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 500
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -92301,7 +93518,7 @@ Body:
     WalkSpeed: 400
     AttackDelay: 924
     AttackMotion: 912
-    ClientAttackMotion: 912
+    ClientAttackMotion: 816
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -92345,7 +93562,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 2456
     AttackMotion: 912
-    ClientAttackMotion: 456
+    ClientAttackMotion: 408
     DamageMotion: 504
     Ai: 19
     Drops:
@@ -92395,7 +93612,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1826
     AttackMotion: 816
-    ClientAttackMotion: 576
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 19
     Modes:
@@ -92437,7 +93654,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackMotion: 1
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     Drops:
       - Item: Alchol
         Rate: 50
@@ -92482,7 +93699,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 864
-    ClientAttackMotion: 768
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 19
     Class: Boss
@@ -92742,7 +93959,7 @@ Body:
     WalkSpeed: 190
     AttackDelay: 1720
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -92836,7 +94053,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2864
     AttackMotion: 864
-    ClientAttackMotion: 672
+    ClientAttackMotion: 336
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -92884,7 +94101,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 768
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -92932,7 +94149,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1450
     AttackMotion: 864
-    ClientAttackMotion: 864
+    ClientAttackMotion: 672
     DamageMotion: 288
     Ai: 19
     Drops:
@@ -93023,6 +94240,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 960
     AttackMotion: 500
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -93071,6 +94289,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 1000
     Ai: 04
     Drops:
@@ -93282,7 +94501,7 @@ Body:
     ElementLevel: 2
     WalkSpeed: 1000
     AttackDelay: 1344
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     Drops:
       - Item: Frozen_PieceOfRock
         Rate: 200
@@ -93379,7 +94598,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 500
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 500
     Modes:
       NORANDOMWALK: true
@@ -93407,7 +94626,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 500
     AttackMotion: 500
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 500
     Modes:
       NORANDOMWALK: true
@@ -93598,7 +94817,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1440
+    ClientAttackMotion: 1248
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -93648,7 +94867,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1452
     AttackMotion: 483
-    ClientAttackMotion: 1296
+    ClientAttackMotion: 1200
     DamageMotion: 528
     Ai: 21
     Drops:
@@ -93759,6 +94978,7 @@ Body:
     WalkSpeed: 170
     AttackDelay: 768
     AttackMotion: 1632
+    ClientAttackMotion: 288
     DamageMotion: 576
     Ai: 21
     Class: Boss
@@ -93813,6 +95033,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 2496
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -93852,6 +95073,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -93891,6 +95113,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -93938,6 +95161,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -93985,6 +95209,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -94032,6 +95257,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -94235,6 +95461,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 512
     AttackMotion: 780
+    ClientAttackMotion: 540
     DamageMotion: 504
     Ai: 21
     Modes:
@@ -94960,7 +96187,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 300
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 384
     Modes:
       NoRandomWalk: true
@@ -94993,7 +96220,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 860
     AttackMotion: 660
-    ClientAttackMotion: 660
+    ClientAttackMotion: 540
     DamageMotion: 624
     Ai: 07
     Drops:
@@ -95043,7 +96270,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 632
     AttackMotion: 518
-    ClientAttackMotion: 384
+    ClientAttackMotion: 720
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -95093,7 +96320,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
-    ClientAttackMotion: 900
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 10
     Drops:
@@ -95393,6 +96620,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1332
     AttackMotion: 1332
+    ClientAttackMotion: 936
     DamageMotion: 672
     Ai: 24
   - Id: 20279
@@ -95420,6 +96648,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 857
     AttackMotion: 1056
+    ClientAttackMotion: 420
     DamageMotion: 576
     Ai: 24
   - Id: 20280
@@ -95447,6 +96676,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 912
     AttackMotion: 1344
+    ClientAttackMotion: 420
     DamageMotion: 480
     Ai: 24
 #  - Id: 20281
@@ -95639,6 +96869,7 @@ Body:
     WalkSpeed: 110
     AttackDelay: 741
     AttackMotion: 1536
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -95718,6 +96949,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 432
     AttackMotion: 864
+    ClientAttackMotion: 360
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -95755,6 +96987,7 @@ Body:
     ElementLevel: 1
     WalkSpeed: 1000
     AttackDelay: 101
+    ClientAttackMotion: 480
     DamageMotion: 480
     Modes:
       IgnoreMagic: true
@@ -95786,6 +97019,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 360
     Modes:
       IgnoreMagic: true
@@ -95893,6 +97127,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1872
     AttackMotion: 360
+    ClientAttackMotion: 384
     DamageMotion: 864
     Ai: 04
     Drops:
@@ -95933,6 +97168,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -95973,6 +97209,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 206
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 288
     Ai: 04
     Drops:
@@ -96003,6 +97240,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 76
     AttackMotion: 384
+    ClientAttackMotion: 0
     DamageMotion: 288
     Class: Boss
     Modes:
@@ -96037,6 +97275,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1100
     AttackMotion: 650
+    ClientAttackMotion: 528
     DamageMotion: 500
     Ai: 04
   - Id: 20353
@@ -96066,6 +97305,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1872
     AttackMotion: 672
+    ClientAttackMotion: 540
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -96098,6 +97338,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -96143,6 +97384,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1270
     AttackMotion: 1268
+    ClientAttackMotion: 144
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -96188,6 +97430,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 432
     AttackMotion: 1268
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -96233,6 +97476,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 432
     AttackMotion: 1268
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 19
     Drops:
@@ -96278,6 +97522,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 528
     DamageMotion: 240
     Ai: 19
     Drops:
@@ -96321,6 +97566,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1289
     AttackMotion: 1080
+    ClientAttackMotion: 528
     DamageMotion: 240
     Ai: 19
     Drops:
@@ -96364,6 +97610,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -96407,6 +97654,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1781
     AttackMotion: 768
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 19
     Drops:
@@ -96450,6 +97698,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 792
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -96495,6 +97744,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 792
+    ClientAttackMotion: 360
     DamageMotion: 432
     Ai: 19
     Drops:
@@ -96540,6 +97790,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -96583,6 +97834,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 1020
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 19
     Drops:
@@ -96626,6 +97878,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 824
     AttackMotion: 780
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 21
     Drops:
@@ -96670,6 +97923,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 972
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -96711,6 +97965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 600
     DamageMotion: 384
     Ai: 05
     Drops:
@@ -96758,6 +98013,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 528
     AttackMotion: 500
+    ClientAttackMotion: 336
     DamageMotion: 240
     Ai: 21
     Drops:
@@ -96803,6 +98059,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1960
     AttackMotion: 576
+    ClientAttackMotion: 336
     DamageMotion: 420
     Ai: 05
     Drops:
@@ -96849,6 +98106,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1732
     AttackMotion: 1332
+    ClientAttackMotion: 468
     DamageMotion: 540
     Ai: 21
     Drops:
@@ -96898,6 +98156,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1216
     AttackMotion: 816
+    ClientAttackMotion: 720
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -96946,6 +98205,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1020
     AttackMotion: 720
+    ClientAttackMotion: 336
     DamageMotion: 384
     Ai: 21
     Drops:
@@ -96994,6 +98254,7 @@ Body:
     WalkSpeed: 175
     AttackDelay: 1024
     AttackMotion: 624
+    ClientAttackMotion: 336
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -97042,6 +98303,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 1260
     AttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -97090,6 +98352,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1700
     AttackMotion: 1000
+    ClientAttackMotion: 432
     DamageMotion: 500
     Ai: 21
     Drops:
@@ -97138,6 +98401,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 2190
     AttackMotion: 2040
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -97187,6 +98451,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 384
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -97233,6 +98498,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1056
     AttackMotion: 1056
+    ClientAttackMotion: 432
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -97327,6 +98593,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1028
     AttackMotion: 1020
+    ClientAttackMotion: 384
     DamageMotion: 420
     Ai: 21
 #  - Id: 20383
@@ -97428,6 +98695,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 608
     AttackMotion: 408
+    ClientAttackMotion: 1056
     DamageMotion: 336
     DamageTaken: 10
     Ai: 21
@@ -97482,6 +98750,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 672
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 192
     Ai: 21
     Drops:
@@ -97528,6 +98797,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1020
     AttackMotion: 500
+    ClientAttackMotion: 1056
     DamageMotion: 768
     DamageTaken: 10
     Ai: 21
@@ -97580,6 +98850,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 868
     AttackMotion: 768
+    ClientAttackMotion: 408
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -97901,6 +99172,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 17
 #  - Id: 20561
@@ -97992,6 +99264,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 1056
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -98039,6 +99312,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 768
     AttackMotion: 1440
+    ClientAttackMotion: 1056
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -98086,6 +99360,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -98133,6 +99408,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -98180,6 +99456,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -98227,6 +99504,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 648
     AttackMotion: 480
+    ClientAttackMotion: 300
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -98274,6 +99552,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 360
     AttackMotion: 360
+    ClientAttackMotion: 480
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -98319,6 +99598,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 360
     AttackMotion: 360
+    ClientAttackMotion: 480
     DamageMotion: 600
     Ai: 21
     Drops:
@@ -98344,6 +99624,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1008
     AttackMotion: 1200
+    ClientAttackMotion: 1536
     DamageMotion: 540
     Ai: 21
     Class: Boss
@@ -98397,6 +99678,7 @@ Body:
     WalkSpeed: 350
     AttackDelay: 420
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 21
     Class: Boss
@@ -98447,6 +99729,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 360
+    ClientAttackMotion: 120
     DamageMotion: 360
     Ai: 02
     Drops:
@@ -98494,6 +99777,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 960
     AttackMotion: 336
+    ClientAttackMotion: 480
     DamageMotion: 300
     Ai: 04
     Drops:
@@ -98576,6 +99860,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 480
     AttackMotion: 1632
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -98628,6 +99913,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 480
     AttackMotion: 1632
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Class: Boss
@@ -98679,6 +99965,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -98720,6 +100007,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -98767,6 +100055,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Modes:
@@ -98812,6 +100101,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 512
     AttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 240
     Ai: 04
     Modes:
@@ -98860,6 +100150,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 360
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -98905,6 +100196,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 500
     AttackMotion: 576
+    ClientAttackMotion: 360
     DamageMotion: 504
     Ai: 04
     Modes:
@@ -98953,6 +100245,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 336
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -98993,6 +100286,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99031,6 +100325,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99075,6 +100370,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99119,6 +100415,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99165,6 +100462,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99220,6 +100518,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99273,6 +100572,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 672
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99319,6 +100619,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99367,6 +100668,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99414,6 +100716,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
   - Id: 20639
@@ -99445,6 +100748,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99491,6 +100795,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 02
     Drops:
@@ -99535,6 +100840,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99583,6 +100889,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 648
     AttackMotion: 1296
+    ClientAttackMotion: 720
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -99678,7 +100985,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1200
     AttackMotion: 1200
-    ClientAttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -99821,6 +101128,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 384
     DamageMotion: 480
     Ai: 04
     Modes:
@@ -99872,6 +101180,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
@@ -99925,6 +101234,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -99971,6 +101281,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100017,6 +101328,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100063,6 +101375,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100109,6 +101422,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100151,6 +101465,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
   - Id: 20655
@@ -100178,6 +101493,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
   - Id: 20656
@@ -100205,6 +101521,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 720
+    ClientAttackMotion: 960
     DamageMotion: 432
     Ai: 04
   - Id: 20657
@@ -100232,6 +101549,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
   - Id: 20658
@@ -100259,6 +101577,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 720
+    ClientAttackMotion: 960
     DamageMotion: 432
     Ai: 04
   - Id: 20659
@@ -100289,6 +101608,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 768
     AttackMotion: 768
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 21
     Modes:
@@ -100334,6 +101654,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100378,6 +101699,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100422,6 +101744,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100466,6 +101789,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100510,6 +101834,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1540
     AttackMotion: 2112
+    ClientAttackMotion: 960
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -100554,6 +101879,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1344
     AttackMotion: 1344
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100595,6 +101921,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 1344
     AttackMotion: 1344
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100639,6 +101966,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 384
     DamageMotion: 840
     Ai: 21
     Modes:
@@ -100682,6 +102010,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1136
     AttackMotion: 720
+    ClientAttackMotion: 384
     DamageMotion: 840
     Ai: 21
     Modes:
@@ -100728,6 +102057,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100771,6 +102101,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100817,6 +102148,7 @@ Body:
     WalkSpeed: 155
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100860,6 +102192,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -100904,6 +102237,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 576
     DamageMotion: 1
     Ai: 06
     Class: Battlefield
@@ -100940,6 +102274,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -100983,6 +102318,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 1152
     AttackMotion: 1152
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 01
     Drops:
@@ -101027,6 +102363,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 576
     DamageMotion: 1
     Ai: 06
     Class: Battlefield
@@ -101063,6 +102400,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1440
     AttackMotion: 1440
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -101102,6 +102440,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1440
     AttackMotion: 1440
+    ClientAttackMotion: 864
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -101136,7 +102475,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1
     AttackMotion: 1
-    ClientAttackMotion: 96
+    ClientAttackMotion: 0
     DamageMotion: 1
     Ai: 06
     Class: Battlefield
@@ -101173,6 +102512,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -101220,6 +102560,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
   - Id: 20682
@@ -101251,6 +102592,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 1268
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -101300,6 +102642,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 576
     AttackMotion: 576
+    ClientAttackMotion: 240
     DamageMotion: 420
     Ai: 04
     Drops:
@@ -101346,6 +102689,7 @@ Body:
     WalkSpeed: 130
     AttackDelay: 912
     AttackMotion: 1824
+    ClientAttackMotion: 960
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -101392,6 +102736,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 768
     AttackMotion: 1536
+    ClientAttackMotion: 360
     DamageMotion: 960
     Ai: 04
     Drops:
@@ -101526,6 +102871,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 384
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 05
     Drops:
@@ -101573,6 +102919,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 1768
     AttackMotion: 768
+    ClientAttackMotion: 540
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -101617,6 +102964,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -101661,6 +103009,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1280
     AttackMotion: 1080
+    ClientAttackMotion: 528
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -101707,6 +103056,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 480
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -101753,6 +103103,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -101799,6 +103150,7 @@ Body:
     WalkSpeed: 120
     AttackDelay: 912
     AttackMotion: 1248
+    ClientAttackMotion: 1296
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -101843,6 +103195,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 01
   - Id: 20697
@@ -101870,6 +103223,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1152
     AttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 01
   - Id: 20698
@@ -101897,6 +103251,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 480
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
   - Id: 20699
@@ -101924,6 +103279,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 384
     AttackMotion: 384
+    ClientAttackMotion: 288
     DamageMotion: 480
     Ai: 04
   - Id: 20700
@@ -101951,6 +103307,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 960
     AttackMotion: 960
+    ClientAttackMotion: 768
     DamageMotion: 480
     Ai: 04
 #  - Id: 20701
@@ -102226,7 +103583,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 936
     AttackMotion: 1155
-    ClientAttackMotion: 288
+    ClientAttackMotion: 384
     DamageMotion: 672
     Ai: 04
     Drops:
@@ -102318,7 +103675,7 @@ Body:
     WalkSpeed: 270
     AttackDelay: 1070
     AttackMotion: 1512
-    ClientAttackMotion: 936
+    ClientAttackMotion: 468
     DamageMotion: 485
     Ai: 04
     Drops:
@@ -102366,7 +103723,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 708
     AttackMotion: 1225
-    ClientAttackMotion: 504
+    ClientAttackMotion: 384
     DamageMotion: 675
     Ai: 04
     Drops:
@@ -102460,7 +103817,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 335
     AttackMotion: 1250
-    ClientAttackMotion: 384
+    ClientAttackMotion: 192
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -102508,7 +103865,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 276
     AttackMotion: 672
-    ClientAttackMotion: 480
+    ClientAttackMotion: 108
     DamageMotion: 384
     Ai: 04
     Drops:
@@ -102556,7 +103913,7 @@ Body:
     WalkSpeed: 220
     AttackDelay: 168
     AttackMotion: 1154
-    ClientAttackMotion: 528
+    ClientAttackMotion: 432
     DamageMotion: 865
     Ai: 04
     Drops:
@@ -102604,7 +103961,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 480
     AttackMotion: 960
-    ClientAttackMotion: 480
+    ClientAttackMotion: 360
     DamageMotion: 970
     Ai: 04
     Drops:
@@ -102650,7 +104007,7 @@ Body:
     WalkSpeed: 180
     AttackDelay: 422
     AttackMotion: 870
-    ClientAttackMotion: 384
+    ClientAttackMotion: 480
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -102739,6 +104096,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 648
     DamageMotion: 300
     Ai: 20
   - Id: 20835
@@ -102764,6 +104122,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 576
     DamageMotion: 300
     Ai: 20
   - Id: 20836
@@ -102789,6 +104148,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 672
     DamageMotion: 300
     Ai: 20
   - Id: 20837
@@ -102814,6 +104174,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
+    ClientAttackMotion: 840
     DamageMotion: 300
     Ai: 20
 #  - Id: 20838
@@ -102902,6 +104263,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 432
     AttackMotion: 288
+    ClientAttackMotion: 0
     DamageMotion: 576
     Ai: 10
     Class: Battlefield
@@ -102934,6 +104296,7 @@ Body:
     WalkSpeed: 100
     AttackDelay: 1
     AttackMotion: 1
+    ClientAttackMotion: 0
     DamageMotion: 1
     Ai: 06
   - Id: 20848
@@ -102959,7 +104322,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 960
+    ClientAttackMotion: 480
     DamageMotion: 300
     Ai: 20
   - Id: 20849
@@ -102985,7 +104348,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 864
     DamageMotion: 300
     Ai: 20
   - Id: 20850
@@ -103011,7 +104374,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 840
+    ClientAttackMotion: 0
     DamageMotion: 300
     Ai: 20
   - Id: 20851
@@ -103037,7 +104400,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 500
-    ClientAttackMotion: 1080
+    ClientAttackMotion: 840
     DamageMotion: 300
     Ai: 20
 #  - Id: 20856
@@ -103893,7 +105256,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1332
     AttackMotion: 2664
-    ClientAttackMotion: 936
+    ClientAttackMotion: 528
     DamageMotion: 480
     Ai: 04
     Drops:
@@ -104335,7 +105698,7 @@ Body:
     WalkSpeed: 125
     AttackDelay: 510
     AttackMotion: 1020
-    ClientAttackMotion: 720
+    ClientAttackMotion: 1440
     DamageMotion: 576
     Ai: 04
     Drops:
@@ -104765,6 +106128,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104787,6 +106151,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104809,6 +106174,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104831,6 +106197,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104853,6 +106220,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104875,6 +106243,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104897,6 +106266,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104919,6 +106289,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104941,6 +106312,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104963,6 +106335,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -104985,6 +106358,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105007,6 +106381,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105029,6 +106404,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105052,6 +106428,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 482
     Modes:
       NoRandomWalk: true
@@ -105074,6 +106451,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105097,6 +106475,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105120,6 +106499,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105143,6 +106523,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105166,6 +106547,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105189,6 +106571,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105212,6 +106595,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105235,6 +106619,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105258,6 +106643,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1672
     AttackMotion: 672
+    ClientAttackMotion: 0
     DamageMotion: 480
     Class: Boss
     Modes:
@@ -105864,7 +107250,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 936
     AttackMotion: 1872
-    ClientAttackMotion: 1872
+    ClientAttackMotion: 1728
     DamageMotion: 432
     Ai: 04
     Drops:
@@ -106185,7 +107571,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 576
-    ClientAttackMotion: 360
+    ClientAttackMotion: 216
     DamageMotion: 648
     Ai: 04
     Drops:
@@ -106311,7 +107697,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 792
     AttackMotion: 792
-    ClientAttackMotion: 432
+    ClientAttackMotion: 216
     DamageMotion: 360
     Ai: 04
     Drops:
@@ -106405,7 +107791,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 648
     AttackMotion: 648
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
   - Id: 21311
@@ -106433,7 +107819,7 @@ Body:
     WalkSpeed: 140
     AttackDelay: 648
     AttackMotion: 648
-    ClientAttackMotion: 1344
+    ClientAttackMotion: 1152
     DamageMotion: 480
     Ai: 04
   - Id: 21312
@@ -106461,7 +107847,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 432
-    ClientAttackMotion: 1152
+    ClientAttackMotion: 960
     DamageMotion: 360
     Ai: 04
   - Id: 21313
@@ -106597,7 +107983,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 1440
-    ClientAttackMotion: 2880
+    ClientAttackMotion: 2592
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -106632,7 +108018,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 736
     AttackMotion: 1104
-    ClientAttackMotion: 672
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -106667,7 +108053,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
-    ClientAttackMotion: 672
+    ClientAttackMotion: 480
     DamageMotion: 720
     Ai: 04
     Drops:
@@ -106806,7 +108192,7 @@ Body:
     WalkSpeed: 165
     AttackDelay: 540
     AttackMotion: 1080
-    ClientAttackMotion: 660
+    ClientAttackMotion: 720
     DamageMotion: 336
     Ai: 04
     Drops:
@@ -106852,7 +108238,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 1600
     AttackMotion: 900
-    ClientAttackMotion: 252
+    ClientAttackMotion: 216
     DamageMotion: 240
     Ai: 04
     Drops:
@@ -106964,6 +108350,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 720
     AttackMotion: 1440
+    ClientAttackMotion: 504
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -107000,6 +108387,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 736
     AttackMotion: 1104
+    ClientAttackMotion: 576
     DamageMotion: 480
     Ai: 21
     Class: Boss
@@ -107064,6 +108452,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 576
     AttackMotion: 1152
+    ClientAttackMotion: 480
     DamageMotion: 720
     Ai: 04
   - Id: 21378
@@ -107091,6 +108480,7 @@ Body:
     WalkSpeed: 150
     AttackDelay: 864
     AttackMotion: 432
+    ClientAttackMotion: 288
     DamageMotion: 360
     Ai: 05
 #  - Id: 21379
@@ -107230,7 +108620,7 @@ Body:
     WalkSpeed: 200
     AttackDelay: 1000
     AttackMotion: 792
-    ClientAttackMotion: 336
+    ClientAttackMotion: 96
     DamageMotion: 336
     Ai: 21
     Drops:
@@ -107322,7 +108712,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1288
     AttackMotion: 288
-    ClientAttackMotion: 96
+    ClientAttackMotion: 144
     DamageMotion: 576
     Ai: 21
     Drops:
@@ -107361,7 +108751,7 @@ Body:
     WalkSpeed: 1000
     AttackDelay: 1001
     AttackMotion: 1
-    ClientAttackMotion: 768
+    ClientAttackMotion: 672
     DamageMotion: 1
     Ai: 06
     Drops:
@@ -107409,7 +108799,7 @@ Body:
     WalkSpeed: 250
     AttackDelay: 1848
     AttackMotion: 1296
-    ClientAttackMotion: 1008
+    ClientAttackMotion: 480
     DamageMotion: 432
     Ai: 21
     Drops:
@@ -107503,7 +108893,7 @@ Body:
     WalkSpeed: 300
     AttackDelay: 1768
     AttackMotion: 768
-    ClientAttackMotion: 432
+    ClientAttackMotion: 576
     DamageMotion: 384
     Ai: 21
     Drops:

--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -78,7 +78,7 @@
 
 Header:
   Type: MOB_DB
-  Version: 3
+  Version: 4
 
 Body:
   - Id: 1001

--- a/doc/mob_db.txt
+++ b/doc/mob_db.txt
@@ -205,15 +205,14 @@ AttackMotion: Attack animation motion. Low value means monster's attack will be 
 ---------------------------------------
 
 ClientAttackMotion: The time from the start of a normal attack until the damage frame shows on client. At the same time you also get stopped on the client.
-This value is only needed if you use the "synchronize_damage" feature (battle/client.conf).
-If you created a custom sprite, you want to set this value to the timing of the damage frame in your *.act file.
+This value is only needed if you use the "synchronize_damage" feature (battle/battle.conf).
 
-Background:
-When a clif_damage packet is sent to the client it will also send "sdelay" (AttackMotion) as value.
-The client will ignore all values above 432, and 432 stands for 1.0x animation speed. 216 for example means play the animation at double the speed.
-Each monster has an attack animation and can define the frame in the attack animation on which it displays the damage and makes the target flinch / stop.
-If the damage frame is undefined, it instead displays the damage / flinch / stop at the very end of the animation.
-Knowing when the damage frame happens in the animation allows us to synchronize the timing between client and server.
+If you created a custom sprite, you want to set this value to the timing of the damage frame in your *.act file.
+In Act Editor you can set the damage frame by setting the frame sound to "atk". If you don't define a damage frame, it will default to the second to last
+frame. Also keep in mind that the Act Editor displays slightly inaccurate speed. Every 25ms in Act Editor is 24ms in reality.
+
+Example: Drops has a animation speed of 24ms per frame and the 13th frame (frame #12) is the damage frame. This means the damage shows after 12 frames.
+That's why Drops has a ClientAttackMotion of 24*12 = 288.
 
 ---------------------------------------
 

--- a/doc/mob_db.txt
+++ b/doc/mob_db.txt
@@ -204,6 +204,14 @@ AttackMotion: Attack animation motion. Low value means monster's attack will be 
 
 ---------------------------------------
 
+ClientAttackMotion: When a clif_damage packet is sent to the client it will also send "sdelay" (AttackMotion) as value.
+
+The client will ignore all values above 432, and 432 stands for 1.0x animation speed. 216 for example means play the animation at double the speed.
+Each monster has an attack animation and can define the frame in the attack animation on which it displays the damage and makes the target flinch / stop.
+If the damage frame is undefined, it instead displays the damage / flinch / stop at the very end of the animation.
+
+---------------------------------------
+
 DamageMotion: Damage animation motion, same as aMotion but used to display the "I am hit" animation. Coincidentally, this same value is used to determine how long it is before the monster/player can move again. Endure is dMotion = 0, obviously.
 
 ---------------------------------------

--- a/doc/mob_db.txt
+++ b/doc/mob_db.txt
@@ -204,11 +204,16 @@ AttackMotion: Attack animation motion. Low value means monster's attack will be 
 
 ---------------------------------------
 
-ClientAttackMotion: When a clif_damage packet is sent to the client it will also send "sdelay" (AttackMotion) as value.
+ClientAttackMotion: The time from the start of a normal attack until the damage frame shows on client. At the same time you also get stopped on the client.
+This value is only needed if you use the "synchronize_damage" feature (battle/client.conf).
+If you created a custom sprite, you want to set this value to the timing of the damage frame in your *.act file.
 
+Background:
+When a clif_damage packet is sent to the client it will also send "sdelay" (AttackMotion) as value.
 The client will ignore all values above 432, and 432 stands for 1.0x animation speed. 216 for example means play the animation at double the speed.
 Each monster has an attack animation and can define the frame in the attack animation on which it displays the damage and makes the target flinch / stop.
 If the damage frame is undefined, it instead displays the damage / flinch / stop at the very end of the animation.
+Knowing when the damage frame happens in the animation allows us to synchronize the timing between client and server.
 
 ---------------------------------------
 

--- a/doc/yaml/db/mob_db.yml
+++ b/doc/yaml/db/mob_db.yml
@@ -39,7 +39,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
-#   ClientAttackMotion      Client attack speed. (Default: 432)
+#   ClientAttackMotion      Client attack speed. (Default: AttackMotion)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/doc/yaml/db/mob_db.yml
+++ b/doc/yaml/db/mob_db.yml
@@ -39,6 +39,7 @@
 #   WalkSpeed               Walk speed. (Default: DEFAULT_WALK_SPEED)
 #   AttackDelay             Attack speed. (Default: 0)
 #   AttackMotion            Attack animation speed. (Default: 0)
+#   ClientAttackMotion      Client attack speed. (Default: 432)
 #   DamageMotion            Damage animation speed. (Default: 0)
 #   DamageTaken             Rate at which the monster will receive incoming damage. (Default: 100)
 #   Ai                      Aegis monster type AI behavior. (Default: 06)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -416,7 +416,7 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 	dat->additional_effects = additional_effects;
 	dat->src_type = src->type;
 	dat->isspdamage = isspdamage;
-	if (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage && amotion > status_get_clientamotion(src)) {
+	if (battle_config.synchronize_damage && skill_id == 0 && src->type == BL_MOB && amotion > status_get_clientamotion(src)) {
 		// The client refuses to display animations slower than 1x speed
 		// So we need to shorten AttackMotion to be in-sync with the client in this case
 		amotion = status_get_clientamotion(src);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -393,8 +393,12 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 		damage = 0;
 	}
 
-	// If the synchronize damage feature is activated then disabling delay battle damage should only affect skills
-	if ((!battle_config.delay_battle_damage && (!battle_config.synchronize_damage || skill_id != 0)) || amotion <= 1) {
+	// If the synchronize damage feature is activated then disabling delay battle damage should only affect skills (for monsters)
+	// If clientamotion is 1 or lower for monsters, we can apply damage directly for normal attacks and don't need to create a timer
+	// Same applies for all types, normal attacks and skills if amotion is 1 or lower
+	if ((!battle_config.delay_battle_damage && (src->type != BL_MOB || !battle_config.synchronize_damage || skill_id != 0))
+		|| (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage && status_get_clientamotion(src) <= 1)
+		|| amotion <= 1) {
 		//Deal damage
 		battle_damage(src, target, damage, ddelay, skill_lv, skill_id, dmg_lv, attack_type, additional_effects, gettick(), isspdamage);
 		return 0;
@@ -412,12 +416,10 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 	dat->additional_effects = additional_effects;
 	dat->src_type = src->type;
 	dat->isspdamage = isspdamage;
-	if (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage) {
-		mob_data* md = BL_CAST(BL_MOB, src);
+	if (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage && amotion > status_get_clientamotion(src)) {
 		// The client refuses to display animations slower than 1x speed
 		// So we need to shorten AttackMotion to be in-sync with the client in this case
-		if (md != nullptr && amotion > md->status.clientamotion)
-			amotion = md->status.clientamotion;
+		amotion = status_get_clientamotion(src);
 	}
 	else if (src->type != BL_PC && amotion > 1000)
 		amotion = 1000; //Aegis places a damage-delay cap of 1 sec to non player attacks. [Skotlex]

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -393,12 +393,16 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 		damage = 0;
 	}
 
-	// If the synchronize damage feature is activated then disabling delay battle damage should only affect skills (for monsters)
+	// Check for delay battle damage config
+	// If the synchronize damage feature is activated then disabling the config should only affect skills (for monsters)
+	if (!battle_config.delay_battle_damage && (!battle_config.synchronize_damage || skill_id != 0 || src->type != BL_MOB))
+		amotion = 1;
 	// If clientamotion is 1 or lower for monsters, we can apply damage directly for normal attacks and don't need to create a timer
-	// Same applies for all types, normal attacks and skills if amotion is 1 or lower
-	if ((!battle_config.delay_battle_damage && (src->type != BL_MOB || !battle_config.synchronize_damage || skill_id != 0))
-		|| (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage && status_get_clientamotion(src) <= 1)
-		|| amotion <= 1) {
+	else if (battle_config.synchronize_damage && skill_id == 0 && src->type == BL_MOB && status_get_clientamotion(src) <= 1)
+		amotion = 1;
+
+	// Skip creation of timer
+	if (amotion <= 1) {
 		//Deal damage
 		battle_damage(src, target, damage, ddelay, skill_lv, skill_id, dmg_lv, attack_type, additional_effects, gettick(), isspdamage);
 		return 0;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11475,7 +11475,7 @@ static const struct _battle_data {
 #else
 	{ "feature.instance_allow_reconnect",   &battle_config.instance_allow_reconnect,        0,      0,      1,              },
 #endif
-	{ "synchronize_damage",                  &battle_config.synchronize_damage,             0,      0,      1,              },
+	{ "synchronize_damage",                 &battle_config.synchronize_damage,              0,      0,      1,              },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -393,14 +393,13 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 		damage = 0;
 	}
 
-	// Check for delay battle damage config
-	// If the synchronize damage feature is activated then disabling the config should only affect skills (for monsters)
-	if (!battle_config.delay_battle_damage && (!battle_config.synchronize_damage || skill_id != 0 || src->type != BL_MOB))
-		amotion = 1;
 	// The client refuses to display animations slower than 1x speed
 	// So we need to shorten AttackMotion to be in-sync with the client in this case
-	else if (battle_config.synchronize_damage && skill_id == 0 && src->type == BL_MOB && amotion > status_get_clientamotion(src))
+	if (battle_config.synchronize_damage && skill_id == 0 && src->type == BL_MOB && amotion > status_get_clientamotion(src))
 		amotion = status_get_clientamotion(src);
+	// Check for delay battle damage config
+	else if (!battle_config.delay_battle_damage)
+		amotion = 1;
 	// Aegis places a damage-delay cap of 1 sec to non player attacks
 	// We only want to apply this cap if damage was not synchronized
 	else if (src->type != BL_PC && amotion > 1000)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -416,7 +416,7 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 		mob_data* md = BL_CAST(BL_MOB, src);
 		// The client refuses to display animations slower than 1x speed
 		// So we need to shorten AttackMotion to be in-sync with the client in this case
-		if (amotion > md->status.clientamotion)
+		if (md != nullptr && amotion > md->status.clientamotion)
 			amotion = md->status.clientamotion;
 	}
 	else if (src->type != BL_PC && amotion > 1000)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -393,7 +393,8 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 		damage = 0;
 	}
 
-	if ( !battle_config.delay_battle_damage || amotion <= 1 ) {
+	// If the synchronize damage feature is activated then disabling delay battle damage should only affect skills
+	if ((!battle_config.delay_battle_damage && (!battle_config.synchronize_damage || skill_id != 0)) || amotion <= 1) {
 		//Deal damage
 		battle_damage(src, target, damage, ddelay, skill_lv, skill_id, dmg_lv, attack_type, additional_effects, gettick(), isspdamage);
 		return 0;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -411,7 +411,14 @@ int battle_delay_damage(t_tick tick, int amotion, struct block_list *src, struct
 	dat->additional_effects = additional_effects;
 	dat->src_type = src->type;
 	dat->isspdamage = isspdamage;
-	if (src->type != BL_PC && amotion > 1000)
+	if (skill_id == 0 && src->type == BL_MOB && battle_config.synchronize_damage) {
+		mob_data* md = BL_CAST(BL_MOB, src);
+		// The client refuses to display animations slower than 1x speed
+		// So we need to shorten AttackMotion to be in-sync with the client in this case
+		if (amotion > md->status.clientamotion)
+			amotion = md->status.clientamotion;
+	}
+	else if (src->type != BL_PC && amotion > 1000)
 		amotion = 1000; //Aegis places a damage-delay cap of 1 sec to non player attacks. [Skotlex]
 
 	if( src->type == BL_PC )
@@ -11461,6 +11468,7 @@ static const struct _battle_data {
 #else
 	{ "feature.instance_allow_reconnect",   &battle_config.instance_allow_reconnect,        0,      0,      1,              },
 #endif
+	{ "synchronize_damage",                  &battle_config.synchronize_damage,             0,      0,      1,              },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -755,6 +755,7 @@ struct Battle_Config
 	int feature_stylist;
 	int feature_banking_state_enforce;
 	int instance_allow_reconnect;
+	int synchronize_damage;
 
 #include <custom/battle_config_struct.inc>
 };

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5245,7 +5245,7 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 	}
 
 	// Calculate what sdelay to send to the client so it applies damage at the same time as the server
-	if (battle_config.synchronize_damage && src->type == BL_MOB && status_get_clientamotion(src) != 0) {
+	if (battle_config.synchronize_damage && src->type == BL_MOB) {
 		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
 		sdelay = sdelay * DEFAULT_ANIMATION_SPEED / status_get_clientamotion(src);
 	}

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5193,6 +5193,8 @@ static int clif_hallucination_damage()
 	return (rnd() % 32767);
 }
 
+#define DEFAULT_ANIMATION_SPEED 432
+
 /// Sends a 'damage' packet (src performs action on dst)
 /// 008a <src ID>.L <dst ID>.L <server tick>.L <src speed>.L <dst speed>.L <damage>.W <div>.W <type>.B <damage2>.W (ZC_NOTIFY_ACT)
 /// 02e1 <src ID>.L <dst ID>.L <server tick>.L <src speed>.L <dst speed>.L <damage>.L <div>.W <type>.B <damage2>.L (ZC_NOTIFY_ACT2)
@@ -5245,7 +5247,7 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 	// Calculate what sdelay to send to the client so it applies damage at the same time as the server
 	if (battle_config.synchronize_damage && src->type == BL_MOB && status_get_clientamotion(src) != 0) {
 		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
-		sdelay = sdelay * 432 / status_get_clientamotion(src);
+		sdelay = sdelay * DEFAULT_ANIMATION_SPEED / status_get_clientamotion(src);
 	}
 
 	WBUFW(buf,0) = cmd;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5246,7 +5246,8 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 	if (src->type == BL_MOB && battle_config.synchronize_damage) {
 		mob_data* md = BL_CAST(BL_MOB, src);
 		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
-		sdelay = sdelay * 432 / md->status.clientamotion;
+		if (md != nullptr && md->status.clientamotion != 0)
+			sdelay = sdelay * 432 / md->status.clientamotion;
 	}
 
 	WBUFW(buf,0) = cmd;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5243,11 +5243,9 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 	}
 
 	// Calculate what sdelay to send to the client so it applies damage at the same time as the server
-	if (src->type == BL_MOB && battle_config.synchronize_damage) {
-		mob_data* md = BL_CAST(BL_MOB, src);
+	if (src->type == BL_MOB && battle_config.synchronize_damage && status_get_clientamotion(src) != 0) {
 		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
-		if (md != nullptr && md->status.clientamotion != 0)
-			sdelay = sdelay * 432 / md->status.clientamotion;
+		sdelay = sdelay * 432 / status_get_clientamotion(src);
 	}
 
 	WBUFW(buf,0) = cmd;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5255,9 +5255,11 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 		// it displays the damage and makes the target flinch / stop. If the damage frame is undefined,
 		// it instead displays the damage / flinch / stop at the beginning of the second to last frame.
 		// We define the time after which the damage frame shows at 1x speed as clientamotion.
+		uint16 clientamotion = std::max((uint16)1, status_get_clientamotion(src));
+
 		// Knowing when the damage frame happens in the animation allows us to synchronize the timing
 		// between client and server using the formula below.
-		sdelay = sdelay * DEFAULT_ANIMATION_SPEED / std::max(1ui16, status_get_clientamotion(src));
+		sdelay = sdelay * DEFAULT_ANIMATION_SPEED / clientamotion;
 
 		// Hint: If amotion is larger than clientamotion this results in a value above 432 which makes the
 		// client display the attack at 1x speed. In this case we need to shorten the delay damage timer

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5242,6 +5242,13 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 		}
 	}
 
+	// Calculate what sdelay to send to the client so it applies damage at the same time as the server
+	if (src->type == BL_MOB && battle_config.synchronize_damage) {
+		mob_data* md = BL_CAST(BL_MOB, src);
+		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
+		sdelay = sdelay * 432 / md->status.clientamotion;
+	}
+
 	WBUFW(buf,0) = cmd;
 	WBUFL(buf,2) = src->id;
 	WBUFL(buf,6) = dst->id;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5243,7 +5243,7 @@ int clif_damage(struct block_list* src, struct block_list* dst, t_tick tick, int
 	}
 
 	// Calculate what sdelay to send to the client so it applies damage at the same time as the server
-	if (src->type == BL_MOB && battle_config.synchronize_damage && status_get_clientamotion(src) != 0) {
+	if (battle_config.synchronize_damage && src->type == BL_MOB && status_get_clientamotion(src) != 0) {
 		// The client only accepts values between 0 and 432; 432 stands for 1x animation speed
 		sdelay = sdelay * 432 / status_get_clientamotion(src);
 	}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4817,10 +4817,10 @@ uint64 MobDatabase::parseBodyNode(const ryml::NodeRef& node) {
 		if (!this->asUInt16(node, "ClientAttackMotion", speed))
 			return 0;
 
-		mob->status.clientamotion = speed;
+		mob->status.clientamotion = cap_value(speed, 1, USHRT_MAX);
 	} else {
 		if (!exists)
-			mob->status.clientamotion = 432;
+			mob->status.clientamotion = cap_value(mob->status.amotion, 1, USHRT_MAX);
 	}
 
 	if (this->nodeExists(node, "DamageMotion")) {

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4811,6 +4811,18 @@ uint64 MobDatabase::parseBodyNode(const ryml::NodeRef& node) {
 		mob->status.amotion = cap_value(speed, battle_config.monster_max_aspd, 2000);
 	}
 
+	if (this->nodeExists(node, "ClientAttackMotion")) {
+		uint16 speed;
+
+		if (!this->asUInt16(node, "ClientAttackMotion", speed))
+			return 0;
+
+		mob->status.clientamotion = speed;
+	} else {
+		if (!exists)
+			mob->status.clientamotion = 432;
+	}
+
 	if (this->nodeExists(node, "DamageMotion")) {
 		uint16 speed;
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4388,6 +4388,7 @@ s_mob_db::s_mob_db()
 	status.speed = DEFAULT_WALK_SPEED;
 	status.adelay = cap_value(0, battle_config.monster_max_aspd * 2, 4000);
 	status.amotion = cap_value(0, battle_config.monster_max_aspd, 2000);
+	status.clientamotion = cap_value(status.amotion, 1, USHRT_MAX);
 	status.mode = static_cast<e_mode>(MONSTER_TYPE_06);
 
 	vd.class_ = id;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -277,7 +277,7 @@ private:
 	bool parseDropNode(std::string nodeName, const ryml::NodeRef& node, uint8 max, s_mob_drop *drops);
 
 public:
-	MobDatabase() : TypesafeCachedYamlDatabase("MOB_DB", 3, 1) {
+	MobDatabase() : TypesafeCachedYamlDatabase("MOB_DB", 4, 1) {
 
 	}
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3172,7 +3172,7 @@ struct status_data {
 #endif
 		matk_min, matk_max,
 		speed,
-		amotion, adelay, dmotion;
+		amotion, clientamotion, adelay, dmotion;
 	int mode;
 	short
 		hit, flee, cri, flee2,

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3392,6 +3392,7 @@ defType status_get_def(struct block_list *bl);
 unsigned short status_get_speed(struct block_list *bl);
 #define status_get_adelay(bl) status_get_status_data(bl)->adelay
 #define status_get_amotion(bl) status_get_status_data(bl)->amotion
+#define status_get_clientamotion(bl) status_get_status_data(bl)->clientamotion
 #define status_get_dmotion(bl) status_get_status_data(bl)->dmotion
 #define status_get_patk(bl) status_get_status_data(bl)->patk
 #define status_get_smatk(bl) status_get_status_data(bl)->smatk


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #259 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Added a new monster stat "ClientAttackMotion" to mob_db.yml which is the time from when a monster attacks until which the damage shows on the client at 1x speed
- Added a new config synchronize_damage; when set to "yes", the client will display the damage of normal monster attacks at the exact time it is applied on the server, removing position lag (fixes #259)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
