### PR TITLE
Max RES/MRES and max RES/MRES ignored

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -298,12 +298,9 @@ trait_points_job_change: 7
 // Official is 100.
 max_trait_parameter: 100
 
-// Max amount of RES/MRES to take into the resistance damage reduction formula.
-// A setting of 625 means the max reduction of damage allowed is 50.0%.
-// Formula is 100 - 100 * (5000 + RES) / (5000 + 10 * RES)
-// Note: Best to leave this setting alone unless you know what your doing.
-// Default: 625
-max_res_mres_reduction: 625
+// Max percent of RES/MRES that can be ignored by item bonus/skill.
+// Default: 50
+max_res_mres_ignored: 50
 
 // Maximum AP
 // Default: 1000

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7513,15 +7513,10 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 					ignore_res += sc->getSCE(SC_POTENT_VENOM)->val2;
 			}
 
-			ignore_res = min(ignore_res, 100);
+			ignore_res = min(ignore_res, battle_config.max_res_mres_ignored);
 
 			if (ignore_res > 0)
 				res -= res * ignore_res / 100;
-
-			// Max damage reduction from Res is officially 50%.
-			// That means 625 Res is needed to hit that cap.
-			if (res > battle_config.max_res_mres_reduction)
-				res = battle_config.max_res_mres_reduction;
 
 			// Apply damage reduction.
 			wd.damage = wd.damage * (5000 + res) / (5000 + 10 * res);
@@ -8786,15 +8781,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 			if (sc && sc->getSCE(SC_A_VITA))
 				ignore_mres += sc->getSCE(SC_A_VITA)->val2;
 
-			ignore_mres = min(ignore_mres, 100);
+			ignore_mres = min(ignore_mres, battle_config.max_res_mres_ignored);
 
 			if (ignore_mres > 0)
 				mres -= mres * ignore_mres / 100;
-
-			// Max damage reduction from MRes is officially 50%.
-			// That means 625 MRes is needed to hit that cap.
-			if (mres > battle_config.max_res_mres_reduction)
-				mres = battle_config.max_res_mres_reduction;
 
 			// Apply damage reduction.
 			ad.damage = ad.damage * (5000 + mres) / (5000 + 10 * mres);
@@ -11499,7 +11489,7 @@ static const struct _battle_data {
 	{ "use_traitpoint_table",               &battle_config.use_traitpoint_table,            1,      0,      1,              },
 	{ "trait_points_job_change",            &battle_config.trait_points_job_change,         7,      1,      1000,           },
 	{ "max_trait_parameter",                &battle_config.max_trait_parameter,             100,    10,     SHRT_MAX,       },
-	{ "max_res_mres_reduction",             &battle_config.max_res_mres_reduction,          625,    1,      SHRT_MAX,       },
+	{ "max_res_mres_ignored",               &battle_config.max_res_mres_ignored,            50,     1,      100,            },
 	{ "max_ap",                             &battle_config.max_ap,                          200,    100,    1000000000,     },
 	{ "ap_rate",                            &battle_config.ap_rate,                         100,    1,      INT_MAX,        },
 	{ "restart_ap_rate",                    &battle_config.restart_ap_rate,                 0,      0,      100,            },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11489,7 +11489,7 @@ static const struct _battle_data {
 	{ "use_traitpoint_table",               &battle_config.use_traitpoint_table,            1,      0,      1,              },
 	{ "trait_points_job_change",            &battle_config.trait_points_job_change,         7,      1,      1000,           },
 	{ "max_trait_parameter",                &battle_config.max_trait_parameter,             100,    10,     SHRT_MAX,       },
-	{ "max_res_mres_ignored",               &battle_config.max_res_mres_ignored,            50,     1,      100,            },
+	{ "max_res_mres_ignored",               &battle_config.max_res_mres_ignored,            50,     0,      100,            },
 	{ "max_ap",                             &battle_config.max_ap,                          200,    100,    1000000000,     },
 	{ "ap_rate",                            &battle_config.ap_rate,                         100,    1,      INT_MAX,        },
 	{ "restart_ap_rate",                    &battle_config.restart_ap_rate,                 0,      0,      100,            },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -730,7 +730,7 @@ struct Battle_Config
 	int trait_points_job_change;
 	int use_traitpoint_table;
 	int max_trait_parameter;
-	int max_res_mres_reduction;
+	int max_res_mres_ignored;
 	int max_ap;
 	int ap_rate;
 	int restart_ap_rate;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

According to the tipbox 106 and 107 :
`The physical resistance ignore option only applies up to 50%.`
`Ignore magic resistance option only applies up to 50%.`

There should be no limit to the max RES/MRES a unit can have. A unit can only ignore (pierce) 50% of the target's RES/MRES.

Content
--------------------------------------------
* Removed the limit of RES/MRES and remove `max_res_mres_reduction` battle config
* Added a limit of RES/MRES ignored by items and skills in `max_res_mres_ignored` battle config

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
