### PR TITLE
Clean-up sc_display

### DIFF
--- a/doc/status.txt
+++ b/doc/status.txt
@@ -196,9 +196,12 @@ Options: Special option/client effect state when status is active.
 Flags: Various status flags for specific status change events.
 
 	None                  - No special flag. (Default)
-	BlEffect              - Status should have BL_SCEFFECT as relevant effect, must have an EFST (displays on BL_PC, BL_HOM, BL_MER, BL_MOB, BL_ELEM). BL_PC is the default value.
-	DisplayPc             - Displays status effect when player logs in.
-	DislpayNpc            - Displays status effect on a NPC.
+	BlEffect              - Flag to send a visual effect to clients around if the affected unit is BL_PC, BL_HOM, BL_MER, BL_MOB, BL_ELEM or BL_NPC when the status is given.
+	                        The status must have an EFST defined in Icon - other than EFST_BLANK.
+	                        When not defined (default) the status is displayed to clients around when the affected unit is BL_PC (player) only.
+	DisplayPc             - Whether the status is displayed (again) to client around when the affected unit (player) appears in the client's range.
+	DisplayNpc            - Whether the status is displayed (again) to client around when the affected unit (NPC) appears in the client's range.
+	DisplayMob            - Whether the status is displayed (again) to client around when the affected unit (monster) appears in the client's range.
 	Debuff                - Status is considered a debuff. Used in combination with 'battle_config.debuff_on_logout'.
 	SetStand              - Sets player to standing state.
 	OverlapIgnoreLevel    - The status will successfully activate for any level if the status is already active.
@@ -208,9 +211,9 @@ Flags: Various status flags for specific status change events.
 	MobLoseTarget         - When active on a monster it will lose the target.
 	RestartOnMapWarp      - Restarts the timer of a status when warping to another map.
 	SpreadEffect          - Passes the status onto a target when SC_DEADLYINFECT is active.
-	SendVal1              - Notifies the client of a status change (val1).
-	SendVal2              - Notifies the client of a status change (val2).
-	SendVal3              - Notifies the client of a status change (val3).
+	SendVal1              - Whether val1 must be saved for DisplayPc, DisplayNpc, DisplayMob. If false, the value is ignored when the status is displayed again.
+	SendVal2              - Whether val2 must be saved for DisplayPc, DisplayNpc, DisplayMob. If false, the value is ignored when the status is displayed again.
+	SendVal3              - Whether val3 must be saved for DisplayPc, DisplayNpc, DisplayMob. If false, the value is ignored when the status is displayed again.
 
 	NoClearbuff           - Cannot be removed by 'status_change_clear_buffs()', 'sc_end SC_ALL', 'status_change_clear(3)', etc.
 	NoForcedEnd           - Cannot be removed by sc_end.

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -947,7 +947,7 @@ void clif_changemapcell(int fd, int16 m, int x, int y, int type, enum send_targe
 #define clif_status_load(bl, type, flag) clif_status_change((bl), (type), (flag), 0, 0, 0, 0)
 void clif_status_change(struct block_list *bl, int type, int flag, t_tick tick, int val1, int val2, int val3);
 void clif_efst_status_change(struct block_list *bl, int tid, enum send_target target, int type, t_tick tick, int val1, int val2, int val3);
-void clif_efst_status_change_sub(struct block_list *tbl, struct block_list *bl, enum send_target target);
+void clif_efst_status_change_sub( block_list& tbl, block_list& bl, enum send_target target );
 
 void clif_wis_message(map_session_data* sd, const char* nick, const char* mes, size_t mes_len, int gmlvl);
 void clif_wis_end( map_session_data& sd, e_ack_whisper result );

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -388,6 +388,8 @@ struct mob_data {
 	uint16 damagetaken;
 
 	e_mob_bosstype get_bosstype();
+
+	std::unordered_map<sc_type, std::shared_ptr<sc_display_entry>> sc_display;
 };
 
 class MobAvailDatabase : public YamlDatabase {

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -50,8 +50,6 @@ static int npc_mob=0;
 static int npc_delay_mob=0;
 static int npc_cache_mob=0;
 
-struct eri *npc_sc_display_ers;
-
 // Market Shop
 #if PACKETVER >= 20131223
 struct s_npc_market {
@@ -3527,18 +3525,10 @@ int npc_unload(struct npc_data* nd, bool single) {
 		}
 		if( nd->u.scr.guild_id )
 			guild_flag_remove(nd);
-		if( nd->sc_display_count ){
-			unsigned char i;
-
-			for( i = 0; i < nd->sc_display_count; i++ )
-				ers_free(npc_sc_display_ers, nd->sc_display[i]);
-			nd->sc_display_count = 0;
-			aFree(nd->sc_display);
-			nd->sc_display = nullptr;
-		}
 	}
 
 	nd->qi_data.clear();
+	nd->sc_display.clear();
 
 	script_stop_sleeptimers(nd->bl.id);
 
@@ -3772,8 +3762,6 @@ struct npc_data *npc_create_npc(int16 m, int16 x, int16 y){
 	nd->bl.m = m;
 	nd->bl.x = x;
 	nd->bl.y = y;
-	nd->sc_display = nullptr;
-	nd->sc_display_count = 0;
 	nd->progressbar.timeout = 0;
 	nd->vd = npc_viewdb[0]; // Default to JT_INVISIBLE
 	nd->dynamicnpc.owner_char_id = 0;
@@ -6146,7 +6134,6 @@ void do_final_npc(void) {
 	stylist_db.clear();
 	barter_db.clear();
 	ers_destroy(timer_event_ers);
-	ers_destroy(npc_sc_display_ers);
 	npc_src_files.clear();
 }
 
@@ -6212,7 +6199,6 @@ void do_init_npc(void){
 #endif
 
 	timer_event_ers = ers_new(sizeof(struct timer_event_data),"npc.cpp::timer_event_ers",ERS_OPT_NONE);
-	npc_sc_display_ers = ers_new(sizeof(struct sc_display_entry), "npc.cpp:npc_sc_display_ers", ERS_OPT_NONE);
 
 	npc_loadsrcfiles();
 

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -216,10 +216,9 @@ struct npc_data {
 		} barter;
 	} u;
 
-	struct sc_display_entry **sc_display;
-	unsigned char sc_display_count;
-
 	std::vector<std::shared_ptr<s_questinfo>> qi_data;
+
+	std::unordered_map<sc_type, std::shared_ptr<sc_display_entry>> sc_display;
 
 	struct {
 		t_tick timeout;
@@ -238,9 +237,6 @@ struct npc_data {
 #endif
 	bool is_invisible;
 };
-
-struct eri;
-extern struct eri *npc_sc_display_ers;
 
 #define START_NPC_NUM 110000000
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -84,7 +84,6 @@ SkillTreeDatabase skill_tree_db;
 int day_timer_tid = INVALID_TIMER;
 int night_timer_tid = INVALID_TIMER;
 
-struct eri *pc_sc_display_ers = nullptr;
 struct eri *num_reg_ers;
 struct eri *str_reg_ers;
 int pc_expiration_tid = INVALID_TIMER;
@@ -2208,10 +2207,6 @@ bool pc_authok(map_session_data *sd, uint32 login_id2, time_t expiration_time, i
 	}
 
 	pc_validate_skill(sd);
-
-	/* [Ind] */
-	sd->sc_display = nullptr;
-	sd->sc_display_count = 0;
 
 	// Player has not yet received the CashShop list
 	sd->status.cashshop_sent = false;
@@ -15847,7 +15842,6 @@ void do_final_pc(void) {
 	db_destroy(itemcd_db);
 	do_final_pc_groups();
 
-	ers_destroy(pc_sc_display_ers);
 	ers_destroy(num_reg_ers);
 	ers_destroy(str_reg_ers);
 
@@ -15906,11 +15900,9 @@ void do_init_pc(void) {
 
 	do_init_pc_groups();
 
-	pc_sc_display_ers = ers_new(sizeof(struct sc_display_entry), "pc.cpp:pc_sc_display_ers", ERS_OPT_FLEX_CHUNK);
 	num_reg_ers = ers_new(sizeof(struct script_reg_num), "pc.cpp:num_reg_ers", (ERSOptions)(ERS_OPT_CLEAN|ERS_OPT_FLEX_CHUNK));
 	str_reg_ers = ers_new(sizeof(struct script_reg_str), "pc.cpp:str_reg_ers", (ERSOptions)(ERS_OPT_CLEAN|ERS_OPT_FLEX_CHUNK));
 
-	ers_chunk_size(pc_sc_display_ers, 150);
 	ers_chunk_size(num_reg_ers, 300);
 	ers_chunk_size(str_reg_ers, 50);
 }

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -863,9 +863,7 @@ public:
 	unsigned char fontcolor;
 	t_tick *channel_tick;
 
-	/* [Ind] */
-	struct sc_display_entry **sc_display;
-	unsigned char sc_display_count;
+	std::unordered_map<enum sc_type, std::shared_ptr<sc_display_entry>> sc_display;
 
 	unsigned char delayed_damage; //[Ind]
 
@@ -944,7 +942,6 @@ public:
 	std::vector<uint32> party_booking_requests;
 };
 
-extern struct eri *pc_sc_display_ers; /// Player's SC display table
 
 /**
  * ERS for the bulk of pc vars

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -11230,6 +11230,7 @@
 	export_constant(SCF_REMOVEONUNEQUIPARMOR);
 	export_constant(SCF_REMOVEONHERMODE);
 	export_constant(SCF_REQUIRENOWEAPON);
+	export_constant(SCF_DISPLAYMOB);
 
 	/* enchantgrades */
 	export_constant(ENCHANTGRADE_NONE);

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3057,6 +3057,7 @@ enum e_status_change_flag : uint16 {
 	SCF_REMOVEONUNEQUIPARMOR,
 	SCF_REMOVEONHERMODE,
 	SCF_REQUIRENOWEAPON,
+	SCF_DISPLAYMOB,
 	SCF_MAX
 };
 
@@ -3140,7 +3141,7 @@ enum e_refine_chance_type {
 ///Define to determine who has regen
 #define BL_REGEN (BL_PC|BL_HOM|BL_MER|BL_ELEM)
 ///Define to determine who will receive a clif_status_change packet for effects that require one to display correctly
-#define BL_SCEFFECT (BL_PC|BL_HOM|BL_MER|BL_MOB|BL_ELEM)
+#define BL_SCEFFECT (BL_PC|BL_HOM|BL_MER|BL_MOB|BL_ELEM|BL_NPC)
 
 /** Basic damage info of a weapon
 * Required because players have two of these, one in status_data

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3439,7 +3439,6 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 	switch( bl->type ) {
 		case BL_PC: {
 			map_session_data *sd = (map_session_data*)bl;
-			int i;
 
 			if( status_isdead(bl) )
 				pc_setrestartvalue(sd,2);
@@ -3495,14 +3494,7 @@ int unit_free(struct block_list *bl, clr_type clrtype)
 
 			sd->combos.clear();
 
-			if( sd->sc_display_count ) { /* [Ind] */
-				for( i = 0; i < sd->sc_display_count; i++ )
-					ers_free(pc_sc_display_ers, sd->sc_display[i]);
-
-				sd->sc_display_count = 0;
-				aFree(sd->sc_display);
-				sd->sc_display = nullptr;
-			}
+			sd->sc_display.clear();
 
 			if( sd->quest_log != nullptr ) {
 				aFree(sd->quest_log);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Content
----------------------------------
* Statuses can now also be saved for monsters
* Updated the status.txt docs
* Added missing BL_NPC to BL_SCEFFECT
* Corrected conditions for saving statuses depending on the unit type affected
* Corrected conditions for displaying status depending on the unit type affected when the status is given

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
