### PR TITLE
Fixed clif_move to use the correct movement packets

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1452,9 +1452,9 @@ static void clif_set_unit_walking( struct block_list& bl, map_session_data* tsd,
 	}
 
 	if( bl.type == BL_MOB ){
-		p.isBoss = static_cast<mob_data*>( &bl )->get_bosstype();
+		p.isBoss = reinterpret_cast<mob_data*>( &bl )->get_bosstype();
 	}else if( bl.type == BL_PET ){
-		p.isBoss = static_cast<pet_data*>( &bl )->db->get_bosstype();
+		p.isBoss = reinterpret_cast<pet_data*>( &bl )->db->get_bosstype();
 	}else{
 		p.isBoss = BOSSTYPE_NONE;
 	}
@@ -2018,7 +2018,7 @@ void clif_move( struct unit_data& ud )
 	switch (bl->type) {
 	case BL_PC:
 		{
-			map_session_data* sd = static_cast<map_session_data*>( bl );
+			map_session_data* sd = reinterpret_cast<map_session_data*>( bl );
 			if (sd->state.size == SZ_BIG) // tiny/big players [Valaris]
 				clif_specialeffect(&sd->bl, EF_GIANTBODY2, AREA);
 			else if (sd->state.size == SZ_MEDIUM)
@@ -2029,7 +2029,7 @@ void clif_move( struct unit_data& ud )
 	break;
 	case BL_MOB:
 		{
-			mob_data* md = static_cast<mob_data*>( bl );
+			mob_data* md = reinterpret_cast<mob_data*>( bl );
 			if (md->special_state.size == SZ_BIG) // tiny/big mobs [Valaris]
 				clif_specialeffect(&md->bl, EF_GIANTBODY2, AREA);
 			else if (md->special_state.size == SZ_MEDIUM)

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1987,7 +1987,7 @@ void clif_walkok( map_session_data& sd ){
 
 /// Notifies clients in an area, that an other visible object is walking.
 /// Note: unit must not be self
-void clif_move(struct unit_data& ud)
+void clif_move( struct unit_data& ud )
 {
 	struct block_list* bl = ud.bl;
 	struct view_data* vd = status_get_viewdata(bl);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1452,9 +1452,9 @@ static void clif_set_unit_walking( struct block_list& bl, map_session_data* tsd,
 	}
 
 	if( bl.type == BL_MOB ){
-		p.isBoss = ( BL_CAST(BL_MOB, &bl) )->get_bosstype();
+		p.isBoss = static_cast<mob_data*>( &bl )->get_bosstype();
 	}else if( bl.type == BL_PET ){
-		p.isBoss = ( BL_CAST(BL_PET, &bl) )->db->get_bosstype();
+		p.isBoss = static_cast<pet_data*>( &bl )->db->get_bosstype();
 	}else{
 		p.isBoss = BOSSTYPE_NONE;
 	}
@@ -1992,8 +1992,11 @@ void clif_move( struct unit_data& ud )
 	struct block_list* bl = ud.bl;
 	struct view_data* vd = status_get_viewdata(bl);
 
+	if (bl == nullptr || vd == nullptr)
+		return;
+
 	// This performance check is needed to keep GM-hidden objects from being notified to bots.
-	if (bl == nullptr || vd == nullptr || vd->class_ == JT_INVISIBLE)
+	if (vd->class_ == JT_INVISIBLE)
 		return;
 
 	// Hide NPC from Maya Purple card
@@ -2015,26 +2018,22 @@ void clif_move( struct unit_data& ud )
 	switch (bl->type) {
 	case BL_PC:
 		{
-			map_session_data* sd = BL_CAST(BL_PC, bl);
-			if (sd != nullptr) {
-				if (sd->state.size == SZ_BIG) // tiny/big players [Valaris]
-					clif_specialeffect(&sd->bl, EF_GIANTBODY2, AREA);
-				else if (sd->state.size == SZ_MEDIUM)
-					clif_specialeffect(&sd->bl, EF_BABYBODY2, AREA);
-				if (sd->status.robe)
-					clif_refreshlook(bl, bl->id, LOOK_ROBE, sd->status.robe, AREA);
-			}
+			map_session_data* sd = static_cast<map_session_data*>( bl );
+			if (sd->state.size == SZ_BIG) // tiny/big players [Valaris]
+				clif_specialeffect(&sd->bl, EF_GIANTBODY2, AREA);
+			else if (sd->state.size == SZ_MEDIUM)
+				clif_specialeffect(&sd->bl, EF_BABYBODY2, AREA);
+			if (sd->status.robe)
+				clif_refreshlook(bl, bl->id, LOOK_ROBE, sd->status.robe, AREA);
 		}
 	break;
 	case BL_MOB:
 		{
-			mob_data* md = BL_CAST(BL_MOB, bl);
-			if (md != nullptr) {
-				if (md->special_state.size == SZ_BIG) // tiny/big mobs [Valaris]
-					clif_specialeffect(&md->bl, EF_GIANTBODY2, AREA);
-				else if (md->special_state.size == SZ_MEDIUM)
-					clif_specialeffect(&md->bl, EF_BABYBODY2, AREA);
-			}
+			mob_data* md = static_cast<mob_data*>( bl );
+			if (md->special_state.size == SZ_BIG) // tiny/big mobs [Valaris]
+				clif_specialeffect(&md->bl, EF_GIANTBODY2, AREA);
+			else if (md->special_state.size == SZ_MEDIUM)
+				clif_specialeffect(&md->bl, EF_BABYBODY2, AREA);
 		}
 	break;
 	case BL_PET:

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -811,7 +811,7 @@ void clif_clearunit_area( block_list& bl, clr_type type );
 void clif_clearunit_delayed(struct block_list* bl, clr_type type, t_tick tick);
 int clif_spawn(struct block_list *bl, bool walking = false);	//area
 void clif_walkok( map_session_data& sd );
-void clif_move(struct unit_data &ud); //area
+void clif_move( struct unit_data& ud ); //area
 void clif_changemap( map_session_data& sd, short m, uint16 x, uint16 y );
 void clif_changemapserver( map_session_data& sd, const char* map, uint16 x, uint16 y, uint32 ip, uint16 port );
 void clif_blown(struct block_list *bl); // area

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -811,7 +811,7 @@ void clif_clearunit_area( block_list& bl, clr_type type );
 void clif_clearunit_delayed(struct block_list* bl, clr_type type, t_tick tick);
 int clif_spawn(struct block_list *bl, bool walking = false);	//area
 void clif_walkok( map_session_data& sd );
-void clif_move(struct unit_data *ud); //area
+void clif_move(struct unit_data &ud); //area
 void clif_changemap( map_session_data& sd, short m, uint16 x, uint16 y );
 void clif_changemapserver( map_session_data& sd, const char* map, uint16 x, uint16 y, uint32 ip, uint16 port );
 void clif_blown(struct block_list *bl); // area

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3430,7 +3430,6 @@ int mob_class_change (struct mob_data *md, int mob_id)
 	status_set_viewdata(&md->bl, mob_id);
 	clif_mob_class_change(md,md->vd->class_);
 	status_calc_mob(md,SCO_FIRST);
-	md->ud.state.speed_changed = 1; //Speed change update.
 
 	if (battle_config.monster_class_change_recover) {
 		memset(md->dmglog, 0, sizeof(md->dmglog));

--- a/src/map/packets.hpp
+++ b/src/map/packets.hpp
@@ -611,6 +611,8 @@ struct PACKET_ZC_HOSKILLINFO_UPDATE {
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_HOSKILLINFO_UPDATE, 0x239)
 
+// Unused packet (alpha?)
+/*
 struct PACKET_ZC_NOTIFY_MOVE {
 	int16 packetType;
 	uint32 gid;
@@ -618,6 +620,7 @@ struct PACKET_ZC_NOTIFY_MOVE {
 	uint32 moveStartTime;
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_NOTIFY_MOVE, 0x86)
+*/
 
 struct PACKET_ZC_NOTIFY_PLAYERMOVE {
 	int16 packetType;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1768,6 +1768,7 @@ static int pet_ai_sub_hard(struct pet_data *pd, map_session_data *sd, t_tick tic
 			return 0; // Wait until the pet finishes walking back to master.
 
 		pd->status.speed = pd->get_pet_walk_speed();
+		pd->ud.state.change_walk_target = 1;
 	}
 
 	if (pd->target_id) {

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1768,7 +1768,6 @@ static int pet_ai_sub_hard(struct pet_data *pd, map_session_data *sd, t_tick tic
 			return 0; // Wait until the pet finishes walking back to master.
 
 		pd->status.speed = pd->get_pet_walk_speed();
-		pd->ud.state.change_walk_target = pd->ud.state.speed_changed = 1;
 	}
 
 	if (pd->target_id) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -16075,7 +16075,6 @@ BUILDIN_FUNC(npcspeed)
 
 	if( nd ) {
 		nd->speed = speed;
-		nd->ud.state.speed_changed = 1;
 	}
 
 	return SCRIPT_CMD_SUCCESS;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5597,7 +5597,7 @@ void status_calc_bl_main(struct block_list *bl, std::bitset<SCB_MAX> flag)
 		* piece of code triggers the walk-timer is set on INVALID_TIMER)
 		**/
 		if (ud)
-			ud->state.change_walk_target = ud->state.speed_changed = 1;
+			ud->state.change_walk_target = 1;
 	}
 
 	if(flag[SCB_STR]) {

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -140,7 +140,7 @@ int unit_walktoxy_sub(struct block_list *bl)
 		unit_refresh( bl, true );
 	}
 #endif
-	clif_move(ud);
+	clif_move( *ud );
 
 	if(ud->walkpath.path_pos>=ud->walkpath.path_len)
 		i = -1;
@@ -556,7 +556,7 @@ static TIMER_FUNC(unit_walktoxy_timer)
 					return 0;
 				}
 				// Resend walk packet for proper Self Destruction display.
-				clif_move(ud);
+				clif_move( *ud );
 			}
 			break;
 		case BL_NPC:
@@ -626,7 +626,7 @@ static TIMER_FUNC(unit_walktoxy_timer)
 		}
 		ud->walktimer = add_timer(tick+speed,unit_walktoxy_timer,id,speed);
 		if( md && DIFF_TICK(tick,md->dmgtick) < 3000 ) // Not required not damaged recently
-			clif_move(ud);
+			clif_move( *ud );
 	} else if(ud->state.running) { // Keep trying to run.
 		if (!(unit_run(bl, nullptr, SC_RUN) || unit_run(bl, sd, SC_WUGDASH)) )
 			ud->state.running = 0;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -52,7 +52,6 @@ struct unit_data {
 		unsigned step_attack : 1;
 		unsigned walk_easy : 1 ;
 		unsigned running : 1;
-		unsigned speed_changed : 1;
 		unsigned walk_script : 1;
 		unsigned blockedmove : 1;
 		unsigned blockedskill : 1;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: n/a

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
 Fixes clif_move to use the correct movement packets (unit_walkingType) instead of the unused ZC_NOTIFY_MOVE (0x86) packet.
 Removes speed_changed unit state since is no longer needed
 Official servers never seemed to use ZC_NOTIFY_MOVE at all, so maybe is an alpha packet.
 Slightly fixes movement de-sync.

Packet ZC_NOTIFY_MOVE (0x86) was introduced in https://github.com/rathena/rathena/commit/96921544 as a way to reduce bandwidth usage even though the packet was never used on official servers, probably because it caused desync

speed_changed state was introduced in https://github.com/rathena/rathena/commit/d404a449a15d6f2372115d36609a606351d36a4c to use the (correct) walking packets when the speed is changed, since ZC_NOTIFY_MOVE cannot update the speed of the unit

In https://github.com/rathena/rathena/commit/ae7050eb1a00e7fb32faf70130468c696e5a3464 the use of this wrong packet was extended further without any need instead of using the correct packet.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
