### PR TITLE
Added some missing DisplayPc in status_db.yml

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7957,6 +7957,7 @@ Body:
     DurationLookup: EM_SPELL_ENCHANTING
     CalcFlags:
       Smatk: true
+      DisplayPc: true
   - Status: Summon_Elemental_Ardor
     Icon: EFST_SUMMON_ELEMENTAL_ARDOR
     DurationLookup: EM_SUMMON_ELEMENTAL_ARDOR

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7957,6 +7957,7 @@ Body:
     DurationLookup: EM_SPELL_ENCHANTING
     CalcFlags:
       Smatk: true
+    Flags:
       DisplayPc: true
   - Status: Summon_Elemental_Ardor
     Icon: EFST_SUMMON_ELEMENTAL_ARDOR

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -8010,17 +8010,23 @@ Body:
     DurationLookup: TR_MUSICAL_INTERLUDE
     CalcFlags:
       Res: true
+    Flags:
+      DisplayPc: true
   - Status: Jawaii_Serenade
     Icon: EFST_JAWAII_SERENADE
     DurationLookup: TR_JAWAII_SERENADE
     CalcFlags:
       Smatk: true
       Speed: true
+    Flags:
+      DisplayPc: true
   - Status: Pron_March
     Icon: EFST_PRON_MARCH
     DurationLookup: TR_PRON_MARCH
     CalcFlags:
       Patk: true
+    Flags:
+      DisplayPc: true
   - Status: Roseblossom
     Icon: EFST_ROSEBLOSSOM
     DurationLookup: TR_ROSEBLOSSOM
@@ -8034,6 +8040,8 @@ Body:
       Powerful_Faith: true
       Firm_Faith: true
       Sincere_Faith: true
+    Flags:
+      DisplayPc: true
   - Status: Sincere_Faith
     Icon: EFST_SINCERE_FAITH
     DurationLookup: IQ_SINCERE_FAITH


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Some status should be displayed again to client around when the affected unit appears in the client's range.

Updated
------------------------------------------
- `SC_SPELL_ENCHANTING` from skill `EM_SPELL_ENCHANTING`

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
