### PR TITLE
Updated setunitdata UMOB_MODE

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -377,8 +377,10 @@ e_mob_bosstype s_mob_db::get_bosstype(){
 }
 
 e_mob_bosstype mob_data::get_bosstype(){
-	if( this->db != nullptr ){
-		return this->db->get_bosstype();
+	if( status_has_mode( &this->status, MD_MVP ) ){
+		return BOSSTYPE_MVP;
+	}else if( this->status.class_ == CLASS_BOSS ){
+		return BOSSTYPE_MINIBOSS;
 	}else{
 		return BOSSTYPE_NONE;
 	}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -19264,7 +19264,12 @@ BUILDIN_FUNC(setunitdata)
 			case UMOB_X: if (!unit_walktoxy(bl, (short)value, md->bl.y, 2)) unit_movepos(bl, (short)value, md->bl.y, 0, 0); break;
 			case UMOB_Y: if (!unit_walktoxy(bl, md->bl.x, (short)value, 2)) unit_movepos(bl, md->bl.x, (short)value, 0, 0); break;
 			case UMOB_SPEED: md->base_status->speed = (unsigned short)value; status_calc_misc(bl, &md->status, md->level); calc_status = true; break;
-			case UMOB_MODE: md->base_status->mode = (enum e_mode)value; calc_status = true; break;
+			case UMOB_MODE:
+				md->base_status->mode = (enum e_mode)value;
+				// Mob mode must be updated before calling unit_refresh
+				status_calc_bl_(&md->bl, status_db.getSCB_BATTLE());
+				unit_refresh(bl);
+				break;
 			case UMOB_AI: md->special_state.ai = (enum mob_ai)value; break;
 			case UMOB_SCOPTION: md->sc.option = (unsigned short)value; break;
 			case UMOB_SEX: md->vd->sex = (char)value; unit_refresh(bl); break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Updated `mob_data::get_bosstype()` to use current mob data instead of db data to fix issue when the mode is changed via the setunitdata script command.
Added `unit_refresh` in UMOB_MODE to refresh the mini icon near the monster indicating the monster type.

Test script (if anyone wants to test)
---------------------------------------------
```
alberta,97,55,0	script	UMOB_MODE	84,{
	monster "alberta",97,60,"--ja--", 1002,1;
	.@gid = $@mobid[0];
	getunitdata .@gid, .@data;
	
	// Boss type
	// setunitdata .@gid, UMOB_MODE, 0x6200000;
	
	// Mvp type
	setunitdata .@gid, UMOB_MODE, 0x6200000 | MD_MVP;
	
	// "Normal" type
	// setunitdata .@gid, UMOB_MODE, .@data[UMOB_MODE];
	end;
}
```
![screenrAthena033](https://github.com/rathena/rathena/assets/5231893/12b60ea5-ee2a-4b42-9172-047a7da50862)

![screenrAthena032](https://github.com/rathena/rathena/assets/5231893/ff52ce4f-f521-4ea2-8457-390d668b14f6)


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
