### PR TITLE
Renewal Spiral Pierce, Element vs. Status Attack

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3394,7 +3394,7 @@ static bool battle_skill_stacks_masteries_vvs(uint16 skill_id, e_bonus_chk_flag 
 			return false;
 #ifndef RENEWAL
 		case LK_SPIRALPIERCE:
-			// Spiral Pierce is influenced only by refine bonus and Star Crumbs for players
+			// In Pre-Renewal Spiral Pierce is influenced only by refine bonus and Star Crumbs for players
 			if (chk_flag != BCHK_REFINE && chk_flag != BCHK_STAR)
 				return false;
 #endif
@@ -3962,6 +3962,7 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 		wd->statusAtk = battle_attr_fix(src, target, wd->statusAtk, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
 		wd->statusAtk2 = battle_attr_fix(src, target, wd->statusAtk2, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
 	}
+
 	// Right-hand status attack is doubled after elemental adjustments
 	wd->statusAtk *= 2;
 
@@ -4058,7 +4059,7 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 					sd->inventory_data[index]->type == IT_WEAPON)
 					wd->equipAtk += sd->inventory_data[index]->weight / 10;
 
-				// Official 70% damage modifier is applied to base attack + weight
+				// 70% damage modifier is applied to base attack + weight
 				ATK_RATE(wd->equipAtk, wd->equipAtk2, 70);
 				
 				switch (tstatus->size) { //Second size fix

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2389,15 +2389,6 @@ static int battle_calc_sizefix(int64 damage, map_session_data *sd, unsigned char
 	return (int)cap_value(damage, INT_MIN, INT_MAX);
 }
 
-static int battle_calc_status_attack(struct status_data *status, short hand)
-{
-	//left-hand penalty on sATK is always 50% [Baalberith]
-	if (hand == EQI_HAND_L)
-		return status->batk;
-	else
-		return 2 * status->batk;
-}
-
 /**
  * Calculates renewal Variance, OverUpgradeBonus, and SizePenaltyMultiplier of weapon damage parts for player
  * @param src Block list of attacker
@@ -3401,10 +3392,12 @@ static bool battle_skill_stacks_masteries_vvs(uint16 skill_id, e_bonus_chk_flag 
 		case LG_EARTHDRIVE:
 		case NPC_DRAGONBREATH:
 			return false;
+#ifndef RENEWAL
 		case LK_SPIRALPIERCE:
 			// Spiral Pierce is influenced only by refine bonus and Star Crumbs for players
 			if (chk_flag != BCHK_REFINE && chk_flag != BCHK_STAR)
 				return false;
+#endif
 			break;
 	}
 
@@ -3959,8 +3952,8 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 	int right_element = battle_get_weapon_element(wd, src, target, skill_id, skill_lv, EQI_HAND_R, false);
 	int left_element = battle_get_weapon_element(wd, src, target, skill_id, skill_lv, EQI_HAND_L, false);
 
-	wd->statusAtk += battle_calc_status_attack(sstatus, EQI_HAND_R);
-	wd->statusAtk2 += battle_calc_status_attack(sstatus, EQI_HAND_L);
+	wd->statusAtk += sstatus->batk;
+	wd->statusAtk2 += sstatus->batk;
 
 	if (sd && sd->sc.getSCE(SC_SEVENWIND)) { // Mild Wind applies element to status ATK as well as weapon ATK [helvetica]
 		wd->statusAtk = battle_attr_fix(src, target, wd->statusAtk, right_element, tstatus->def_ele, tstatus->ele_lv);
@@ -3969,6 +3962,8 @@ static void battle_calc_damage_parts(struct Damage* wd, struct block_list *src,s
 		wd->statusAtk = battle_attr_fix(src, target, wd->statusAtk, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
 		wd->statusAtk2 = battle_attr_fix(src, target, wd->statusAtk2, ELE_NEUTRAL, tstatus->def_ele, tstatus->ele_lv);
 	}
+	// Right-hand status attack is doubled after elemental adjustments
+	wd->statusAtk *= 2;
 
 	// Check critical
 	if (wd->type == DMG_MULTI_HIT_CRITICAL || wd->type == DMG_CRITICAL)
@@ -4047,26 +4042,33 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 		case LK_SPIRALPIERCE:
 		case ML_SPIRALPIERCE:
 			if (sd) {
-				short index = sd->equip_index[EQI_HAND_R];
+				battle_calc_damage_parts(wd, src, target, skill_id, skill_lv);
 
+				// Officially statusAtk + weaponAtk + equipAtk make base attack
+				// We simulate this here by adding them all into equip attack
+				ATK_ADD2(wd->equipAtk, wd->equipAtk2, wd->statusAtk + wd->weaponAtk, wd->statusAtk2 + wd->weaponAtk2);
+				// Set statusAtk and weaponAtk to 0
+				ATK_RATE(wd->statusAtk, wd->statusAtk2, 0);
+				ATK_RATE(wd->weaponAtk, wd->weaponAtk2, 0);
+
+				// Add weight
+				short index = sd->equip_index[EQI_HAND_R];
 				if (index >= 0 &&
 					sd->inventory_data[index] &&
 					sd->inventory_data[index]->type == IT_WEAPON)
-					wd->equipAtk += sd->inventory_data[index]->weight*7/100; // weight from spear is treated as equipment ATK on official [helvetica]
+					wd->equipAtk += sd->inventory_data[index]->weight / 10;
 
-				battle_calc_damage_parts(wd, src, target, skill_id, skill_lv);
-				wd->masteryAtk = 0; // weapon mastery is ignored for spiral
+				// Official 70% damage modifier is applied to base attack + weight
+				ATK_RATE(wd->equipAtk, wd->equipAtk2, 70);
 				
-				switch (tstatus->size) { //Size-fix. Is this modified by weapon perfection?
-					case SZ_SMALL: //Small: 115%
-						ATK_RATE(wd->damage, wd->damage2, 115);
-						RE_ALLATK_RATE(wd, 115);
+				switch (tstatus->size) { //Second size fix
+					case SZ_SMALL: //Small: 130%
+						ATK_RATE(wd->equipAtk, wd->equipAtk2, 130);
 						break;
-					//case SZ_MEDIUM: //Medium: 100%
-					case SZ_BIG: //Large: 85%
-						ATK_RATE(wd->damage, wd->damage2, 85);
-						RE_ALLATK_RATE(wd, 85);
+					case SZ_MEDIUM: //Medium: 115%
+						ATK_RATE(wd->equipAtk, wd->equipAtk2, 115);
 						break;
+					//case SZ_BIG: //Large: 100%
 				}
 			} else {
 				wd->damage = battle_calc_base_damage(src, sstatus, &sstatus->rhw, sc, tstatus->size, 0); //Monsters have no weight and use ATK instead

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -4061,8 +4061,9 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 
 				// 70% damage modifier is applied to base attack + weight
 				ATK_RATE(wd->equipAtk, wd->equipAtk2, 70);
-				
-				switch (tstatus->size) { //Second size fix
+
+				// Additional skill-specific size fix
+				switch (tstatus->size) {
 					case SZ_SMALL: //Small: 130%
 						ATK_RATE(wd->equipAtk, wd->equipAtk2, 130);
 						break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8410 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When using Spiral Pierce the base damage will now be multiplied with 0.7
- Weight bonus of Spiral Pierce is no longer affected by elemental adjustments
- Size modifiers updated: Small 130%, Medium 115%, Large 100%
- Spiral Pierce will now store its base damage in equipAtk to prevent rounding errors (temporary solution)
- Status Attack will now first apply the elemental table before doubling the right-hand damage
- Fixes #8410

**Hints for Reviewers**:

Further tests in #8380 indicate that the attribute table should be applied to the sum of weaponAtk and equipAtk. And the tests on Spiral Pierce show that later adjustments (such as the 0.7x damage multiplier and the 1.15x / 1.3x size modifiers) apply to the sum of statusAtk, weaponAtk and equipAtk. As long as we keep those values in separate variables, we will always have rounding issues with our damage.
The solution for Spiral Pierce to put everything into equipAtk is just a temporary solution, we should consider putting the different attack values into a single variable, but first we need to go through all the status changes and other abilities that only affect one of them in a percentual way. This should be done gradually so we don't have one huge PR that changes thousands of lines of code. Maybe first combine equipAtk and weaponAtk into just equipAtk and at the end merge it with statusAtk.
We should also check how percentAtk behaves in the future. I assume it was put into a separate variable because the AtkRate bonus should not affect other bonuses.

On the status attack change, see also #8380 for further proof that this applies globally to all skills and normal attacks.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
