### PR TITLE
Fixed GRANDCROSS skill display mode

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3747,8 +3747,6 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 				dsrc = src;
 			if( src == bl)
 				dmg_type = DMG_ENDURE;
-			else
-				flag|= SD_ANIMATION;
 			break;
 		case NJ_TATAMIGAESHI: //For correct knockback.
 			dsrc = src;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: All

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

    As an official behavior, a skill motion of ```CR_GRANDCROSS``` should not be skipped.
This will fix an interval of ```CR_GRANDCROSS``` damage displayed irregularly.
Reference : https://www.youtube.com/watch?v=V_9-4sEKjSU<!-- Describe how this pull request will resolve the issue(s) listed above. -->
