### PR TITLE
Triple Attack vs. Plant Mode

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6795,6 +6795,10 @@ static void battle_calc_attack_plant(struct Damage* wd, struct block_list *src,s
 		return;
 	}
 
+	//Triple Attack has a special property that it does not split damage on plant mode
+	if (skill_id == MO_TRIPLEATTACK && wd->div_ < 0)
+		wd->div_ *= -1;
+
 	//For plants we don't continue with the weapon attack code, so we have to apply DAMAGE_DIV_FIX here
 	battle_apply_div_fix(wd, skill_id);
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6795,8 +6795,13 @@ static void battle_calc_attack_plant(struct Damage* wd, struct block_list *src,s
 		return;
 	}
 
-	//Triple Attack has a special property that it does not split damage on plant mode
-	if (skill_id == MO_TRIPLEATTACK && wd->div_ < 0)
+	// Triple Attack has a special property that it does not split damage on plant mode
+	// In pre-renewal, it requires the monster to have exactly 100 def
+	if (skill_id == MO_TRIPLEATTACK && wd->div_ < 0
+#ifndef RENEWAL
+		&& tstatus->def == 100
+#endif
+		)
 		wd->div_ *= -1;
 
 	//For plants we don't continue with the weapon attack code, so we have to apply DAMAGE_DIV_FIX here


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8401 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Triple Attack will now deal 3 damage to monsters with plant mode (infinite defense)

**Hint for Reviewer**

Usually "div" determines whether a skill can damage plant-mode monsters or not. We put a negative div value on all skills that miss plant-mode monsters and a positive div value on all skills that hit plant-mode monsters. Triple Attack is a special case that was specifically hard-coded to not split damage when attacking a monster with infinite defense. In pre-renewal this is determined by the monster having exactly 100 DEF.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
