### PR TITLE
Spawn and Free Cell Search Behavior

### DIFF
--- a/conf/battle/misc.conf
+++ b/conf/battle/misc.conf
@@ -187,6 +187,6 @@ hide_fav_sell: no
 // When searching for a random position on the map, how much of the border of the map shall not be considered?
 // Officially the 15 tiles from the edge of the map on each side are not considered as target cells.
 // On some maps like in Pyramids this causes there to be very few monsters in the outer areas. This also
-// affects teleportation. Set this to 4 if you want it to be closer to the old emulator behavior.
-// Valid values: 4-40
+// affects teleportation. Set this to 1 if you want it to be closer to the old emulator behavior.
+// Valid values: 1-40
 map_edge_size: 15

--- a/conf/battle/misc.conf
+++ b/conf/battle/misc.conf
@@ -183,3 +183,10 @@ mail_delay: 1000
 
 // Hides items from the player's favorite tab from being sold to a NPC. (Note 1)
 hide_fav_sell: no
+
+// When searching for a random position on the map, how much of the border of the map shall not be considered?
+// Officially the 15 tiles from the edge of the map on each side are not considered as target cells.
+// On some maps like in Pyramids this causes there to be very few monsters in the outer areas. This also
+// affects teleportation. Set this to 4 if you want it to be closer to the old emulator behavior.
+// Valid values: 4-40
+map_edge_size: 15

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -163,6 +163,15 @@ no_spawn_on_player: 0
 // map regardless of what the mob-spawn file says.
 force_random_spawn: no
 
+// Should each monster's center cell be randomized? (Note 1)
+// Officially, at server start, each monster's center cell is set to a random cell in the spawn area.
+// Each time the monster spawns it will spawn in an area around its center cell rather than the
+// original center of the spawn definition. This results in a much larger total spawn area and a
+// different experience each server start.
+// Set this to "no" if you want all monsters of a spawn to spawn around the original center of the
+// spawn definition, making the total spawn area much smaller (old eAthena behavior).
+randomize_center_cell: yes
+
 // Do summon slaves inherit the passive/aggressive traits of their master?
 // 0: No, retain original mode.
 // 1: Slaves are always aggressive.

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -138,11 +138,11 @@ Map name is the name of the map the monsters will spawn on. x,y are the
 coordinates where the mob should spawn. Putting zeros instead of these
 coordinates will spawn the monsters randomly.
 
-If xs and ys are above 1, each monster will spawn in a radius around x,y.
-At server start, each monster will get assigned its own center cell adding or
-substracting up to (xs-1),(ys-1) from the given x,y coordinates.
-Each time a monster respawns, it will spawn in a radius around its personal
-center cell by adding or substracting up to (xs-1),(ys-1) again.
+If the coordinates are non-zero and xs and ys are above 1, each monster will
+spawn in a radius around x,y. At server start, each monster will get assigned
+its own center cell adding or substracting up to (xs-1),(ys-1) from the given
+x,y coordinates. Each time a monster respawns, it will spawn in a radius around
+its personal center cell by adding or substracting up to (xs-1),(ys-1) again.
 This results in a total possible spawn area over all monsters of the spawn line
 of (xs,ys)*4-3, but with a strong bias towards the center of that area:
 2,2 - 5x5
@@ -153,6 +153,8 @@ etc.
 
 Note this is only the initial spawn zone, as mobs random-walk, they are free
 to move away from their specified spawn region.
+You can disable the picking of a random center cell for each monster in the
+battle config. (See /conf/battle/monster.conf::randomize_center_cell.)
 
 Monster name is the name the monsters will have on screen, and has no relation
 whatsoever to their names anywhere else. It's the mob id that counts, which

--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -1,4 +1,4 @@
-//===== rAthena Documentation================================
+﻿//===== rAthena Documentation================================
 //= rAthena Script Commands
 //===== By:==================================================
 //= rAthena Dev Team
@@ -135,9 +135,22 @@ and 'doc/mapflags.txt'.
 <map name>{,<x>{,<y>{,<xs>{,<ys>}}}}%TAB%monster%TAB%<monster name>{,<monster level>}%TAB%<mob id>,<amount>{,<delay1>{,<delay2>{,<event>{,<mob size>{,<mob ai>}}}}}
 
 Map name is the name of the map the monsters will spawn on. x,y are the
-coordinates where the mob should spawn. If xs and ys are non-zero, they
-specify the 'radius' of a spawn-rectangle area centered at x,y.
-Putting zeros instead of these coordinates will spawn the monsters randomly.
+coordinates where the mob should spawn. Putting zeros instead of these
+coordinates will spawn the monsters randomly.
+
+If xs and ys are above 1, each monster will spawn in a radius around x,y.
+At server start, each monster will get assigned its own center cell adding or
+substracting up to (xs-1),(ys-1) from the given x,y coordinates.
+Each time a monster respawns, it will spawn in a radius around its personal
+center cell by adding or substracting up to (xs-1),(ys-1) again.
+This results in a total possible spawn area over all monsters of the spawn line
+of (xs,ys)*4-3, but with a strong bias towards the center of that area:
+2,2 - 5x5
+3,3 - 9x9
+4,4 - 13x13
+5,5 - 17x17
+etc.
+
 Note this is only the initial spawn zone, as mobs random-walk, they are free
 to move away from their specified spawn region.
 
@@ -188,6 +201,8 @@ Natural enemies for AI monsters are normal monsters.
 
 Alternately, a monster spawned using 'boss_monster' instead of 'monster' is able
 to be detected on the map with the SC_BOSSMAPINFO status (used by Convex Mirror).
+A boss monster spawn with fixed coordinates will always spawn at the given 
+coordinates, even if they are blocked (e.g. by Icewall).
 
 ** NPC names
 

--- a/npc/re/mobs/championmobs.txt
+++ b/npc/re/mobs/championmobs.txt
@@ -3,329 +3,334 @@
 //===== By: ==================================================
 //= nanakiwurtz
 //===== Current Version: =====================================
-//= 1.1
+//= 1.2
 //===== Compatible With: =====================================
 //= rAthena Project
 //===== Additional Comments: =================================
 //= 1.0 First version
 //= 1.1 Correct Spawn by Navigation's mob data. [attackjom]
+//= 1.2 Correct respawn times and prontera field spawns [Playtester]
 //============================================================
 
-abbey02,0,0	monster	Swift Zombie Slaughter	2603,3,300000
-gl_prison,0,0	monster	Solid Zombie Prisoner	2604,1,300000
-gld_dun04,0,0	monster	Zombie Master Ringleader	2605,2,300000
-pay_dun00,0,0	monster	Furious Zombie	2606,2,300000
-schg_dun01,0,0	monster	Elusive Zakudam	2607,2,300000
-prt_fild03,0,0	monster	Swift Yoyo	2608,2,300000
-ayo_fild02,0,0	monster	Solid Yoyo	2609,1,300000
-pay_fild06,0,0	monster	Wormtail Ringleader	2610,3,300000
-um_fild02,0,0	monster	Furious Wootan Fighter	2611,1,300000
-mosk_dun01,0,0	monster	Elusive Wood Goblin	2612,2,300000
-moc_fild03,0,0	monster	Swift Wolf	2613,2,300000
-gl_step,0,0	monster	Solid Wind Ghost	2614,2,300000
-gef_dun03,0,0	monster	Solid Wind Ghost	2614,1,300000
-pay_fild01,0,0	monster	Willow Ringleader	2615,2,300000
-um_fild04,0,0	monster	Furious Wild Rose	2616,1,300000
-gon_dun03,0,0	monster	Elusive Evil Nymph	2617,2,300000
-gl_sew01,0,0	monster	Solid Whisper	2618,1,300000
-treasure_n2,0,0	monster	Weak Skeleton Ringleader	2619,2,300000
-gl_cas02,0,0	monster	Furious Wanderer	2620,2,300000
-gefenia04,0,0	monster	Elusive Violy	2621,2,300000
-gefenia03,0,0	monster	Swift Violy	2622,2,300000
-gefenia02,0,0	monster	Solid Violy	2623,2,300000
-ein_fild04,0,0	monster	Venomous Ringleader	2624,2,300000
-juperos_01,0,0	monster	Furious Venatu	2625,3,300000
-mosk_dun03,0,0	monster	Elusive Vavayaga	2626,2,300000
-ra_san01,0,0	monster	Swift Vanberk	2627,2,300000
-iz_dun01,0,0	monster	Solid Vadon	2628,2,300000
-ein_fild02,0,0	monster	Ungoliant Ringleader	2629,2,300000
-bra_fild01,0,0	monster	Furious Toucan	2630,3,300000
-ma_fild01,0,0	monster	Elusive Tiyanak	2631,2,300000
-prt_sewb4,0,0	monster	Solid Thief Bug	2632,2,300000
-prt_sewb3,0,0	monster	Thief Bug Ringleader	2633,3,300000
-prt_sewb2,0,0	monster	Furious Thief Bug	2634,2,300000
-beach_dun3,0,0	monster	Elusive Thara Frog	2635,2,300000
-ein_fild03,0,0	monster	Swift Teddy Bear	2636,2,300000
-man_fild03,0,0	monster	Solid Tatacho	2637,1,300000
-mjo_dun01,0,0	monster	Tarou Ringleader	2638,2,300000
-ayo_dun02,0,0	monster	Furious Tamruan	2639,2,300000
-gl_sew03,0,0	monster	Elusive Sting	2640,2,300000
-lhz_fild02,0,0	monster	Swift Stem Worm	2641,2,300000
-moc_fild13,0,0	monster	Solid Steel Chonchon	2642,3,300000
-ve_fild07,0,0	monster	Stapo Ringleader	2643,2,300000
-beach_dun2,0,0	monster	Furious Stalactic Golem	2644,2,300000
-prt_fild02,0,0	monster	Elusive Stainer	2645,3,300000
-treasure_n1,0,0	monster	Swift Spore	2646,2,300000
-tur_dun02,0,0	monster	Solid Solider	2647,2,300000
-pay_dun02,0,0	monster	Soldier Skeleton Ringleader	2648,3,300000
-pay_dun01,0,0	monster	Furious Soldier Skeleton	2649,2,300000
-tha_t09,0,0	monster	Elusive Lady Solace	2650,2,300000	//--Remove after Thanatos Ravamped Patch
-pay_dun03,0,0	monster	Swift Sohee	2651,2,300000
-ice_dun02,0,0	monster	Solid Snowier	2652,2,300000
-pay_fild02,0,0	monster	Boa Ringleader	2653,3,300000
-ayo_fild01,0,0	monster	Furious Smokie	2654,2,300000
-yuno_fild06,0,0	monster	Elusive Sleeper	2655,1,300000
-yuno_fild02,0,0	monster	Swift Sleeper	2656,2,300000
-odin_tem02,0,0	monster	Solid Skogul	2657,1,300000
-gld2_pay,0,0	monster	Skeleton General Ringleader	2658,2,300000
-gld_dun01_2,0,0	monster	Furious Skeleton General	2659,2,300000
-mjo_dun03,0,0	monster	Elusive Skeleton Worker	2660,2,300000
-ice_dun01,0,0	monster	Swift Siroma	2661,1,300000
-mosk_fild02,0,0	monster	Solid Side Winder	2662,1,300000
-mjolnir_03,0,0	monster	Side Winder Ringleader	2663,2,300000
-ama_dun03,0,0	monster	Furious Shinobi	2664,2,300000
-tha_t11,0,0	monster	Elusive Mistress of Shelter	2665,2,300000	//--Remove after Thanatos Ravamped Patch
-hu_fild06,0,0	monster	Swift Shellfish	2666,1,300000
-lhz_dun03,0,0	monster	Solid Cecil Damon	2667,3,300000
-cmd_fild04,0,0	monster	Sea Otter Ringleader	2668,2,300000
-iz_dun05,0,0	monster	Furious Lamp Rey	2669,2,300000
-moc_fild18,0,0	monster	Elusive Scorpion	2670,3,300000
-mjolnir_09,0,0	monster	Swift Savage Babe	2671,2,300000
-prt_maze01,0,0	monster	Solid Savage	2672,2,300000
-mjolnir_07,0,0	monster	Savage Ringleader	2673,3,300000
-moc_fild16,0,0	monster	Furious Sandman	2674,2,300000
-thor_v03,0,0	monster	Elusive Salamander	2675,2,300000
-treasure02,0,0	monster	Swift Sailor Skeleton	2676,1,300000
-ra_fild12,0,0	monster	Solid Roween	2677,2,300000
-prt_fild00,0,0	monster	Roda Frog Ringleader	2678,2,300000
-gef_fild01,0,0	monster	Furious Roda Frog	2679,2,300000
-prt_fild07,0,0	monster	Elusive Rocker	2680,2,300000
-tha_t01,0,0	monster	Swift Rideword	2681,2,300000
-//tha_t01,0,0	monster	Swift Rideword	2681,1,300000	//--Applied after Thanatos Revamped Patch.
-c_tower1,0,0	monster	Solid Rideword	2682,2,300000
-gon_fild01,0,0	monster	Dumpling Child Ringleader	2683,2,300000
-tha_t10,0,0	monster	Furious Baroness of Retribution	2684,2,300000	//--Remove after Thanatos Ravamped Patch
-tha_t08,0,0	monster	Elusive Baroness of Retribution	2685,2,300000
-//tha_t08,0,0	monster	Elusive Baroness of Retribution	2685,1,300000	//--Applied after Thanatos Revamped Patch.
-tha_t07,0,0	monster	Swift Baroness of Retribution	2686,2,300000
-//tha_t07,0,0	monster	Swift Baroness of Retribution	2686,1,300000	//--Applied after Thanatos Revamped Patch.
-in_sphinx2,0,0	monster	Solid Requiem	2687,2,300000
-lhz_dun01,0,0	monster	Remover Ringleader	2688,3,300000
-mal_dun01,0,0	monster	Elusive Red Eruma	2689,2,300000
-gl_knt02,0,0	monster	Swift Raydric	2690,2,300000
-gl_knt01,0,0	monster	Solid Raydric	2691,2,300000
-lhz_dun02,0,0	monster	Laurell Weinder Ringleader	2692,3,300000
-dic_dun03,0,0	monster	Furious Rake Scaraba	2693,2,300000
-cmd_fild07,0,0	monster	Elusive Raggler	2694,2,300000
-lhz_fild01,0,0	monster	Swift Rafflesia	2695,3,300000
-lhz_fild01,0,0	monster	Poring Ringleader	2696,2,300000
-lhz_fild01,0,0	monster	Furious Poring	2697,2,300000
-lhz_fild01,0,0	monster	Elusive Poring	2698,2,300000
-gef_fild07,0,0	monster	Swift Poring	2699,2,300000
-ein_fild09,0,0	monster	Solid Porcellio	2700,2,300000
-prt_maze03,0,0	monster	Poporing Ringleader	2701,2,300000
-prt_maze02,0,0	monster	Furious Poporing	2702,2,300000
-pay_fild04,0,0	monster	Elusive Poporing	2703,2,300000
-ama_dun02,0,0	monster	Swift Poison Toad	2704,1,300000
-mjolnir_06,0,0	monster	Solid Poison Spore	2705,3,300000
-odin_tem03,0,0	monster	Plasma Ringleader	2706,2,300000
-iz_dun00,0,0	monster	Furious Plankton	2707,2,300000
-ein_dun01,0,0	monster	Elusive Pitman	2708,2,300000
-bra_dun01,0,0	monster	Swift Piranha	2709,2,300000
-spl_fild01,0,0	monster	Solid Dark Pinguicula	2710,2,300000
-spl_fild02,0,0	monster	Pinguicula Ringleader	2711,2,300000
-moc_fild12,0,0	monster	Furious Picky	2712,2,300000
-iz_dun03,0,0	monster	Elusive Phen	2713,2,300000
-gef_fild08,0,0	monster	Swift Petite	2714,2,300000
-gef_fild06,0,0	monster	Solid Petite	2715,2,300000
-treasure02,0,0	monster	Penomena Ringleader	2716,2,300000
-alde_dun03,0,0	monster	Furious Penomena	2717,2,300000
-moc_fild02,0,0	monster	Elusive Peco Peco	2718,2,300000
-in_sphinx5,0,0	monster	Swift Pasana	2719,2,300000
-um_fild03,0,0	monster	Solid Parasite	2720,1,300000
-tha_t05,0,0	monster	Owl Duke Ringleader	2721,2,300000
-//tha_t05,0,0	monster	Owl Duke Ringleader	2721,3,300000	//--Applied after Thanatos Revamped Patch.
-gef_fild10,0,0	monster	Furious Orc Warrior	2722,2,300000
-orcsdun01,0,0	monster	Elusive Orc Zombie	2723,2,300000
-orcsdun02,0,0	monster	Swift Orc Skeleton	2724,2,300000
-gef_fild03,0,0	monster	Solid Orc Lady	2725,3,300000
-tha_t12,0,0	monster	Dame of Sentinel Ringleader	2726,2,300000	//--Remove after Thanatos Ravamped Patch
-ein_fild05,0,0	monster	Furious Noxious	2727,2,300000
-hu_fild05,0,0	monster	Elusive Novus	2728,2,300000
-hu_fild04,0,0	monster	Swift Novus	2729,2,300000
-hu_fild02,0,0	monster	Solid Novus	2730,2,300000
-hu_fild01,0,0	monster	Novus Ringleader	2731,2,300000
-mag_dun02,0,0	monster	Furious Nightmare Terror	2732,2,300000
-gl_chyard_,0,0	monster	Elusive Wraith Dead (Nightmare)	2733,2,180000,0
+abbey01,0,0	monster	Swift Banshee	2887,3,180000
+abbey02,0,0	monster	Swift Zombie Slaughter	2603,3,180000
+abbey03,0,0	monster	Necromancer Ringleader	2736,2,180000
+abyss_01,0,0	monster	Furious Ferus	2832,2,180000
+abyss_02,0,0	monster	Acidus Ringleader	2913,2,180000
+abyss_03,0,0	monster	Solid Acidus	2912,2,180000
+alde_dun01,0,0	monster	Arclouze Ringleader	2894,1,180000
+alde_dun02,0,0	monster	Solid High Orc	2805,2,180000
+alde_dun03,0,0	monster	Furious Penomena	2717,2,180000
+alde_dun04,0,0	monster	Furious Bathory	2885,1,180000
+ama_dun01,0,0	monster	Miyabi Doll Ringleader	2746,2,180000
+ama_dun02,0,0	monster	Swift Poison Toad	2704,1,180000
+ama_dun03,0,0	monster	Furious Shinobi	2664,2,180000
+ama_fild01,0,0	monster	Swift Karakasa	2789,2,180000
+anthell01,0,0	monster	Elusive Deniro	2857,3,180000
+anthell02,0,0	monster	Solid Andre	2902,2,180000
+arug_dun01,0,0	monster	Elusive Banshee Master	2886,2,180000
+ayo_dun01,0,0	monster	Leaf Cat Ringleader	2781,2,180000
+ayo_dun02,0,0	monster	Furious Tamruan	2639,2,180000
+ayo_fild01,0,0	monster	Furious Smokie	2654,2,180000
+ayo_fild02,0,0	monster	Solid Yoyo	2609,1,180000
+beach_dun,0,0	monster	Swift Medusa	2759,2,180000
+beach_dun2,0,0	monster	Furious Stalactic Golem	2644,2,180000
+beach_dun3,0,0	monster	Elusive Thara Frog	2635,2,180000
+bif_fild01,0,0	monster	Miming Ringleader	2751,2,180000
+bif_fild02,0,0	monster	Furious Little Fatum	2777,2,180000
+bra_dun01,0,0	monster	Swift Piranha	2709,2,180000
+bra_dun02,0,0	monster	Solid Iara	2795,3,180000
+bra_fild01,0,0	monster	Furious Toucan	2630,3,180000
+c_tower1,0,0	monster	Solid Rideword	2682,2,180000
+c_tower2,0,0	monster	Furious Clock	2871,1,180000
+c_tower3,0,0	monster	Elusive Alarm	2910,1,180000
+c_tower4,0,0	monster	Clock Ringleader	2870,2,180000
+cmd_fild01,0,0	monster	Elusive Grove	2808,2,180000
+cmd_fild02,0,0	monster	Swift Seal	2829,3,180000
+cmd_fild03,0,0	monster	Solid Alligator	2907,3,180000
+cmd_fild04,0,0	monster	Sea Otter Ringleader	2668,2,180000
+cmd_fild06,0,0	monster	Furious Golem	2812,2,180000
+cmd_fild07,0,0	monster	Elusive Raggler	2694,2,180000
+cmd_fild08,0,0	monster	Elusive Deniro	2857,2,180000
+cmd_fild09,0,0	monster	Swift Metaller	2754,2,180000
+dew_dun01,0,0	monster	Elusive Comodo	2867,2,180000
+dew_dun02,0,0	monster	Solid Banaspaty	2888,2,180000
+dew_fild01,0,0	monster	Swift Rafflesia Arnoldi	2906,2,180000
+dic_dun01,0,0	monster	Swift Uni-horn Scaraba	2799,2,180000
+dic_dun02,0,0	monster	Elusive Antler Scaraba	2896,2,180000
+dic_dun03,0,0	monster	Furious Rake Scaraba	2693,2,180000
+dic_fild01,0,0	monster	Swift Centipede	2873,2,180000
+dic_fild02,0,0	monster	Dolomedes Ringleader	2850,2,180000
+ecl_fild01,0,0	monster	Elusive Menblatt	2758,1,180000
+ecl_tdun01,0,0	monster	Solid Cenere	2874,1,180000
+ecl_tdun02,0,0	monster	Solid Antique Book	2898,1,180000
+ecl_tdun03,0,0	monster	Swift Antique Book	2897,1,180000
+ein_dun01,0,0	monster	Elusive Pitman	2708,2,180000
+ein_dun02,0,0	monster	Solid Mineral	2750,2,180000
+ein_fild02,0,0	monster	Ungoliant Ringleader	2629,2,180000
+ein_fild03,0,0	monster	Swift Teddy Bear	2636,2,180000
+ein_fild04,0,0	monster	Venomous Ringleader	2624,2,180000
+ein_fild05,0,0	monster	Furious Noxious	2727,2,180000
+ein_fild06,0,0	monster	Solid Holden	2745,2,180000
+ein_fild07,0,0	monster	Metaling Ringleader	2756,2,180000
+ein_fild08,0,0	monster	Solid Metaling	2755,2,180000
+ein_fild09,0,0	monster	Solid Porcellio	2700,2,180000
+gef_dun00,0,0	monster	Furious Hunter Fly	2797,1,180000
+gef_dun01,0,0	monster	Elusive Ghoul	2823,2,180000
+gef_dun02,0,0	monster	Solid Deviruchi	2854,2,180000
+gef_dun03,0,0	monster	Solid Wind Ghost	2614,1,180000
+gef_fild00,0,0	monster	Elusive Chonchon	2872,2,180000
+gef_fild01,0,0	monster	Furious Roda Frog	2679,2,180000
+gef_fild02,0,0	monster	Solid Coco	2869,3,180000
+gef_fild03,0,0	monster	Solid Orc Lady	2725,3,180000
+gef_fild04,0,0	monster	Solid Mandragora	2765,2,180000
+gef_fild05,0,0	monster	Swift Creamy	2863,2,180000
+gef_fild06,0,0	monster	Solid Petite	2715,2,180000
+gef_fild07,0,0	monster	Swift Poring	2699,2,180000
+gef_fild08,0,0	monster	Swift Petite	2714,2,180000
+gef_fild09,0,0	monster	Swift Coco	2868,2,180000
+gef_fild10,0,0	monster	Furious Orc Warrior	2722,2,180000
+gef_fild11,0,0	monster	Swift Goblin	2814,3,180000
+gefenia01,0,0	monster	Swift False Angel	2834,2,180000
+gefenia02,0,0	monster	Solid Violy	2623,2,180000
+gefenia03,0,0	monster	Swift Violy	2622,2,180000
+gefenia04,0,0	monster	Elusive Violy	2621,2,180000
+gl_cas01,0,0	monster	Elusive Carat	2877,2,180000
 gl_cas02_,0,0	monster	Furious Wanderer (Nightmare)	2734,2,180000,0
-man_fild01,0,0	monster	Solid Nephentes	2735,2,300000
-abbey03,0,0	monster	Necromancer Ringleader	2736,2,300000
-xmas_dun02,0,0	monster	Furious Myst Case	2737,2,300000
-ve_fild04,0,0	monster	Elusive Muscipular	2738,2,300000
-moc_pryd03,0,0	monster	Swift Mummy	2739,2,300000
-moc_pryd02,0,0	monster	Solid Mummy	2740,2,300000
-moc_fild01,0,0	monster	Muka Ringleader	2741,3,300000
-moc_fild22,0,0	monster	Furious Incarnation of Morocc	2742,3,300000
-moc_fild21,0,0	monster	Elusive Incarnation of Morocc	2743,2,300000
-moc_fild20,0,0	monster	Swift Incarnation of Morocc	2744,1,300000
-ein_fild06,0,0	monster	Solid Holden	2745,2,300000
-ama_dun01,0,0	monster	Miyabi Doll Ringleader	2746,2,300000
-moc_prydn1,0,0	monster	Furious Minorous	2747,2,300000
-moc_pryd05,0,0	monster	Elusive Minorous	2748,2,300000
-in_sphinx4,0,0	monster	Swift Minorous	2749,1,300000
-ein_dun02,0,0	monster	Solid Mineral	2750,2,300000
-bif_fild01,0,0	monster	Miming Ringleader	2751,2,300000
-moc_prydn2,0,0	monster	Furious Mimic	2752,2,300000
-moc_pryd06,0,0	monster	Elusive Mimic	2753,2,300000
-cmd_fild09,0,0	monster	Swift Metaller	2754,2,300000
-ein_fild08,0,0	monster	Solid Metaling	2755,2,300000
-ein_fild07,0,0	monster	Metaling Ringleader	2756,2,300000
-iz_dun04,0,0	monster	Furious Merman	2757,2,300000
-ecl_fild01,0,0	monster	Elusive Menblatt	2758,1,300000
-beach_dun,0,0	monster	Swift Medusa	2759,2,300000
-mjo_dun02,0,0	monster	Solid Martin	2760,2,300000
-gl_in01,0,0	monster	Marionette Ringleader	2761,1,300000
-xmas_fild01,0,0	monster	Furious Marin	2762,1,300000
-in_sphinx3,0,0	monster	Elusive Marduk	2763,1,300000
-prt_maze03,0,0	monster	Swift Mantis	2764,2,300000
-gef_fild04,0,0	monster	Solid Mandragora	2765,2,300000
-ma_dun01,0,0	monster	Manananggal Ringleader	2766,2,300000
-gl_dun02,0,0	monster	Furious Majoruros	2767,1,300000
-prt_fild09,0,0	monster	Elusive Magnolia	2768,2,300000
-ve_fild03,0,0	monster	Swift Magmaring	2769,2,300000
-prt_fild08,0,0	monster	Solid Lunatic	2770,1,300000
-prt_fild01,0,0	monster	Lunatic Ringleader	2771,2,300000
-niflheim,0,0	monster	Furious Lude	2772,1,300000
-spl_fild03,0,0	monster	Elusive Luciola Vespa	2773,1,300000
-nif_fild02,0,0	monster	Swift Loli Ruri	2774,1,300000
-gon_dun02,0,0	monster	Solid Enchanted Peach Tree	2775,1,300000
-new_1-3,0,0	monster	Baby Poring Ringleader	2776,2,300000
-bif_fild02,0,0	monster	Furious Little Fatum	2777,2,300000
-lou_dun01,0,0	monster	Elusive Jing Guai	2778,2,300000
-mosk_dun02,0,0	monster	Swift Les	2779,1,300000
-gld_dun01,0,0	monster	Solid Leib Olmai	2780,2,300000
-ayo_dun01,0,0	monster	Leaf Cat Ringleader	2781,2,300000
-teg_dun02,0,0	monster	Furious Wickebine Tres	2782,2,300000,0
-teg_dun01,0,0	monster	Elusive Eremes	2783,2,300000,0
-ra_fild06,0,0	monster	Swift Kobold Archer	2784,3,300000
-ra_fild05,0,0	monster	Solid Kobold	2785,3,300000
-thor_v02,0,0	monster	Knocker Ringleader	2786,1,300000
-mjolnir_08,0,0	monster	Furious Beetle King	2787,2,300000
-thor_v01,0,0	monster	Elusive Kasa	2788,2,300000
-ama_fild01,0,0	monster	Swift Karakasa	2789,2,300000
-moc_pryd04,0,0	monster	Solid Isis	2790,2,300000
-ra_san02,0,0	monster	Isilla Ringleader	2791,2,300000
-gl_prison1,0,0	monster	Furious Injustice	2792,2,300000
-lou_fild01,0,0	monster	Elusive Mi Gao	2793,1,300000
-ice_dun03,0,0	monster	Swift Ice Titan	2794,2,300000
-bra_dun02,0,0	monster	Solid Iara	2795,3,300000
-lou_dun02,0,0	monster	Yao Jun Ringleader	2796,1,300000
-gef_dun00,0,0	monster	Furious Hunter Fly	2797,1,300000
-prt_fild05,0,0	monster	Elusive Hornet	2798,2,300000
-dic_dun01,0,0	monster	Swift Uni-horn Scaraba	2799,2,300000
-pay_fild09,0,0	monster	Solid Horn	2800,2,300000
-ra_san03,0,0	monster	Hodremlin Ringleader	2801,2,300000
-moc_fild17,0,0	monster	Furious Hode	2802,2,300000
-ra_fild04,0,0	monster	Elusive Hill Wind	2803,3,300000
-ra_fild03,0,0	monster	Swift Hill Wind	2804,3,300000
-alde_dun02,0,0	monster	Solid High Orc	2805,2,300000
-yuno_fild04,0,0	monster	Harpy Ringleader	2806,3,300000
-yuno_fild03,0,0	monster	Furious Harpy	2807,3,300000
-cmd_fild01,0,0	monster	Elusive Grove	2808,2,300000
-pay_fild10,0,0	monster	Swift Greatest General	2809,2,300000
-yuno_fild09,0,0	monster	Solid Grand Peco	2810,2,300000
-yuno_fild08,0,0	monster	Grand Peco Ringleader	2811,2,300000
-cmd_fild06,0,0	monster	Furious Golem	2812,2,300000
-prt_fild11,0,0	monster	Elusive Goblin	2813,3,300000
-gef_fild11,0,0	monster	Swift Goblin	2814,3,300000
-yuno_fild11,0,0	monster	Solid Goat	2815,2,300000
-yuno_fild07,0,0	monster	Goat Ringleader	2816,2,300000
-gld2_prt,0,0	monster	Furious Dark Hammer Kobold	2817,2,300000
-gld_dun03_2,0,0	monster	Elusive Dark Hammer Kobold	2818,2,300000
-gld2_gef,0,0	monster	Swift Dark Shadow	2819,2,300000
-gld_dun04_2,0,0	monster	Solid Dark Shadow	2820,2,300000
-gld_dun02,0,0	monster	Giant Hornet Ringleader	2821,2,300000
-nameless_n,0,0	monster	Furious Ghoul	2822,1,300000
-gef_dun01,0,0	monster	Elusive Ghoul	2823,2,300000
-yuno_fild12,0,0	monster	Swift Geographer	2824,1,300000
-yuno_fild01,0,0	monster	Solid Geographer	2825,2,300000
-glast_01,0,0	monster	Gargoyle Ringleader	2826,1,300000
-gl_sew02,0,0	monster	Furious Gargoyle	2827,1,300000
-ve_fild01,0,0	monster	Elusive Galion	2828,1,300000
-cmd_fild02,0,0	monster	Swift Seal	2829,3,300000
-tur_dun05,0,0	monster	Solid Freezer	2830,1,300000
-tur_dun03,0,0	monster	Freezer Ringleader	2831,1,300000
-abyss_01,0,0	monster	Furious Ferus	2832,2,300000
-prt_sewb1,0,0	monster	Elusive Familiar	2833,1,300000
-gefenia01,0,0	monster	Swift False Angel	2834,2,300000
-prt_fild06,0,0	monster	Solid Fabre	2835,2,300000
-pay_fild03,0,0	monster	Fabre Ringleader	2836,3,300000
-mag_dun01,0,0	monster	Furious Explosion	2837,1,300000
-gl_church,0,0	monster	Elusive Evil Druid	2838,2,300000
-prt_fild10,0,0	monster	Swift Elder Willow	2839,3,300000
-mjolnir_02,0,0	monster	Solid Elder Willow	2840,3,300000
-ra_san04,0,0	monster	Echio Ringleader	2841,1,300000
-mjolnir_12,0,0	monster	Furious Dustiness	2842,2,300000
-um_fild01,0,0	monster	Swift Dryad	2843,2,300000
-ve_fild02,0,0	monster	Solid Drosera	2844,2,300000
-moc_fild07,0,0	monster	Drops Ringleader	2845,3,300000
-mjolnir_04,0,0	monster	Furious Driller	2846,3,300000
-in_sphinx1,0,0	monster	Elusive Drainliar	2847,1,300000
-tur_dun01,0,0	monster	Swift Dragon Tail	2848,1,300000
-nyd_dun01,0,0	monster	Solid Draco	2849,2,300000
-dic_fild02,0,0	monster	Dolomedes Ringleader	2850,2,300000
-pay_dun04,0,0	monster	Furious Dokebi	2851,2,300000
-nif_fild01,0,0	monster	Elusive Disguise	2852,2,300000
-jupe_core,0,0	monster	Swift Dimik	2853,3,300000
-gef_dun02,0,0	monster	Solid Deviruchi	2854,2,300000
-ra_fild01,0,0	monster	Baby Desert Wolf Ringleader	2855,2,300000
-moc_fild11,0,0	monster	Furious Baby Desert Wolf	2856,3,300000
-cmd_fild08,0,0	monster	Elusive Deniro	2857,2,300000
-anthell01,0,0	monster	Elusive Deniro	2857,3,300000
-tha_t06,0,0	monster	Swift Death Word	2858,2,300000
-//tha_t06,0,0	monster	Swift Death Word	2858,3,300000	//--Applied after Thanatos Revamped Patch.
-tha_t04,0,0	monster	Solid Death Word	2859,2,300000
-tha_t03,0,0	monster	Death Word Ringleader	2860,2,300000
-gl_chyard,0,0	monster	Furious Dark Priest	2861,2,300000
-lou_dun03,0,0	monster	Elusive Zhu Po Long	2862,1,300000
-gef_fild05,0,0	monster	Swift Creamy	2863,2,300000
-iz_dun02,0,0	monster	Solid Cornutus	2864,2,300000
-xmas_dun01,0,0	monster	Cookie Ringleader	2865,2,300000
-kh_kiehl01,0,0	monster	Furious Constant	2866,2,300000
-dew_dun01,0,0	monster	Elusive Comodo	2867,2,300000
-gef_fild09,0,0	monster	Swift Coco	2868,2,300000
-gef_fild02,0,0	monster	Solid Coco	2869,3,300000
-c_tower4,0,0	monster	Clock Ringleader	2870,2,300000
-c_tower2,0,0	monster	Furious Clock	2871,1,300000
-gef_fild00,0,0	monster	Elusive Chonchon	2872,2,300000
-dic_fild01,0,0	monster	Swift Centipede	2873,2,300000
-ecl_tdun01,0,0	monster	Solid Cenere	2874,1,300000
-lhz_dun04,0,0	monster	Celia Ringleader	2875,3,300000
-gld_dun03,0,0	monster	Furious Caterpillar	2876,2,300000
-gl_cas01,0,0	monster	Elusive Carat	2877,2,300000
-mjolnir_01,0,0	monster	Swift Caramel	2878,2,300000
-ma_fild02,0,0	monster	Solid Bungisngis	2879,2,300000
-odin_tem01,0,0	monster	Breeze Ringleader	2880,1,300000
-lhz_fild03,0,0	monster	Furious Breeze	2881,3,300000
-man_fild02,0,0	monster	Elusive Bradium Golem	2882,2,300000
-gon_dun01,0,0	monster	Swift Bloody Butterfly	2883,2,300000
-pay_fild07,0,0	monster	Bigfoot Ringleader	2884,2,300000
-alde_dun04,0,0	monster	Furious Bathory	2885,1,300000
-arug_dun01,0,0	monster	Elusive Banshee Master	2886,2,300000
-abbey01,0,0	monster	Swift Banshee	2887,3,300000
-dew_dun02,0,0	monster	Solid Banaspaty	2888,2,300000
-tur_dun04,0,0	monster	Assaulter Ringleader	2889,1,300000
-mjolnir_10,0,0	monster	Furious Argos	2890,2,300000
-mjolnir_11,0,0	monster	Elusive Argiope	2891,2,300000
-mjolnir_05,0,0	monster	Swift Argiope	2892,2,300000
-gl_dun01,0,0	monster	Solid Arclouze	2893,1,300000
-alde_dun01,0,0	monster	Arclouze Ringleader	2894,1,300000
-juperos_02,0,0	monster	Furious Apocalypse	2895,3,300000
-dic_dun02,0,0	monster	Elusive Antler Scaraba	2896,2,300000
-ecl_tdun03,0,0	monster	Swift Antique Book	2897,1,300000
-ecl_tdun02,0,0	monster	Solid Antique Book	2898,1,300000
-gl_sew04,0,0	monster	Furious Anolian	2899,2,300000
-gld2_ald,0,0	monster	Elusive Angra Mantis	2900,2,300000
-gld_dun02_2,0,0	monster	Swift Angra Mantis	2901,2,300000
-anthell02,0,0	monster	Solid Andre	2902,2,300000
-tha_t02,0,0	monster	Ancient Mimic Ringleader	2903,2,300000
-ra_fild08,0,0	monster	Furious Anacondaq	2904,2,300000
-prt_fild04,0,0	monster	Elusive Ambernite	2905,2,300000
-dew_fild01,0,0	monster	Swift Rafflesia Arnoldi	2906,2,300000
-cmd_fild03,0,0	monster	Solid Alligator	2907,3,300000
-kh_dun01,0,0	monster	Aliza Ringleader	2908,1,300000
-kh_dun02,0,0	monster	Furious Alicel	2909,1,300000
-c_tower3,0,0	monster	Elusive Alarm	2910,1,300000
-ra_san05,0,0	monster	Swift Agav	2911,2,300000
-abyss_03,0,0	monster	Solid Acidus	2912,2,300000
-abyss_02,0,0	monster	Acidus Ringleader	2913,2,300000
+gl_cas02,0,0	monster	Furious Wanderer	2620,2,180000
+gl_church,0,0	monster	Elusive Evil Druid	2838,2,180000
+gl_chyard_,0,0	monster	Elusive Wraith Dead (Nightmare)	2733,2,180000,0
+gl_chyard,0,0	monster	Furious Dark Priest	2861,2,180000
+gl_dun01,0,0	monster	Solid Arclouze	2893,1,180000
+gl_dun02,0,0	monster	Furious Majoruros	2767,1,180000
+gl_in01,0,0	monster	Marionette Ringleader	2761,1,180000
+gl_knt01,0,0	monster	Solid Raydric	2691,2,180000
+gl_knt02,0,0	monster	Swift Raydric	2690,2,180000
+gl_prison,0,0	monster	Solid Zombie Prisoner	2604,1,180000
+gl_prison1,0,0	monster	Furious Injustice	2792,2,180000
+gl_sew01,0,0	monster	Solid Whisper	2618,1,180000
+gl_sew02,0,0	monster	Furious Gargoyle	2827,1,180000
+gl_sew03,0,0	monster	Elusive Sting	2640,2,180000
+gl_sew04,0,0	monster	Furious Anolian	2899,2,180000
+gl_step,0,0	monster	Solid Wind Ghost	2614,2,180000
+glast_01,0,0	monster	Gargoyle Ringleader	2826,1,180000
+gld_dun01_2,0,0	monster	Furious Skeleton General	2659,2,180000
+gld_dun01,0,0	monster	Solid Leib Olmai	2780,2,180000
+gld_dun02_2,0,0	monster	Swift Angra Mantis	2901,2,180000
+gld_dun02,0,0	monster	Giant Hornet Ringleader	2821,2,180000
+gld_dun03_2,0,0	monster	Elusive Dark Hammer Kobold	2818,2,180000
+gld_dun03,0,0	monster	Furious Caterpillar	2876,2,180000
+gld_dun04_2,0,0	monster	Solid Dark Shadow	2820,2,180000
+gld_dun04,0,0	monster	Zombie Master Ringleader	2605,2,180000
+gld2_ald,0,0	monster	Elusive Angra Mantis	2900,2,180000
+gld2_gef,0,0	monster	Swift Dark Shadow	2819,2,180000
+gld2_pay,0,0	monster	Skeleton General Ringleader	2658,2,180000
+gld2_prt,0,0	monster	Furious Dark Hammer Kobold	2817,2,180000
+gon_dun01,0,0	monster	Swift Bloody Butterfly	2883,2,180000
+gon_dun02,0,0	monster	Solid Enchanted Peach Tree	2775,1,180000
+gon_dun03,0,0	monster	Elusive Evil Nymph	2617,2,180000
+gon_fild01,0,0	monster	Dumpling Child Ringleader	2683,2,180000
+hu_fild01,0,0	monster	Novus Ringleader	2731,2,180000
+hu_fild02,0,0	monster	Solid Novus	2730,2,180000
+hu_fild04,0,0	monster	Swift Novus	2729,2,180000
+hu_fild05,0,0	monster	Elusive Novus	2728,2,180000
+hu_fild06,0,0	monster	Swift Shellfish	2666,1,180000
+ice_dun01,0,0	monster	Swift Siroma	2661,1,180000
+ice_dun02,0,0	monster	Solid Snowier	2652,2,180000
+ice_dun03,0,0	monster	Swift Ice Titan	2794,2,180000
+in_sphinx1,0,0	monster	Elusive Drainliar	2847,1,180000
+in_sphinx2,0,0	monster	Solid Requiem	2687,2,180000
+in_sphinx3,0,0	monster	Elusive Marduk	2763,1,180000
+in_sphinx4,0,0	monster	Swift Minorous	2749,1,180000
+in_sphinx5,0,0	monster	Swift Pasana	2719,2,180000
+iz_dun00,0,0	monster	Furious Plankton	2707,2,180000
+iz_dun01,0,0	monster	Solid Vadon	2628,2,180000
+iz_dun02,0,0	monster	Solid Cornutus	2864,2,180000
+iz_dun03,0,0	monster	Elusive Phen	2713,2,180000
+iz_dun04,0,0	monster	Furious Merman	2757,2,180000
+iz_dun05,0,0	monster	Furious Lamp Rey	2669,2,180000
+jupe_core,0,0	monster	Swift Dimik	2853,3,180000
+juperos_01,0,0	monster	Furious Venatu	2625,3,180000
+juperos_02,0,0	monster	Furious Apocalypse	2895,3,180000
+kh_dun01,0,0	monster	Aliza Ringleader	2908,1,180000
+kh_dun02,0,0	monster	Furious Alicel	2909,1,180000
+kh_kiehl01,0,0	monster	Furious Constant	2866,2,180000
+lhz_dun01,0,0	monster	Remover Ringleader	2688,3,180000
+lhz_dun02,0,0	monster	Laurell Weinder Ringleader	2692,3,180000
+lhz_dun03,0,0	monster	Solid Cecil Damon	2667,3,180000
+lhz_dun04,0,0	monster	Celia Ringleader	2875,3,180000
+lhz_fild01,0,0	monster	Swift Rafflesia	2695,3,180000
+lhz_fild01,0,0	monster	Poring Ringleader	2696,2,180000
+lhz_fild01,0,0	monster	Furious Poring	2697,2,180000
+lhz_fild01,0,0	monster	Elusive Poring	2698,2,180000
+lhz_fild02,0,0	monster	Swift Stem Worm	2641,2,180000
+lhz_fild03,0,0	monster	Furious Breeze	2881,3,180000
+lou_dun01,0,0	monster	Elusive Jing Guai	2778,2,180000
+lou_dun02,0,0	monster	Yao Jun Ringleader	2796,1,180000
+lou_dun03,0,0	monster	Elusive Zhu Po Long	2862,1,180000
+lou_fild01,0,0	monster	Elusive Mi Gao	2793,1,180000
+ma_dun01,0,0	monster	Manananggal Ringleader	2766,2,180000
+ma_fild01,0,0	monster	Elusive Tiyanak	2631,2,180000
+ma_fild02,0,0	monster	Solid Bungisngis	2879,2,180000
+mag_dun01,0,0	monster	Furious Explosion	2837,1,180000
+mag_dun02,0,0	monster	Furious Nightmare Terror	2732,2,180000
+mal_dun01,0,0	monster	Elusive Red Eruma	2689,2,180000
+man_fild01,0,0	monster	Solid Nephentes	2735,2,180000
+man_fild02,0,0	monster	Elusive Bradium Golem	2882,2,180000
+man_fild03,0,0	monster	Solid Tatacho	2637,1,180000
+mjo_dun01,0,0	monster	Tarou Ringleader	2638,2,180000
+mjo_dun02,0,0	monster	Solid Martin	2760,2,180000
+mjo_dun03,0,0	monster	Elusive Skeleton Worker	2660,2,180000
+mjolnir_01,0,0	monster	Swift Caramel	2878,2,180000
+mjolnir_02,0,0	monster	Solid Elder Willow	2840,3,180000
+mjolnir_03,0,0	monster	Side Winder Ringleader	2663,2,180000
+mjolnir_04,0,0	monster	Furious Driller	2846,3,180000
+mjolnir_05,0,0	monster	Swift Argiope	2892,2,180000
+mjolnir_06,0,0	monster	Solid Poison Spore	2705,3,180000
+mjolnir_07,0,0	monster	Savage Ringleader	2673,3,180000
+mjolnir_08,0,0	monster	Furious Beetle King	2787,2,180000
+mjolnir_09,0,0	monster	Swift Savage Babe	2671,2,180000
+mjolnir_10,0,0	monster	Furious Argos	2890,2,180000
+mjolnir_11,0,0	monster	Elusive Argiope	2891,2,180000
+mjolnir_12,0,0	monster	Furious Dustiness	2842,2,180000
+moc_fild01,0,0	monster	Muka Ringleader	2741,3,180000
+moc_fild02,0,0	monster	Elusive Peco Peco	2718,2,180000
+moc_fild03,0,0	monster	Swift Wolf	2613,2,180000
+moc_fild07,0,0	monster	Drops Ringleader	2845,3,180000
+moc_fild11,0,0	monster	Furious Baby Desert Wolf	2856,3,180000
+moc_fild12,0,0	monster	Furious Picky	2712,2,180000
+moc_fild13,0,0	monster	Solid Steel Chonchon	2642,3,180000
+moc_fild16,0,0	monster	Furious Sandman	2674,2,180000
+moc_fild17,0,0	monster	Furious Hode	2802,2,180000
+moc_fild18,0,0	monster	Elusive Scorpion	2670,3,180000
+moc_fild20,0,0	monster	Swift Incarnation of Morocc	2744,1,180000
+moc_fild21,0,0	monster	Elusive Incarnation of Morocc	2743,2,180000
+moc_fild22,0,0	monster	Furious Incarnation of Morocc	2742,3,180000
+moc_pryd02,0,0	monster	Solid Mummy	2740,2,180000
+moc_pryd03,0,0	monster	Swift Mummy	2739,2,180000
+moc_pryd04,0,0	monster	Solid Isis	2790,2,180000
+moc_pryd05,0,0	monster	Elusive Minorous	2748,2,180000
+moc_pryd06,0,0	monster	Elusive Mimic	2753,2,180000
+moc_prydn1,0,0	monster	Furious Minorous	2747,2,180000
+moc_prydn2,0,0	monster	Furious Mimic	2752,2,180000
+mosk_dun01,0,0	monster	Elusive Wood Goblin	2612,2,180000
+mosk_dun02,0,0	monster	Swift Les	2779,1,180000
+mosk_dun03,0,0	monster	Elusive Vavayaga	2626,2,180000
+mosk_fild02,0,0	monster	Solid Side Winder	2662,1,180000
+nameless_n,0,0	monster	Furious Ghoul	2822,1,180000
+new_1-3,0,0	monster	Baby Poring Ringleader	2776,2,180000
+nif_fild01,0,0	monster	Elusive Disguise	2852,2,180000
+nif_fild02,0,0	monster	Swift Loli Ruri	2774,1,180000
+niflheim,0,0	monster	Furious Lude	2772,1,180000
+nyd_dun01,0,0	monster	Solid Draco	2849,2,180000
+odin_tem01,0,0	monster	Breeze Ringleader	2880,1,180000
+odin_tem02,0,0	monster	Solid Skogul	2657,1,180000
+odin_tem03,0,0	monster	Plasma Ringleader	2706,2,180000
+orcsdun01,0,0	monster	Elusive Orc Zombie	2723,2,180000
+orcsdun02,0,0	monster	Swift Orc Skeleton	2724,2,180000
+pay_dun00,0,0	monster	Furious Zombie	2606,2,180000
+pay_dun01,0,0	monster	Furious Soldier Skeleton	2649,2,180000
+pay_dun02,0,0	monster	Soldier Skeleton Ringleader	2648,3,180000
+pay_dun03,0,0	monster	Swift Sohee	2651,2,180000
+pay_dun04,0,0	monster	Furious Dokebi	2851,2,180000
+pay_fild01,0,0	monster	Willow Ringleader	2615,2,180000
+pay_fild02,0,0	monster	Boa Ringleader	2653,3,180000
+pay_fild03,0,0	monster	Fabre Ringleader	2836,3,180000
+pay_fild04,0,0	monster	Elusive Poporing	2703,2,180000
+pay_fild06,0,0	monster	Wormtail Ringleader	2610,3,180000
+pay_fild07,0,0	monster	Bigfoot Ringleader	2884,2,180000
+pay_fild09,0,0	monster	Solid Horn	2800,2,180000
+pay_fild10,0,0	monster	Swift Greatest General	2809,2,180000
+prt_fild00,0,0	monster	Roda Frog Ringleader	2678,2,180000
+prt_fild01,0,0	monster	Lunatic Ringleader	2771,2,180000
+prt_fild02,0,0	monster	Elusive Stainer	2645,3,180000
+prt_fild03,0,0	monster	Swift Yoyo	2608,2,180000
+prt_fild04,0,0	monster	Elusive Ambernite	2905,2,180000
+prt_fild05,0,0	monster	Elusive Hornet	2798,2,180000
+prt_fild06,0,0	monster	Solid Fabre	2835,2,180000
+prt_fild07,0,0	monster	Elusive Rocker	2680,3,180000
+prt_fild08,0,0	monster	Solid Lunatic	2770,1,180000
+prt_fild08,0,0	monster	Poring Ringleader	2696,1,180000
+prt_fild08,0,0	monster	Furious Poring	2697,1,180000
+prt_fild08,0,0	monster	Elusive Poring	2698,1,180000
+prt_fild08,0,0	monster	Swift Poring	2699,1,180000
+prt_fild09,0,0	monster	Elusive Magnolia	2768,2,180000
+prt_fild10,0,0	monster	Swift Elder Willow	2839,3,180000
+prt_fild11,0,0	monster	Elusive Goblin	2813,3,180000
+prt_maze01,0,0	monster	Solid Savage	2672,2,180000
+prt_maze02,0,0	monster	Furious Poporing	2702,2,180000
+prt_maze03,0,0	monster	Poporing Ringleader	2701,2,180000
+prt_maze03,0,0	monster	Swift Mantis	2764,2,180000
+prt_sewb1,0,0	monster	Elusive Familiar	2833,1,180000
+prt_sewb2,0,0	monster	Furious Thief Bug	2634,2,180000
+prt_sewb3,0,0	monster	Thief Bug Ringleader	2633,3,180000
+prt_sewb4,0,0	monster	Solid Thief Bug	2632,2,180000
+ra_fild01,0,0	monster	Baby Desert Wolf Ringleader	2855,2,180000
+ra_fild03,0,0	monster	Swift Hill Wind	2804,3,180000
+ra_fild04,0,0	monster	Elusive Hill Wind	2803,3,180000
+ra_fild05,0,0	monster	Solid Kobold	2785,3,180000
+ra_fild06,0,0	monster	Swift Kobold Archer	2784,3,180000
+ra_fild08,0,0	monster	Furious Anacondaq	2904,2,180000
+ra_fild12,0,0	monster	Solid Roween	2677,2,180000
+ra_san01,0,0	monster	Swift Vanberk	2627,2,180000
+ra_san02,0,0	monster	Isilla Ringleader	2791,2,180000
+ra_san03,0,0	monster	Hodremlin Ringleader	2801,2,180000
+ra_san04,0,0	monster	Echio Ringleader	2841,1,180000
+ra_san05,0,0	monster	Swift Agav	2911,2,180000
+schg_dun01,0,0	monster	Elusive Zakudam	2607,2,180000
+spl_fild01,0,0	monster	Solid Dark Pinguicula	2710,2,180000
+spl_fild02,0,0	monster	Pinguicula Ringleader	2711,2,180000
+spl_fild03,0,0	monster	Elusive Luciola Vespa	2773,1,180000
+teg_dun01,0,0	monster	Elusive Eremes	2783,2,180000,0
+teg_dun02,0,0	monster	Furious Wickebine Tres	2782,2,180000,0
+tha_t01,0,0	monster	Swift Rideword	2681,2,180000
+//tha_t01,0,0	monster	Swift Rideword	2681,1,180000	//--Applied after Thanatos Revamped Patch.
+tha_t02,0,0	monster	Ancient Mimic Ringleader	2903,2,180000
+tha_t03,0,0	monster	Death Word Ringleader	2860,2,180000
+tha_t04,0,0	monster	Solid Death Word	2859,2,180000
+tha_t05,0,0	monster	Owl Duke Ringleader	2721,2,180000
+//tha_t05,0,0	monster	Owl Duke Ringleader	2721,3,180000	//--Applied after Thanatos Revamped Patch.
+tha_t06,0,0	monster	Swift Death Word	2858,2,180000
+//tha_t06,0,0	monster	Swift Death Word	2858,3,180000	//--Applied after Thanatos Revamped Patch.
+tha_t07,0,0	monster	Swift Baroness of Retribution	2686,2,180000
+//tha_t07,0,0	monster	Swift Baroness of Retribution	2686,1,180000	//--Applied after Thanatos Revamped Patch.
+tha_t08,0,0	monster	Elusive Baroness of Retribution	2685,2,180000
+//tha_t08,0,0	monster	Elusive Baroness of Retribution	2685,1,180000	//--Applied after Thanatos Revamped Patch.
+tha_t09,0,0	monster	Elusive Lady Solace	2650,2,180000	//--Remove after Thanatos Ravamped Patch
+tha_t10,0,0	monster	Furious Baroness of Retribution	2684,2,180000	//--Remove after Thanatos Ravamped Patch
+tha_t11,0,0	monster	Elusive Mistress of Shelter	2665,2,180000	//--Remove after Thanatos Ravamped Patch
+tha_t12,0,0	monster	Dame of Sentinel Ringleader	2726,2,180000	//--Remove after Thanatos Ravamped Patch
+thor_v01,0,0	monster	Elusive Kasa	2788,2,180000
+thor_v02,0,0	monster	Knocker Ringleader	2786,1,180000
+thor_v03,0,0	monster	Elusive Salamander	2675,2,180000
+treasure_n1,0,0	monster	Swift Spore	2646,2,180000
+treasure_n2,0,0	monster	Weak Skeleton Ringleader	2619,2,180000
+treasure02,0,0	monster	Swift Sailor Skeleton	2676,1,180000
+treasure02,0,0	monster	Penomena Ringleader	2716,2,180000
+tur_dun01,0,0	monster	Swift Dragon Tail	2848,1,180000
+tur_dun02,0,0	monster	Solid Solider	2647,2,180000
+tur_dun03,0,0	monster	Freezer Ringleader	2831,1,180000
+tur_dun04,0,0	monster	Assaulter Ringleader	2889,1,180000
+tur_dun05,0,0	monster	Solid Freezer	2830,1,180000
+um_fild01,0,0	monster	Swift Dryad	2843,2,180000
+um_fild02,0,0	monster	Furious Wootan Fighter	2611,1,180000
+um_fild03,0,0	monster	Solid Parasite	2720,1,180000
+um_fild04,0,0	monster	Furious Wild Rose	2616,1,180000
+ve_fild01,0,0	monster	Elusive Galion	2828,1,180000
+ve_fild02,0,0	monster	Solid Drosera	2844,2,180000
+ve_fild03,0,0	monster	Swift Magmaring	2769,2,180000
+ve_fild04,0,0	monster	Elusive Muscipular	2738,2,180000
+ve_fild07,0,0	monster	Stapo Ringleader	2643,2,180000
+xmas_dun01,0,0	monster	Cookie Ringleader	2865,2,180000
+xmas_dun02,0,0	monster	Furious Myst Case	2737,2,180000
+xmas_fild01,0,0	monster	Furious Marin	2762,1,180000
+yuno_fild01,0,0	monster	Solid Geographer	2825,2,180000
+yuno_fild02,0,0	monster	Swift Sleeper	2656,2,180000
+yuno_fild03,0,0	monster	Furious Harpy	2807,3,180000
+yuno_fild04,0,0	monster	Harpy Ringleader	2806,3,180000
+yuno_fild06,0,0	monster	Elusive Sleeper	2655,1,180000
+yuno_fild07,0,0	monster	Goat Ringleader	2816,2,180000
+yuno_fild08,0,0	monster	Grand Peco Ringleader	2811,2,180000
+yuno_fild09,0,0	monster	Solid Grand Peco	2810,2,180000
+yuno_fild11,0,0	monster	Solid Goat	2815,2,180000
+yuno_fild12,0,0	monster	Swift Geographer	2824,1,180000

--- a/npc/re/mobs/fields/prontera.txt
+++ b/npc/re/mobs/fields/prontera.txt
@@ -3,7 +3,7 @@
 //===== By: ==================================================
 //= Athena (1.0)
 //===== Current Version: =====================================
-//= 1.7
+//= 1.8
 //===== Additional Comments: =================================
 //= 1.2 fixed some map name typos [Lupus]
 //= 1.3 Official kRO 10.1 spawns [Playtester]
@@ -11,6 +11,7 @@
 //= 1.5 Updated to Renewal spawns.
 //= 1.6 Added Prontera Field 8 duplicates. [Euphy]
 //= 1.7 Correct Spawn by Navigation's mob data. [attackjom]
+//= 1.8 Official 18.1 Field 8 spawns, duplicates removed [Playtester]
 //============================================================
 
 //==================================================
@@ -90,36 +91,27 @@ prt_fild07,225,110,5,5	monster	Black Mushroom	1084,3,360000,180000
 //==================================================
 // prt_fild08 - Prontera Field
 //==================================================
-prt_fild08,0,0	monster	Poring	1002,110,5000
-prt_fild08,0,0	monster	Lunatic	1063,110,5000
-prt_fild08,0,0	monster	Fabre	1007,88,5000
-prt_fild08,0,0	monster	Little Poring	2398,33,50000
-prt_fild08,0,0	monster	Pupa	1008,66,5000
-
-//==================================================
-// prt_fild08 - Duplicates
-//==================================================
-prt_fild08a,0,0	monster	Poring	1002,110,5000
-prt_fild08a,0,0	monster	Lunatic	1063,110,5000
-prt_fild08a,0,0	monster	Fabre	1007,88,5000
-prt_fild08a,0,0	monster	Little Poring	2398,33,50000
-prt_fild08a,0,0	monster	Pupa	1008,66,5000
-prt_fild08b,0,0	monster	Poring	1002,110,5000
-prt_fild08b,0,0	monster	Lunatic	1063,110,5000
-prt_fild08b,0,0	monster	Fabre	1007,88,5000
-prt_fild08b,0,0	monster	Little Poring	2398,33,50000
-prt_fild08b,0,0	monster	Pupa	1008,66,5000
-prt_fild08c,0,0	monster	Poring	1002,110,5000
-prt_fild08c,0,0	monster	Lunatic	1063,110,5000
-prt_fild08c,0,0	monster	Fabre	1007,88,5000
-prt_fild08c,0,0	monster	Little Poring	2398,33,50000
-prt_fild08c,0,0	monster	Pupa	1008,66,5000
-prt_fild08d,0,0	monster	Poring	1002,110,5000
-prt_fild08d,0,0	monster	Lunatic	1063,110,5000
-prt_fild08d,0,0	monster	Fabre	1007,88,5000
-prt_fild08d,0,0	monster	Little Poring	2398,33,50000
-prt_fild08d,0,0	monster	Pupa	1008,66,5000
-
+prt_fild08,0,0	monster	Poring	1002,20,5000
+prt_fild08,0,0	monster	Lunatic	1063,20,5000
+prt_fild08,0,0	monster	Fabre	1007,10,5000
+prt_fild08,305,233,10,10	monster	Poring	1002,2,15000
+prt_fild08,305,233,10,10	monster	Lunatic	1063,2,15000
+prt_fild08,305,233,10,10	monster	Fabre	1007,2,15000
+prt_fild08,271,249,20,20	monster	Poring	1002,5,15000
+prt_fild08,271,249,20,20	monster	Lunatic	1063,5,15000
+prt_fild08,271,249,20,20	monster	Fabre	1007,5,15000
+prt_fild08,94,335,50,50	monster	Poring	1002,20,10000
+prt_fild08,166,334,50,50	monster	Poring	1002,20,10000
+prt_fild08,253,337,50,50	monster	Poring	1002,20,10000
+prt_fild08,228,230,30,30	monster	Lunatic	1063,10,10000
+prt_fild08,246,263,50,50	monster	Lunatic	1063,10,10000
+prt_fild08,190,237,50,50	monster	Lunatic	1063,10,10000
+prt_fild08,100,256,50,50	monster	Lunatic	1063,10,10000
+prt_fild08,70,164,70,70	monster	Fabre	1007,20,10000
+prt_fild08,144,147,70,70	monster	Fabre	1007,20,10000
+prt_fild08,263,79,90,90	monster	Fabre	1007,20,10000
+prt_fild08,336,113,40,40	monster	Pupa	1008,20,10000
+prt_fild08,330,269,40,40	monster	Little Poring	2398,20,10000
 
 //==================================================
 // prt_fild09 - Prontera Field

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11482,6 +11482,7 @@ static const struct _battle_data {
 	{ "mob_respawn_time",                   &battle_config.mob_respawn_time,                1000,   1000,   INT_MAX,        },
 	{ "mob_unlock_time",                    &battle_config.mob_unlock_time,                 2000,   0,      INT_MAX,        },
 	{ "map_edge_size",                      &battle_config.map_edge_size,                   15,     1,      40,             },
+	{ "randomize_center_cell",              &battle_config.randomize_center_cell,           1,      0,      1,              },
 
 	{ "feature.stylist",                    &battle_config.feature_stylist,                 1,      0,      1,              },
 	{ "feature.banking_state_enforce",      &battle_config.feature_banking_state_enforce,   0,      0,      1,              },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11458,7 +11458,7 @@ static const struct _battle_data {
 
 	{ "mob_respawn_time",                   &battle_config.mob_respawn_time,                1000,   1000,   INT_MAX,        },
 	{ "mob_unlock_time",                    &battle_config.mob_unlock_time,                 2000,   0,      INT_MAX,        },
-	{ "map_edge_size",                      &battle_config.map_edge_size,                   15,     4,      40,             },
+	{ "map_edge_size",                      &battle_config.map_edge_size,                   15,     1,      40,             },
 
 	{ "feature.stylist",                    &battle_config.feature_stylist,                 1,      0,      1,              },
 	{ "feature.banking_state_enforce",      &battle_config.feature_banking_state_enforce,   0,      0,      1,              },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11458,6 +11458,7 @@ static const struct _battle_data {
 
 	{ "mob_respawn_time",                   &battle_config.mob_respawn_time,                1000,   1000,   INT_MAX,        },
 	{ "mob_unlock_time",                    &battle_config.mob_unlock_time,                 2000,   0,      INT_MAX,        },
+	{ "map_edge_size",                      &battle_config.map_edge_size,                   15,     4,      40,             },
 
 	{ "feature.stylist",                    &battle_config.feature_stylist,                 1,      0,      1,              },
 	{ "feature.banking_state_enforce",      &battle_config.feature_banking_state_enforce,   0,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -750,6 +750,7 @@ struct Battle_Config
 	int mob_respawn_time;
 	int mob_unlock_time;
 	int map_edge_size;
+	int randomize_center_cell;
 
 	int feature_stylist;
 	int feature_banking_state_enforce;

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -749,6 +749,7 @@ struct Battle_Config
 
 	int mob_respawn_time;
 	int mob_unlock_time;
+	int map_edge_size;
 
 	int feature_stylist;
 	int feature_banking_state_enforce;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1731,10 +1731,10 @@ int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int1
 		return 0;
 	}
 
+	int16 edge = battle_config.map_edge_size;
 	// In most situations there are 50 tries officially (default value)
 	while(tries--) {
 		// For map-wide search, the cells 15 tiles from the edge are not considered
-		int16 edge = battle_config.map_edge_size;
 		*x = (rx >= 0) ? rnd_value(bx - rx, bx + rx) : rnd_value<int16>(edge, mapdata->xs - edge - 1);
 		*y = (ry >= 0) ? rnd_value(by - ry, by + ry) : rnd_value<int16>(edge, mapdata->ys - edge - 1);
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1699,7 +1699,7 @@ static int map_count_sub(struct block_list *bl,va_list ap)
  * &2 = the target should be able to walk to the target tile.
  * &4 = there shouldn't be any players around the target tile (use the no_spawn_on_player setting)
  *------------------------------------------*/
-int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int16 rx, int16 ry, int flag, int32 tries)
+int map_search_freecell(struct block_list *src, int16 m, int16 *x, int16 *y, int16 rx, int16 ry, int flag, int32 tries)
 {
 	int spawn=0;
 	int bx, by;
@@ -1732,17 +1732,20 @@ int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int1
 	}
 
 	int16 edge = battle_config.map_edge_size;
+	int16 edge_valid = std::min(edge, (int16)5);
 	// In most situations there are 50 tries officially (default value)
 	while(tries--) {
-		// For map-wide search, the cells 15 tiles from the edge are not considered
+		// For map-wide search, the configured tiles from the edge are not considered (default: 15)
 		*x = (rx >= 0) ? rnd_value(bx - rx, bx + rx) : rnd_value<int16>(edge, mapdata->xs - edge - 1);
 		*y = (ry >= 0) ? rnd_value(by - ry, by + ry) : rnd_value<int16>(edge, mapdata->ys - edge - 1);
 
 		if (*x == bx && *y == by)
 			continue; //Avoid picking the same target tile.
 
-		// Cells outside the map or within 4-5 cells of the map edge are considered invalid
-		if (*x < 5 || *x > mapdata->xs - 5 || *y < 5 || *y > mapdata->ys - 5)
+		// Cells outside the map or within 4-5 cells of the map edge are considered invalid officially
+		// Note that unlike the other edge, this isn't symmetric (NE - 4 cells, SW - 5 cells)
+		// If for some reason edge size was set to below 5 cells, we consider them as valid
+		if (*x < edge_valid || *x > mapdata->xs - edge_valid || *y < edge_valid || *y > mapdata->ys - edge_valid)
 			continue;
 
 		if (map_getcell(m,*x,*y,CELL_CHKREACH))

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1699,7 +1699,7 @@ static int map_count_sub(struct block_list *bl,va_list ap)
  * &2 = the target should be able to walk to the target tile.
  * &4 = there shouldn't be any players around the target tile (use the no_spawn_on_player setting)
  *------------------------------------------*/
-int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int16 rx, int16 ry, int flag, int tries)
+int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int16 rx, int16 ry, int flag, int32 tries)
 {
 	int spawn=0;
 	int bx, by;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1699,9 +1699,9 @@ static int map_count_sub(struct block_list *bl,va_list ap)
  * &2 = the target should be able to walk to the target tile.
  * &4 = there shouldn't be any players around the target tile (use the no_spawn_on_player setting)
  *------------------------------------------*/
-int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int16 rx, int16 ry, int flag)
+int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int16 rx, int16 ry, int flag, int tries)
 {
-	int tries, spawn=0;
+	int spawn=0;
 	int bx, by;
 
 	if( !src && (!(flag&1) || flag&2) )
@@ -1731,20 +1731,19 @@ int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int1
 		return 0;
 	}
 
-	if (rx >= 0 && ry >= 0) {
-		tries = (rx * 2 + 1) * (ry * 2 + 1);
-		if (tries > 100) tries = 100;
-	} else {
-		tries = mapdata->xs*mapdata->ys;
-		if (tries > 500) tries = 500;
-	}
-
+	// In most situations there are 50 tries officially (default value)
 	while(tries--) {
-		*x = (rx >= 0) ? rnd_value(bx - rx, bx + rx) : rnd_value<int16>(1, mapdata->xs - 1);
-		*y = (ry >= 0) ? rnd_value(by - ry, by + ry) : rnd_value<int16>(1, mapdata->ys - 1);
+		// For map-wide search, the cells 15 tiles from the edge are not considered
+		int16 edge = battle_config.map_edge_size;
+		*x = (rx >= 0) ? rnd_value(bx - rx, bx + rx) : rnd_value<int16>(edge, mapdata->xs - edge - 1);
+		*y = (ry >= 0) ? rnd_value(by - ry, by + ry) : rnd_value<int16>(edge, mapdata->ys - edge - 1);
 
 		if (*x == bx && *y == by)
 			continue; //Avoid picking the same target tile.
+
+		// Cells outside the map or within 4-5 cells of the map edge are considered invalid
+		if (*x < 5 || *x > mapdata->xs - 5 || *y < 5 || *y > mapdata->ys - 5)
+			continue;
 
 		if (map_getcell(m,*x,*y,CELL_CHKREACH))
 		{
@@ -1754,10 +1753,11 @@ int map_search_freecell(struct block_list *src, int16 m, int16 *x,int16 *y, int1
 				if (spawn >= 100) return 0; //Limit of retries reached.
 				if (spawn++ < battle_config.no_spawn_on_player &&
 					map_foreachinallarea(map_count_sub, m,
-						*x-AREA_SIZE, *y-AREA_SIZE,
-					  	*x+AREA_SIZE, *y+AREA_SIZE, BL_PC)
-				)
-				continue;
+						*x - AREA_SIZE, *y - AREA_SIZE,
+						*x + AREA_SIZE, *y + AREA_SIZE, BL_PC)) {
+					tries++; // This failure should not affect the number of official tries
+					continue;
+				}
 			}
 			return 1;
 		}

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1124,7 +1124,7 @@ int map_count_oncell(int16 m,int16 x,int16 y,int type,int flag);
 struct skill_unit *map_find_skill_unit_oncell(struct block_list *,int16 x,int16 y,uint16 skill_id,struct skill_unit *, int flag);
 // search and creation
 int map_get_new_object_id(void);
-int map_search_freecell(struct block_list *src, int16 m, int16 *x, int16 *y, int16 rx, int16 ry, int flag);
+int map_search_freecell(struct block_list *src, int16 m, int16 *x, int16 *y, int16 rx, int16 ry, int flag, int tries = 50);
 bool map_closest_freecell(int16 m, int16 *x, int16 *y, int type, int flag);
 //
 int map_quit(map_session_data *);

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1124,7 +1124,7 @@ int map_count_oncell(int16 m,int16 x,int16 y,int type,int flag);
 struct skill_unit *map_find_skill_unit_oncell(struct block_list *,int16 x,int16 y,uint16 skill_id,struct skill_unit *, int flag);
 // search and creation
 int map_get_new_object_id(void);
-int map_search_freecell(struct block_list *src, int16 m, int16 *x, int16 *y, int16 rx, int16 ry, int flag, int tries = 50);
+int map_search_freecell(struct block_list *src, int16 m, int16 *x, int16 *y, int16 rx, int16 ry, int flag, int32 tries = 50);
 bool map_closest_freecell(int16 m, int16 *x, int16 *y, int type, int flag);
 //
 int map_quit(map_session_data *);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1084,7 +1084,7 @@ int mob_setdelayspawn(struct mob_data *md)
 int mob_count_sub(struct block_list *bl, va_list ap) {
     int mobid[10], i;
     ARR_FIND(0, 10, i, (mobid[i] = va_arg(ap, int)) == 0); //fetch till 0
-	TBL_MOB* md = BL_CAST(BL_MOB, bl);
+	mob_data* md = BL_CAST(BL_MOB, bl);
 	if (md && mobid[0]) { //if there one let's check it otherwise go backward
         ARR_FIND(0, 10, i, md->mob_id == mobid[i]);
         return (i < 10) ? 1 : 0;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2098,13 +2098,13 @@ static int mob_ai_sub_lazy(struct mob_data *md, va_list args)
 	md->last_thinktime=tick;
 
 	if (md->master_id) {
-		// Get mob data of master
-		mob_data* mmd = map_id2md(md->master_id);
-
-		// If neither master nor slave have been spotted we don't have to execute the slave AI
-		if (mmd && !mob_is_spotted(mmd) && !mob_is_spotted(md))
-			return 0;
-
+		if (!mob_is_spotted(md)) {
+			// Get mob data of master
+			mob_data* mmd = map_id2md(md->master_id);
+			// If neither master nor slave have been spotted we don't have to execute the slave AI
+			if (mmd && !mob_is_spotted(mmd))
+				return 0;
+		}
 		mob_ai_sub_hard_slavemob (md,tick);
 		return 0;
 	}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1125,9 +1125,13 @@ int mob_spawn (struct mob_data *md)
 		{
 			// Officially the area is split into 4 squares, 4 lines and 1 dot and for each of those there is one attempt
 			// We simplify this to trying 8 times in the whole area and then at the center cell even though that's not fully accurate
+			// The search for a spawn location is called twice, meaning the area is doubled in size but with a strong bias towards the center
+			// The center cell has a 1/(xs*ys) chance to be picked, otherwise we call the search function to get the start coordinates
+			if ((md->spawn->xs > 1 || md->spawn->ys > 1) && !rnd_chance(1, md->spawn->xs * md->spawn->ys))
+				map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs-1, md->spawn->ys-1, 0, 8);
 
 			// Try to spawn monster in defined area (8 tries)
-			if (!map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs, md->spawn->ys, battle_config.no_spawn_on_player?4:0, 8))
+			if (!map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs-1, md->spawn->ys-1, battle_config.no_spawn_on_player?4:0, 8))
 			{
 				// If area search failed and center cell not reachable, try to spawn the monster anywhere on the map (50 tries)
 				if (!map_getcell(md->bl.m, md->bl.x, md->bl.y, CELL_CHKREACH) && !map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, -1, -1, battle_config.no_spawn_on_player?4:0))

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1084,11 +1084,12 @@ int mob_setdelayspawn(struct mob_data *md)
 int mob_count_sub(struct block_list *bl, va_list ap) {
     int mobid[10], i;
     ARR_FIND(0, 10, i, (mobid[i] = va_arg(ap, int)) == 0); //fetch till 0
-    if (mobid[0]) { //if there one let's check it otherwise go backward
-        TBL_MOB *md = BL_CAST(BL_MOB, bl);
+	TBL_MOB* md = BL_CAST(BL_MOB, bl);
+	if (md && mobid[0]) { //if there one let's check it otherwise go backward
         ARR_FIND(0, 10, i, md->mob_id == mobid[i]);
         return (i < 10) ? 1 : 0;
     }
+	// If not counting monsters, count all
     return 1; //backward compatibility
 }
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1123,13 +1123,13 @@ int mob_spawn (struct mob_data *md)
 		if( (md->bl.x == 0 && md->bl.y == 0) || md->spawn->xs || md->spawn->ys )
 		{
 			// Officially the area is split into 4 squares, 4 lines and 1 dot and for each of those there is one attempt
-			// We simplify this to trying 9 times in the whole area even though that's not fully accurate
+			// We simplify this to trying 8 times in the whole area and then at the center cell even though that's not fully accurate
 
-			// Try to spawn monster in defined area (9 tries)
-			if (!map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs, md->spawn->ys, battle_config.no_spawn_on_player?4:0, 9))
+			// Try to spawn monster in defined area (8 tries)
+			if (!map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs, md->spawn->ys, battle_config.no_spawn_on_player?4:0, 8))
 			{
-				// If area search failed, try to spawn the monster anywhere on the map (50 tries)
-				if (!map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, -1, -1, battle_config.no_spawn_on_player?4:0))
+				// If area search failed and center cell not reachable, try to spawn the monster anywhere on the map (50 tries)
+				if (!map_getcell(md->bl.m, md->bl.x, md->bl.y, CELL_CHKREACH) && !map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, -1, -1, battle_config.no_spawn_on_player?4:0))
 				{
 					// Retry again later
 					if (md->spawn_timer != INVALID_TIMER)
@@ -1139,7 +1139,7 @@ int mob_spawn (struct mob_data *md)
 				}
 			}
 		}
-		else if( battle_config.no_spawn_on_player > 99 && map_foreachinallrange(mob_count_sub, &md->bl, AREA_SIZE, BL_PC) )
+		if( battle_config.no_spawn_on_player > 99 && map_foreachinallrange(mob_count_sub, &md->bl, AREA_SIZE, BL_PC) )
 		{ // retry again later (players on sight)
 			if( md->spawn_timer != INVALID_TIMER )
 				delete_timer(md->spawn_timer, mob_delayspawn);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1120,7 +1120,7 @@ int mob_spawn (struct mob_data *md)
 		md->bl.x = md->spawn->x;
 		md->bl.y = md->spawn->y;
 
-		// Search be skipped if spawn location is fixed
+		// Search can be skipped if spawn location is fixed
 		if( (md->bl.x == 0 && md->bl.y == 0) || md->spawn->xs || md->spawn->ys )
 		{
 			// Officially the area is split into 4 squares, 4 lines and 1 dot and for each of those there is one attempt

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1121,12 +1121,13 @@ int mob_spawn (struct mob_data *md)
 		md->bl.y = md->spawn->y;
 
 		// Search can be skipped if spawn location is fixed
-		if( (md->bl.x == 0 && md->bl.y == 0) || md->spawn->xs || md->spawn->ys )
+		if ((md->bl.x == 0 && md->bl.y == 0) || md->spawn->xs != 1 || md->spawn->ys != 1)
 		{
 			// Officially the area is split into 4 squares, 4 lines and 1 dot and for each of those there is one attempt
 			// We simplify this to trying 8 times in the whole area and then at the center cell even though that's not fully accurate
 			// The search for a spawn location is called twice, meaning the area is doubled in size but with a strong bias towards the center
 			// The center cell has a 1/(xs*ys) chance to be picked, otherwise we call the search function to get the start coordinates
+			// On this first iteration we don't care if the search succeeds or if it's visible to player as it's not the final spawn location
 			if ((md->spawn->xs > 1 || md->spawn->ys > 1) && !rnd_chance(1, md->spawn->xs * md->spawn->ys))
 				map_search_freecell(&md->bl, -1, &md->bl.x, &md->bl.y, md->spawn->xs-1, md->spawn->ys-1, 0, 8);
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -354,6 +354,7 @@ struct mob_data {
 	uint32 spotted_log[DAMAGELOG_SIZE];
 	struct spawn_data *spawn; //Spawn data.
 	int spawn_timer; //Required for Convex Mirror
+	int16 centerX, centerY; // Spawn center of this individual monster
 	struct s_mob_lootitem *lootitems;
 	short mob_id;
 	unsigned int tdmg; //Stores total damage given to the mob, for exp calculations. [Skotlex]

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5193,7 +5193,7 @@ void npc_parse_mob2(struct spawn_data* mob)
 static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const char* start, const char* buffer, const char* filepath)
 {
 	int num, mob_id, mob_lv = -1, delay = 5000, size = -1, w1count, w4count;
-	short m, x = 0, y = 0, xs = -1, ys = -1;
+	short m, x = 0, y = 0, xs = 0, ys = 0;
 	char mapname[MAP_NAME_LENGTH_EXT], mobname[NAME_LENGTH], sprite[NAME_LENGTH];
 	struct spawn_data mob, *data;
 	int ai = AI_NONE; // mob_ai
@@ -5294,25 +5294,21 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 		mob.state.ai = static_cast<enum mob_ai>(ai);
 
 	if (mob.xs < 0) {
-		if (w1count > 3) {
-			ShowWarning("npc_parse_mob: Negative x-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.xs, mob_id, filepath, strline(buffer, start - buffer));
-		}
-		mob.xs = -1;
+		ShowWarning("npc_parse_mob: Negative x-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.xs, mob_id, filepath, strline(buffer, start - buffer));
+		mob.xs = 0;
 	}
-	else if (mob.xs == 0) {
-		// Both 0 and 1 result in fixed x-coordinate
+	else if (mob.xs == 0 && mob.x > 0) {
+		// Fixed X coordinate
 		// Need to set this to 1 as we reduce it by 1 when calling the search function
 		mob.xs = 1;
 	}
 
 	if (mob.ys < 0) {
-		if (w1count > 4) {
-			ShowWarning("npc_parse_mob: Negative y-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.ys, mob_id, filepath, strline(buffer, start - buffer));
-		}
-		mob.ys = -1;
+		ShowWarning("npc_parse_mob: Negative y-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.ys, mob_id, filepath, strline(buffer, start - buffer));
+		mob.ys = 0;
 	}
-	else if (mob.ys == 0) {
-		// Both 0 and 1 result in fixed y-coordinate
+	else if (mob.ys == 0 && mob.y > 0) {
+		// Fixed Y coordinate
 		// Need to set this to 1 as we reduce it by 1 when calling the search function
 		mob.ys = 1;
 	}
@@ -5323,10 +5319,10 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	}
 
 	if (battle_config.force_random_spawn || (mob.x == 0 && mob.y == 0)
-		|| (mob.xs <= 1 && mob.ys <= 1 && !map_getcell(mob.m, mob.x, mob.y, CELL_CHKREACH)))
+		|| (mob.xs == 1 && mob.ys == 1 && !map_getcell(mob.m, mob.x, mob.y, CELL_CHKREACH)))
 	{	//Force a random spawn anywhere on the map.
 		mob.x = mob.y = 0;
-		mob.xs = mob.ys = -1;
+		mob.xs = mob.ys = 0;
 	}
 
 	// Check if monsters should have variance applied to their respawn time

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5181,10 +5181,12 @@ void npc_parse_mob2(struct spawn_data* mob)
 		struct mob_data* md = mob_spawn_dataset(mob);
 		md->spawn = mob;
 		// Determine center cell for each mob in the spawn line
-		if (mob->xs > 1)
-			md->centerX = rnd_value(mob->x - mob->xs + 1, mob->x + mob->xs - 1);
-		if (mob->ys > 1)
-			md->centerY = rnd_value(mob->y - mob->ys + 1, mob->y + mob->ys - 1);
+		if (battle_config.randomize_center_cell) {
+			if (mob->xs > 1)
+				md->centerX = rnd_value(mob->x - mob->xs + 1, mob->x + mob->xs - 1);
+			if (mob->ys > 1)
+				md->centerY = rnd_value(mob->y - mob->ys + 1, mob->y + mob->ys - 1);
+		}
 		md->spawn->active++;
 		mob_spawn(md);
 	}

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5294,12 +5294,20 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 		}
 		mob.xs = 0;
 	}
+	else if (mob.xs == 0) {
+		// Both 0 and 1 result in fixed x-coordinate
+		mob.xs = 1;
+	}
 
 	if (mob.ys < 0) {
 		if (w1count > 4) {
 			ShowWarning("npc_parse_mob: Negative y-span %hd for mob ID %d (file '%s', line '%d').\n", mob.ys, mob_id, filepath, strline(buffer, start - buffer));
 		}
 		mob.ys = 0;
+	}
+	else if (mob.ys == 0) {
+		// Both 0 and 1 result in fixed y-coordinate
+		mob.ys = 1;
 	}
 
 	if (mob.num > 1 && battle_config.mob_count_rate != 100) {

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5296,6 +5296,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	}
 	else if (mob.xs == 0) {
 		// Both 0 and 1 result in fixed x-coordinate
+		// Need to set this to 1 as we reduce it by 1 when calling the search function
 		mob.xs = 1;
 	}
 
@@ -5307,6 +5308,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	}
 	else if (mob.ys == 0) {
 		// Both 0 and 1 result in fixed y-coordinate
+		// Need to set this to 1 as we reduce it by 1 when calling the search function
 		mob.ys = 1;
 	}
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5197,7 +5197,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 
 	mob.state.boss = !strcmpi(w2,"boss_monster");
 
-	// w1=<map name>{,<x>,<y>,<xs>{,<ys>}}
+	// w1=<map name>{,<x>,<y>{,<xs>,<ys>}}
 	// w3=<mob name>{,<mob level>}
 	// w4=<mob id>,<amount>{,<delay1>{,<delay2>{,<event>{,<mob size>{,<mob ai>}}}}}
 	if( ( w1count = sscanf(w1, "%15[^,],%6hd,%6hd,%6hd,%6hd", mapname, &x, &y, &xs, &ys) ) < 1
@@ -5307,7 +5307,8 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 			mob.num = 1;
 	}
 
-	if (battle_config.force_random_spawn || (mob.x == 0 && mob.y == 0))
+	if (battle_config.force_random_spawn || (mob.x == 0 && mob.y == 0)
+		|| (mob.xs <= 1 && mob.ys <= 1 && !map_getcell(mob.m, mob.x, mob.y, CELL_CHKREACH)))
 	{	//Force a random spawn anywhere on the map.
 		mob.x = mob.y = 0;
 		mob.xs = mob.ys = -1;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5180,6 +5180,11 @@ void npc_parse_mob2(struct spawn_data* mob)
 	{
 		struct mob_data* md = mob_spawn_dataset(mob);
 		md->spawn = mob;
+		// Determine center cell for each mob in the spawn line
+		if (mob->xs > 1)
+			md->centerX = rnd_value(mob->x - mob->xs + 1, mob->x + mob->xs - 1);
+		if (mob->ys > 1)
+			md->centerY = rnd_value(mob->y - mob->ys + 1, mob->y + mob->ys - 1);
 		md->spawn->active++;
 		mob_spawn(md);
 	}
@@ -5290,9 +5295,9 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 
 	if (mob.xs < 0) {
 		if (w1count > 3) {
-			ShowWarning("npc_parse_mob: Negative x-span %hd for mob ID %d (file '%s', line '%d').\n", mob.xs, mob_id, filepath, strline(buffer, start - buffer));
+			ShowWarning("npc_parse_mob: Negative x-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.xs, mob_id, filepath, strline(buffer, start - buffer));
 		}
-		mob.xs = 0;
+		mob.xs = -1;
 	}
 	else if (mob.xs == 0) {
 		// Both 0 and 1 result in fixed x-coordinate
@@ -5302,9 +5307,9 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 
 	if (mob.ys < 0) {
 		if (w1count > 4) {
-			ShowWarning("npc_parse_mob: Negative y-span %hd for mob ID %d (file '%s', line '%d').\n", mob.ys, mob_id, filepath, strline(buffer, start - buffer));
+			ShowWarning("npc_parse_mob: Negative y-span %hd for mob ID %d (file '%s', line '%d'). Defaulting to map-wide.\n", mob.ys, mob_id, filepath, strline(buffer, start - buffer));
 		}
-		mob.ys = 0;
+		mob.ys = -1;
 	}
 	else if (mob.ys == 0) {
 		// Both 0 and 1 result in fixed y-coordinate

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7047,8 +7047,9 @@ char pc_randomwarp(map_session_data *sd, clr_type type, bool ignore_mapflag)
 		return 3;
 
 	do {
-		x = rnd()%(mapdata->xs-2)+1;
-		y = rnd()%(mapdata->ys-2)+1;
+		int edge = battle_config.map_edge_size;
+		x = rnd()%(mapdata->xs - edge*2) + edge;
+		y = rnd()%(mapdata->ys - edge*2) + edge;
 	} while((map_getcell(sd->bl.m,x,y,CELL_CHKNOPASS) || (!battle_config.teleport_on_portal && npc_check_areanpc(1,sd->bl.m,x,y,1))) && (i++) < 1000);
 
 	if (i < 1000)

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7037,7 +7037,7 @@ enum e_setpos pc_setpos_savepoint( map_session_data& sd, clr_type clrtype ){
  *------------------------------------------*/
 char pc_randomwarp(map_session_data *sd, clr_type type, bool ignore_mapflag)
 {
-	int x,y,i=0;
+	int16 x,y,i=0;
 
 	nullpo_ret(sd);
 
@@ -7048,8 +7048,8 @@ char pc_randomwarp(map_session_data *sd, clr_type type, bool ignore_mapflag)
 
 	int edge = battle_config.map_edge_size;
 	do {
-		x = rnd()%(mapdata->xs - edge*2) + edge;
-		y = rnd()%(mapdata->ys - edge*2) + edge;
+		x = rnd_value<int16>(edge, mapdata->xs - edge - 1);
+		y = rnd_value<int16>(edge, mapdata->ys - edge - 1);
 	} while((map_getcell(sd->bl.m,x,y,CELL_CHKNOPASS) || (!battle_config.teleport_on_portal && npc_check_areanpc(1,sd->bl.m,x,y,1))) && (i++) < 1000);
 
 	if (i < 1000)

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7046,8 +7046,8 @@ char pc_randomwarp(map_session_data *sd, clr_type type, bool ignore_mapflag)
 	if (mapdata->getMapFlag(MF_NOTELEPORT) && !ignore_mapflag) //Teleport forbidden
 		return 3;
 
+	int edge = battle_config.map_edge_size;
 	do {
-		int edge = battle_config.map_edge_size;
 		x = rnd()%(mapdata->xs - edge*2) + edge;
 		y = rnd()%(mapdata->ys - edge*2) + edge;
 	} while((map_getcell(sd->bl.m,x,y,CELL_CHKNOPASS) || (!battle_config.teleport_on_portal && npc_check_areanpc(1,sd->bl.m,x,y,1))) && (i++) < 1000);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8300 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When searching for a map-wide free cell, the tiles 15 cells from the edge are no longer considered
  * Added a configuration to change the edge size to any value between 1 and 40
- When searching for a free cell, the tiles 4-5 cells from the edge are now considered invalid and trigger a retry
  * If you make the edge size smaller than this, it will use edge size instead
- Searching for a free cell now defaults to 50 tries, but if the "no spawn on player" option is active, those failed attempts are not counted towards the limit anymore
- When a monster spawns in a defined area there will now be 8 attempts to spawn it on a valid cell within the area and then one attempt on the center cell; if all 9 attempts fail, there will now be 50 tries to spawn it map-wide before it gives up
- When a monster has fixed spawn coordinates, but those coordinates are a wall, it will now spawn in a random location map-wide instead
  * This also applies to icewall blocking the cell unless the boss_monster command was used
- Each monster in an area spawn will now receive its own spawn center within the spawn area on server start
  * This results in the spawn area being larger but having a bias towards the center
  * Added a configuration to disable this behavior
- Fixed slave monsters always being active and constantly calling the "search freecell" function even though neither them nor their master have been spotted yet
- Fixed map server crash when setting no_spawn_on_player to 100 (follow-up to 33b2b02)
- Updated prontera field spawns to official episode 18+
- Updated all champion mob respawn times to 3 minutes and sorted them by map name
- Fixes #8300

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
