### PR TITLE
Fixes a couple of clif_message constant values

### DIFF
--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -577,7 +577,7 @@ enum clif_messages : uint16_t {
 	MSI_PARTY_MASTER_CHANGE_SAME_MAP = 2095,
 
 	// Merge items available does not exist.
-	MSI_NOT_EXIST_MERGE_ITEM = 2183,
+	MSI_NOT_EXIST_MERGE_ITEM = 2184,
 
 	// This bullet is not suitable for the weapon you are equipping.
 	MSI_WRONG_BULLET = 2494,
@@ -595,7 +595,7 @@ enum clif_messages : uint16_t {
 	MSI_PARTY_MASTER_CHANGE_SAME_MAP = 2094,
 
 	// Merge items available does not exist.
-	MSI_NOT_EXIST_MERGE_ITEM = 2182,
+	MSI_NOT_EXIST_MERGE_ITEM = 2183,
 
 	// This bullet is not suitable for the weapon you are equipping.
 	MSI_WRONG_BULLET = 2493,

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -565,7 +565,7 @@ enum clif_messages : uint16_t {
 
 #if (PACKETVER >= 20130807 && PACKETVER <= 20130814) && !defined(PACKETVER_ZERO)
 	// %d seconds left until you can use
-	MSI_ITEM_REUSE_LIMIT_SECOND = 1862,
+	MSI_ITEM_REUSE_LIMIT_SECOND = 1863,
 
 	// Any work in progress (NPC dialog, manufacturing ...) quit and try again.
 	MSI_BUSY = 1924,
@@ -583,7 +583,7 @@ enum clif_messages : uint16_t {
 	MSI_WRONG_BULLET = 2494,
 #else
 	// %d seconds left until you can use
-	MSI_ITEM_REUSE_LIMIT_SECOND = 1861,
+	MSI_ITEM_REUSE_LIMIT_SECOND = 1862,
 
 	// Any work in progress (NPC dialog, manufacturing ...) quit and try again.
 	MSI_BUSY = 1923,


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/pull/8374

2013-08-07 Client
![20130807_msgstringtable](https://github.com/rathena/rathena/assets/34960872/ec10f81c-4b69-4258-a9cf-a62ee4d8ff7b)

Base on 2013-08-07 Client the line for ```%d seconds left until you can use#``` is in ```1864```. if client process it by -1 it should be ```1863```

20211103 Client
![20211103_msgstringtable](https://github.com/rathena/rathena/assets/34960872/d3310e7f-d856-428c-9191-c880601fb494)

While in 2021-11-03 client the ```%d seconds left until you can use#``` is in ```1863```. if client process it by -1 it should be ```1862```

* **Server Mode**:  Both

* **Description of Pull Request**:  
Correcting ID numbers for MSI_ITEM_REUSE_LIMIT_SECOND base on msgstringtable.txt of client.
thanks to @llchrisll for helping me.