### PR TITLE
Fixed Random Spawns

### DIFF
--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5323,7 +5323,8 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	if (battle_config.force_random_spawn || (mob.x == 0 && mob.y == 0)
 		|| (mob.xs == 1 && mob.ys == 1 && !map_getcell(mob.m, mob.x, mob.y, CELL_CHKREACH)))
 	{	//Force a random spawn anywhere on the map.
-		mob.x = mob.y = 0;
+		// Set x and y to -1 to prevent fallback spawn on cell 0,0
+		mob.x = mob.y = -1;
 		mob.xs = mob.ys = 0;
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Follow-up to 5d232db

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Fixed monsters with random spawn location to sometimes spawn on (0,0) if that cell is not a wall
- Follow-up to 5d232db

**Note for Reviewers**:

Officially the cells 5 from SW edge and 4 from NE edge are considered "invalid" cells. This affects spawns, but also ground spells (e.g. can't cast Icewall on those cells). However, we cannot just update "map_getcellp" to consider those cells as unwalkable as this would also affect other things (such as walking), which don't check for "invalid" cells officially.

While investigating, I also found a problem with our walkpath algorithm not working with (0,0) coordinates. As a 100% official implementation turned out to be quite complex to do, I decided to just do this quick fix for now.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
