### PR TITLE
Update build_servers_gcc.yml

### DIFF
--- a/.github/workflows/build_servers_gcc.yml
+++ b/.github/workflows/build_servers_gcc.yml
@@ -31,7 +31,11 @@ jobs:
           # Available: ubuntu-22.04, ubuntu-20.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
-          gcc: ['9', '10', '11', '12', '13']
+          gcc: ['9', '10', '11', '12']
+          # GCC 13 was removed from 22.04, include it as a separate job
+          include:
+            - os: ubuntu-24.04
+              gcc: 13
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* **Addressed Issue(s)**: actions/runner-images#9866

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 

  * Add a separate job to run specifically for GCC 13 in Ubuntu 24.04 as the package was removed from Ubuntu 22.04.