### PR TITLE
Illusion of underwater fix

### DIFF
--- a/npc/re/quests/quests_illusion_dungeons.txt
+++ b/npc/re/quests/quests_illusion_dungeons.txt
@@ -9563,6 +9563,7 @@ iz_d04_i,127,228,4	script	Jerrymon#jerry3	1_M_01,{
 			.@menu$[0] = "^999999" + getitemname(25899) + " Collection - Pending^000000";
 			break;
 		case 2:
+			.@menu$[0] = "Collect " + getitemname(25899) + "";
 			break;
 		}
 
@@ -9586,6 +9587,7 @@ iz_d04_i,127,228,4	script	Jerrymon#jerry3	1_M_01,{
 			.@menu$[1] = "^999999Deep Sea Creatures Killed - Pending^000000";
 			break;
 		case 2:
+			.@menu$[1] = "Kill Deep Sea Creatures";
 			break;
 		}
 


### PR DESCRIPTION
Add a variable update in order to correct a bug in the refresh of daily quest for Illusion of underwater dungeon.

Addressed issue: #8364

Server Mode:
Renewal

Description of Pull Request:

When you complete the main quest for illusion of underwater dungeon, the 2 quest goes to cooldown (3414 & 3416).
When the cooldown is completed for both quest (quest status 2), the script is unable to make the player to retake the quests. This happerd because when the script checks the quest status via "switch( checkquest(3414,PLAYTIME) ) {" in line 9545 and "switch( checkquest(3416,PLAYTIME) ) {" in line 9569, the case 2 fo each switch menu is only doing a break;