### PR TITLE
Cannon Ball Skills (P.ATK and Res)

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3420,7 +3420,9 @@ static int battle_calc_equip_attack(struct block_list *src, int skill_id)
 		struct status_data *status = status_get_status_data(src);
 		map_session_data *sd = BL_CAST(BL_PC, src);
 
-		if (sd) // add arrow atk if using an applicable skill
+		// Cart Cannon is an arrow skill but adds arrow attack as mastery damage instead
+		if (sd && skill_id != GN_CARTCANNON)
+			// add arrow atk if using an applicable skill
 			eatk += (is_skill_using_arrow(src, skill_id) ? sd->bonus.arrow_atk : 0);
 
 		return eatk + status->eatk;
@@ -3903,6 +3905,16 @@ static void battle_calc_attack_masteries(struct Damage* wd, struct block_list *s
 #endif
 				}
 				break;
+#ifdef RENEWAL
+			case GN_CARTCANNON:
+				// These skills add arrow attack as mastery attack instead of equip attack
+				// The only way to determine this is by confirming that the arrow attack isn't influenced by P.ATK
+				if (sd) {
+					struct status_data* tstatus = status_get_status_data(target);
+					ATK_ADD(wd->masteryAtk, wd->masteryAtk2, battle_attr_fix(src, target, sd->bonus.arrow_atk, sd->bonus.arrow_ele, tstatus->def_ele, tstatus->ele_lv));
+				}
+				break;
+#endif
 		}
 
 		if (sc) { // Status change considered as masteries
@@ -7442,7 +7454,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			if( is_attack_left_handed( src, skill_id ) ){
 				wd.damage2 = wd.statusAtk2 + wd.weaponAtk2 + wd.equipAtk2 + wd.percentAtk2;
 			}
-			// Apply PATK mod
+			// Apply P.ATK mod
 			// But for Dragonbreaths it only applies if Dragonic Aura is skilled
 			if( ( skill_id != RK_DRAGONBREATH && skill_id != RK_DRAGONBREATH_WATER ) || pc_checkskill( sd, DK_DRAGONIC_AURA ) > 0 ){
 				wd.damage = (int64)floor( (float)( wd.damage * ( 100 + sstatus->patk ) / 100 ) );
@@ -7493,7 +7505,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		// Res reduces physical damage by a percentage and
 		// is calculated before DEF and other reductions.
 		// This should be the official formula. [Rytech]
-		if ((wd.damage + wd.damage2) && tstatus->res > 0 && skill_id != MO_EXTREMITYFIST) {
+		if ((wd.damage + wd.damage2) && tstatus->res > 0 && skill_id != MO_EXTREMITYFIST && skill_id != GN_CARTCANNON) {
 			short res = tstatus->res;
 			short ignore_res = 0;// Value used as a percentage.
 
@@ -8733,7 +8745,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += 25;
 				}
 #ifdef RENEWAL
-				// SMATK needs to be applied before the skill ratio to prevent rounding issues
+				// S.MATK needs to be applied before the skill ratio to prevent rounding issues
 				if (sd && sstatus->smatk > 0)
 					ad.damage += ad.damage * sstatus->smatk / 100;
 #endif

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7507,8 +7507,10 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 
 		// Res reduces physical damage by a percentage and
 		// is calculated before DEF and other reductions.
-		// This should be the official formula. [Rytech]
-		if ((wd.damage + wd.damage2) && tstatus->res > 0 && skill_id != MO_EXTREMITYFIST && skill_id != GN_CARTCANNON) {
+		// TODO: It seems all skills that use the simple defense formula (damage substracted by DEF+DEF2) ignore Res
+		// TODO: We should add a flag for those skills or use the IgnoreDefense flag after confirming all
+		// TODO: Res formula probably should be: (2000+x)/(2000+5x), but with the reduction rounded down
+		if ((wd.damage + wd.damage2) && tstatus->res > 0 && skill_id != MO_EXTREMITYFIST && skill_id != GN_CARTCANNON && skill_id != NC_ARMSCANNON) {
 			short res = tstatus->res;
 			short ignore_res = 0;// Value used as a percentage.
 
@@ -8784,7 +8786,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 #ifdef RENEWAL
 		// MRes reduces magical damage by a percentage and
 		// is calculated before MDEF and other reductions.
-		// This should be the official formula. [Rytech]
+		// TODO: Check if there are skills that ignore Mres, similar to skills that ignore Res
+		// TODO: MRes formula probably should be: (2000+x)/(2000+5x), but with the reduction rounded down
 		if (ad.damage && tstatus->mres > 0) {
 			short mres = tstatus->mres;
 			short ignore_mres = 0;// Value used as percentage.

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3421,7 +3421,7 @@ static int battle_calc_equip_attack(struct block_list *src, int skill_id)
 		map_session_data *sd = BL_CAST(BL_PC, src);
 
 		// Cart Cannon is an arrow skill but adds arrow attack as mastery damage instead
-		if (sd && skill_id != GN_CARTCANNON)
+		if (sd != nullptr && skill_id != GN_CARTCANNON)
 			// add arrow atk if using an applicable skill
 			eatk += (is_skill_using_arrow(src, skill_id) ? sd->bonus.arrow_atk : 0);
 
@@ -3909,7 +3909,7 @@ static void battle_calc_attack_masteries(struct Damage* wd, struct block_list *s
 			case GN_CARTCANNON:
 				// These skills add arrow attack as mastery attack instead of equip attack
 				// The only way to determine this is by confirming that the arrow attack isn't influenced by P.ATK
-				if (sd) {
+				if (sd != nullptr) {
 					struct status_data* tstatus = status_get_status_data(target);
 					ATK_ADD(wd->masteryAtk, wd->masteryAtk2, battle_attr_fix(src, target, sd->bonus.arrow_atk, sd->bonus.arrow_ele, tstatus->def_ele, tstatus->ele_lv));
 				}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8380 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When using Cart Cannon or Arm Cannon, the arrow attack you get from cannon balls is no longer affected by P.ATK
- Cart Cannon and Arm Cannon are no longer reduced by Res
- More consistent naming (PATK -> P.ATK, SMATK -> S.MATK)
- Fixes #8380

**Hints for Reviewers**:

- It seems that Cannon Balls are generally not adding any equip attack, but the damage of Cart Cannon and Arm Cannon is still increased by arrow attack, so my assumption is that this bonus is hard-coded into the two skills
- So far all tests indicate that all skills that use the simple defense formula also ignore Res, should be turned into a general rule later on after all skills have been tested
- Test numbers for Cart Cannon / Arm Cannon in the linked issue all match already, but if you run other tests you still might find small deviations when doing elemental tests, see #8414 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
