### PR TITLE
Fix Boss Meow not having boss class in db/re/mob_db.yml

### DIFF
--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -98959,6 +98959,7 @@ Body:
     DamageMotion: 480
     DamageTaken: 10
     Ai: 21
+    Class: Boss
     Modes:
       Mvp: true
     MvpDrops:


### PR DESCRIPTION
Mob 20648 (Boss Meow) is not a boss mob and it should be.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

It is possible to use Silvervine Root Twist or blade stop for 10 seconds on Boss Meow mob (20648)
This is not supposed to happen because it is a boss class mob. (https://www.divine-pride.net/database/monster/20648/boss-meow)
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

Renewal
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Add "Class: Boss" to mob 20648 (Boss Meow).
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
