### PR TITLE
Fixed container item checks

### DIFF
--- a/db/import-tmpl/item_db.yml
+++ b/db/import-tmpl/item_db.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)
@@ -401,6 +402,8 @@ Header:
 #    Name: Valentine Gift Box
 #    Type: Usable
 #    Buy: 10
+#    Flags:
+#      Container: true
 #    Script: |
 #      getitem 7946,1;
 #  - Id: 12743
@@ -408,6 +411,8 @@ Header:
 #    Name: Valentine Gift Box
 #    Type: Usable
 #    Buy: 10
+#    Flags:
+#      Container: true
 #    Script: |
 #      getitem 7947,1;
 #  - Id: 12744
@@ -415,6 +420,8 @@ Header:
 #    Name: Chocolate Box
 #    Type: Usable
 #    Buy: 10
+#    Flags:
+#      Container: true
 #    Script: |
 #      getitem 558,1;
 #  - Id: 14466
@@ -422,6 +429,8 @@ Header:
 #    Name: Valentine's Emblem Box
 #    Type: Usable
 #    Buy: 10
+#    Flags:
+#      Container: true
 #    Script: |
 #      getitem 5817,1;
 

--- a/db/pre-re/item_db.yml
+++ b/db/pre-re/item_db.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)

--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)

--- a/db/pre-re/item_db_etc.yml
+++ b/db/pre-re/item_db_etc.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)

--- a/db/pre-re/item_db_usable.yml
+++ b/db/pre-re/item_db_usable.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)
@@ -1059,9 +1060,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BLUEBOX
     Script: |
-      getrandgroupitem(IG_BlueBox,1);
+      getrandgroupitem(IG_BLUEBOX,1);
   - Id: 604
     AegisName: Branch_Of_Dead_Tree
     Name: Dead Branch
@@ -1197,9 +1198,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM
     Script: |
-      getrandgroupitem(IG_CardAlbum,1);
+      getrandgroupitem(IG_CARDALBUM,1);
   - Id: 617
     AegisName: Old_Violet_Box
     Name: Old Purple Box
@@ -1208,9 +1209,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_VIOLETBOX
     Script: |
-      getrandgroupitem(IG_VioletBox,1);
+      getrandgroupitem(IG_VIOLETBOX,1);
   - Id: 618
     AegisName: Worn_Out_Scroll
     Name: Worn Out Scroll
@@ -1526,9 +1527,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX
     Script: |
-      getrandgroupitem(IG_GiftBox,1);
+      getrandgroupitem(IG_GIFTBOX,1);
   - Id: 645
     AegisName: Center_Potion
     Name: Concentration Potion
@@ -1672,9 +1673,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_1
     Script: |
-      getrandgroupitem(IG_GiftBox_1,1);
+      getrandgroupitem(IG_GIFTBOX_1,1);
   - Id: 665
     AegisName: Gift_Box_2
     Name: Gift Box
@@ -1683,9 +1684,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_2
     Script: |
-      getrandgroupitem(IG_GiftBox_2,1);
+      getrandgroupitem(IG_GIFTBOX_2,1);
   - Id: 666
     AegisName: Gift_Box_3
     Name: Gift Box
@@ -1694,9 +1695,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_3
     Script: |
-      getrandgroupitem(IG_GiftBox_3,1);
+      getrandgroupitem(IG_GIFTBOX_3,1);
   - Id: 667
     AegisName: Gift_Box_4
     Name: Gift Box
@@ -1705,9 +1706,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_4
     Script: |
-      getrandgroupitem(IG_GiftBox_4,1);
+      getrandgroupitem(IG_GIFTBOX_4,1);
   - Id: 668
     AegisName: Handsei
     Name: Red Envelope
@@ -2482,6 +2483,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1750,500;
   - Id: 12005
@@ -2492,6 +2494,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1770,500;
   - Id: 12006
@@ -2502,6 +2505,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1753,500;
   - Id: 12007
@@ -2512,6 +2516,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1765,500;
   - Id: 12008
@@ -2522,6 +2527,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1752,500;
   - Id: 12009
@@ -2532,6 +2538,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1751,500;
   - Id: 12010
@@ -2542,6 +2549,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1755,500;
   - Id: 12011
@@ -2552,6 +2560,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1756,500;
   - Id: 12012
@@ -2562,6 +2571,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1754,500;
   - Id: 12013
@@ -2572,6 +2582,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1767,500;
   - Id: 12014
@@ -2582,6 +2593,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1757,500;
   - Id: 12015
@@ -2592,6 +2604,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1762,500;
   - Id: 12016
@@ -2660,10 +2673,9 @@ Body:
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_GIFTBOXCHINA
     Script: |
-      getrandgroupitem(IG_GiftBoxChina,1);
+      getrandgroupitem(IG_GIFTBOXCHINA,1);
   - Id: 12024
     AegisName: Red_Pouch_Of_Surprise
     Name: Red Pouch
@@ -2680,20 +2692,18 @@ Body:
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_EGGBOY
     Script: |
-      getrandgroupitem(IG_EggBoy,1);
+      getrandgroupitem(IG_EGGBOY,1);
   - Id: 12026
     AegisName: Egg_Girl
     Name: Dano Festival Egg
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_EGGGIRL
     Script: |
-      getrandgroupitem(IG_EggGirl,1);
+      getrandgroupitem(IG_EGGGIRL,1);
   - Id: 12027
     AegisName: Giggling_Box
     Name: Giggling Box
@@ -2797,6 +2807,8 @@ Body:
     Name: Lotto Box 01
     Type: Usable
     Weight: 20
+    Flags:
+      Container: true
     Script: |
       getitem rand(7361,7370),1;
   - Id: 12036
@@ -2804,6 +2816,8 @@ Body:
     Name: Lotto Box 02
     Type: Usable
     Weight: 20
+    Flags:
+      Container: true
     Script: |
       getitem rand(7371,7380),1;
   - Id: 12037
@@ -2811,6 +2825,8 @@ Body:
     Name: Lotto Box 03
     Type: Usable
     Weight: 20
+    Flags:
+      Container: true
     Script: |
       getitem rand(7381,7390),1;
   - Id: 12038
@@ -2818,15 +2834,16 @@ Body:
     Name: Lotto Box 04
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX
     Script: |
-      getrandgroupitem(IG_LottoBox,1);
+      getrandgroupitem(IG_LOTTOBOX,1);
   - Id: 12039
     AegisName: Lotto_Box05
     Name: Lotto Box 05
     Type: Usable
     Weight: 20
+    Flags:
+      Container: true
     Script: |
       getitem rand(7542,7546),1;
   - Id: 12040
@@ -3534,9 +3551,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_QUIVER
     Script: |
-      getrandgroupitem(IG_Quiver,1);
+      getrandgroupitem(IG_QUIVER,1);
   - Id: 12105
     AegisName: Set_Of_Taiming_Item
     Name: Taming Gift Set
@@ -3545,11 +3562,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_TAMING
     Script: |
-      getrandgroupitem(IG_Taming,1);
-      getrandgroupitem(IG_Taming,1);
-      getrandgroupitem(IG_Taming,1);
+      getrandgroupitem(IG_TAMING,1);
+      getrandgroupitem(IG_TAMING,1);
+      getrandgroupitem(IG_TAMING,1);
   - Id: 12106
     AegisName: Accessory_Box
     Name: Jewelry Box
@@ -3558,9 +3575,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ACCESORY
     Script: |
-      getrandgroupitem(IG_Accesory,1);
+      getrandgroupitem(IG_ACCESORY,1);
   - Id: 12107
     AegisName: Wrapped_Mask
     Name: Wrapped Mask
@@ -3569,9 +3586,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MASK
     Script: |
-      getrandgroupitem(IG_Mask,1);
+      getrandgroupitem(IG_MASK,1);
   - Id: 12108
     AegisName: Bundle_Of_Magic_Scroll
     Name: Scroll Package
@@ -3580,13 +3597,13 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SCROLL
     Script: |
-      getrandgroupitem(IG_Scroll,1);
-      getrandgroupitem(IG_Scroll,1);
-      getrandgroupitem(IG_Scroll,1);
-      getrandgroupitem(IG_Scroll,1);
-      getrandgroupitem(IG_Scroll,1);
+      getrandgroupitem(IG_SCROLL,1);
+      getrandgroupitem(IG_SCROLL,1);
+      getrandgroupitem(IG_SCROLL,1);
+      getrandgroupitem(IG_SCROLL,1);
+      getrandgroupitem(IG_SCROLL,1);
   - Id: 12109
     AegisName: Poring_Box
     Name: Poring Box
@@ -3606,13 +3623,13 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FIRSTAID
     Script: |
-      getrandgroupitem(IG_FirstAid,1);
-      getrandgroupitem(IG_FirstAid,1);
-      getrandgroupitem(IG_FirstAid,1);
-      getrandgroupitem(IG_FirstAid,1);
-      getrandgroupitem(IG_FirstAid,1);
+      getrandgroupitem(IG_FIRSTAID,1);
+      getrandgroupitem(IG_FIRSTAID,1);
+      getrandgroupitem(IG_FIRSTAID,1);
+      getrandgroupitem(IG_FIRSTAID,1);
+      getrandgroupitem(IG_FIRSTAID,1);
   - Id: 12111
     AegisName: Food_Package
     Name: Bundle of Food
@@ -3621,11 +3638,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FOODBAG
     Script: |
-      getrandgroupitem(IG_FoodBag,1);
-      getrandgroupitem(IG_FoodBag,1);
-      getrandgroupitem(IG_FoodBag,1);
+      getrandgroupitem(IG_FOODBAG,1);
+      getrandgroupitem(IG_FOODBAG,1);
+      getrandgroupitem(IG_FOODBAG,1);
   - Id: 12112
     AegisName: Tropical_Sograt
     Name: Tropical Sograt
@@ -3815,11 +3832,11 @@ Body:
     Weight: 70
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_COOKIEBAG
     Script: |
-      getrandgroupitem(IG_CookieBag,1);
-      getrandgroupitem(IG_CookieBag,1);
-      getrandgroupitem(IG_CookieBag,1);
+      getrandgroupitem(IG_COOKIEBAG,1);
+      getrandgroupitem(IG_COOKIEBAG,1);
+      getrandgroupitem(IG_COOKIEBAG,1);
   - Id: 12131
     AegisName: Lucky_Potion
     Name: Lucky Potion
@@ -3867,6 +3884,8 @@ Body:
     Name: Women's Bundle
     Type: Usable
     Weight: 100
+    Flags:
+      Container: true
     Script: |
       getitem callfunc("F_Rand",558,529,2668,7518),1;
   - Id: 12137
@@ -3918,6 +3937,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13204,500;
   - Id: 12145
@@ -3928,6 +3948,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13206,500;
   - Id: 12146
@@ -3938,6 +3959,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13205,500;
   - Id: 12147
@@ -3948,6 +3970,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13207,500;
   - Id: 12148
@@ -3958,6 +3981,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13203,500;
   - Id: 12149
@@ -3968,6 +3992,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13200,500;
   - Id: 12150
@@ -3978,6 +4003,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13202,500;
   - Id: 12151
@@ -3988,6 +4014,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13201,500;
   - Id: 12152
@@ -4483,6 +4510,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1772,500;
   - Id: 12184
@@ -4511,20 +4539,18 @@ Body:
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_REDBOX
     Script: |
-      getrandgroupitem(IG_RedBox,1);
+      getrandgroupitem(IG_REDBOX,1);
   - Id: 12187
     AegisName: Green_Box
     Name: Old Green Box
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_GREENBOX
     Script: |
-      getrandgroupitem(IG_GreenBox,1);
+      getrandgroupitem(IG_GREENBOX,1);
   - Id: 12188
     AegisName: Magical_Moon_Cake
     Name: Grace Moon Cake
@@ -4539,10 +4565,9 @@ Body:
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_REDBOX_2
     Script: |
-      getrandgroupitem(IG_RedBox_2,1);
+      getrandgroupitem(IG_REDBOX_2,1);
   - Id: 12190
     AegisName: Moon_Cake
     Name: Moon Cake
@@ -4577,11 +4602,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HOMETOWNGIFT
     Script: |
-      getrandgroupitem(IG_HometownGift,1);
-      getrandgroupitem(IG_HometownGift,1);
-      getrandgroupitem(IG_HometownGift,1);
+      getrandgroupitem(IG_HOMETOWNGIFT,1);
+      getrandgroupitem(IG_HOMETOWNGIFT,1);
+      getrandgroupitem(IG_HOMETOWNGIFT,1);
   - Id: 12195
     AegisName: Plain_Rice_Cake
     Name: Plain Rice Cake
@@ -5182,10 +5207,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_YELLOWBOX
     Script: |
-      getrandgroupitem(IG_YellowBox,1);
+      getrandgroupitem(IG_YELLOWBOX,1);
   - Id: 12241
     AegisName: M_Center_Potion
     Name: Mercenary Concentration Potion
@@ -5222,10 +5246,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_OLDGIFTBOX
     Script: |
-      getrandgroupitem(IG_OldGiftBox,1);
+      getrandgroupitem(IG_OLDGIFTBOX,1);
   - Id: 12245
     AegisName: Green_Ale_US
     Name: Green Ale
@@ -5242,9 +5265,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MAGICCARDALBUM
     Script: |
-      getrandgroupitem(IG_MagicCardAlbum,1);
+      getrandgroupitem(IG_MAGICCARDALBUM,1);
   - Id: 12247
     AegisName: Halohalo
     Name: Halo-Halo
@@ -5260,10 +5283,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MASQUERADE
     Script: |
-      getrandgroupitem(IG_Masquerade,1);
+      getrandgroupitem(IG_MASQUERADE,1);
   - Id: 12249
     AegisName: Payroll_Of_Kafra_
     Name: Payment Statement for Kafra Employee
@@ -5675,10 +5697,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 150
-    Flags:
-      Container: true
+    ItemGroup: IG_TRESURE_BOX_WOE
     Script: |
-      getrandgroupitem(IG_Tresure_Box_WoE,1);
+      getrandgroupitem(IG_TRESURE_BOX_WOE,1);
   - Id: 12282
     AegisName: Internet_Cafe1
     Name: Internet Cafe1
@@ -5725,10 +5746,9 @@ Body:
     Name: Masquerade Ball Box2
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MASQUERADE_2
     Script: |
-      getrandgroupitem(IG_Masquerade_2,1);
+      getrandgroupitem(IG_MASQUERADE_2,1);
   - Id: 12287
     AegisName: Love_Angel
     Name: Love Angel Magic Powder
@@ -5833,6 +5853,8 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -5849,6 +5871,8 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -5865,6 +5889,8 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -5881,6 +5907,8 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -6338,10 +6366,9 @@ Body:
     Name: Treasure Edition Helm Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHERISH_BOX
     Script: |
-      getrandgroupitem(IG_Cherish_Box,1);
+      getrandgroupitem(IG_CHERISH_BOX,1);
   - Id: 12335
     AegisName: Yummy_Skewered_Dish
     Name: Grilled Delicious Skewer
@@ -6381,10 +6408,9 @@ Body:
     Name: Treasure Edition Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHERISH_BOX_ORI
     Script: |
-      getrandgroupitem(IG_Cherish_Box_Ori,1);
+      getrandgroupitem(IG_CHERISH_BOX_ORI,1);
   - Id: 12340
     AegisName: Mysterious_Rice_Powder
     Name: Chewy Rice Powder
@@ -6410,6 +6436,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 7940,100;
   - Id: 12342
@@ -6621,9 +6648,9 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_XMAS_GIFT
     Script: |
-      getrandgroupitem(IG_Xmas_Gift,1);
+      getrandgroupitem(IG_XMAS_GIFT,1);
   - Id: 12356
     AegisName: Louise_Costume_Box
     Name: Louise Costume Box
@@ -6632,9 +6659,9 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LOUISE_COSTUME_BOX
     Script: |
-      getrandgroupitem(IG_Louise_Costume_Box,1);
+      getrandgroupitem(IG_LOUISE_COSTUME_BOX,1);
   - Id: 12357
     AegisName: Shiny_Wing_Gown
     Name: Shiny Wing Gown
@@ -6954,6 +6981,7 @@ Body:
     Weight: 500
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 6145,1000;
   - Id: 12384
@@ -7147,6 +7175,8 @@ Body:
     Type: Delayconsume
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     NoUse:
       Sitting: true
     Trade:
@@ -7171,6 +7201,8 @@ Body:
     Type: Delayconsume
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     NoUse:
       Sitting: true
     Trade:
@@ -8675,11 +8707,10 @@ Body:
     Name: Old Navy Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_BLEUBOX
     Script: |
-      getrandgroupitem(IG_BleuBox,1);
-      getrandgroupitem(IG_BleuBox,1);
+      getrandgroupitem(IG_BLEUBOX,1);
+      getrandgroupitem(IG_BLEUBOX,1);
   - Id: 12703
     AegisName: Holy_Egg_2
     Name: Holy Egg
@@ -8786,8 +8817,6 @@ Body:
     Type: Usable
     Buy: 1
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -8795,8 +8824,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EASTER_SCROLL
     Script: |
-      getrandgroupitem(IG_Easter_Scroll,1);
+      getrandgroupitem(IG_EASTER_SCROLL,1);
   - Id: 12715
     AegisName: Black_Treasure_Box
     Name: Black Treasure Box
@@ -13617,6 +13647,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 682,1;
       getitem 12123,1;
@@ -13627,6 +13659,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 683,1;
       getitem 12123,1;
@@ -13637,6 +13671,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12118,1;
       getitem 12119,1;
@@ -13646,6 +13682,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12120,1;
       getitem 12121,1;
@@ -17539,6 +17577,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17555,6 +17595,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17571,6 +17613,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17587,6 +17631,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20223,6 +20269,8 @@ Body:
     Name: Clothing Dye Coupon Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6046,1;
   - Id: 14292
@@ -20230,6 +20278,8 @@ Body:
     Name: Clothing Dye Coupon Box II
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6047,1;
   - Id: 14296
@@ -20293,6 +20343,8 @@ Body:
     Name: Phreeoni Scroll Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20308,6 +20360,8 @@ Body:
     Name: Ghostring Scroll Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21619,15 +21673,14 @@ Body:
     Name: Pierre's Treasure Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_PIERRE_TREASUREBOX
     Script: |
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
-      getrandgroupitem(IG_Pierre_Treasurebox,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
+      getrandgroupitem(IG_PIERRE_TREASUREBOX,1);
   - Id: 14597
     AegisName: PhreeoniS
     Name: Phreeoni Scroll
@@ -21877,6 +21930,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21891,6 +21946,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21905,6 +21962,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21919,6 +21978,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21957,6 +22018,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21971,6 +22034,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21985,6 +22050,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -21999,6 +22066,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoSell: true
@@ -22034,6 +22103,8 @@ Body:
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,10;
   - Id: 16678
@@ -22041,6 +22112,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,50;
   - Id: 16679
@@ -22048,6 +22121,8 @@ Body:
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,10;
   - Id: 16680
@@ -22055,6 +22130,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,50;
   - Id: 16776
@@ -22062,6 +22139,8 @@ Body:
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,10;
   - Id: 16777
@@ -22069,6 +22148,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12581,50;
   - Id: 17104
@@ -22077,6 +22158,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6240,50;
   - Id: 17105
@@ -22085,6 +22168,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6241,50;
   - Id: 22777

--- a/db/re/item_db.yml
+++ b/db/re/item_db.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)

--- a/db/re/item_db_etc.yml
+++ b/db/re/item_db_etc.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -50,7 +50,7 @@
 #   Flags:                  Item flags. (Default: null)
 #     BuyingStore           If the item is available for Buyingstores. (Default: false)
 #     DeadBranch            If the item is a Dead Branch. (Default: false)
-#     Container             If the item is part of a container. (Default: false)
+#     Container             If the item is a container. (Default: false) Cash type items and items with an ItemGroup are always considered containers and ignore this flag.
 #     UniqueId              If the item is a unique stack. (Default: false)
 #     BindOnEquip           If the item is bound to the character upon equipping. (Default: false)
 #     DropAnnounce          If the item has a special announcement to self on drop. (Default: false)
@@ -79,6 +79,7 @@
 #     NoGuildStorage        If the item can not be put in a guild storage. (Default: false)
 #     NoMail                If the item can not be put in a mail. (Default: false)
 #     NoAuction             If the item can not be put in an auction. (Default: false)
+#   ItemGroup               Item group the item is a container for. (Default: null)
 #   Script                  Script to execute when the item is used/equipped. (Default: null)
 #   EquipScript             Script to execute when the item is equipped. (Default: null)
 #   UnEquipScript           Script to execute when the item is unequipped or when a rental item expires. (Default: null)
@@ -1101,11 +1102,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
     Trade:
       NoSell: true
+    ItemGroup: IG_BLUEBOX
     Script: |
-      getgroupitem(IG_BlueBox);
+      getgroupitem(IG_BLUEBOX);
   - Id: 604
     AegisName: Branch_Of_Dead_Tree
     Name: Dead Branch
@@ -1241,9 +1242,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM
     Script: |
-      getgroupitem(IG_CardAlbum);
+      getgroupitem(IG_CARDALBUM);
   - Id: 617
     AegisName: Old_Violet_Box
     Name: Old Purple Box
@@ -1252,11 +1253,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
     Trade:
       NoSell: true
+    ItemGroup: IG_VIOLETBOX
     Script: |
-      getgroupitem(IG_VioletBox);
+      getgroupitem(IG_VIOLETBOX);
   - Id: 618
     AegisName: Worn_Out_Scroll
     Name: Worn Out Scroll
@@ -1571,9 +1572,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX
     Script: |
-      getgroupitem(IG_GiftBox);
+      getgroupitem(IG_GIFTBOX);
   - Id: 645
     AegisName: Center_Potion
     Name: Concentration Potion
@@ -1721,9 +1722,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_1
     Script: |
-      getgroupitem(IG_GiftBox_1);
+      getgroupitem(IG_GIFTBOX_1);
   - Id: 665
     AegisName: Gift_Box_2
     Name: Gift Box
@@ -1732,9 +1733,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_2
     Script: |
-      getgroupitem(IG_GiftBox_2);
+      getgroupitem(IG_GIFTBOX_2);
   - Id: 666
     AegisName: Gift_Box_3
     Name: Gift Box
@@ -1743,9 +1744,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_3
     Script: |
-      getgroupitem(IG_GiftBox_3);
+      getgroupitem(IG_GIFTBOX_3);
   - Id: 667
     AegisName: Gift_Box_4
     Name: Gift Box
@@ -1754,9 +1755,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GIFTBOX_4
     Script: |
-      getgroupitem(IG_GiftBox_4);
+      getgroupitem(IG_GIFTBOX_4);
   - Id: 668
     AegisName: Handsei
     Name: Red Envelope
@@ -2097,10 +2098,9 @@ Body:
     Name: Costume Enchant Stone Box 17
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX17
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box17);
+      getgroupitem(IG_ENCHANT_STONE_BOX17);
   - Id: 9514
     AegisName: Ein_Ddbox
     Name: Physical Modification Permit
@@ -2121,8 +2121,7 @@ Body:
     Name: Einbeck Weapon Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EIN_1HITEMBOX
     Script: |
       getgroupitem(IG_EIN_1HITEMBOX);
   - Id: 9517
@@ -2131,8 +2130,8 @@ Body:
     Type: Usable
     Weight: 10
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_EIN_UNDIUM
     Script: |
       getgroupitem(IG_EIN_UNDIUM);
   - Id: 9523
@@ -2169,14 +2168,15 @@ Body:
     Name: 300 Points Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_PC_COSTUME_BOX
     Script: |
       getgroupitem(IG_PC_COSTUME_BOX);
   - Id: 9539
     AegisName: Blue_Potion_B_10
     Name: "[Event] Blue Potion Box"
     Type: Healing
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2208,7 +2208,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_C_CATPAW_7DAY_BOX_
     Script: |
       getgroupitem(IG_C_CATPAW_7DAY_BOX_);
   - Id: 9569
@@ -2221,8 +2221,6 @@ Body:
     AegisName: Wet_Sealed_Card
     Name: Sealed Wet Card
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2231,6 +2229,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WET_SEALED_CARD
     Script: |
       getgroupitem(IG_WET_SEALED_CARD);
   - Id: 9582
@@ -2263,16 +2262,13 @@ Body:
     AegisName: 2019_SStarR_Tbox
     Name: 2019 Superstar R Ticket Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_2019_SSTARR_TBOX
     Script: |
       getgroupitem(IG_2019_SSTARR_TBOX);
   - Id: 9587
     AegisName: E_Life_Potion_Pack
     Name: "[Event]Life Potion 20 Box"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2280,14 +2276,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_LIFE_POTION_PACK
     Script: |
       getgroupitem(IG_E_LIFE_POTION_PACK);
   - Id: 9588
     AegisName: E_DEF_Scroll_Box
     Name: "[Not For Sale] Brilliant Protection Box (20)"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2295,14 +2290,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_DEF_SCROLL_BOX
     Script: |
       getgroupitem(IG_E_DEF_SCROLL_BOX);
   - Id: 9589
     AegisName: E_Almighty_Box
     Name: "[Not For Sale] Almighty Box (10)"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2310,14 +2304,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_ALMIGHTY_BOX
     Script: |
       getgroupitem(IG_E_ALMIGHTY_BOX);
   - Id: 9590
     AegisName: E_LimitPowerBooster
     Name: "[Not For Sale] Power Booster Box (10)"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2325,6 +2318,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_LIMITPOWERBOOSTER
     Script: |
       getgroupitem(IG_E_LIMITPOWERBOOSTER);
   - Id: 9610
@@ -2475,7 +2469,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ROYAL_SECRET_BOX
     Script: |
       getgroupitem(IG_ROYAL_SECRET_BOX);
   - Id: 9933
@@ -2504,6 +2498,8 @@ Body:
     Name: Healing Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2521,6 +2517,8 @@ Body:
     Name: Stick Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2542,6 +2540,8 @@ Body:
     Name: Major Battle Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2562,6 +2562,8 @@ Body:
     Name: Battle Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2582,6 +2584,8 @@ Body:
     Name: Major Ark of Life    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2600,6 +2604,8 @@ Body:
     Name: Ark of Life    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2618,6 +2624,8 @@ Body:
     Name: Divine Major Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2639,6 +2647,8 @@ Body:
     Name: Divine Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2658,6 +2668,8 @@ Body:
     Name: Major Refining Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2675,6 +2687,8 @@ Body:
     Name: Refining Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2692,6 +2706,8 @@ Body:
     Name: Perfect Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2710,6 +2726,8 @@ Body:
     Name: Ore Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2728,6 +2746,8 @@ Body:
     Name: Scroll Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2746,6 +2766,8 @@ Body:
     Name: Special Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2762,6 +2784,8 @@ Body:
     Name: Major Celestial Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2779,6 +2803,8 @@ Body:
     Name: Major Celestial Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2796,6 +2822,8 @@ Body:
     Name: Potions Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2817,6 +2845,8 @@ Body:
     Name: Reset Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2834,6 +2864,8 @@ Body:
     Name: Major Evolve Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2852,6 +2884,8 @@ Body:
     Name: Evolve Ark    # !todo check english name
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2870,8 +2904,6 @@ Body:
     Name: "[Not For Sale] Boarding Halter 7D Box"
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2880,14 +2912,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOARDING_HALTER_BOX7
     Script: |
       getgroupitem(IG_BOARDING_HALTER_BOX7);
   - Id: 9999
     AegisName: Season_Evt_Reward_2
     Name: Sweets Snack Pack
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2897,6 +2928,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD_2
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_2);
   - Id: 10625
@@ -2904,8 +2936,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package V
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -2914,6 +2944,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_5
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_5);
   - Id: 11500
@@ -4529,6 +4560,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1750,500;
   - Id: 12005
@@ -4540,6 +4572,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1770,500;
   - Id: 12006
@@ -4551,6 +4584,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1753,500;
   - Id: 12007
@@ -4562,6 +4596,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1765,500;
   - Id: 12008
@@ -4573,6 +4608,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1752,500;
   - Id: 12009
@@ -4584,6 +4620,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1751,500;
   - Id: 12010
@@ -4595,6 +4632,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1755,500;
   - Id: 12011
@@ -4606,6 +4644,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1756,500;
   - Id: 12012
@@ -4617,6 +4656,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1754,500;
   - Id: 12013
@@ -4628,6 +4668,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1767,500;
   - Id: 12014
@@ -4639,6 +4680,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1757,500;
   - Id: 12015
@@ -4650,6 +4692,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1762,500;
   - Id: 12016
@@ -4718,10 +4761,9 @@ Body:
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_GIFTBOXCHINA
     Script: |
-      getgroupitem(IG_GiftBoxChina);
+      getgroupitem(IG_GIFTBOXCHINA);
   - Id: 12024
     AegisName: Red_Pouch_Of_Surprise
     Name: Red Pouch
@@ -4738,20 +4780,18 @@ Body:
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_EGGBOY
     Script: |
-      getgroupitem(IG_EggBoy);
+      getgroupitem(IG_EGGBOY);
   - Id: 12026
     AegisName: Egg_Girl
     Name: Dano Festival Egg
     Type: Usable
     Buy: 1000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_EGGGIRL
     Script: |
-      getgroupitem(IG_EggGirl);
+      getgroupitem(IG_EGGGIRL);
   - Id: 12027
     AegisName: Giggling_Box
     Name: Giggling Box
@@ -4855,46 +4895,41 @@ Body:
     Name: Lotto Box 01
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX1
     Script: |
-      getgroupitem(IG_LottoBox1);
+      getgroupitem(IG_LOTTOBOX1);
   - Id: 12036
     AegisName: Lotto_Box02
     Name: Lotto Box 02
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX2
     Script: |
-      getgroupitem(IG_LottoBox2);
+      getgroupitem(IG_LOTTOBOX2);
   - Id: 12037
     AegisName: Lotto_Box03
     Name: Lotto Box 03
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX3
     Script: |
-      getgroupitem(IG_LottoBox3);
+      getgroupitem(IG_LOTTOBOX3);
   - Id: 12038
     AegisName: Lotto_Box04
     Name: Lotto Box 04
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX4
     Script: |
-      getgroupitem(IG_LottoBox4);
+      getgroupitem(IG_LOTTOBOX4);
   - Id: 12039
     AegisName: Lotto_Box05
     Name: Lotto Box 05
     Type: Usable
     Weight: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_LOTTOBOX5
     Script: |
-      getgroupitem(IG_LottoBox5);
+      getgroupitem(IG_LOTTOBOX5);
   - Id: 12040
     AegisName: Stone_Of_Intelligence_
     Name: Stone of Sage
@@ -5604,9 +5639,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_QUIVER
     Script: |
-      getgroupitem(IG_Quiver);
+      getgroupitem(IG_QUIVER);
   - Id: 12105
     AegisName: Set_Of_Taiming_Item
     Name: Taming Gift Set
@@ -5615,11 +5650,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_TAMING
     Script: |
-      getgroupitem(IG_Taming);
-      getgroupitem(IG_Taming);
-      getgroupitem(IG_Taming);
+      getgroupitem(IG_TAMING);
+      getgroupitem(IG_TAMING);
+      getgroupitem(IG_TAMING);
   - Id: 12106
     AegisName: Accessory_Box
     Name: Jewelry Box
@@ -5628,9 +5663,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ACCESORY
     Script: |
-      getgroupitem(IG_Accesory);
+      getgroupitem(IG_ACCESORY);
   - Id: 12107
     AegisName: Wrapped_Mask
     Name: Wrapped Mask
@@ -5639,9 +5674,9 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MASK
     Script: |
-      getgroupitem(IG_Mask);
+      getgroupitem(IG_MASK);
   - Id: 12108
     AegisName: Bundle_Of_Magic_Scroll
     Name: Scroll Package
@@ -5650,13 +5685,13 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SCROLL
     Script: |
-      getgroupitem(IG_Scroll);
-      getgroupitem(IG_Scroll);
-      getgroupitem(IG_Scroll);
-      getgroupitem(IG_Scroll);
-      getgroupitem(IG_Scroll);
+      getgroupitem(IG_SCROLL);
+      getgroupitem(IG_SCROLL);
+      getgroupitem(IG_SCROLL);
+      getgroupitem(IG_SCROLL);
+      getgroupitem(IG_SCROLL);
   - Id: 12109
     AegisName: Poring_Box
     Name: Poring Box
@@ -5676,13 +5711,13 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FIRSTAID
     Script: |
-      getgroupitem(IG_FirstAid);
-      getgroupitem(IG_FirstAid);
-      getgroupitem(IG_FirstAid);
-      getgroupitem(IG_FirstAid);
-      getgroupitem(IG_FirstAid);
+      getgroupitem(IG_FIRSTAID);
+      getgroupitem(IG_FIRSTAID);
+      getgroupitem(IG_FIRSTAID);
+      getgroupitem(IG_FIRSTAID);
+      getgroupitem(IG_FIRSTAID);
   - Id: 12111
     AegisName: Food_Package
     Name: Bundle of Food
@@ -5691,11 +5726,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FOODBAG
     Script: |
-      getgroupitem(IG_FoodBag);
-      getgroupitem(IG_FoodBag);
-      getgroupitem(IG_FoodBag);
+      getgroupitem(IG_FOODBAG);
+      getgroupitem(IG_FOODBAG);
+      getgroupitem(IG_FOODBAG);
   - Id: 12112
     AegisName: Tropical_Sograt
     Name: Tropical Sograt
@@ -5885,11 +5920,11 @@ Body:
     Weight: 70
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_COOKIEBAG
     Script: |
-      getgroupitem(IG_CookieBag);
-      getgroupitem(IG_CookieBag);
-      getgroupitem(IG_CookieBag);
+      getgroupitem(IG_COOKIEBAG);
+      getgroupitem(IG_COOKIEBAG);
+      getgroupitem(IG_COOKIEBAG);
   - Id: 12131
     AegisName: Lucky_Potion
     Name: Lucky Potion
@@ -5943,6 +5978,8 @@ Body:
     Name: Women's Bundle
     Type: Usable
     Weight: 100
+    Flags:
+      Container: true
     Script: |
       getitem callfunc("F_Rand",558,529,2668,7518),1;
   - Id: 12137
@@ -5996,6 +6033,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13204,500;
   - Id: 12145
@@ -6006,6 +6044,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13206,500;
   - Id: 12146
@@ -6016,6 +6055,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13205,500;
   - Id: 12147
@@ -6026,6 +6066,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13207,500;
   - Id: 12148
@@ -6036,6 +6077,7 @@ Body:
     Weight: 350
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13203,500;
   - Id: 12149
@@ -6046,6 +6088,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13200,500;
   - Id: 12150
@@ -6056,6 +6099,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13202,500;
   - Id: 12151
@@ -6066,6 +6110,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 13201,500;
   - Id: 12152
@@ -6073,10 +6118,9 @@ Body:
     Name: Special Present
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX
     Script: |
-      getgroupitem(IG_Special_Box);
+      getgroupitem(IG_SPECIAL_BOX);
   - Id: 12153
     AegisName: Bow_Mercenary_Scroll1
     Name: Bowman Scroll 1
@@ -6566,6 +6610,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1772,500;
   - Id: 12184
@@ -6594,20 +6639,18 @@ Body:
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_REDBOX
     Script: |
-      getgroupitem(IG_RedBox);
+      getgroupitem(IG_REDBOX);
   - Id: 12187
     AegisName: Green_Box
     Name: Old Green Box
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_GREENBOX
     Script: |
-      getgroupitem(IG_GreenBox);
+      getgroupitem(IG_GREENBOX);
   - Id: 12188
     AegisName: Magical_Moon_Cake
     Name: Grace Moon Cake
@@ -6622,10 +6665,9 @@ Body:
     Type: Usable
     Buy: 50000
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_REDBOX_2
     Script: |
-      getgroupitem(IG_RedBox_2);
+      getgroupitem(IG_REDBOX_2);
   - Id: 12190
     AegisName: Moon_Cake
     Name: Moon Cake
@@ -6667,11 +6709,11 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HOMETOWNGIFT
     Script: |
-      getgroupitem(IG_HometownGift);
-      getgroupitem(IG_HometownGift);
-      getgroupitem(IG_HometownGift);
+      getgroupitem(IG_HOMETOWNGIFT);
+      getgroupitem(IG_HOMETOWNGIFT);
+      getgroupitem(IG_HOMETOWNGIFT);
   - Id: 12195
     AegisName: Plain_Rice_Cake
     Name: Plain Rice Cake
@@ -7299,10 +7341,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_YELLOWBOX
     Script: |
-      getgroupitem(IG_YellowBox);
+      getgroupitem(IG_YELLOWBOX);
   - Id: 12241
     AegisName: M_Center_Potion
     Name: Mercenary Concentration Potion
@@ -7339,10 +7380,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_OLDGIFTBOX
     Script: |
-      getgroupitem(IG_OldGiftBox);
+      getgroupitem(IG_OLDGIFTBOX);
   - Id: 12245
     AegisName: Green_Ale_US
     Name: Green Ale
@@ -7359,9 +7399,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MAGICCARDALBUM
     Script: |
-      getgroupitem(IG_MagicCardAlbum);
+      getgroupitem(IG_MAGICCARDALBUM);
   - Id: 12247
     AegisName: Halohalo
     Name: Halo-Halo
@@ -7377,10 +7417,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MASQUERADE
     Script: |
-      getgroupitem(IG_Masquerade);
+      getgroupitem(IG_MASQUERADE);
   - Id: 12249
     AegisName: Payroll_Of_Kafra_
     Name: Payment Statement for Kafra Employee
@@ -7799,8 +7838,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 150
-    Flags:
-      Container: true
+    ItemGroup: IG_TRESURE_BOX_WOE
     Script: |
       getgroupitem(IG_TRESURE_BOX_WOE);
   - Id: 12282
@@ -7849,10 +7887,9 @@ Body:
     Name: Masquerade Ball Box2
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MASQUERADE_2
     Script: |
-      getgroupitem(IG_Masquerade_2);
+      getgroupitem(IG_MASQUERADE_2);
   - Id: 12287
     AegisName: Love_Angel
     Name: Love Angel Magic Powder
@@ -7957,8 +7994,6 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -7968,6 +8003,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_BANG_COIN_BOX1
     Script: |
       getgroupitem(IG_PC_BANG_COIN_BOX1);
   - Id: 12295
@@ -7975,8 +8011,6 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -7986,6 +8020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_BANG_COIN_BOX2
     Script: |
       getgroupitem(IG_PC_BANG_COIN_BOX2);
   - Id: 12296
@@ -7993,8 +8028,6 @@ Body:
     Name: Splendid Spring Hat Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -8004,6 +8037,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_BANG_COIN_BOX3
     Script: |
       getgroupitem(IG_PC_BANG_COIN_BOX3);
   - Id: 12297
@@ -8011,8 +8045,6 @@ Body:
     Name: PC-Room Coin Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -8022,6 +8054,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_BANG_COIN_BOX4
     Script: |
       getgroupitem(IG_PC_BANG_COIN_BOX4);
   - Id: 12298
@@ -8275,8 +8308,6 @@ Body:
     Name: Adventurer Returns Support Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -8286,8 +8317,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NOIVE_BOX
     Script: |
-      getgroupitem(IG_Noive_Box);
+      getgroupitem(IG_NOIVE_BOX);
   - Id: 12315
     AegisName: Goddess_Bless
     Name: Goddess Of Blessing
@@ -8510,10 +8542,9 @@ Body:
     Name: Treasure Edition Helm Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHERISH_BOX
     Script: |
-      getgroupitem(IG_Cherish_Box);
+      getgroupitem(IG_CHERISH_BOX);
   - Id: 12335
     AegisName: Yummy_Skewered_Dish
     Name: Grilled Delicious Skewer
@@ -8553,10 +8584,9 @@ Body:
     Name: Treasure Edition Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHERISH_BOX_ORI
     Script: |
-      getgroupitem(IG_Cherish_Box_Ori);
+      getgroupitem(IG_CHERISH_BOX_ORI);
   - Id: 12340
     AegisName: Mysterious_Rice_Powder
     Name: Chewy Rice Powder
@@ -8583,6 +8613,7 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 7940,500;
   - Id: 12342
@@ -8723,9 +8754,9 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_XMAS_GIFT
     Script: |
-      getgroupitem(IG_Xmas_Gift);
+      getgroupitem(IG_XMAS_GIFT);
   - Id: 12356
     AegisName: Louise_Costume_Box
     Name: Louise Costume Box
@@ -8734,9 +8765,9 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LOUISE_COSTUME_BOX
     Script: |
-      getgroupitem(IG_Louise_Costume_Box);
+      getgroupitem(IG_LOUISE_COSTUME_BOX);
   - Id: 12357
     AegisName: Shiny_Wing_Gown
     Name: Shiny Wing Gown
@@ -9050,6 +9081,7 @@ Body:
     Weight: 500
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 6145,1000;
   - Id: 12384
@@ -9185,8 +9217,6 @@ Body:
     Name: Lucky Egg C
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9195,8 +9225,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C
     Script: |
-      getgroupitem(IG_Lucky_Egg_C);
+      getgroupitem(IG_LUCKY_EGG_C);
   - Id: 12392
     AegisName: RepairA
     Name: Repair A
@@ -9264,6 +9295,8 @@ Body:
     Type: DelayConsume
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     NoUse:
       Sitting: true
     Script: |
@@ -9283,6 +9316,8 @@ Body:
     Type: DelayConsume
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     NoUse:
       Sitting: true
     Script: |
@@ -9302,8 +9337,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9313,6 +9346,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_GIFT_BOX
     Script: |
       getgroupitem(IG_PCBANG_GIFT_BOX);
   - Id: 12399
@@ -9355,8 +9389,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9365,8 +9397,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C2
     Script: |
-      getgroupitem(IG_Lucky_Egg_C2);
+      getgroupitem(IG_LUCKY_EGG_C2);
   - Id: 12404
     AegisName: Acti_Potion
     Name: Acti Potion
@@ -9424,8 +9457,6 @@ Body:
     Name: PC Cafe Coupon Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9434,6 +9465,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX);
   - Id: 12408
@@ -9472,8 +9504,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9482,6 +9512,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX2
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX2);
   - Id: 12414
@@ -9519,8 +9550,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -9529,8 +9558,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C3
     Script: |
-      getgroupitem(IG_Lucky_Egg_C3);
+      getgroupitem(IG_LUCKY_EGG_C3);
   - Id: 12417
     AegisName: Boost500
     Name: Boost500
@@ -9995,8 +10025,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     NoUse:
       Sitting: true
     Trade:
@@ -10006,16 +10034,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_PARTI_BOX
     Script: |
-      getgroupitem(IG_RWC_Parti_Box);
+      getgroupitem(IG_RWC_PARTI_BOX);
   - Id: 12474
     AegisName: RWC_Final_Comp_Box
     Name: RWC Final Comp Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     NoUse:
       Sitting: true
     Trade:
@@ -10025,8 +10052,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_FINAL_COMP_BOX
     Script: |
-      getgroupitem(IG_RWC_Final_Comp_Box);
+      getgroupitem(IG_RWC_FINAL_COMP_BOX);
   - Id: 12475
     AegisName: Cure_Free
     Name: Cure Free
@@ -10049,8 +10077,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10059,14 +10085,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX3
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX3);
   - Id: 12477
     AegisName: Gift_Bundle
     Name: Prontera Costume Pack
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_GIFT_BUNDLE
     Script: |
       getgroupitem(IG_GIFT_BUNDLE);
   - Id: 12478
@@ -10075,8 +10101,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10086,6 +10110,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHANCE_BOX
     Script: |
       getgroupitem(IG_CHANCE_BOX);
   - Id: 12479
@@ -10093,8 +10118,6 @@ Body:
     Name: Test Your Luck Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10104,6 +10127,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CARACAS_RING_BOX
     Script: |
       getgroupitem(IG_CARACAS_RING_BOX);
   - Id: 12480
@@ -10111,8 +10135,6 @@ Body:
     Name: Attendance 3day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10121,6 +10143,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_3DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_3DAY_BOX);
   - Id: 12481
@@ -10128,8 +10151,6 @@ Body:
     Name: Attendance 7day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10138,6 +10159,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_7DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_7DAY_BOX);
   - Id: 12482
@@ -10145,8 +10167,6 @@ Body:
     Name: Attendance 10day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10155,6 +10175,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_10DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_10DAY_BOX);
   - Id: 12483
@@ -10162,8 +10183,6 @@ Body:
     Name: Attendance 15day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10172,6 +10191,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_15DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_15DAY_BOX);
   - Id: 12484
@@ -10179,8 +10199,6 @@ Body:
     Name: Attendance 20day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10189,6 +10207,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_20DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_20DAY_BOX);
   - Id: 12485
@@ -10196,8 +10215,6 @@ Body:
     Name: Attendance 25day Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10206,6 +10223,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_25DAY_BOX
     Script: |
       getgroupitem(IG_ATTEND_25DAY_BOX);
   - Id: 12486
@@ -10213,8 +10231,6 @@ Body:
     Name: Beast Summoning Seal Book
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10223,6 +10239,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDPC_FIRST_BOX
     Script: |
       getgroupitem(IG_GOLDPC_FIRST_BOX);
   - Id: 12487
@@ -10243,8 +10260,6 @@ Body:
     Name: Valkyrie Mercenary Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10253,6 +10268,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TICKET_GIFT_BOX
     Script: |
       getgroupitem(IG_TICKET_GIFT_BOX);
   - Id: 12489
@@ -10260,8 +10276,6 @@ Body:
     Name: Ticket Gift Box II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10270,6 +10284,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TICKET_GIFT_BOX2
     Script: |
       getgroupitem(IG_TICKET_GIFT_BOX2);
   - Id: 12490
@@ -10294,8 +10309,6 @@ Body:
     Type: Usable
     Buy: 2
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10304,15 +10317,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRUMPLED_PAPER
     Script: |
-      getgroupitem(IG_Crumpled_Paper);
+      getgroupitem(IG_CRUMPLED_PAPER);
   - Id: 12493
     AegisName: Lucky_Egg_C4
     Name: Lucky Egg C4
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10321,8 +10333,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C4
     Script: |
-      getgroupitem(IG_Lucky_Egg_C4);
+      getgroupitem(IG_LUCKY_EGG_C4);
   - Id: 12494
     AegisName: E_Giant_Fly_Wing
     Name: E Giant Fly Wing
@@ -10715,6 +10728,8 @@ Body:
     AegisName: White_Slim_Potion_Box
     Name: White Slim Potion Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10729,6 +10744,8 @@ Body:
     AegisName: Mastela_Fruit_Box
     Name: Mastela Fruit Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10743,6 +10760,8 @@ Body:
     AegisName: White_Potion_Box
     Name: White Potion Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10757,6 +10776,8 @@ Body:
     AegisName: Royal_Jelly_Box2
     Name: Royal Jelly Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10771,6 +10792,8 @@ Body:
     AegisName: Blue_Herb_Box2
     Name: Blue Herb Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10785,6 +10808,8 @@ Body:
     AegisName: Yggdrasil_Seed_Box
     Name: Yggdrasil Seed Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10799,6 +10824,8 @@ Body:
     AegisName: Iggdrasilberry_Box
     Name: Iggdrasilberry Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10825,8 +10852,7 @@ Body:
     Type: Usable
     Buy: 1000
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SOLO_GIFT_BASKET
     Script: |
       getgroupitem(IG_SOLO_GIFT_BASKET);
   - Id: 12538
@@ -10835,8 +10861,7 @@ Body:
     Type: Usable
     Buy: 2000
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_COUPLE_EVENT_BASKET
     Script: |
       getgroupitem(IG_COUPLE_EVENT_BASKET);
   - Id: 12539
@@ -10847,17 +10872,15 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SPLENDID_BOX
     Script: |
-      getgroupitem(IG_Splendid_Box);
+      getgroupitem(IG_SPLENDID_BOX);
   - Id: 12540
     AegisName: GM_Warp_Box
     Name: GM Warp Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10866,16 +10889,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GM_WARP_BOX
     Script: |
-      getgroupitem(IG_GM_Warp_Box);
+      getgroupitem(IG_GM_WARP_BOX);
   - Id: 12541
     AegisName: Fortune_Cookie1
     Name: Fortune Cookie1
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10884,16 +10906,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FORTUNE_COOKIE1
     Script: |
-      getgroupitem(IG_Fortune_Cookie1);
+      getgroupitem(IG_FORTUNE_COOKIE1);
   - Id: 12542
     AegisName: Fortune_Cookie2
     Name: Fortune Cookie2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10902,16 +10923,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FORTUNE_COOKIE2
     Script: |
-      getgroupitem(IG_Fortune_Cookie2);
+      getgroupitem(IG_FORTUNE_COOKIE2);
   - Id: 12543
     AegisName: Fortune_Cookie3
     Name: Fortune Cookie3
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10920,8 +10940,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FORTUNE_COOKIE3
     Script: |
-      getgroupitem(IG_Fortune_Cookie3);
+      getgroupitem(IG_FORTUNE_COOKIE3);
   - Id: 12544
     AegisName: Mystic_Tree_Branch
     Name: Mystic Tree Branch
@@ -10934,8 +10955,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10944,8 +10963,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C5
     Script: |
-      getgroupitem(IG_Lucky_Egg_C5);
+      getgroupitem(IG_LUCKY_EGG_C5);
   - Id: 12546
     AegisName: Suspicious_Dish
     Name: Suspicious Dish
@@ -10971,6 +10991,8 @@ Body:
     AegisName: White_Slim_Pot_Box2
     Name: White Slim Pot Box2
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -10987,6 +11009,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 678,30;
   - Id: 12551
@@ -11085,8 +11108,7 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_3D_GLASSES_BOX
     Script: |
       getgroupitem(IG_3D_GLASSES_BOX);
   - Id: 12565
@@ -11094,8 +11116,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11104,6 +11124,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF_BOX);
   - Id: 12566
@@ -11111,8 +11132,6 @@ Body:
     Name: Cheering Scarf II Box
     Type: Cash
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11121,6 +11140,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF2_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF2_BOX);
   - Id: 12567
@@ -11128,8 +11148,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11139,6 +11157,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF3_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF3_BOX);
   - Id: 12568
@@ -11146,8 +11165,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11157,6 +11174,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF4_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF4_BOX);
   - Id: 12569
@@ -11164,8 +11182,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11175,6 +11191,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF6_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF6_BOX);
   - Id: 12570
@@ -11182,8 +11199,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11193,6 +11208,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF8_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF8_BOX);
   - Id: 12571
@@ -11200,8 +11216,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11211,6 +11225,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF10_BOX
     Script: |
       getgroupitem(IG_CHEER_SCARF10_BOX);
   - Id: 12572
@@ -11218,8 +11233,6 @@ Body:
     Name: Cheering Scarf Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11229,6 +11242,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEER_SCARF10_BOX2
     Script: |
       getgroupitem(IG_CHEER_SCARF10_BOX2);
   - Id: 12573
@@ -11237,12 +11251,11 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_FRUIT_BASKET
     Script: |
-      getgroupitem(IG_Fruit_Basket);
-      getgroupitem(IG_Fruit_Basket);
-      getgroupitem(IG_Fruit_Basket);
+      getgroupitem(IG_FRUIT_BASKET);
+      getgroupitem(IG_FRUIT_BASKET);
+      getgroupitem(IG_FRUIT_BASKET);
   - Id: 12574
     AegisName: Mora_Berry
     Name: Mora Berry
@@ -11263,6 +11276,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1773,500;
   - Id: 12576
@@ -11274,6 +11288,7 @@ Body:
     Weight: 250
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1774,500;
   - Id: 12577
@@ -11282,8 +11297,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11292,8 +11305,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C6
     Script: |
-      getgroupitem(IG_Lucky_Egg_C6);
+      getgroupitem(IG_LUCKY_EGG_C6);
   - Id: 12578
     AegisName: Rapid_Life_Water
     Name: Rapid Life Water
@@ -11316,8 +11330,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11327,6 +11339,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RING_OF_VALKYRIE_BOX
     Script: |
       getgroupitem(IG_RING_OF_VALKYRIE_BOX);
   - Id: 12580
@@ -11358,7 +11371,7 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SIEGE_SUPPLY_BOX
     Script: |
       getgroupitem(IG_SIEGE_SUPPLY_BOX);
   - Id: 12583
@@ -11519,8 +11532,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11529,8 +11540,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C7
     Script: |
-      getgroupitem(IG_Lucky_Egg_C7);
+      getgroupitem(IG_LUCKY_EGG_C7);
   - Id: 12596
     AegisName: Magic_Candy
     Name: Magic Candy
@@ -11595,8 +11607,7 @@ Body:
     Type: Usable
     Buy: 100
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX1
     Script: |
       getgroupitem(IG_SPECIAL_BOX1);
   - Id: 12603
@@ -11605,8 +11616,7 @@ Body:
     Type: Usable
     Buy: 100
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX2
     Script: |
       getgroupitem(IG_SPECIAL_BOX2);
   - Id: 12604
@@ -11615,8 +11625,7 @@ Body:
     Type: Usable
     Buy: 100
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX3
     Script: |
       getgroupitem(IG_SPECIAL_BOX3);
   - Id: 12605
@@ -11625,8 +11634,7 @@ Body:
     Type: Usable
     Buy: 100
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX4
     Script: |
       getgroupitem(IG_SPECIAL_BOX4);
   - Id: 12606
@@ -11635,8 +11643,7 @@ Body:
     Type: Usable
     Buy: 100
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SPECIAL_BOX5
     Script: |
       getgroupitem(IG_SPECIAL_BOX5);
   - Id: 12607
@@ -11645,8 +11652,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11656,6 +11661,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LOLLI_POP_BOX
     Script: |
       getgroupitem(IG_LOLLI_POP_BOX);
   - Id: 12608
@@ -11666,9 +11672,9 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SPLENDID_BOX2
     Script: |
-      getgroupitem(IG_Splendid_Box2);
+      getgroupitem(IG_SPLENDID_BOX2);
   - Id: 12609
     AegisName: Old_Ore_Box
     Name: Old Ore Box
@@ -11677,14 +11683,16 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_OLD_ORE_BOX
     Script: |
-      getgroupitem(IG_Old_Ore_Box);
+      getgroupitem(IG_OLD_ORE_BOX);
   - Id: 12610
     AegisName: Mysterious_Egg
     Name: Mysterious Egg
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11703,9 +11711,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_OLD_COIN_POCKET
     Script: |
-      getgroupitem(IG_Old_Coin_Pocket);
+      getgroupitem(IG_OLD_COIN_POCKET);
   - Id: 12613
     AegisName: High_Coin_Pocket
     Name: Improved Coin Bag
@@ -11714,9 +11722,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HIGH_COIN_POCKET
     Script: |
-      getgroupitem(IG_High_Coin_Pocket);
+      getgroupitem(IG_HIGH_COIN_POCKET);
   - Id: 12614
     AegisName: Mid_Coin_Pocket
     Name: Intermediate Coin Bag
@@ -11725,9 +11733,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MID_COIN_POCKET
     Script: |
-      getgroupitem(IG_Mid_Coin_Pocket);
+      getgroupitem(IG_MID_COIN_POCKET);
   - Id: 12615
     AegisName: Low_Coin_Pocket
     Name: Minor Coin Bag
@@ -11736,9 +11744,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LOW_COIN_POCKET
     Script: |
-      getgroupitem(IG_Low_Coin_Pocket);
+      getgroupitem(IG_LOW_COIN_POCKET);
   - Id: 12616
     AegisName: Sgrade_Pocket
     Name: S Grade Coin Bag
@@ -11747,9 +11755,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SGRADE_POCKET
     Script: |
-      getgroupitem(IG_Sgrade_Pocket);
+      getgroupitem(IG_SGRADE_POCKET);
   - Id: 12617
     AegisName: Agrade_Pocket
     Name: A Grade Coin Bag
@@ -11758,9 +11766,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_AGRADE_POCKET
     Script: |
-      getgroupitem(IG_Agrade_Pocket);
+      getgroupitem(IG_AGRADE_POCKET);
   - Id: 12618
     AegisName: Bgrade_Pocket
     Name: B Grade Coin Bag
@@ -11769,9 +11777,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BGRADE_POCKET
     Script: |
-      getgroupitem(IG_Bgrade_Pocket);
+      getgroupitem(IG_BGRADE_POCKET);
   - Id: 12619
     AegisName: Cgrade_Pocket
     Name: C Grade Coin Bag
@@ -11780,9 +11788,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CGRADE_POCKET
     Script: |
-      getgroupitem(IG_Cgrade_Pocket);
+      getgroupitem(IG_CGRADE_POCKET);
   - Id: 12620
     AegisName: Dgrade_Pocket
     Name: D Grade Coin Bag
@@ -11791,9 +11799,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_DGRADE_POCKET
     Script: |
-      getgroupitem(IG_Dgrade_Pocket);
+      getgroupitem(IG_DGRADE_POCKET);
   - Id: 12621
     AegisName: Egrade_Pocket
     Name: E Grade Coin Bag
@@ -11802,9 +11810,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_EGRADE_POCKET
     Script: |
-      getgroupitem(IG_Egrade_Pocket);
+      getgroupitem(IG_EGRADE_POCKET);
   - Id: 12622
     AegisName: Boarding_Halter
     Name: Reins Of Mount
@@ -11836,9 +11844,9 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ADVANCED_WEAPONS_BOX
     Script: |
-      getgroupitem(IG_Advanced_Weapons_Box);
+      getgroupitem(IG_ADVANCED_WEAPONS_BOX);
   - Id: 12624
     AegisName: Delicious_Jelly
     Name: Delicious Jelly
@@ -11851,8 +11859,6 @@ Body:
     AegisName: Sapa_Feat_Cert_Pack
     Name: Sapha Certification Bag
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11861,6 +11867,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAPA_FEAT_CERT_PACK
     Script: |
       getgroupitem(IG_SAPA_FEAT_CERT_PACK);
   - Id: 12626
@@ -11956,6 +11963,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 500
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11972,6 +11981,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 2000
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -11988,6 +11999,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 2000
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12004,6 +12017,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 500
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12020,8 +12035,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12030,12 +12043,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C8
     Script: |
-      getgroupitem(IG_Lucky_Egg_C8);
+      getgroupitem(IG_LUCKY_EGG_C8);
   - Id: 12642
     AegisName: Fruit_Of_Mastela_Box2
     Name: Fruit Of Mastela 100 Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12050,6 +12066,8 @@ Body:
     AegisName: E_Coin_Pack50
     Name: E Coin Pack50
     Type: Usable
+    Flags:
+      Container: true
     Script: |
       getitem 6422,50;
   - Id: 12644
@@ -12058,8 +12076,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12068,6 +12084,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX4
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX4);
   - Id: 12645
@@ -12103,16 +12120,17 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 30
-    Flags:
-      Container: true
+    ItemGroup: IG_INK_BALL
     Script: |
-      getgroupitem(IG_Ink_Ball);
+      getgroupitem(IG_INK_BALL);
   - Id: 12648
     AegisName: Special_Potion_Set
     Name: Comprehensive Set Of Potions
     Type: Usable
     Buy: 20
     Weight: 100
+    Flags:
+      Container: true
     Script: |
       getitem 501,10;
       getitem 502,10;
@@ -12125,6 +12143,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12147,6 +12167,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12164,6 +12186,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12184,6 +12208,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12201,6 +12227,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12221,8 +12249,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12231,8 +12257,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C9
     Script: |
-      getgroupitem(IG_Lucky_Egg_C9);
+      getgroupitem(IG_LUCKY_EGG_C9);
   - Id: 12655
     AegisName: Brain_Powder
     Name: Brain Powder
@@ -12449,6 +12476,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12468,8 +12497,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12478,18 +12505,18 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_EGG_C10
     Script: |
-      getgroupitem(IG_Lucky_Egg_C10);
+      getgroupitem(IG_LUCKY_EGG_C10);
   - Id: 12674
     AegisName: God_Material_Box
     Name: God Material Box
     Type: Usable
     Buy: 20
     Weight: 500
-    Flags:
-      Container: true
+    ItemGroup: IG_GOD_MATERIAL_BOX
     Script: |
-      getgroupitem(IG_God_Material_Box);
+      getgroupitem(IG_GOD_MATERIAL_BOX);
   - Id: 12675
     AegisName: Sg_Weapon_Supply_Box
     Name: WoE Weapon Supply Box
@@ -12498,9 +12525,9 @@ Body:
     Weight: 500
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SG_WEAPON_SUPPLY_BOX
     Script: |
-      getgroupitem(IG_Sg_Weapon_Supply_Box);
+      getgroupitem(IG_SG_WEAPON_SUPPLY_BOX);
   - Id: 12676
     AegisName: Sg_Violet_Potion_Box
     Name: Siege Violet Potion Box
@@ -12509,6 +12536,7 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 11547,50;
   - Id: 12677
@@ -12521,6 +12549,7 @@ Body:
     EquipLevelMin: 130
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1775,500;
   - Id: 12678
@@ -12533,6 +12562,7 @@ Body:
     EquipLevelMin: 95
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 1776,500;
   - Id: 12679
@@ -12543,6 +12573,7 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 11548,30;
   - Id: 12680
@@ -12553,6 +12584,7 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 11549,10;
   - Id: 12681
@@ -12573,6 +12605,7 @@ Body:
     Weight: 200
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 11547,200;
   - Id: 12684
@@ -12599,8 +12632,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12609,6 +12640,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GRYPHON_EGG_SCROLL
     Script: |
       getgroupitem(IG_GRYPHON_EGG_SCROLL);
   - Id: 12686
@@ -12639,9 +12671,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_HELM
     Script: |
-      getgroupitem(IG_CardAlbum_Helm);
+      getgroupitem(IG_CARDALBUM_HELM);
   - Id: 12691
     AegisName: Old_C_Album_Armor
     Name: Armor Card Album
@@ -12650,9 +12682,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_ARMOR
     Script: |
-      getgroupitem(IG_CardAlbum_Armor);
+      getgroupitem(IG_CARDALBUM_ARMOR);
   - Id: 12692
     AegisName: Old_C_Album_Shield
     Name: Shield Card Album
@@ -12661,9 +12693,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_SHIELD
     Script: |
-      getgroupitem(IG_CardAlbum_Shield);
+      getgroupitem(IG_CARDALBUM_SHIELD);
   - Id: 12693
     AegisName: Old_C_Album_Garment
     Name: Garment Card Album
@@ -12672,9 +12704,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_GARMENT
     Script: |
-      getgroupitem(IG_CardAlbum_Garment);
+      getgroupitem(IG_CARDALBUM_GARMENT);
   - Id: 12694
     AegisName: Old_C_Album_Shoes
     Name: Shoes Card Album
@@ -12683,9 +12715,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_SHOES
     Script: |
-      getgroupitem(IG_CardAlbum_Shoes);
+      getgroupitem(IG_CARDALBUM_SHOES);
   - Id: 12695
     AegisName: Old_C_Album_Acc
     Name: Accessory Card Album
@@ -12694,9 +12726,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_ACC
     Script: |
-      getgroupitem(IG_CardAlbum_Acc);
+      getgroupitem(IG_CARDALBUM_ACC);
   - Id: 12696
     AegisName: RWC_Cele_Fire
     Name: RWC Celebration Firecracker
@@ -12719,9 +12751,9 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CARDALBUM_WEAPON
     Script: |
-      getgroupitem(IG_CardAlbum_Weapon);
+      getgroupitem(IG_CARDALBUM_WEAPON);
   - Id: 12699
     AegisName: Tikbalang_Belt
     Name: Tikbalang Harness
@@ -12752,26 +12784,24 @@ Body:
     Name: Old Navy Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoTrade: true
       NoCart: true
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLEUBOX
     Script: |
-      getgroupitem(IG_BleuBox);
-      getgroupitem(IG_BleuBox);
+      getgroupitem(IG_BLEUBOX);
+      getgroupitem(IG_BLEUBOX);
   - Id: 12703
     AegisName: Holy_Egg_2
     Name: Holy Egg
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_HOLY_EGG_2
     Script: |
-      getgroupitem(IG_Holy_Egg_2);
+      getgroupitem(IG_HOLY_EGG_2);
   - Id: 12704
     AegisName: Elixir_Of_Life
     Name: Elixir of Life
@@ -12873,8 +12903,6 @@ Body:
     Type: Usable
     Buy: 1
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -12882,8 +12910,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EASTER_SCROLL
     Script: |
-      getgroupitem(IG_Easter_Scroll);
+      getgroupitem(IG_EASTER_SCROLL);
   - Id: 12715
     AegisName: Black_Treasure_Box
     Name: Black Treasure Box
@@ -13271,18 +13300,24 @@ Body:
     AegisName: Valentine_Gift_Box1
     Name: Valentine Gift Box
     Type: Usable
+    Flags:
+      Container: true
     Script: |
       getitem 7946,1;
   - Id: 12743
     AegisName: Valentine_Gift_Box2
     Name: Valentine Gift Box
     Type: Usable
+    Flags:
+      Container: true
     Script: |
       getitem 7947,1;
   - Id: 12744
     AegisName: Chocotate_Box
     Name: Chocolate Box
     Type: Usable
+    Flags:
+      Container: true
     Script: |
       getitem 558,1;
   - Id: 12745
@@ -13378,10 +13413,9 @@ Body:
     Type: Usable
     Buy: 2
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_NEW_GIFT_ENVELOPE
     Script: |
-      getgroupitem(IG_New_Gift_Envelope);
+      getgroupitem(IG_NEW_GIFT_ENVELOPE);
   - Id: 12757
     AegisName: Loyal_Ring1_Box
     Name: Loyal Ring1 Box
@@ -13458,64 +13492,57 @@ Body:
     AegisName: Passion_FB_Hat_Box
     Name: Passion FB Hat Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_PASSION_FB_HAT_BOX
     Script: |
-      /*getgroupitem(IG_Passion_FB_Hat_Box);*/
+      /*getgroupitem(IG_PASSION_FB_HAT_BOX);*/
       rentitem 5856,3600;
   - Id: 12768
     AegisName: Cool_FB_Hat_Box
     Name: Cool FB Hat Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_COOL_FB_HAT_BOX
     Script: |
-      /*getgroupitem(IG_Cool_FB_Hat_Box);*/
+      /*getgroupitem(IG_COOL_FB_HAT_BOX);*/
       rentitem 5857,3600;
   - Id: 12769
     AegisName: Victory_FB_Hat_Box
     Name: Victory FB Hat Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_VICTORY_FB_HAT_BOX
     Script: |
-      /*getgroupitem(IG_Victory_FB_Hat_Box);*/
+      /*getgroupitem(IG_VICTORY_FB_HAT_BOX);*/
       rentitem 5858,3600;
   - Id: 12770
     AegisName: Glory_FB_Hat_Box
     Name: Glory FB Hat Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_GLORY_FB_HAT_BOX
     Script: |
-      /*getgroupitem(IG_Glory_FB_Hat_Box);*/
+      /*getgroupitem(IG_GLORY_FB_HAT_BOX);*/
       rentitem 5859,86400;
   - Id: 12771
     AegisName: Passion_Hat_Box2
     Name: Passion Hat Box2
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_PASSION_HAT_BOX2
     Script: |
-      /*getgroupitem(IG_Passion_Hat_Box2);*/
+      /*getgroupitem(IG_PASSION_HAT_BOX2);*/
       rentitem 5856,21600;
   - Id: 12772
     AegisName: Cool_Hat_Box2
     Name: Cool Hat Box2
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_COOL_HAT_BOX2
     Script: |
-      /*getgroupitem(IG_Cool_Hat_Box2);*/
+      /*getgroupitem(IG_COOL_HAT_BOX2);*/
       rentitem 5857,21600;
   - Id: 12773
     AegisName: Victory_Hat_Box2
     Name: Victory Hat Box2
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_VICTORY_HAT_BOX2
     Script: |
-      /*getgroupitem(IG_Victory_Hat_Box2);*/
+      /*getgroupitem(IG_VICTORY_HAT_BOX2);*/
       rentitem 5858,21600;
   - Id: 12774
     AegisName: Empty_Potion_Bottle
@@ -13584,8 +13611,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13594,6 +13619,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DRAGON_EGG_SCROLL
     Script: |
       getgroupitem(IG_DRAGON_EGG_SCROLL);
   - Id: 12786
@@ -13667,6 +13693,8 @@ Body:
     Name: Combat Pill Box10
     Type: Usable
     Buy: 20
+    Flags:
+      Container: true
     Script: |
       getitem 12791,10;
   - Id: 12794
@@ -13674,6 +13702,8 @@ Body:
     Name: P Combat Pill Box10
     Type: Usable
     Buy: 20
+    Flags:
+      Container: true
     Script: |
       getitem 12792,10;
   - Id: 12795
@@ -13682,8 +13712,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13692,6 +13720,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2011_RWC_SCROLL_KR
     Script: |
       getgroupitem(IG_2011_RWC_SCROLL_KR);
   - Id: 12796
@@ -13733,8 +13762,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13743,6 +13770,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX5
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX5);
   - Id: 12800
@@ -13765,8 +13793,6 @@ Body:
     AegisName: Time_Guardian_Box
     Name: Time Keeper Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13776,14 +13802,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TIME_GUARDIAN_BOX
     Script: |
       getgroupitem(IG_TIME_GUARDIAN_BOX);
   - Id: 12803
     AegisName: Beginner_Kit_Box
     Name: Novice Support Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13793,6 +13818,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BEGINNER_KIT_BOX
     Script: |
       getgroupitem(IG_BEGINNER_KIT_BOX);
   - Id: 12804
@@ -13801,8 +13827,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13811,6 +13835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRU_SCROLL
     Script: |
       getgroupitem(IG_CRU_SCROLL);
   - Id: 12805
@@ -13843,6 +13868,8 @@ Body:
     Name: Mercenary Casting
     Type: Usable
     EquipLevelMin: 20
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13862,8 +13889,6 @@ Body:
     Name: Mother's Gentle Heart Box
     Type: Usable
     EquipLevelMax: 120
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13873,6 +13898,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOTHER_LOVE_BOX
     Script: |
       getgroupitem(IG_MOTHER_LOVE_BOX);
   - Id: 12809
@@ -13880,6 +13906,8 @@ Body:
     Name: Level Up Box
     Type: Usable
     EquipLevelMin: 120
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13901,8 +13929,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13912,6 +13938,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVENT_GIFT_BOX
     Script: |
       getgroupitem(IG_EVENT_GIFT_BOX);
   - Id: 12811
@@ -13920,8 +13947,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13930,6 +13955,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVENT_GIFT_BOX_
     Script: |
       getgroupitem(IG_EVENT_GIFT_BOX_);
   - Id: 12812
@@ -13985,8 +14011,6 @@ Body:
     Name: Old Ore Box
     Type: Usable
     EquipLevelMin: 60
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -13996,6 +14020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OLD_ORE_BOX_
     Script: |
       getgroupitem(IG_OLD_ORE_BOX_);
   - Id: 12817
@@ -14003,8 +14028,6 @@ Body:
     Name: Old Card Album
     Type: Usable
     EquipLevelMin: 80
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14014,16 +14037,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CARDALBUM
     Script: |
-      getgroupitem(IG_CardAlbum);
+      getgroupitem(IG_CARDALBUM);
       getitem 12818,1;
   - Id: 12818
     AegisName: High_Weapon_Box_
     Name: High Weapon Box
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14033,14 +14055,17 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ADVANCED_WEAPONS_BOX
     Script: |
-      getgroupitem(IG_Advanced_Weapons_Box);
+      getgroupitem(IG_ADVANCED_WEAPONS_BOX);
       getitem 12809,1;
   - Id: 12819
     AegisName: Zherlthsh_Tck_Box_
     Name: Zherlthsh Tck Box
     Type: Usable
     EquipLevelMin: 150
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14074,6 +14099,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 663,50;
   - Id: 12823
@@ -14098,8 +14125,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14108,6 +14133,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FLIPPACKAGE
     Script: |
       getgroupitem(IG_FLIPPACKAGE);
   - Id: 12826
@@ -14116,46 +14142,44 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_WIND_TYPE_SCROLL
     Script: |
-      getgroupitem(IG_Wind_Type_Scroll);
+      getgroupitem(IG_WIND_TYPE_SCROLL);
   - Id: 12827
     AegisName: Water_Type_Scroll
     Name: Water Type Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_WATER_TYPE_SCROLL
     Script: |
-      getgroupitem(IG_Water_Type_Scroll);
+      getgroupitem(IG_WATER_TYPE_SCROLL);
   - Id: 12828
     AegisName: Fire_Type_Scroll
     Name: Fire Type Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_FIRE_TYPE_SCROLL
     Script: |
-      getgroupitem(IG_Fire_Type_Scroll);
+      getgroupitem(IG_FIRE_TYPE_SCROLL);
   - Id: 12829
     AegisName: Earth_Type_Scroll
     Name: Earth Type Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EARTH_TYPE_SCROLL
     Script: |
-      getgroupitem(IG_Earth_Type_Scroll);
+      getgroupitem(IG_EARTH_TYPE_SCROLL);
   - Id: 12830
     AegisName: Dead_Tree_Box
     Name: Ancient Tree Wooden Box
     Type: Usable
     Buy: 20
     Weight: 50
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14172,6 +14196,8 @@ Body:
     Name: Potion Box
     Type: Usable
     Weight: 50
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14224,8 +14250,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14234,6 +14258,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNDEAD_EGG
     Script: |
       getgroupitem(IG_UNDEAD_EGG);
   - Id: 12835
@@ -14242,8 +14267,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14252,6 +14275,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GIRLS_HEART
     Script: |
       getgroupitem(IG_GIRLS_HEART);
   - Id: 12837
@@ -14362,40 +14386,36 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HEAVEN_SCROLL
     Script: |
-      getgroupitem(IG_Heaven_Scroll);
+      getgroupitem(IG_HEAVEN_SCROLL);
   - Id: 12851
     AegisName: Vocation_Scroll
     Name: Vocation Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VOCATION_SCROLL
     Script: |
-      getgroupitem(IG_Vocation_Scroll);
+      getgroupitem(IG_VOCATION_SCROLL);
   - Id: 12852
     AegisName: Wisdom_Scroll
     Name: Wisdom Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_WISDOM_SCROLL
     Script: |
-      getgroupitem(IG_Wisdom_Scroll);
+      getgroupitem(IG_WISDOM_SCROLL);
   - Id: 12853
     AegisName: Patron_Scroll
     Name: Patron Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_PATRON_SCROLL
     Script: |
-      getgroupitem(IG_Patron_Scroll);
+      getgroupitem(IG_PATRON_SCROLL);
   - Id: 12854
     AegisName: Full_Spray_Of_Flowers
     Name: Voluminous Spray of Flowers
@@ -14416,8 +14436,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14426,6 +14444,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POPE_SCROLL
     Script: |
       getgroupitem(IG_POPE_SCROLL);
   - Id: 12856
@@ -14484,8 +14503,6 @@ Body:
     Name: Mysterious Egg2
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -14494,6 +14511,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_EGG2
     Script: |
       getgroupitem(IG_MYSTERIOUS_EGG2);
   - Id: 12872
@@ -15035,8 +15053,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15045,8 +15061,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASPERSIO_5_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Aspersio_5_Scroll_Box);
+      getgroupitem(IG_ASPERSIO_5_SCROLL_BOX);
   - Id: 12916
     AegisName: Assumptio_5_Scroll_Box
     Name: Assumptio 5 Scroll Box
@@ -15179,48 +15196,44 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX1
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box1);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX1);
   - Id: 12924
     AegisName: Pet_Egg_Scroll_Box2
     Name: Pet Egg Box 2
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX2
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box2);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX2);
   - Id: 12925
     AegisName: Pet_Egg_Scroll1
     Name: Kafra Item Mall Prize Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_PET_EGG_SCROLL1
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll1);
+      getgroupitem(IG_PET_EGG_SCROLL1);
   - Id: 12926
     AegisName: Pet_Egg_Scroll2
     Name: December Lucky Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_PET_EGG_SCROLL2
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll2);
+      getgroupitem(IG_PET_EGG_SCROLL2);
   - Id: 12927
     AegisName: J_Aspersio_5_Scroll_Box
     Name: Aspersio Scroll Box
@@ -15261,8 +15274,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15271,16 +15282,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX3
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box3);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX3);
   - Id: 12930
     AegisName: Pet_Egg_Scroll_Box4
     Name: Pet Egg Box 4
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15289,16 +15299,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX4
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box4);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX4);
   - Id: 12931
     AegisName: Pet_Egg_Scroll_Box5
     Name: Pet Egg Box 5
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15307,16 +15316,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX5
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box5);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX5);
   - Id: 12932
     AegisName: Pet_Egg_Scroll3
     Name: Episode 13.2 Key Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15325,16 +15333,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL3
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll3);
+      getgroupitem(IG_PET_EGG_SCROLL3);
   - Id: 12933
     AegisName: Pet_Egg_Scroll4
     Name: Summer Hat Pack
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15343,16 +15350,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL4
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll4);
+      getgroupitem(IG_PET_EGG_SCROLL4);
   - Id: 12934
     AegisName: Pet_Egg_Scroll5
     Name: Pet Egg Scroll5
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15361,16 +15367,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL5
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll5);
+      getgroupitem(IG_PET_EGG_SCROLL5);
   - Id: 12935
     AegisName: Infiltrator_Box
     Name: Infiltrator Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15379,16 +15384,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFILTRATOR_BOX
     Script: |
-      getgroupitem(IG_Infiltrator_Box);
+      getgroupitem(IG_INFILTRATOR_BOX);
   - Id: 12936
     AegisName: Muramasa_Box
     Name: Muramasa Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15397,16 +15401,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MURAMASA_BOX
     Script: |
-      getgroupitem(IG_Muramasa_Box);
+      getgroupitem(IG_MURAMASA_BOX);
   - Id: 12937
     AegisName: Excalibur_Box
     Name: Excalibur Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15415,15 +15418,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EXCALIBUR_BOX
     Script: |
-      getgroupitem(IG_Excalibur_Box);
+      getgroupitem(IG_EXCALIBUR_BOX);
   - Id: 12938
     AegisName: Combat_Knife_Box
     Name: Combat Knife Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15432,15 +15434,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMBAT_KNIFE_BOX
     Script: |
-      getgroupitem(IG_Combat_Knife_Box);
+      getgroupitem(IG_COMBAT_KNIFE_BOX);
   - Id: 12939
     AegisName: Counter_Dagger_Box
     Name: Dagger of Counter Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15449,15 +15450,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COUNTER_DAGGER_BOX
     Script: |
-      getgroupitem(IG_Counter_Dagger_Box);
+      getgroupitem(IG_COUNTER_DAGGER_BOX);
   - Id: 12940
     AegisName: Kaiser_Knuckle_Box
     Name: Kaiser Knuckle Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15466,15 +15466,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KAISER_KNUCKLE_BOX
     Script: |
-      getgroupitem(IG_Kaiser_Knuckle_Box);
+      getgroupitem(IG_KAISER_KNUCKLE_BOX);
   - Id: 12941
     AegisName: Pole_Axe_Box
     Name: Poll Axe Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15483,15 +15482,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POLE_AXE_BOX
     Script: |
-      getgroupitem(IG_Pole_Axe_Box);
+      getgroupitem(IG_POLE_AXE_BOX);
   - Id: 12942
     AegisName: Mighty_Staff_Box
     Name: Mighty Staff Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15500,15 +15498,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MIGHTY_STAFF_BOX
     Script: |
-      getgroupitem(IG_Mighty_Staff_Box);
+      getgroupitem(IG_MIGHTY_STAFF_BOX);
   - Id: 12943
     AegisName: Right_Epsilon_Box
     Name: Light Epsilon Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15517,15 +15514,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RIGHT_EPSILON_BOX
     Script: |
-      getgroupitem(IG_Right_Epsilon_Box);
+      getgroupitem(IG_RIGHT_EPSILON_BOX);
   - Id: 12944
     AegisName: Balistar_Box
     Name: Ballista Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15534,15 +15530,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BALISTAR_BOX
     Script: |
-      getgroupitem(IG_Balistar_Box);
+      getgroupitem(IG_BALISTAR_BOX);
   - Id: 12945
     AegisName: Diary_Of_Great_Sage_Box
     Name: Sage's Diary Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15551,15 +15546,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DIARY_OF_GREAT_SAGE_BOX
     Script: |
-      getgroupitem(IG_Diary_Of_Great_Sage_Box);
+      getgroupitem(IG_DIARY_OF_GREAT_SAGE_BOX);
   - Id: 12946
     AegisName: Asura_Box
     Name: Asura Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15568,15 +15562,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASURA_BOX
     Script: |
-      getgroupitem(IG_Asura_Box);
+      getgroupitem(IG_ASURA_BOX);
   - Id: 12947
     AegisName: Apple_Of_Archer_Box
     Name: Apple of Archer Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15585,15 +15578,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_APPLE_OF_ARCHER_BOX
     Script: |
-      getgroupitem(IG_Apple_Of_Archer_Box);
+      getgroupitem(IG_APPLE_OF_ARCHER_BOX);
   - Id: 12948
     AegisName: Bunny_Band_Box
     Name: Bunny Band Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15602,16 +15594,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BUNNY_BAND_BOX
     Script: |
-      getgroupitem(IG_Bunny_Band_Box);
+      getgroupitem(IG_BUNNY_BAND_BOX);
   - Id: 12949
     AegisName: Sahkkat_Box
     Name: Sakkat Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15620,16 +15611,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAHKKAT_BOX
     Script: |
-      getgroupitem(IG_Sahkkat_Box);
+      getgroupitem(IG_SAHKKAT_BOX);
   - Id: 12950
     AegisName: Lord_Circlet_Box
     Name: Grand Circlet Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15638,15 +15628,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LORD_CIRCLET_BOX
     Script: |
-      getgroupitem(IG_Lord_Circlet_Box);
+      getgroupitem(IG_LORD_CIRCLET_BOX);
   - Id: 12951
     AegisName: Elven_Ears_Box
     Name: Elven Ears Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15655,15 +15644,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ELVEN_EARS_BOX
     Script: |
-      getgroupitem(IG_Elven_Ears_Box);
+      getgroupitem(IG_ELVEN_EARS_BOX);
   - Id: 12952
     AegisName: Steel_Flower_Box
     Name: Steel Flower Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15672,15 +15660,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STEEL_FLOWER_BOX
     Script: |
-      getgroupitem(IG_Steel_Flower_Box);
+      getgroupitem(IG_STEEL_FLOWER_BOX);
   - Id: 12953
     AegisName: Critical_Ring_Box
     Name: Critical Ring Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15689,15 +15676,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRITICAL_RING_BOX
     Script: |
-      getgroupitem(IG_Critical_Ring_Box);
+      getgroupitem(IG_CRITICAL_RING_BOX);
   - Id: 12954
     AegisName: Earring_Box
     Name: Earring Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15706,16 +15692,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EARRING_BOX
     Script: |
-      getgroupitem(IG_Earring_Box);
+      getgroupitem(IG_EARRING_BOX);
   - Id: 12955
     AegisName: Ring_Box
     Name: Ring Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15724,15 +15709,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RING_BOX
     Script: |
-      getgroupitem(IG_Ring_Box);
+      getgroupitem(IG_RING_BOX);
   - Id: 12956
     AegisName: Necklace_Box
     Name: Necklace Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15741,15 +15725,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NECKLACE_BOX
     Script: |
-      getgroupitem(IG_Necklace_Box);
+      getgroupitem(IG_NECKLACE_BOX);
   - Id: 12957
     AegisName: Glove_Box
     Name: Glove Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15758,15 +15741,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GLOVE_BOX
     Script: |
-      getgroupitem(IG_Glove_Box);
+      getgroupitem(IG_GLOVE_BOX);
   - Id: 12958
     AegisName: Brooch_Box
     Name: Brooch Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15775,15 +15757,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROOCH_BOX
     Script: |
-      getgroupitem(IG_Brooch_Box);
+      getgroupitem(IG_BROOCH_BOX);
   - Id: 12959
     AegisName: Rosary_Box
     Name: Rosary Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15792,15 +15773,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ROSARY_BOX
     Script: |
-      getgroupitem(IG_Rosary_Box);
+      getgroupitem(IG_ROSARY_BOX);
   - Id: 12960
     AegisName: Safety_Ring_Box
     Name: Safety Ring Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15809,16 +15789,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAFETY_RING_BOX
     Script: |
-      getgroupitem(IG_Safety_Ring_Box);
+      getgroupitem(IG_SAFETY_RING_BOX);
   - Id: 12961
     AegisName: Vesper_Core01_Box
     Name: Vesper Core 01 Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15827,16 +15806,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE01_BOX
     Script: |
-      getgroupitem(IG_Vesper_Core01_Box);
+      getgroupitem(IG_VESPER_CORE01_BOX);
   - Id: 12962
     AegisName: Vesper_Core02_Box
     Name: Vesper Core 02 Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15845,16 +15823,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE02_BOX
     Script: |
-      getgroupitem(IG_Vesper_Core02_Box);
+      getgroupitem(IG_VESPER_CORE02_BOX);
   - Id: 12963
     AegisName: Vesper_Core03_Box
     Name: Vesper Core 03 Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15863,16 +15840,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE03_BOX
     Script: |
-      getgroupitem(IG_Vesper_Core03_Box);
+      getgroupitem(IG_VESPER_CORE03_BOX);
   - Id: 12964
     AegisName: Vesper_Core04_Box
     Name: Vesper Core 04 Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -15881,8 +15857,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE04_BOX
     Script: |
-      getgroupitem(IG_Vesper_Core04_Box);
+      getgroupitem(IG_VESPER_CORE04_BOX);
   - Id: 12965
     AegisName: Emergency_Box1
     Name: Emergency Level 1 Scroll Box
@@ -16204,8 +16181,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16214,16 +16189,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX6
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box6);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX6);
   - Id: 12984
     AegisName: Pet_Egg_Scroll_Box7
     Name: Pet Egg Scroll Box 7
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16232,16 +16206,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX7
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box7);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX7);
   - Id: 12985
     AegisName: Pet_Egg_Scroll_Box8
     Name: Pet Egg Scroll Box 8
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16250,16 +16223,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX8
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box8);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX8);
   - Id: 12986
     AegisName: Pet_Egg_Scroll_Box9
     Name: Adventurer Pack Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16268,16 +16240,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX9
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box9);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX9);
   - Id: 12987
     AegisName: Pet_Egg_Scroll_Box10
     Name: Pet Egg Scroll Box 10
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16286,16 +16257,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX10
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box10);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX10);
   - Id: 12988
     AegisName: Pet_Egg_Scroll_Box11
     Name: Pet Egg Scroll Box 11
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16304,15 +16274,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_BOX11
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_Box11);
+      getgroupitem(IG_PET_EGG_SCROLL_BOX11);
   - Id: 12989
     AegisName: Pet_Egg_Scroll6
     Name: Pet Egg Scroll 6
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16321,15 +16290,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL6
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll6);
+      getgroupitem(IG_PET_EGG_SCROLL6);
   - Id: 12990
     AegisName: Pet_Egg_Scroll7
     Name: Pet Egg Scroll 7
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16338,15 +16306,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL7
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll7);
+      getgroupitem(IG_PET_EGG_SCROLL7);
   - Id: 12991
     AegisName: Pet_Egg_Scroll8
     Name: Party Hard Pack
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16355,15 +16322,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL8
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll8);
+      getgroupitem(IG_PET_EGG_SCROLL8);
   - Id: 12992
     AegisName: Pet_Egg_Scroll9
     Name: Adventurer Pack
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16372,15 +16338,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL9
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll9);
+      getgroupitem(IG_PET_EGG_SCROLL9);
   - Id: 12993
     AegisName: Pet_Egg_Scroll10
     Name: Pet Egg Scroll 10
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16389,15 +16354,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL10
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll10);
+      getgroupitem(IG_PET_EGG_SCROLL10);
   - Id: 12994
     AegisName: Pet_Egg_Scroll11
     Name: Pet Egg Scroll 11
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16406,8 +16370,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL11
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll11);
+      getgroupitem(IG_PET_EGG_SCROLL11);
   - Id: 12995
     AegisName: White_Herb_Box
     Name: White Herb Box
@@ -16522,8 +16487,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16532,6 +16495,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASSORTED_SCROLL_BOX
     Script: |
       getgroupitem(IG_ASSORTED_SCROLL_BOX);
   - Id: 13502
@@ -16540,8 +16504,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16550,6 +16512,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DROOPING_KITTY_BOX
     Script: |
       getgroupitem(IG_DROOPING_KITTY_BOX);
   - Id: 13503
@@ -16558,8 +16521,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16568,6 +16529,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGESTIC_GOAT_BOX
     Script: |
       getgroupitem(IG_MAGESTIC_GOAT_BOX);
   - Id: 13504
@@ -16576,8 +16538,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16586,6 +16546,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEVIRUCHI_CAP_BOX
     Script: |
       getgroupitem(IG_DEVIRUCHI_CAP_BOX);
   - Id: 13505
@@ -16594,8 +16555,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16604,6 +16563,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EXECUTIONER_BOX
     Script: |
       getgroupitem(IG_EXECUTIONER_BOX);
   - Id: 13506
@@ -16612,8 +16572,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16622,6 +16580,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROOD_AXE_BOX
     Script: |
       getgroupitem(IG_BROOD_AXE_BOX);
   - Id: 13507
@@ -16630,8 +16589,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16640,6 +16597,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TOMAHAWK_BOX
     Script: |
       getgroupitem(IG_TOMAHAWK_BOX);
   - Id: 13508
@@ -16648,8 +16606,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16658,6 +16614,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOW_OF_RUDRA_BOX
     Script: |
       getgroupitem(IG_BOW_OF_RUDRA_BOX);
   - Id: 13509
@@ -16666,8 +16623,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16676,6 +16631,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CUTLAS_BOX
     Script: |
       getgroupitem(IG_CUTLAS_BOX);
   - Id: 13510
@@ -16684,8 +16640,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16694,6 +16648,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SOLAR_SWORD_BOX
     Script: |
       getgroupitem(IG_SOLAR_SWORD_BOX);
   - Id: 13511
@@ -16702,8 +16657,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16712,6 +16665,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SWORD_BREAKER_BOX
     Script: |
       getgroupitem(IG_SWORD_BREAKER_BOX);
   - Id: 13512
@@ -16720,8 +16674,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16730,6 +16682,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAIL_BREAKER_BOX
     Script: |
       getgroupitem(IG_MAIL_BREAKER_BOX);
   - Id: 13513
@@ -16738,8 +16691,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16748,6 +16699,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOONLIGHT_SWORD_BOX
     Script: |
       getgroupitem(IG_MOONLIGHT_SWORD_BOX);
   - Id: 13514
@@ -16756,8 +16708,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -16766,6 +16716,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPANNER_BOX
     Script: |
       getgroupitem(IG_SPANNER_BOX);
   - Id: 13515
@@ -17278,8 +17229,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17288,16 +17237,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CP_HELM_SCROLL_BOX
     Script: |
-      getgroupitem(IG_CP_Helm_Scroll_Box);
+      getgroupitem(IG_CP_HELM_SCROLL_BOX);
   - Id: 13544
     AegisName: CP_Shield_Scroll_Box
     Name: Chemical Protection Shield Scroll Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17306,16 +17254,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CP_SHIELD_SCROLL_BOX
     Script: |
-      getgroupitem(IG_CP_Shield_Scroll_Box);
+      getgroupitem(IG_CP_SHIELD_SCROLL_BOX);
   - Id: 13545
     AegisName: CP_Armor_Scroll_Box
     Name: Chemical Protection Armor Scroll Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17324,16 +17271,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CP_ARMOR_SCROLL_BOX
     Script: |
-      getgroupitem(IG_CP_Armor_Scroll_Box);
+      getgroupitem(IG_CP_ARMOR_SCROLL_BOX);
   - Id: 13546
     AegisName: CP_Weapon_Scroll_Box
     Name: Chemical Protection Weapon Scroll Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17342,16 +17288,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CP_WEAPON_SCROLL_BOX
     Script: |
-      getgroupitem(IG_CP_Weapon_Scroll_Box);
+      getgroupitem(IG_CP_WEAPON_SCROLL_BOX);
   - Id: 13547
     AegisName: Repair_Scroll_Box
     Name: Repair Weapon Scroll Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17360,8 +17305,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REPAIR_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Repair_Scroll_Box);
+      getgroupitem(IG_REPAIR_SCROLL_BOX);
   - Id: 13548
     AegisName: Big_Bun_Box
     Name: Big Bun Box
@@ -17548,8 +17494,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17558,6 +17502,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WEAPON_CARD_SCROLL
     Script: |
       getgroupitem(IG_WEAPON_CARD_SCROLL);
   - Id: 13559
@@ -17566,8 +17511,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17576,6 +17519,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ARMOR_CARD_SCROLL
     Script: |
       getgroupitem(IG_ARMOR_CARD_SCROLL);
   - Id: 13560
@@ -17584,8 +17528,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17594,6 +17536,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HELMET_CARD_SCROLL
     Script: |
       getgroupitem(IG_HELMET_CARD_SCROLL);
   - Id: 13561
@@ -17602,8 +17545,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17612,6 +17553,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOOD_CARD_SCROLL
     Script: |
       getgroupitem(IG_HOOD_CARD_SCROLL);
   - Id: 13562
@@ -17620,8 +17562,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17630,6 +17570,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOOD_CARD_SCROLL2
     Script: |
       getgroupitem(IG_HOOD_CARD_SCROLL2);
   - Id: 13563
@@ -17638,8 +17579,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17648,6 +17587,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHOES_CARD_SCROLL
     Script: |
       getgroupitem(IG_SHOES_CARD_SCROLL);
   - Id: 13564
@@ -17656,8 +17596,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17666,6 +17604,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACCY_CARD_SCROLL
     Script: |
       getgroupitem(IG_ACCY_CARD_SCROLL);
   - Id: 13565
@@ -17674,8 +17613,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17684,6 +17621,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WEAPON_CARD_SCROLL2
     Script: |
       getgroupitem(IG_WEAPON_CARD_SCROLL2);
   - Id: 13566
@@ -17692,8 +17630,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17702,6 +17638,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WEAPON_CARD_SCROLL3
     Script: |
       getgroupitem(IG_WEAPON_CARD_SCROLL3);
   - Id: 13567
@@ -17710,8 +17647,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17720,6 +17655,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ARMOR_CARD_SCROLL2
     Script: |
       getgroupitem(IG_ARMOR_CARD_SCROLL2);
   - Id: 13568
@@ -17728,8 +17664,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -17738,6 +17672,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACCY_CARD_SCROLL2
     Script: |
       getgroupitem(IG_ACCY_CARD_SCROLL2);
   - Id: 13569
@@ -18124,8 +18059,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18134,6 +18067,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASPERSIO_5_BOX30
     Script: |
       getgroupitem(IG_ASPERSIO_5_BOX30);
   - Id: 13591
@@ -18142,8 +18076,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18152,6 +18084,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASPERSIO_5_BOX50
     Script: |
       getgroupitem(IG_ASPERSIO_5_BOX50);
   - Id: 13592
@@ -18520,8 +18453,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18530,6 +18461,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HANDCUFF_BOX
     Script: |
       getgroupitem(IG_HANDCUFF_BOX);
   - Id: 13613
@@ -18610,8 +18542,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18620,16 +18550,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG1
     Script: |
-      getgroupitem(IG_Super_Pet_Egg1);
+      getgroupitem(IG_SUPER_PET_EGG1);
   - Id: 13618
     AegisName: Super_Pet_Egg2
     Name: Super Pet Egg 2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18638,16 +18567,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG2
     Script: |
-      getgroupitem(IG_Super_Pet_Egg2);
+      getgroupitem(IG_SUPER_PET_EGG2);
   - Id: 13619
     AegisName: Super_Pet_Egg3
     Name: Super Pet Egg 3
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18656,16 +18584,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG3
     Script: |
-      getgroupitem(IG_Super_Pet_Egg3);
+      getgroupitem(IG_SUPER_PET_EGG3);
   - Id: 13620
     AegisName: Super_Pet_Egg4
     Name: Super Pet Egg 4
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18674,8 +18601,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG4
     Script: |
-      getgroupitem(IG_Super_Pet_Egg4);
+      getgroupitem(IG_SUPER_PET_EGG4);
   - Id: 13621
     AegisName: Greed_Box30
     Name: Greed Scroll 30 Box
@@ -18844,8 +18772,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18854,16 +18780,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_CARD_PET_EGG1
     Script: |
-      getgroupitem(IG_Super_Card_Pet_Egg1);
+      getgroupitem(IG_SUPER_CARD_PET_EGG1);
   - Id: 13631
     AegisName: Super_Card_Pet_Egg2
     Name: Super Card Pet Egg 2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18872,16 +18797,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_CARD_PET_EGG2
     Script: |
-      getgroupitem(IG_Super_Card_Pet_Egg2);
+      getgroupitem(IG_SUPER_CARD_PET_EGG2);
   - Id: 13632
     AegisName: Super_Card_Pet_Egg3
     Name: Super Card Pet Egg 3
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18890,16 +18814,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_CARD_PET_EGG3
     Script: |
-      getgroupitem(IG_Super_Card_Pet_Egg3);
+      getgroupitem(IG_SUPER_CARD_PET_EGG3);
   - Id: 13633
     AegisName: Super_Card_Pet_Egg4
     Name: Super Card Pet Egg 4
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18908,16 +18831,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_CARD_PET_EGG4
     Script: |
-      getgroupitem(IG_Super_Card_Pet_Egg4);
+      getgroupitem(IG_SUPER_CARD_PET_EGG4);
   - Id: 13634
     AegisName: Vigorgra_Package1
     Name: 1 Hour Package Vol. 1
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18926,16 +18848,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE1
     Script: |
-      getgroupitem(IG_Vigorgra_Package1);
+      getgroupitem(IG_VIGORGRA_PACKAGE1);
   - Id: 13635
     AegisName: Vigorgra_Package2
     Name: 1 Hour Package Vol. 2
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18944,16 +18865,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE2
     Script: |
-      getgroupitem(IG_Vigorgra_Package2);
+      getgroupitem(IG_VIGORGRA_PACKAGE2);
   - Id: 13636
     AegisName: Vigorgra_Package3
     Name: 1 Hour Package Vol. 3
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18962,16 +18882,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE3
     Script: |
-      getgroupitem(IG_Vigorgra_Package3);
+      getgroupitem(IG_VIGORGRA_PACKAGE3);
   - Id: 13637
     AegisName: Vigorgra_Package4
     Name: 1 Hour Package Vol. 4
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18980,16 +18899,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE4
     Script: |
-      getgroupitem(IG_Vigorgra_Package4);
+      getgroupitem(IG_VIGORGRA_PACKAGE4);
   - Id: 13638
     AegisName: Vigorgra_Package5
     Name: 1 Hour Package Vol. 5
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -18998,16 +18916,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE5
     Script: |
-      getgroupitem(IG_Vigorgra_Package5);
+      getgroupitem(IG_VIGORGRA_PACKAGE5);
   - Id: 13639
     AegisName: Vigorgra_Package6
     Name: 1 Hour Package Vol. 6
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19016,16 +18933,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE6
     Script: |
-      getgroupitem(IG_Vigorgra_Package6);
+      getgroupitem(IG_VIGORGRA_PACKAGE6);
   - Id: 13640
     AegisName: Vigorgra_Package7
     Name: 2 Hour Package Vol. 1
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19034,16 +18950,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE7
     Script: |
-      getgroupitem(IG_Vigorgra_Package7);
+      getgroupitem(IG_VIGORGRA_PACKAGE7);
   - Id: 13641
     AegisName: Vigorgra_Package8
     Name: 2 Hour Package Vol. 2
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19052,16 +18967,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE8
     Script: |
-      getgroupitem(IG_Vigorgra_Package8);
+      getgroupitem(IG_VIGORGRA_PACKAGE8);
   - Id: 13642
     AegisName: Vigorgra_Package9
     Name: 2 Hour Package Vol. 3
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19070,16 +18984,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE9
     Script: |
-      getgroupitem(IG_Vigorgra_Package9);
+      getgroupitem(IG_VIGORGRA_PACKAGE9);
   - Id: 13643
     AegisName: Vigorgra_Package10
     Name: 2 Hour Package Vol. 4
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19088,16 +19001,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE10
     Script: |
-      getgroupitem(IG_Vigorgra_Package10);
+      getgroupitem(IG_VIGORGRA_PACKAGE10);
   - Id: 13644
     AegisName: Vigorgra_Package11
     Name: 2 Hour Package Vol. 5
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19106,16 +19018,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE11
     Script: |
-      getgroupitem(IG_Vigorgra_Package11);
+      getgroupitem(IG_VIGORGRA_PACKAGE11);
   - Id: 13645
     AegisName: Vigorgra_Package12
     Name: 2 Hour Package Vol. 6
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19124,16 +19035,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE12
     Script: |
-      getgroupitem(IG_Vigorgra_Package12);
+      getgroupitem(IG_VIGORGRA_PACKAGE12);
   - Id: 13646
     AegisName: Infiltrator_Box1
     Name: Refined Infiltrator Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19142,6 +19052,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFILTRATOR_BOX1
     Script: |
       getgroupitem(IG_INFILTRATOR_BOX1);
   - Id: 13647
@@ -19150,8 +19061,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19160,6 +19069,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MURAMASA_BOX1
     Script: |
       getgroupitem(IG_MURAMASA_BOX1);
   - Id: 13648
@@ -19168,8 +19078,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19178,6 +19086,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EXCALIBUR_BOX1
     Script: |
       getgroupitem(IG_EXCALIBUR_BOX1);
   - Id: 13649
@@ -19186,8 +19095,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19196,6 +19103,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMBAT_KNIFE_BOX1
     Script: |
       getgroupitem(IG_COMBAT_KNIFE_BOX1);
   - Id: 13650
@@ -19204,8 +19112,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19214,6 +19120,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COUNTER_DAGGER_BOX1
     Script: |
       getgroupitem(IG_COUNTER_DAGGER_BOX1);
   - Id: 13651
@@ -19222,8 +19129,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19232,6 +19137,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KAISER_KNUCKLE_BOX1
     Script: |
       getgroupitem(IG_KAISER_KNUCKLE_BOX1);
   - Id: 13652
@@ -19240,8 +19146,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19250,6 +19154,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POLE_AXE_BOX1
     Script: |
       getgroupitem(IG_POLE_AXE_BOX1);
   - Id: 13653
@@ -19258,8 +19163,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19268,6 +19171,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MIGHTY_STAFF_BOX1
     Script: |
       getgroupitem(IG_MIGHTY_STAFF_BOX1);
   - Id: 13654
@@ -19276,8 +19180,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19286,6 +19188,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RIGHT_EPSILON_BOX1
     Script: |
       getgroupitem(IG_RIGHT_EPSILON_BOX1);
   - Id: 13655
@@ -19294,8 +19197,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19304,6 +19205,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BALISTAR_BOX1
     Script: |
       getgroupitem(IG_BALISTAR_BOX1);
   - Id: 13656
@@ -19312,8 +19214,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19322,6 +19222,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DIARY_OF_SAGE_BOX1
     Script: |
       getgroupitem(IG_DIARY_OF_SAGE_BOX1);
   - Id: 13657
@@ -19330,8 +19231,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19340,6 +19239,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASURA_BOX1
     Script: |
       getgroupitem(IG_ASURA_BOX1);
   - Id: 13658
@@ -19348,8 +19248,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19358,6 +19256,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_APPLE_OF_ARCHER_BOX1
     Script: |
       getgroupitem(IG_APPLE_OF_ARCHER_BOX1);
   - Id: 13659
@@ -19366,8 +19265,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19376,6 +19273,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BUNNY_BAND_BOX1
     Script: |
       getgroupitem(IG_BUNNY_BAND_BOX1);
   - Id: 13660
@@ -19384,8 +19282,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19394,6 +19290,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAHKKAT_BOX1
     Script: |
       getgroupitem(IG_SAHKKAT_BOX1);
   - Id: 13661
@@ -19402,8 +19299,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19412,6 +19307,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LORD_CIRCLET_BOX1
     Script: |
       getgroupitem(IG_LORD_CIRCLET_BOX1);
   - Id: 13662
@@ -19420,8 +19316,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19430,6 +19324,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ELVEN_EARS_BOX1
     Script: |
       getgroupitem(IG_ELVEN_EARS_BOX1);
   - Id: 13663
@@ -19438,8 +19333,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19448,6 +19341,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STEEL_FLOWER_BOX1
     Script: |
       getgroupitem(IG_STEEL_FLOWER_BOX1);
   - Id: 13664
@@ -19456,8 +19350,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19466,6 +19358,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRITICAL_RING_BOX1
     Script: |
       getgroupitem(IG_CRITICAL_RING_BOX1);
   - Id: 13665
@@ -19474,8 +19367,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19484,6 +19375,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EARRING_BOX1
     Script: |
       getgroupitem(IG_EARRING_BOX1);
   - Id: 13666
@@ -19492,8 +19384,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19502,6 +19392,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RING_BOX1
     Script: |
       getgroupitem(IG_RING_BOX1);
   - Id: 13667
@@ -19510,8 +19401,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19520,6 +19409,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NECKLACE_BOX1
     Script: |
       getgroupitem(IG_NECKLACE_BOX1);
   - Id: 13668
@@ -19528,8 +19418,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19538,6 +19426,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GLOVE_BOX1
     Script: |
       getgroupitem(IG_GLOVE_BOX1);
   - Id: 13669
@@ -19546,8 +19435,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19556,6 +19443,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROOCH_BOX1
     Script: |
       getgroupitem(IG_BROOCH_BOX1);
   - Id: 13670
@@ -19564,8 +19452,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19574,6 +19460,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ROSARY_BOX1
     Script: |
       getgroupitem(IG_ROSARY_BOX1);
   - Id: 13671
@@ -19582,8 +19469,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19592,6 +19477,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAFETY_RING_BOX1
     Script: |
       getgroupitem(IG_SAFETY_RING_BOX1);
   - Id: 13672
@@ -19600,8 +19486,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19610,6 +19494,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE01_BOX1
     Script: |
       getgroupitem(IG_VESPER_CORE01_BOX1);
   - Id: 13673
@@ -19618,8 +19503,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19628,6 +19511,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE02_BOX1
     Script: |
       getgroupitem(IG_VESPER_CORE02_BOX1);
   - Id: 13674
@@ -19636,8 +19520,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19646,6 +19528,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE03_BOX1
     Script: |
       getgroupitem(IG_VESPER_CORE03_BOX1);
   - Id: 13675
@@ -19654,8 +19537,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19664,6 +19545,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VESPER_CORE04_BOX1
     Script: |
       getgroupitem(IG_VESPER_CORE04_BOX1);
   - Id: 13676
@@ -19672,8 +19554,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19682,6 +19562,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DROOPING_KITTY_BOX1
     Script: |
       getgroupitem(IG_DROOPING_KITTY_BOX1);
   - Id: 13677
@@ -19690,8 +19571,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19700,6 +19579,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGESTIC_GOAT_BOX1
     Script: |
       getgroupitem(IG_MAGESTIC_GOAT_BOX1);
   - Id: 13678
@@ -19708,8 +19588,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19718,6 +19596,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEVIRUCHI_CAP_BOX1
     Script: |
       getgroupitem(IG_DEVIRUCHI_CAP_BOX1);
   - Id: 13679
@@ -19726,8 +19605,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19736,6 +19613,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EXECUTIONER_BOX1
     Script: |
       getgroupitem(IG_EXECUTIONER_BOX1);
   - Id: 13680
@@ -19744,8 +19622,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19754,6 +19630,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROOD_AXE_BOX1
     Script: |
       getgroupitem(IG_BROOD_AXE_BOX1);
   - Id: 13681
@@ -19762,8 +19639,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19772,6 +19647,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TOMAHAWK_BOX1
     Script: |
       getgroupitem(IG_TOMAHAWK_BOX1);
   - Id: 13682
@@ -19781,7 +19657,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -19791,6 +19666,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOW_OF_RUDRA_BOX1
     Script: |
       getgroupitem(IG_BOW_OF_RUDRA_BOX1);
   - Id: 13683
@@ -19799,8 +19675,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19809,6 +19683,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CUTLAS_BOX1
     Script: |
       getgroupitem(IG_CUTLAS_BOX1);
   - Id: 13684
@@ -19817,8 +19692,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19827,6 +19700,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SOLAR_SWORD_BOX1
     Script: |
       getgroupitem(IG_SOLAR_SWORD_BOX1);
   - Id: 13685
@@ -19836,7 +19710,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -19846,6 +19719,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SWORD_BREAKER_BOX1
     Script: |
       getgroupitem(IG_SWORD_BREAKER_BOX1);
   - Id: 13686
@@ -19855,7 +19729,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -19865,6 +19738,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAIL_BREAKER_BOX1
     Script: |
       getgroupitem(IG_MAIL_BREAKER_BOX1);
   - Id: 13687
@@ -19873,8 +19747,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19883,6 +19755,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOONLIGHT_SWORD_BOX1
     Script: |
       getgroupitem(IG_MOONLIGHT_SWORD_BOX1);
   - Id: 13688
@@ -19891,8 +19764,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19901,6 +19772,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPANNER_BOX1
     Script: |
       getgroupitem(IG_SPANNER_BOX1);
   - Id: 13689
@@ -19944,8 +19816,6 @@ Body:
     Name: Freya's Clothes Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19954,6 +19824,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_OVERCOAT_BOX
     Script: |
       getgroupitem(IG_FREYJA_OVERCOAT_BOX);
   - Id: 13692
@@ -19961,8 +19832,6 @@ Body:
     Name: Freya's Boots Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19971,6 +19840,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_BOOTS_BOX
     Script: |
       getgroupitem(IG_FREYJA_BOOTS_BOX);
   - Id: 13693
@@ -19978,8 +19848,6 @@ Body:
     Name: Freya's Manteau Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -19988,6 +19856,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_CAPE_BOX
     Script: |
       getgroupitem(IG_FREYJA_CAPE_BOX);
   - Id: 13694
@@ -19995,8 +19864,6 @@ Body:
     Name: Freyja Crown Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20005,6 +19872,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_CROWN_BOX
     Script: |
       getgroupitem(IG_FREYJA_CROWN_BOX);
   - Id: 13695
@@ -20114,8 +19982,6 @@ Body:
     Name: Pet Egg Scroll 12
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20124,15 +19990,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL12
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll12);
+      getgroupitem(IG_PET_EGG_SCROLL12);
   - Id: 13702
     AegisName: Pet_Egg_Scroll13
     Name: Pet Egg Scroll 13
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20141,15 +20006,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL13
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll13);
+      getgroupitem(IG_PET_EGG_SCROLL13);
   - Id: 13703
     AegisName: Pet_Egg_Scroll14
     Name: Pet Egg Scroll 14
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20158,16 +20022,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL14
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll14);
+      getgroupitem(IG_PET_EGG_SCROLL14);
   - Id: 13704
     AegisName: Super_Pet_Egg5
     Name: Super Pet Egg 5
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20176,16 +20039,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG5
     Script: |
-      getgroupitem(IG_Super_Pet_Egg5);
+      getgroupitem(IG_SUPER_PET_EGG5);
   - Id: 13705
     AegisName: Super_Pet_Egg6
     Name: Super Pet Egg 6
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20194,16 +20056,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG6
     Script: |
-      getgroupitem(IG_Super_Pet_Egg6);
+      getgroupitem(IG_SUPER_PET_EGG6);
   - Id: 13706
     AegisName: Super_Pet_Egg7
     Name: Super Pet Egg 7
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20212,16 +20073,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG7
     Script: |
-      getgroupitem(IG_Super_Pet_Egg7);
+      getgroupitem(IG_SUPER_PET_EGG7);
   - Id: 13707
     AegisName: Super_Pet_Egg8
     Name: Super Pet Egg 8
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20230,16 +20090,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_PET_EGG8
     Script: |
-      getgroupitem(IG_Super_Pet_Egg8);
+      getgroupitem(IG_SUPER_PET_EGG8);
   - Id: 13708
     AegisName: Pet_Egg_Scroll_E
     Name: Pet Egg Scroll E
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20248,16 +20107,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PET_EGG_SCROLL_E
     Script: |
-      getgroupitem(IG_Pet_Egg_Scroll_E);
+      getgroupitem(IG_PET_EGG_SCROLL_E);
   - Id: 13709
     AegisName: BRO_Package1
     Name: BRO Package Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20266,6 +20124,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BRO_PACKAGE1
     Script: |
       getgroupitem(IG_BRO_PACKAGE1);
   - Id: 13710
@@ -20490,8 +20349,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20500,6 +20357,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PECOPECO_HAIRBAND_BOX
     Script: |
       getgroupitem(IG_PECOPECO_HAIRBAND_BOX);
   - Id: 13723
@@ -20508,8 +20366,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20518,6 +20374,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RED_GLASSES_BOX
     Script: |
       getgroupitem(IG_RED_GLASSES_BOX);
   - Id: 13724
@@ -20526,8 +20383,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20536,6 +20391,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WHISPER_MASK_BOX
     Script: |
       getgroupitem(IG_WHISPER_MASK_BOX);
   - Id: 13725
@@ -20544,8 +20400,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20554,15 +20408,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAMEN_HAT_BOX
     Script: |
-      getgroupitem(IG_Ramen_Hat_Box);
+      getgroupitem(IG_RAMEN_HAT_BOX);
   - Id: 13726
     AegisName: Gold_Box_
     Name: Golden Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20571,6 +20424,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLD_BOX_
     Script: |
       getgroupitem(IG_GOLD_BOX_);
   - Id: 13727
@@ -20578,8 +20432,6 @@ Body:
     Name: Silver Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20588,6 +20440,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVER_BOX_
     Script: |
       getgroupitem(IG_SILVER_BOX_);
   - Id: 13728
@@ -20664,8 +20517,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20674,6 +20525,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PECOPECO_HAIRBAND_BOX1
     Script: |
       getgroupitem(IG_PECOPECO_HAIRBAND_BOX1);
   - Id: 13735
@@ -20682,8 +20534,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20692,6 +20542,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RED_GLASSES_BOX1
     Script: |
       getgroupitem(IG_RED_GLASSES_BOX1);
   - Id: 13736
@@ -20700,8 +20551,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20710,6 +20559,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WHISPER_MASK_BOX1
     Script: |
       getgroupitem(IG_WHISPER_MASK_BOX1);
   - Id: 13737
@@ -20718,8 +20568,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -20728,6 +20576,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAMEN_HAT_BOX1
     Script: |
       getgroupitem(IG_RAMEN_HAT_BOX1);
   - Id: 13738
@@ -21186,8 +21035,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21197,6 +21044,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_5_ANNIVERSARY_COIN_BOX
     Script: |
       getgroupitem(IG_5_ANNIVERSARY_COIN_BOX);
   - Id: 13764
@@ -21223,8 +21071,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21234,6 +21080,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CERTIFICATE_TW_BOX
     Script: |
       getgroupitem(IG_CERTIFICATE_TW_BOX);
   - Id: 13766
@@ -21242,8 +21089,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21252,6 +21097,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NAGAN_BOX
     Script: |
       getgroupitem(IG_NAGAN_BOX);
   - Id: 13767
@@ -21260,8 +21106,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21270,6 +21114,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SKEWER_BOX
     Script: |
       getgroupitem(IG_SKEWER_BOX);
   - Id: 13768
@@ -21278,8 +21123,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21288,6 +21131,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SURVIVAL_ROD_BOX
     Script: |
       getgroupitem(IG_SURVIVAL_ROD_BOX);
   - Id: 13769
@@ -21296,8 +21140,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21306,6 +21148,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_QUADRILLE_BOX
     Script: |
       getgroupitem(IG_QUADRILLE_BOX);
   - Id: 13770
@@ -21314,8 +21157,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21324,6 +21165,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GREAT_AXE_BOX
     Script: |
       getgroupitem(IG_GREAT_AXE_BOX);
   - Id: 13771
@@ -21332,8 +21174,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21342,6 +21182,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_ROAR_BOX
     Script: |
       getgroupitem(IG_BLOODY_ROAR_BOX);
   - Id: 13772
@@ -21350,8 +21191,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21360,6 +21199,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HARDBACK_BOX
     Script: |
       getgroupitem(IG_HARDBACK_BOX);
   - Id: 13773
@@ -21368,8 +21208,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21378,8 +21216,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FIRE_BRAND_BOX
     Script: |
-      getgroupitem(IG_Fire_Brand_Box);
+      getgroupitem(IG_FIRE_BRAND_BOX);
       /*rentitem 13408,604800;*/
   - Id: 13774
     AegisName: Immaterial_Sword_Box
@@ -21387,8 +21226,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21397,6 +21234,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMMATERIAL_SWORD_BOX
     Script: |
       getgroupitem(IG_IMMATERIAL_SWORD_BOX);
   - Id: 13775
@@ -21405,8 +21243,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21415,6 +21251,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNHOLY_TOUCH_BOX
     Script: |
       getgroupitem(IG_UNHOLY_TOUCH_BOX);
   - Id: 13776
@@ -21423,8 +21260,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21433,6 +21268,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOAK_OF_SURVIVAL_BOX
     Script: |
       getgroupitem(IG_CLOAK_OF_SURVIVAL_BOX);
   - Id: 13777
@@ -21441,8 +21277,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21451,6 +21285,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MASQUERADE_BOX
     Script: |
       getgroupitem(IG_MASQUERADE_BOX);
   - Id: 13778
@@ -21459,8 +21294,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21469,6 +21302,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ORC_HERO_HELM_BOX
     Script: |
       getgroupitem(IG_ORC_HERO_HELM_BOX);
   - Id: 13779
@@ -21477,8 +21311,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21487,6 +21319,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVIL_WING_EARS_BOX
     Script: |
       getgroupitem(IG_EVIL_WING_EARS_BOX);
   - Id: 13780
@@ -21495,8 +21328,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21505,6 +21336,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DARK_BLINDFOLD_BOX
     Script: |
       getgroupitem(IG_DARK_BLINDFOLD_BOX);
   - Id: 13781
@@ -21513,8 +21345,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21523,6 +21353,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KRO_DROOPING_KITTY_BOX
     Script: |
       getgroupitem(IG_KRO_DROOPING_KITTY_BOX);
   - Id: 13782
@@ -21531,8 +21362,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21541,6 +21370,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CORSAIR_BOX
     Script: |
       getgroupitem(IG_CORSAIR_BOX);
   - Id: 13783
@@ -21549,8 +21379,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21559,6 +21387,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_IRON_BALL_BOX
     Script: |
       getgroupitem(IG_BLOODY_IRON_BALL_BOX);
   - Id: 13784
@@ -21567,8 +21396,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21577,6 +21404,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIRITUAL_RING_BOX
     Script: |
       getgroupitem(IG_SPIRITUAL_RING_BOX);
   - Id: 13785
@@ -21585,8 +21413,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21595,6 +21421,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NAGAN_BOX1
     Script: |
       getgroupitem(IG_NAGAN_BOX1);
   - Id: 13786
@@ -21603,8 +21430,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21613,6 +21438,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SKEWER_BOX1
     Script: |
       getgroupitem(IG_SKEWER_BOX1);
   - Id: 13787
@@ -21621,8 +21447,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21631,6 +21455,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SURVIVAL_ROD_BOX1
     Script: |
       getgroupitem(IG_SURVIVAL_ROD_BOX1);
   - Id: 13788
@@ -21639,8 +21464,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21649,6 +21472,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_QUADRILLE_BOX1
     Script: |
       getgroupitem(IG_QUADRILLE_BOX1);
   - Id: 13789
@@ -21657,8 +21481,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21667,6 +21489,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GREAT_AXE_BOX1
     Script: |
       getgroupitem(IG_GREAT_AXE_BOX1);
   - Id: 13790
@@ -21676,7 +21499,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -21686,6 +21508,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_ROAR_BOX1
     Script: |
       getgroupitem(IG_BLOODY_ROAR_BOX1);
   - Id: 13791
@@ -21695,7 +21518,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -21705,6 +21527,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HARDBACK_BOX1
     Script: |
       getgroupitem(IG_HARDBACK_BOX1);
   - Id: 13792
@@ -21713,8 +21536,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21723,6 +21544,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FIRE_BRAND_BOX1
     Script: |
       getgroupitem(IG_FIRE_BRAND_BOX1);
   - Id: 13793
@@ -21731,8 +21553,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21741,6 +21561,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMMATERIAL_SWORD_BOX1
     Script: |
       getgroupitem(IG_IMMATERIAL_SWORD_BOX1);
   - Id: 13794
@@ -21749,8 +21570,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21759,6 +21578,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNHOLY_TOUCH_BOX1
     Script: |
       getgroupitem(IG_UNHOLY_TOUCH_BOX1);
   - Id: 13795
@@ -21767,8 +21587,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21777,6 +21595,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOAK_OF_SURVIVAL_BOX1
     Script: |
       getgroupitem(IG_CLOAK_OF_SURVIVAL_BOX1);
   - Id: 13796
@@ -21785,8 +21604,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21795,6 +21612,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MASQUERADE_BOX1
     Script: |
       getgroupitem(IG_MASQUERADE_BOX1);
   - Id: 13797
@@ -21803,8 +21621,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21813,6 +21629,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ORC_HERO_HELM_BOX1
     Script: |
       getgroupitem(IG_ORC_HERO_HELM_BOX1);
   - Id: 13798
@@ -21821,8 +21638,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21831,6 +21646,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVIL_WING_EARS_BOX1
     Script: |
       getgroupitem(IG_EVIL_WING_EARS_BOX1);
   - Id: 13799
@@ -21839,8 +21655,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21849,6 +21663,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DARK_BLINDFOLD_BOX1
     Script: |
       getgroupitem(IG_DARK_BLINDFOLD_BOX1);
   - Id: 13800
@@ -21857,8 +21672,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21867,6 +21680,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KRO_DROOPING_KITTY_BOX1
     Script: |
       getgroupitem(IG_KRO_DROOPING_KITTY_BOX1);
   - Id: 13801
@@ -21875,8 +21689,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21885,6 +21697,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CORSAIR_BOX1
     Script: |
       getgroupitem(IG_CORSAIR_BOX1);
   - Id: 13802
@@ -21894,7 +21707,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -21904,6 +21716,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_IRON_BALL_BOX1
     Script: |
       getgroupitem(IG_BLOODY_IRON_BALL_BOX1);
   - Id: 13803
@@ -21912,8 +21725,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -21922,6 +21733,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIRITUAL_RING_BOX1
     Script: |
       getgroupitem(IG_SPIRITUAL_RING_BOX1);
   - Id: 13804
@@ -22057,7 +21869,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22067,6 +21878,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FOOD_BOX_LV1
     Script: |
       getgroupitem(IG_FOOD_BOX_LV1);
   - Id: 13812
@@ -22076,7 +21888,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22086,6 +21897,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FOOD_BOX_LV2
     Script: |
       getgroupitem(IG_FOOD_BOX_LV2);
   - Id: 13813
@@ -22095,7 +21907,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22105,6 +21916,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FOOD_BOX_LV3
     Script: |
       getgroupitem(IG_FOOD_BOX_LV3);
   - Id: 13814
@@ -22113,8 +21925,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22123,6 +21933,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INDONESIA_BOX
     Script: |
       getgroupitem(IG_INDONESIA_BOX);
   - Id: 13815
@@ -22311,8 +22122,7 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_GREEN_BOX_
     Script: |
       getgroupitem(IG_GREEN_BOX_);
   - Id: 13826
@@ -22322,7 +22132,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22332,6 +22141,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POWER_BOX1
     Script: |
       getgroupitem(IG_POWER_BOX1);
   - Id: 13827
@@ -22341,7 +22151,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22351,6 +22160,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POWER_BOX2
     Script: |
       getgroupitem(IG_POWER_BOX2);
   - Id: 13828
@@ -22359,8 +22169,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22369,6 +22177,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RESIST_BOX1
     Script: |
       getgroupitem(IG_RESIST_BOX1);
   - Id: 13829
@@ -22377,8 +22186,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22387,6 +22194,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RESIST_BOX2
     Script: |
       getgroupitem(IG_RESIST_BOX2);
   - Id: 13830
@@ -22395,8 +22203,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22405,6 +22211,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAT_BOOST1
     Script: |
       getgroupitem(IG_STAT_BOOST1);
   - Id: 13831
@@ -22413,8 +22220,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22423,6 +22228,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAT_BOOST2
     Script: |
       getgroupitem(IG_STAT_BOOST2);
   - Id: 13832
@@ -22431,8 +22237,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22441,6 +22245,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAT_BOOST3
     Script: |
       getgroupitem(IG_STAT_BOOST3);
   - Id: 13833
@@ -22449,8 +22254,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22459,6 +22262,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAT_BOOST4
     Script: |
       getgroupitem(IG_STAT_BOOST4);
   - Id: 13834
@@ -22665,8 +22469,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22675,16 +22477,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_TRAVEL_SACK1
     Script: |
-      getgroupitem(IG_Mysterious_Travel_Sack1);
+      getgroupitem(IG_MYSTERIOUS_TRAVEL_SACK1);
   - Id: 13846
     AegisName: Mysterious_Travel_Sack2
     Name: Mystery Travel Sack B
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22693,16 +22494,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_TRAVEL_SACK2
     Script: |
-      getgroupitem(IG_Mysterious_Travel_Sack2);
+      getgroupitem(IG_MYSTERIOUS_TRAVEL_SACK2);
   - Id: 13847
     AegisName: Mysterious_Travel_Sack3
     Name: Mystery Travel Sack C
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22711,16 +22511,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_TRAVEL_SACK3
     Script: |
-      getgroupitem(IG_Mysterious_Travel_Sack3);
+      getgroupitem(IG_MYSTERIOUS_TRAVEL_SACK3);
   - Id: 13848
     AegisName: Mysterious_Travel_Sack4
     Name: Mystery Travel Sack D
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -22729,8 +22528,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_TRAVEL_SACK4
     Script: |
-      getgroupitem(IG_Mysterious_Travel_Sack4);
+      getgroupitem(IG_MYSTERIOUS_TRAVEL_SACK4);
   - Id: 13849
     AegisName: WOB_Box_Rune5
     Name: Yellow Butterfly Wing 5 Box
@@ -22974,7 +22774,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -22984,6 +22783,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRIAL_BOX
     Script: |
       getgroupitem(IG_TRIAL_BOX);
   - Id: 13863
@@ -22993,7 +22793,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23003,6 +22802,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REPAIR_SCROLL_BOX10
     Script: |
       getgroupitem(IG_REPAIR_SCROLL_BOX10);
   - Id: 13864
@@ -23012,7 +22812,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23022,6 +22821,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOCKEY_MASK_BOX
     Script: |
       getgroupitem(IG_HOCKEY_MASK_BOX);
   - Id: 13865
@@ -23031,8 +22831,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 35
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23041,6 +22839,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OBSERVER_BOX
     Script: |
       getgroupitem(IG_OBSERVER_BOX);
   - Id: 13866
@@ -23139,8 +22938,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23149,8 +22946,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGICIAN_CARD_BOX
     Script: |
-      getgroupitem(IG_Magician_Card_Box);
+      getgroupitem(IG_MAGICIAN_CARD_BOX);
       /*getitem 4327,1; getitem 4309,1; getitem 4325,1; getitem 4208,1; getitem 4258,1; getitem 4191,1;*/
   - Id: 13872
     AegisName: Acolyte_Card_Box
@@ -23158,8 +22956,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23168,8 +22964,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACOLYTE_CARD_BOX
     Script: |
-      getgroupitem(IG_Acolyte_Card_Box);
+      getgroupitem(IG_ACOLYTE_CARD_BOX);
       /*getitem 4185,1; getitem 4312,1; getitem 4217,1; getitem 4280,1; getitem 4293,1;*/
   - Id: 13873
     AegisName: Archer_Card_Box
@@ -23177,8 +22974,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23187,8 +22982,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ARCHER_CARD_BOX
     Script: |
-      getgroupitem(IG_Archer_Card_Box);
+      getgroupitem(IG_ARCHER_CARD_BOX);
       /*getitem 4297,1; getitem 4234,1; getitem 4199,1; getitem 4178,1; getitem 4252,1;*/
   - Id: 13874
     AegisName: Swordman_Card_Box
@@ -23196,8 +22992,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23206,8 +23000,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SWORDMAN_CARD_BOX
     Script: |
-      getgroupitem(IG_Swordman_Card_Box);
+      getgroupitem(IG_SWORDMAN_CARD_BOX);
       /*getitem 4319,1; getitem 4331,1; getitem 4220,1; getitem 4311,1; getitem 4246,1;*/
   - Id: 13875
     AegisName: Thief_Card_Box
@@ -23215,8 +23010,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23225,8 +23018,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_THIEF_CARD_BOX
     Script: |
-      getgroupitem(IG_Thief_Card_Box);
+      getgroupitem(IG_THIEF_CARD_BOX);
       /*getitem 4230,1; getitem 4210,1; getitem 4257,1; getitem 4172,1; getitem 4272,1;*/
   - Id: 13876
     AegisName: Merchant_Card_Box
@@ -23234,8 +23028,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23244,8 +23036,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MERCHANT_CARD_BOX
     Script: |
-      getgroupitem(IG_Merchant_Card_Box);
+      getgroupitem(IG_MERCHANT_CARD_BOX);
       /*getitem 4206,1; getitem 4281,1; getitem 4186,1; getitem 4233,1; getitem 4321,1;*/
   - Id: 13877
     AegisName: Clock_Tower_Card_Box
@@ -23254,7 +23047,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23264,6 +23056,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOCK_TOWER_CARD_BOX
     Script: |
       getgroupitem(IG_CLOCK_TOWER_CARD_BOX);
   - Id: 13878
@@ -23273,7 +23066,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23283,6 +23075,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GEFFENIA_CARD_BOX
     Script: |
       getgroupitem(IG_GEFFENIA_CARD_BOX);
   - Id: 13879
@@ -23292,7 +23085,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23302,6 +23094,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OWL_CARD_BOX
     Script: |
       getgroupitem(IG_OWL_CARD_BOX);
   - Id: 13880
@@ -23311,7 +23104,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23321,6 +23113,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GHOST_CARD_BOX
     Script: |
       getgroupitem(IG_GHOST_CARD_BOX);
   - Id: 13881
@@ -23330,7 +23123,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23340,6 +23132,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NIGHTMARE_CARD_BOX
     Script: |
       getgroupitem(IG_NIGHTMARE_CARD_BOX);
   - Id: 13882
@@ -23582,7 +23375,6 @@ Body:
     Type: Cash
     Buy: 20
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23592,6 +23384,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STARTER_PACK
     Script: |
       getgroupitem(IG_STARTER_PACK);
   - Id: 13896
@@ -23762,8 +23555,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23772,8 +23563,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HARD_CORE_SET_BOX
     Script: |
-      getgroupitem(IG_Hard_Core_Set_Box);
+      getgroupitem(IG_HARD_CORE_SET_BOX);
       /*getitem 12208,10; getitem 12209,10; getitem 12210,10;*/
   - Id: 13906
     AegisName: Kitty_Set_Box
@@ -23781,8 +23573,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23791,8 +23581,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KITTY_SET_BOX
     Script: |
-      getgroupitem(IG_Kitty_Set_Box);
+      getgroupitem(IG_KITTY_SET_BOX);
       /*getitem 5230,1; getitem 5231,1; getitem 5232,1; getitem 5233,1; getitem 5234,1;*/
   - Id: 13907
     AegisName: Soft_Core_Set_Box
@@ -23800,8 +23591,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23810,8 +23599,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SOFT_CORE_SET_BOX
     Script: |
-      getgroupitem(IG_Soft_Core_Set_Box);
+      getgroupitem(IG_SOFT_CORE_SET_BOX);
       /*getitem 12208,5; getitem 12209,5; getitem 12210,5;*/
   - Id: 13908
     AegisName: Deviruchi_Set_Box
@@ -23819,8 +23609,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23829,8 +23617,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEVIRUCHI_SET_BOX
     Script: |
-      getgroupitem(IG_Deviruchi_Set_Box);
+      getgroupitem(IG_DEVIRUCHI_SET_BOX);
       /*getitem 5227,1; getitem 5228,1; getitem 5229,1;*/
   - Id: 13909
     AegisName: MVP_Hunt_Box
@@ -23838,8 +23627,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23848,8 +23635,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MVP_HUNT_BOX
     Script: |
-      getgroupitem(IG_MVP_Hunt_Box);
+      getgroupitem(IG_MVP_HUNT_BOX);
       /*getitem 7621,1; getitem 12210,1; getitem 12221,1; getitem 12214,3;*/
   - Id: 13910
     AegisName: Cook_Box
@@ -23857,8 +23645,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23867,8 +23653,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BREWING_BOX
     Script: |
-      getgroupitem(IG_Brewing_Box);
+      getgroupitem(IG_BREWING_BOX);
       /*getitem 12204,10; getitem 12205,10; getitem 12206,10;*/
   - Id: 13911
     AegisName: Xmas_Pet_Scroll
@@ -23876,8 +23663,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -23886,8 +23671,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAS_PET_SCROLL
     Script: |
-      getgroupitem(IG_Xmas_Pet_Scroll);
+      getgroupitem(IG_XMAS_PET_SCROLL);
   - Id: 13912
     AegisName: Party_Blessing_Box
     Name: Party Blessing 10 Scroll Box
@@ -23949,7 +23735,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23959,6 +23744,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LOVE_ANGEL_BOX
     Script: |
       getgroupitem(IG_LOVE_ANGEL_BOX);
   - Id: 13916
@@ -23968,7 +23754,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23978,6 +23763,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SQUIRREL_BOX
     Script: |
       getgroupitem(IG_SQUIRREL_BOX);
   - Id: 13917
@@ -23987,7 +23773,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -23997,6 +23782,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOGO_BOX
     Script: |
       getgroupitem(IG_GOGO_BOX);
   - Id: 13918
@@ -24131,8 +23917,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24141,8 +23925,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_SCROLL08
     Script: |
-      getgroupitem(IG_Lucky_Scroll08);
+      getgroupitem(IG_LUCKY_SCROLL08);
   - Id: 13926
     AegisName: Crusader_Card_Box
     Name: Crusader Card Box
@@ -24150,7 +23935,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24160,6 +23944,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRUSADER_CARD_BOX
     Script: |
       getgroupitem(IG_CRUSADER_CARD_BOX);
   - Id: 13927
@@ -24169,7 +23954,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24179,6 +23963,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALCHEMIST_CARD_BOX
     Script: |
       getgroupitem(IG_ALCHEMIST_CARD_BOX);
   - Id: 13928
@@ -24188,7 +23973,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24198,6 +23982,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ROGUE_CARD_BOX
     Script: |
       getgroupitem(IG_ROGUE_CARD_BOX);
   - Id: 13929
@@ -24207,7 +23992,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24217,6 +24001,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BARD_DANCER_CARD_BOX
     Script: |
       getgroupitem(IG_BARD_DANCER_CARD_BOX);
   - Id: 13930
@@ -24226,7 +24011,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24236,6 +24020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAGE_CARD_BOX
     Script: |
       getgroupitem(IG_SAGE_CARD_BOX);
   - Id: 13931
@@ -24245,7 +24030,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24255,6 +24039,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONK_CARD_BOX
     Script: |
       getgroupitem(IG_MONK_CARD_BOX);
   - Id: 13932
@@ -24425,8 +24210,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24435,6 +24218,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TW_VALENTINE_SCROLL
     Script: |
       getgroupitem(IG_TW_VALENTINE_SCROLL);
   - Id: 13942
@@ -24444,7 +24228,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24454,6 +24237,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LOVE_ANGEL_BOX_1M
     Script: |
       getgroupitem(IG_LOVE_ANGEL_BOX_1M);
   - Id: 13943
@@ -24463,7 +24247,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24473,6 +24256,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SQUIRREL_BOX_1M
     Script: |
       getgroupitem(IG_SQUIRREL_BOX_1M);
   - Id: 13944
@@ -24482,7 +24266,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24492,6 +24275,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOGO_BOX_1M
     Script: |
       getgroupitem(IG_GOGO_BOX_1M);
   - Id: 13945
@@ -24500,8 +24284,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24510,16 +24292,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_SWORDPACKAGE
     Script: |
-      getgroupitem(IG_Br_SwordPackage);
+      getgroupitem(IG_BR_SWORDPACKAGE);
   - Id: 13946
     AegisName: BRO_MG_Package
     Name: Magician Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24528,16 +24309,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_MAGEPACKAGE
     Script: |
-      getgroupitem(IG_Br_MagePackage);
+      getgroupitem(IG_BR_MAGEPACKAGE);
   - Id: 13947
     AegisName: BRO_AC_Package
     Name: Acolyte Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24546,16 +24326,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_ACOLPACKAGE
     Script: |
-      getgroupitem(IG_Br_AcolPackage);
+      getgroupitem(IG_BR_ACOLPACKAGE);
   - Id: 13948
     AegisName: BRO_AR_Package
     Name: Archer Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24564,16 +24343,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_ARCHERPACKAGE
     Script: |
-      getgroupitem(IG_Br_ArcherPackage);
+      getgroupitem(IG_BR_ARCHERPACKAGE);
   - Id: 13949
     AegisName: BRO_MC_Package
     Name: Merchant Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24582,16 +24360,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_MERPACKAGE
     Script: |
-      getgroupitem(IG_Br_MerPackage);
+      getgroupitem(IG_BR_MERPACKAGE);
   - Id: 13950
     AegisName: BRO_TF_Package
     Name: Thief Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24600,8 +24377,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BR_THIEFPACKAGE
     Script: |
-      getgroupitem(IG_Br_ThiefPackage);
+      getgroupitem(IG_BR_THIEFPACKAGE);
   - Id: 13951
     AegisName: Wasteland_Outlaw_Box
     Name: Western Outlaw Box
@@ -24609,7 +24387,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24619,6 +24396,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WASTELAND_OUTLAW_BOX
     Script: |
       getgroupitem(IG_WASTELAND_OUTLAW_BOX);
   - Id: 13952
@@ -24628,7 +24406,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24638,6 +24415,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVER_ACTION_RIFLE_BOX
     Script: |
       getgroupitem(IG_LEVER_ACTION_RIFLE_BOX);
   - Id: 13953
@@ -24646,8 +24424,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24656,8 +24432,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALL_IN_ONE_RING_BOX
     Script: |
-      getgroupitem(IG_All_In_One_Ring_Box);
+      getgroupitem(IG_ALL_IN_ONE_RING_BOX);
       /*rentitem All_In_One_Ring,604800;*/
   - Id: 13954
     AegisName: Spiritual_Tunic_Box
@@ -24666,7 +24443,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24676,6 +24452,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIRITUAL_TUNIC_BOX
     Script: |
       getgroupitem(IG_SPIRITUAL_TUNIC_BOX);
   - Id: 13955
@@ -24685,7 +24462,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24695,6 +24471,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RECUPERATIVE_ARMOR_BOX
     Script: |
       getgroupitem(IG_RECUPERATIVE_ARMOR_BOX);
   - Id: 13956
@@ -24704,7 +24481,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24714,6 +24490,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHELTER_RESISTANCE_BOX
     Script: |
       getgroupitem(IG_SHELTER_RESISTANCE_BOX);
   - Id: 13957
@@ -24723,7 +24500,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24733,6 +24509,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SYLPHID_MANTEAU_BOX
     Script: |
       getgroupitem(IG_SYLPHID_MANTEAU_BOX);
   - Id: 13958
@@ -24742,7 +24519,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24752,6 +24528,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFRESH_SHOES_BOX
     Script: |
       getgroupitem(IG_REFRESH_SHOES_BOX);
   - Id: 13959
@@ -24761,7 +24538,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24771,6 +24547,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TOAST_BOX
     Script: |
       getgroupitem(IG_TOAST_BOX);
   - Id: 13960
@@ -24924,7 +24701,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -24934,6 +24710,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BUBBLEGUM_LOWER_BOX
     Script: |
       getgroupitem(IG_BUBBLEGUM_LOWER_BOX);
   - Id: 13969
@@ -24942,8 +24719,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -24952,6 +24727,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_CLIP_BOX
     Script: |
       getgroupitem(IG_LUCKY_CLIP_BOX);
   - Id: 13970
@@ -25032,8 +24808,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25042,6 +24816,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TW_SCROLL01
     Script: |
       getgroupitem(IG_TW_SCROLL01);
   - Id: 13975
@@ -25051,7 +24826,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25061,6 +24835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PICTURE_DIARY_BOX
     Script: |
       getgroupitem(IG_PICTURE_DIARY_BOX);
   - Id: 13976
@@ -25070,7 +24845,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25080,6 +24854,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MINI_HEART_BOX
     Script: |
       getgroupitem(IG_MINI_HEART_BOX);
   - Id: 13977
@@ -25089,7 +24864,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25099,6 +24873,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEWCOMER_BOX
     Script: |
       getgroupitem(IG_NEWCOMER_BOX);
   - Id: 13978
@@ -25108,7 +24883,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25118,6 +24892,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KID_BOX
     Script: |
       getgroupitem(IG_KID_BOX);
   - Id: 13979
@@ -25127,7 +24902,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25137,6 +24911,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGIC_CASTLE_BOX
     Script: |
       getgroupitem(IG_MAGIC_CASTLE_BOX);
   - Id: 13980
@@ -25146,7 +24921,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25156,6 +24930,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BULGING_HEAD_BOX
     Script: |
       getgroupitem(IG_BULGING_HEAD_BOX);
   - Id: 13981
@@ -25165,7 +24940,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25175,6 +24949,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PICTURE_DIARY_BOX_1M
     Script: |
       getgroupitem(IG_PICTURE_DIARY_BOX_1M);
   - Id: 13982
@@ -25184,7 +24959,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25194,6 +24968,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MINI_HEART_BOX_1M
     Script: |
       getgroupitem(IG_MINI_HEART_BOX_1M);
   - Id: 13983
@@ -25203,7 +24978,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25213,6 +24987,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEWCOMER_BOX_1M
     Script: |
       getgroupitem(IG_NEWCOMER_BOX_1M);
   - Id: 13984
@@ -25222,7 +24997,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25232,6 +25006,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KID_BOX_1M
     Script: |
       getgroupitem(IG_KID_BOX_1M);
   - Id: 13985
@@ -25241,7 +25016,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25251,6 +25025,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGIC_CASTLE_BOX_1M
     Script: |
       getgroupitem(IG_MAGIC_CASTLE_BOX_1M);
   - Id: 13986
@@ -25260,7 +25035,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25270,6 +25044,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BULGING_HEAD_BOX_1M
     Script: |
       getgroupitem(IG_BULGING_HEAD_BOX_1M);
   - Id: 13987
@@ -25314,8 +25089,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25324,8 +25097,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACIDBOMB_10_BOX
     Script: |
-      getgroupitem(IG_Acidbomb_10_Box);
+      getgroupitem(IG_ACIDBOMB_10_BOX);
       /*getitem 7135,10; getitem 7136,10;*/
   - Id: 13990
     AegisName: Job_Manual50_Box
@@ -25531,8 +25305,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25541,8 +25313,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BASIC_SIEGE_SUPPLY_BOX
     Script: |
-      getgroupitem(IG_Basic_Siege_Supply_Box);
+      getgroupitem(IG_BASIC_SIEGE_SUPPLY_BOX);
       /*getitem 11503,25; getitem 11504,10;*/
   - Id: 14002
     AegisName: Adv_Siege_Supply_Box
@@ -25550,8 +25323,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25560,8 +25331,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ADV_SIEGE_SUPPLY_BOX
     Script: |
-      getgroupitem(IG_Adv_Siege_Supply_Box);
+      getgroupitem(IG_ADV_SIEGE_SUPPLY_BOX);
       /*getitem 11503,50; getitem 11504,20;*/
   - Id: 14003
     AegisName: Elite_Siege_Supply_Box
@@ -25569,8 +25341,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25579,8 +25349,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ELITE_SIEGE_SUPPLY_BOX
     Script: |
-      getgroupitem(IG_Elite_Siege_Supply_Box);
+      getgroupitem(IG_ELITE_SIEGE_SUPPLY_BOX);
       /*getitem 11503,100; getitem 11504,50;*/
   - Id: 14004
     AegisName: Poison_Bottle_10_Box
@@ -25679,7 +25450,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25689,6 +25459,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_LOVE_ANGEL_BOX
     Script: |
       getgroupitem(IG_F_LOVE_ANGEL_BOX);
   - Id: 14010
@@ -25698,7 +25469,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25708,6 +25478,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SQUIRREL_BOX
     Script: |
       getgroupitem(IG_F_SQUIRREL_BOX);
   - Id: 14011
@@ -25717,7 +25488,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25727,6 +25497,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GOGO_BOX
     Script: |
       getgroupitem(IG_F_GOGO_BOX);
   - Id: 14012
@@ -25736,7 +25507,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25746,6 +25516,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_LOVE_ANGEL_BOX_1M
     Script: |
       getgroupitem(IG_F_LOVE_ANGEL_BOX_1M);
   - Id: 14013
@@ -25755,7 +25526,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25765,6 +25535,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SQUIRREL_BOX_1M
     Script: |
       getgroupitem(IG_F_SQUIRREL_BOX_1M);
   - Id: 14014
@@ -25774,7 +25545,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25784,6 +25554,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GOGO_BOX_1M
     Script: |
       getgroupitem(IG_F_GOGO_BOX_1M);
   - Id: 14015
@@ -25793,7 +25564,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25803,6 +25573,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_WASTELAND_OUTLAW_BOX
     Script: |
       getgroupitem(IG_F_WASTELAND_OUTLAW_BOX);
   - Id: 14016
@@ -25811,8 +25582,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25821,6 +25590,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_LEVER_ACTION_RIFLE_BO
     Script: |
       getgroupitem(IG_F_LEVER_ACTION_RIFLE_BO);
   - Id: 14017
@@ -25830,7 +25600,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25840,6 +25609,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ALL_IN_ONE_RING_BOX
     Script: |
       getgroupitem(IG_F_ALL_IN_ONE_RING_BOX);
   - Id: 14018
@@ -25849,7 +25619,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25859,6 +25628,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SPRITUAL_TUNIC_BOX
     Script: |
       getgroupitem(IG_F_SPRITUAL_TUNIC_BOX);
   - Id: 14019
@@ -25868,7 +25638,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25878,6 +25647,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RECUPERATIVE_BOX
     Script: |
       getgroupitem(IG_F_RECUPERATIVE_BOX);
   - Id: 14020
@@ -25887,7 +25657,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25897,6 +25666,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SHELTER_RESIST_BOX
     Script: |
       getgroupitem(IG_F_SHELTER_RESIST_BOX);
   - Id: 14021
@@ -25906,7 +25676,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25916,6 +25685,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SYLPHID_MANTEAU_BOX
     Script: |
       getgroupitem(IG_F_SYLPHID_MANTEAU_BOX);
   - Id: 14022
@@ -25924,8 +25694,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -25934,6 +25702,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_REFRESH_SHOES_BOX
     Script: |
       getgroupitem(IG_F_REFRESH_SHOES_BOX);
   - Id: 14023
@@ -25943,7 +25712,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -25953,6 +25721,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_TOAST_BOX
     Script: |
       getgroupitem(IG_F_TOAST_BOX);
   - Id: 14024
@@ -26196,7 +25965,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26206,6 +25974,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_REPAIR_SCROLL_BOX
     Script: |
       getgroupitem(IG_F_REPAIR_SCROLL_BOX);
   - Id: 14038
@@ -26215,7 +25984,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26225,6 +25993,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_REPAIR_SCROLL_BOX10
     Script: |
       getgroupitem(IG_F_REPAIR_SCROLL_BOX10);
   - Id: 14039
@@ -26234,7 +26003,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26244,6 +26012,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_HOCKEY_MASK_BOX
     Script: |
       getgroupitem(IG_F_HOCKEY_MASK_BOX);
   - Id: 14040
@@ -26253,7 +26022,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26263,6 +26031,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_OBSERVER_BOX
     Script: |
       getgroupitem(IG_F_OBSERVER_BOX);
   - Id: 14041
@@ -26524,7 +26293,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26534,6 +26302,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_NAGAN_BOX
     Script: |
       getgroupitem(IG_F_NAGAN_BOX);
   - Id: 14056
@@ -26543,7 +26312,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26553,6 +26321,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SKEWER_BOX
     Script: |
       getgroupitem(IG_F_SKEWER_BOX);
   - Id: 14057
@@ -26562,7 +26331,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26572,6 +26340,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SURVIVAL_ROD_BOX
     Script: |
       getgroupitem(IG_F_SURVIVAL_ROD_BOX);
   - Id: 14058
@@ -26581,7 +26350,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26591,6 +26359,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_QUADRILLE_BOX
     Script: |
       getgroupitem(IG_F_QUADRILLE_BOX);
   - Id: 14059
@@ -26600,7 +26369,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26610,6 +26378,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GREAT_AXE_BOX
     Script: |
       getgroupitem(IG_F_GREAT_AXE_BOX);
   - Id: 14060
@@ -26619,7 +26388,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26629,6 +26397,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BLOODY_ROAR_BOX
     Script: |
       getgroupitem(IG_F_BLOODY_ROAR_BOX);
   - Id: 14061
@@ -26638,7 +26407,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26648,6 +26416,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_HARDBACK_BOX
     Script: |
       getgroupitem(IG_F_HARDBACK_BOX);
   - Id: 14062
@@ -26657,7 +26426,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26667,6 +26435,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FIRE_BRAND_BOX
     Script: |
       getgroupitem(IG_F_FIRE_BRAND_BOX);
   - Id: 14063
@@ -26676,7 +26445,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26686,6 +26454,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_IMMATERIAL_SWORD_BOX
     Script: |
       getgroupitem(IG_F_IMMATERIAL_SWORD_BOX);
   - Id: 14064
@@ -26695,7 +26464,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26705,6 +26473,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_UNHOLY_TOUCH_BOX
     Script: |
       getgroupitem(IG_F_UNHOLY_TOUCH_BOX);
   - Id: 14065
@@ -26714,7 +26483,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26724,6 +26492,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CLACK_OF_SERVIVAL_BOX
     Script: |
       getgroupitem(IG_F_CLACK_OF_SERVIVAL_BOX);
   - Id: 14066
@@ -26733,7 +26502,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26743,6 +26511,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_MASQUERADE_BOX
     Script: |
       getgroupitem(IG_F_MASQUERADE_BOX);
   - Id: 14067
@@ -26752,7 +26521,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26762,6 +26530,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ORC_HERO_HELM_BOX
     Script: |
       getgroupitem(IG_F_ORC_HERO_HELM_BOX);
   - Id: 14068
@@ -26771,7 +26540,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26781,6 +26549,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_EAR_OF_DEVIL_WING_BOX
     Script: |
       getgroupitem(IG_F_EAR_OF_DEVIL_WING_BOX);
   - Id: 14069
@@ -26790,7 +26559,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26800,6 +26568,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_DARK_BLINDFOLD_BOX
     Script: |
       getgroupitem(IG_F_DARK_BLINDFOLD_BOX);
   - Id: 14070
@@ -26809,7 +26578,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26819,6 +26587,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_K_DROOPING_KITTY_BOX
     Script: |
       getgroupitem(IG_F_K_DROOPING_KITTY_BOX);
   - Id: 14071
@@ -26828,7 +26597,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26838,6 +26606,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CORSAIR_BOX
     Script: |
       getgroupitem(IG_F_CORSAIR_BOX);
   - Id: 14072
@@ -26847,7 +26616,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26857,6 +26625,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BLOODY_IRON_BALL_BOX
     Script: |
       getgroupitem(IG_F_BLOODY_IRON_BALL_BOX);
   - Id: 14073
@@ -26866,7 +26635,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -26876,6 +26644,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SPIRITUAL_RING_BOX
     Script: |
       getgroupitem(IG_F_SPIRITUAL_RING_BOX);
   - Id: 14074
@@ -27316,8 +27085,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -27326,6 +27093,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_PECOPECO_HAIRBAND_BOX
     Script: |
       getgroupitem(IG_F_PECOPECO_HAIRBAND_BOX);
   - Id: 14099
@@ -27334,8 +27102,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -27344,6 +27110,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RED_GLASSES_BOX
     Script: |
       getgroupitem(IG_F_RED_GLASSES_BOX);
   - Id: 14100
@@ -27352,8 +27119,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -27362,6 +27127,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_WHISPER_MASK_BOX
     Script: |
       getgroupitem(IG_F_WHISPER_MASK_BOX);
   - Id: 14101
@@ -27370,8 +27136,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -27380,6 +27144,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RAMEN_HAT_BOX
     Script: |
       getgroupitem(IG_F_RAMEN_HAT_BOX);
   - Id: 14102
@@ -27623,7 +27388,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27633,6 +27397,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_INFILTRATOR_BOX
     Script: |
       getgroupitem(IG_F_INFILTRATOR_BOX);
   - Id: 14116
@@ -27642,7 +27407,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27652,6 +27416,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_MURAMASA_BOX
     Script: |
       getgroupitem(IG_F_MURAMASA_BOX);
   - Id: 14117
@@ -27661,7 +27426,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27671,6 +27435,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_EXCALIBUR_BOX
     Script: |
       getgroupitem(IG_F_EXCALIBUR_BOX);
   - Id: 14118
@@ -27680,7 +27445,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27690,6 +27454,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_COMBAT_KNIFE_BOX
     Script: |
       getgroupitem(IG_F_COMBAT_KNIFE_BOX);
   - Id: 14119
@@ -27699,7 +27464,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27709,6 +27473,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_COUNTER_DAGGER_BOX
     Script: |
       getgroupitem(IG_F_COUNTER_DAGGER_BOX);
   - Id: 14120
@@ -27718,7 +27483,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27728,6 +27492,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_KAISER_KNUCKLE_BOX
     Script: |
       getgroupitem(IG_F_KAISER_KNUCKLE_BOX);
   - Id: 14121
@@ -27737,7 +27502,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27747,6 +27511,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_MIGHTY_STAFF_BOX
     Script: |
       getgroupitem(IG_F_MIGHTY_STAFF_BOX);
   - Id: 14122
@@ -27756,7 +27521,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27766,6 +27530,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RIGHT_EPSILON_BOX
     Script: |
       getgroupitem(IG_F_RIGHT_EPSILON_BOX);
   - Id: 14123
@@ -27775,7 +27540,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27785,6 +27549,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BALISTAR_BOX
     Script: |
       getgroupitem(IG_F_BALISTAR_BOX);
   - Id: 14124
@@ -27794,7 +27559,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27804,6 +27568,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_DIARY_OF_GREAT_SAGE
     Script: |
       getgroupitem(IG_F_DIARY_OF_GREAT_SAGE);
   - Id: 14125
@@ -27813,7 +27578,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27823,6 +27587,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ASURA_BOX
     Script: |
       getgroupitem(IG_F_ASURA_BOX);
   - Id: 14126
@@ -27832,7 +27597,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27842,6 +27606,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_APPLE_OF_ARCHER_BOX
     Script: |
       getgroupitem(IG_F_APPLE_OF_ARCHER_BOX);
   - Id: 14127
@@ -27851,7 +27616,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27861,6 +27625,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BUNNY_BAND_BOX
     Script: |
       getgroupitem(IG_F_BUNNY_BAND_BOX);
   - Id: 14128
@@ -27870,7 +27635,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27880,6 +27644,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SAHKKAT_BOX
     Script: |
       getgroupitem(IG_F_SAHKKAT_BOX);
   - Id: 14129
@@ -27889,7 +27654,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27899,6 +27663,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_LORD_CIRCLET_BOX
     Script: |
       getgroupitem(IG_F_LORD_CIRCLET_BOX);
   - Id: 14130
@@ -27908,7 +27673,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27918,6 +27682,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ELVEN_EARS_BOX
     Script: |
       getgroupitem(IG_F_ELVEN_EARS_BOX);
   - Id: 14131
@@ -27927,7 +27692,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27937,6 +27701,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_STEEL_FLOWER_BOX
     Script: |
       getgroupitem(IG_F_STEEL_FLOWER_BOX);
   - Id: 14132
@@ -27946,7 +27711,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27956,6 +27720,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CRITICAL_RING_BOX
     Script: |
       getgroupitem(IG_F_CRITICAL_RING_BOX);
   - Id: 14133
@@ -27965,7 +27730,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27975,6 +27739,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_EARRING_BOX
     Script: |
       getgroupitem(IG_F_EARRING_BOX);
   - Id: 14134
@@ -27984,7 +27749,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -27994,6 +27758,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RING_BOX
     Script: |
       getgroupitem(IG_F_RING_BOX);
   - Id: 14135
@@ -28003,7 +27768,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28013,6 +27777,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_NECKLACE_BOX
     Script: |
       getgroupitem(IG_F_NECKLACE_BOX);
   - Id: 14136
@@ -28022,7 +27787,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28032,6 +27796,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GLOVE_BOX
     Script: |
       getgroupitem(IG_F_GLOVE_BOX);
   - Id: 14137
@@ -28041,7 +27806,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28051,6 +27815,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BROOCH_BOX
     Script: |
       getgroupitem(IG_F_BROOCH_BOX);
   - Id: 14138
@@ -28060,7 +27825,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28070,6 +27834,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ROSARY_BOX
     Script: |
       getgroupitem(IG_F_ROSARY_BOX);
   - Id: 14139
@@ -28079,7 +27844,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28089,6 +27853,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SAFETY_RING_BOX
     Script: |
       getgroupitem(IG_F_SAFETY_RING_BOX);
   - Id: 14140
@@ -28098,7 +27863,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28108,6 +27872,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VESPER_CORE_BOX01
     Script: |
       getgroupitem(IG_F_VESPER_CORE_BOX01);
   - Id: 14141
@@ -28117,7 +27882,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28127,6 +27891,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VESPER_CORE_BOX02
     Script: |
       getgroupitem(IG_F_VESPER_CORE_BOX02);
   - Id: 14142
@@ -28136,7 +27901,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28146,6 +27910,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VESPER_CORE_BOX03
     Script: |
       getgroupitem(IG_F_VESPER_CORE_BOX03);
   - Id: 14143
@@ -28155,7 +27920,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28165,6 +27929,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VESPER_CORE_BOX04
     Script: |
       getgroupitem(IG_F_VESPER_CORE_BOX04);
   - Id: 14144
@@ -28174,7 +27939,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28184,6 +27948,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE1
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE1);
   - Id: 14145
@@ -28193,7 +27958,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28203,6 +27967,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE2
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE2);
   - Id: 14146
@@ -28211,8 +27976,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -28221,6 +27984,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE3
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE3);
   - Id: 14147
@@ -28229,8 +27993,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -28239,6 +28001,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE4
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE4);
   - Id: 14148
@@ -28248,7 +28011,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28258,6 +28020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE5
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE5);
   - Id: 14149
@@ -28267,7 +28030,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28277,6 +28039,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE6
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE6);
   - Id: 14150
@@ -28286,7 +28049,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28296,6 +28058,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE7
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE7);
   - Id: 14151
@@ -28305,7 +28068,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28315,6 +28077,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE8
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE8);
   - Id: 14152
@@ -28324,7 +28087,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28334,6 +28096,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE9
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE9);
   - Id: 14153
@@ -28343,7 +28106,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28353,6 +28115,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE10
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE10);
   - Id: 14154
@@ -28362,7 +28125,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28372,6 +28134,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE11
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE11);
   - Id: 14155
@@ -28381,7 +28144,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28391,6 +28153,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_VIGORGRA_PACKAGE12
     Script: |
       getgroupitem(IG_F_VIGORGRA_PACKAGE12);
   - Id: 14156
@@ -28670,7 +28433,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -28680,6 +28442,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ASPERSIO_5_SCROLL_BOX
     Script: |
       getgroupitem(IG_F_ASPERSIO_5_SCROLL_BOX);
   - Id: 14172
@@ -29175,7 +28938,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -29185,6 +28947,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ASPERSIO_5_BOX30
     Script: |
       getgroupitem(IG_F_ASPERSIO_5_BOX30);
   - Id: 14200
@@ -29194,7 +28957,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -29204,6 +28966,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ASPERSIO_5_BOX50
     Script: |
       getgroupitem(IG_F_ASPERSIO_5_BOX50);
   - Id: 14201
@@ -29681,7 +29444,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -29691,6 +29453,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HEALING_STAFF_BOX
     Script: |
       getgroupitem(IG_HEALING_STAFF_BOX);
   - Id: 14228
@@ -29700,7 +29463,6 @@ Body:
     Buy: 20
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -29710,6 +29472,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRAXINUS_BOX
     Script: |
       getgroupitem(IG_PRAXINUS_BOX);
   - Id: 14229
@@ -29718,8 +29481,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -29728,8 +29489,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAKURA_SCROLL
     Script: |
-      getgroupitem(IG_Sakura_Scroll);
+      getgroupitem(IG_SAKURA_SCROLL);
   - Id: 14230
     AegisName: Headset_OST_Box
     Name: Note Headphones Box
@@ -29751,8 +29513,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -29761,6 +29521,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NOVICE_SET_BOX
     Script: |
       getgroupitem(IG_NOVICE_SET_BOX);
   - Id: 14232
@@ -29935,8 +29696,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -29945,8 +29704,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BEHOLDER_RING_BOX
     Script: |
-      getgroupitem(IG_Beholder_Ring_Box);
+      getgroupitem(IG_BEHOLDER_RING_BOX);
       /*rentitem 2753,604800;*/
   - Id: 14243
     AegisName: Hallow_Ring_Box
@@ -29954,8 +29714,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -29964,8 +29722,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALLOW_RING_BOX
     Script: |
-      getgroupitem(IG_Hallow_Ring_Box);
+      getgroupitem(IG_HALLOW_RING_BOX);
       /*rentitem 2754,604800;*/
   - Id: 14244
     AegisName: Clamorous_Ring_Box
@@ -29973,8 +29732,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -29983,8 +29740,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLAMOROUS_RING_BOX
     Script: |
-      getgroupitem(IG_Clamorous_Ring_Box);
+      getgroupitem(IG_CLAMOROUS_RING_BOX);
       /*rentitem 2755,604800;*/
   - Id: 14245
     AegisName: Chemical_Ring_Box
@@ -29992,8 +29750,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30002,8 +29758,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEMICAL_RING_BOX
     Script: |
-      getgroupitem(IG_Chemical_Ring_Box);
+      getgroupitem(IG_CHEMICAL_RING_BOX);
       /*rentitem 2756,604800;*/
   - Id: 14246
     AegisName: Insecticide_Ring_Box
@@ -30011,8 +29768,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30021,8 +29776,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INSECTICIDE_RING_BOX
     Script: |
-      getgroupitem(IG_Insecticide_Ring_Box);
+      getgroupitem(IG_INSECTICIDE_RING_BOX);
       /*rentitem 2757,604800;*/
   - Id: 14247
     AegisName: Fisher_Ring_Box
@@ -30030,8 +29786,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30040,8 +29794,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FISHER_RING_BOX
     Script: |
-      getgroupitem(IG_Fisher_Ring_Box);
+      getgroupitem(IG_FISHER_RING_BOX);
       /*rentitem 2758,604800;*/
   - Id: 14248
     AegisName: Decussate_Ring_Box
@@ -30049,8 +29804,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30059,8 +29812,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DECUSSATE_RING_BOX
     Script: |
-      getgroupitem(IG_Decussate_Ring_Box);
+      getgroupitem(IG_DECUSSATE_RING_BOX);
       /*rentitem 2759,604800;*/
   - Id: 14249
     AegisName: Bloody_Ring_Box
@@ -30068,8 +29822,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30078,8 +29830,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_RING_BOX
     Script: |
-      getgroupitem(IG_Bloody_Ring_Box);
+      getgroupitem(IG_BLOODY_RING_BOX);
       /*rentitem 2760,604800;*/
   - Id: 14250
     AegisName: Satanic_Ring_Box
@@ -30087,8 +29840,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30097,8 +29848,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SATANIC_RING_BOX
     Script: |
-      getgroupitem(IG_Satanic_Ring_Box);
+      getgroupitem(IG_SATANIC_RING_BOX);
       /*rentitem 2761,604800;*/
   - Id: 14251
     AegisName: Dragoon_Ring_Box
@@ -30106,8 +29858,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30116,8 +29866,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DRAGOON_RING_BOX
     Script: |
-      getgroupitem(IG_Dragoon_Ring_Box);
+      getgroupitem(IG_DRAGOON_RING_BOX);
       /*rentitem 2762,604800;*/
   - Id: 14252
     AegisName: Beholder_Ring_Box2
@@ -30125,8 +29876,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30135,6 +29884,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BEHOLDER_RING_BOX2
     Script: |
       getgroupitem(IG_BEHOLDER_RING_BOX2);
   - Id: 14253
@@ -30143,8 +29893,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30153,6 +29901,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALLOW_RING_BOX2
     Script: |
       getgroupitem(IG_HALLOW_RING_BOX2);
   - Id: 14254
@@ -30161,8 +29910,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30171,6 +29918,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLAMOROUS_RING_BOX2
     Script: |
       getgroupitem(IG_CLAMOROUS_RING_BOX2);
   - Id: 14255
@@ -30179,8 +29927,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30189,6 +29935,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHEMICAL_RING_BOX2
     Script: |
       getgroupitem(IG_CHEMICAL_RING_BOX2);
   - Id: 14256
@@ -30197,8 +29944,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30207,6 +29952,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INSECTICIDE_RING_BOX2
     Script: |
       getgroupitem(IG_INSECTICIDE_RING_BOX2);
   - Id: 14257
@@ -30215,8 +29961,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30225,6 +29969,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FISHER_RING_BOX2
     Script: |
       getgroupitem(IG_FISHER_RING_BOX2);
   - Id: 14258
@@ -30233,8 +29978,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30243,6 +29986,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DECUSSATE_RING_BOX2
     Script: |
       getgroupitem(IG_DECUSSATE_RING_BOX2);
   - Id: 14259
@@ -30251,8 +29995,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30261,6 +30003,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_RING_BOX2
     Script: |
       getgroupitem(IG_BLOODY_RING_BOX2);
   - Id: 14260
@@ -30269,8 +30012,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30279,6 +30020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SATANIC_RING_BOX2
     Script: |
       getgroupitem(IG_SATANIC_RING_BOX2);
   - Id: 14261
@@ -30287,8 +30029,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30297,6 +30037,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DRAGOON_RING_BOX2
     Script: |
       getgroupitem(IG_DRAGOON_RING_BOX2);
   - Id: 14262
@@ -30305,8 +30046,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30315,6 +30054,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FPICTURE_DIARY_BOX
     Script: |
       getgroupitem(IG_FPICTURE_DIARY_BOX);
   - Id: 14263
@@ -30323,8 +30063,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30333,6 +30071,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FMINI_HEART_BOX
     Script: |
       getgroupitem(IG_FMINI_HEART_BOX);
   - Id: 14264
@@ -30341,8 +30080,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30351,6 +30088,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FNEWCOMER_BOX
     Script: |
       getgroupitem(IG_FNEWCOMER_BOX);
   - Id: 14265
@@ -30359,8 +30097,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30369,6 +30105,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FKID_BOX
     Script: |
       getgroupitem(IG_FKID_BOX);
   - Id: 14266
@@ -30377,8 +30114,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30387,6 +30122,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FMAGIC_CASTLE_BOX
     Script: |
       getgroupitem(IG_FMAGIC_CASTLE_BOX);
   - Id: 14267
@@ -30395,8 +30131,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30405,6 +30139,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FBULGING_HEAD_BOX
     Script: |
       getgroupitem(IG_FBULGING_HEAD_BOX);
   - Id: 14268
@@ -30413,8 +30148,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30423,6 +30156,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FPICTURE_DIARY_BOX_1M
     Script: |
       getgroupitem(IG_FPICTURE_DIARY_BOX_1M);
   - Id: 14269
@@ -30431,8 +30165,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30441,6 +30173,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FMINI_HEART_BOX_1M
     Script: |
       getgroupitem(IG_FMINI_HEART_BOX_1M);
   - Id: 14270
@@ -30449,8 +30182,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30459,6 +30190,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FNEWCOMER_BOX_1M
     Script: |
       getgroupitem(IG_FNEWCOMER_BOX_1M);
   - Id: 14271
@@ -30467,8 +30199,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30477,6 +30207,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FKID_BOX_1M
     Script: |
       getgroupitem(IG_FKID_BOX_1M);
   - Id: 14272
@@ -30485,8 +30216,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30495,6 +30224,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FMAGIC_CASTLE_BOX_1M
     Script: |
       getgroupitem(IG_FMAGIC_CASTLE_BOX_1M);
   - Id: 14273
@@ -30503,8 +30233,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30513,6 +30241,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FBULGING_HEAD_BOX_1M
     Script: |
       getgroupitem(IG_FBULGING_HEAD_BOX_1M);
   - Id: 14274
@@ -30617,8 +30346,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30627,6 +30354,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FHEALING_STAFF_BOX
     Script: |
       getgroupitem(IG_FHEALING_STAFF_BOX);
   - Id: 14281
@@ -30635,8 +30363,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30645,6 +30371,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FPRAXINUS_BOX
     Script: |
       getgroupitem(IG_FPRAXINUS_BOX);
   - Id: 14282
@@ -30688,8 +30415,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 95
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30698,6 +30423,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MUFFLER_C_BOX
     Script: |
       getgroupitem(IG_MUFFLER_C_BOX);
   - Id: 14285
@@ -30707,8 +30433,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 95
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30717,6 +30441,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VALKYRJA_S_SHIELD_C_BOX
     Script: |
       getgroupitem(IG_VALKYRJA_S_SHIELD_C_BOX);
   - Id: 14286
@@ -30726,8 +30451,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 95
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30736,6 +30459,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SKUL_RING_C_BOX
     Script: |
       getgroupitem(IG_SKUL_RING_C_BOX);
   - Id: 14287
@@ -30744,8 +30468,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30754,6 +30476,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BARRICADE_REPAIR_KIT
     Script: |
       getgroupitem(IG_S_BARRICADE_REPAIR_KIT);
   - Id: 14288
@@ -30762,8 +30485,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30772,6 +30493,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GSTONE_REPAIR_KIT
     Script: |
       getgroupitem(IG_S_GSTONE_REPAIR_KIT);
   - Id: 14289
@@ -30815,6 +30537,8 @@ Body:
     Name: Clothing Dye Coupon Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30830,6 +30554,8 @@ Body:
     Name: Clothing Dye Coupon Box II
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30845,6 +30571,8 @@ Body:
     Name: Mercenary Contract Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30860,6 +30588,8 @@ Body:
     Name: Mercenary Contract Box 5ea
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30875,6 +30605,8 @@ Body:
     Name: Mercenary Contract Box 10ea
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30891,8 +30623,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30901,16 +30631,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANGEL_SCROLL
     Script: |
-      getgroupitem(IG_Angel_Scroll);
+      getgroupitem(IG_ANGEL_SCROLL);
   - Id: 14297
     AegisName: Devil_Scroll
     Name: Devil Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30919,16 +30648,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEVIL_SCROLL
     Script: |
-      getgroupitem(IG_Devil_Scroll);
+      getgroupitem(IG_DEVIL_SCROLL);
   - Id: 14298
     AegisName: Surprise_Scroll
     Name: Surprise Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -30937,8 +30665,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SURPRISE_SCROLL
     Script: |
-      getgroupitem(IG_Surprise_Scroll);
+      getgroupitem(IG_SURPRISE_SCROLL);
   - Id: 14299
     AegisName: Evolved_Leaf_Box
     Name: Leaves of Grass Box
@@ -31063,8 +30792,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31073,16 +30800,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_SPECIAL_SCROLL
     Script: |
-      getgroupitem(IG_RWC_Special_Scroll);
+      getgroupitem(IG_RWC_SPECIAL_SCROLL);
   - Id: 14307
     AegisName: RWC_Limited_Scroll
     Name: RWC Limited Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31091,16 +30817,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_LIMITED_SCROLL
     Script: |
-      getgroupitem(IG_RWC_Limited_Scroll);
+      getgroupitem(IG_RWC_LIMITED_SCROLL);
   - Id: 14308
     AegisName: Ardor_Scroll
     Name: Ardor Scroll
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31109,6 +30834,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ARDOR_SCROLL
     Script: |
       getgroupitem(IG_ARDOR_SCROLL);
   - Id: 14309
@@ -31233,8 +30959,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31243,16 +30967,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JULY7_SCROLL
     Script: |
-      getgroupitem(IG_July7_Scroll);
+      getgroupitem(IG_JULY7_SCROLL);
   - Id: 14317
     AegisName: Bacsojin_Scroll
     Name: Bacsojin Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31261,8 +30984,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BACSOJIN_SCROLL
     Script: |
-      getgroupitem(IG_Bacsojin_Scroll);
+      getgroupitem(IG_BACSOJIN_SCROLL);
   - Id: 14318
     AegisName: Radio_Antenna_Box
     Name: Antenna Box
@@ -31317,8 +31041,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31327,6 +31049,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOLY_SABER_BOX
     Script: |
       getgroupitem(IG_HOLY_SABER_BOX);
   - Id: 14322
@@ -31335,8 +31058,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31345,6 +31066,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOK_OF_PRAYER_BOX
     Script: |
       getgroupitem(IG_BOOK_OF_PRAYER_BOX);
   - Id: 14323
@@ -31353,8 +31075,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31363,6 +31083,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PHENOMENA_WHIP_BOX
     Script: |
       getgroupitem(IG_PHENOMENA_WHIP_BOX);
   - Id: 14324
@@ -31371,8 +31092,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31381,6 +31100,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAFF_OF_DARKNESS_BOX
     Script: |
       getgroupitem(IG_STAFF_OF_DARKNESS_BOX);
   - Id: 14325
@@ -31389,8 +31109,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31399,6 +31117,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONK_KNUCKLE_BOX
     Script: |
       getgroupitem(IG_MONK_KNUCKLE_BOX);
   - Id: 14326
@@ -31407,8 +31126,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31417,6 +31134,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MACE_OF_MADNESS_BOX
     Script: |
       getgroupitem(IG_MACE_OF_MADNESS_BOX);
   - Id: 14327
@@ -31425,8 +31143,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31435,6 +31151,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPEAR_OF_EXCELLENT_BOX
     Script: |
       getgroupitem(IG_SPEAR_OF_EXCELLENT_BOX);
   - Id: 14328
@@ -31443,8 +31160,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31453,6 +31168,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOW_OF_EVIL_BOX
     Script: |
       getgroupitem(IG_BOW_OF_EVIL_BOX);
   - Id: 14329
@@ -31461,8 +31177,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31471,6 +31185,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KATAR_OF_SPEED_BOX
     Script: |
       getgroupitem(IG_KATAR_OF_SPEED_BOX);
   - Id: 14330
@@ -31479,8 +31194,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31489,6 +31202,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SS_REVOLVER_BOX
     Script: |
       getgroupitem(IG_SS_REVOLVER_BOX);
   - Id: 14331
@@ -31498,8 +31212,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31508,6 +31220,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUILDSMAN_RECRUITER_BOX
     Script: |
       getgroupitem(IG_GUILDSMAN_RECRUITER_BOX);
   - Id: 14332
@@ -31517,8 +31230,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31527,6 +31238,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PARTY_RECRUITER_HAT_BOX
     Script: |
       getgroupitem(IG_PARTY_RECRUITER_HAT_BOX);
   - Id: 14333
@@ -31536,8 +31248,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31546,6 +31256,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BF_RECRUITER_HAT_BOX
     Script: |
       getgroupitem(IG_BF_RECRUITER_HAT_BOX);
   - Id: 14334
@@ -31555,8 +31266,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31565,6 +31274,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FRIEND_RECR_HAT_BOX
     Script: |
       getgroupitem(IG_FRIEND_RECR_HAT_BOX);
   - Id: 14335
@@ -31574,8 +31284,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31584,6 +31292,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GF_RECRUITER_HAT_BOX
     Script: |
       getgroupitem(IG_GF_RECRUITER_HAT_BOX);
   - Id: 14336
@@ -31593,8 +31302,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31603,6 +31310,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MARCHER_HAT_BOX
     Script: |
       getgroupitem(IG_MARCHER_HAT_BOX);
   - Id: 14337
@@ -31612,8 +31320,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31622,6 +31328,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GUILDSMAN_RECR_BOX
     Script: |
       getgroupitem(IG_F_GUILDSMAN_RECR_BOX);
   - Id: 14338
@@ -31631,8 +31338,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31641,6 +31346,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_PARTY_RECR_HAT_BOX
     Script: |
       getgroupitem(IG_F_PARTY_RECR_HAT_BOX);
   - Id: 14339
@@ -31650,8 +31356,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31660,6 +31364,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FBF_RECRUITER_HAT_BOX
     Script: |
       getgroupitem(IG_FBF_RECRUITER_HAT_BOX);
   - Id: 14340
@@ -31669,8 +31374,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31679,6 +31382,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FRIEND_RECR_HAT_BOX
     Script: |
       getgroupitem(IG_F_FRIEND_RECR_HAT_BOX);
   - Id: 14341
@@ -31688,8 +31392,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31698,6 +31400,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FGF_RECRUITER_HAT_BOX
     Script: |
       getgroupitem(IG_FGF_RECRUITER_HAT_BOX);
   - Id: 14342
@@ -31722,8 +31425,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31732,6 +31433,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIKED_SCARF_BOX
     Script: |
       getgroupitem(IG_SPIKED_SCARF_BOX);
   - Id: 14344
@@ -31740,8 +31442,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31750,6 +31450,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAINBOW_SCARF_BOX
     Script: |
       getgroupitem(IG_RAINBOW_SCARF_BOX);
   - Id: 14345
@@ -31758,8 +31459,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -31768,8 +31467,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANIMAL_SCROLL
     Script: |
-      getgroupitem(IG_Animal_Scroll);
+      getgroupitem(IG_ANIMAL_SCROLL);
   - Id: 14346
     AegisName: Bro_Flag_Box
     Name: Brazilian Flag Hat Box
@@ -32060,8 +31760,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32070,8 +31768,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HEART_SCROLL
     Script: |
-      getgroupitem(IG_Heart_Scroll);
+      getgroupitem(IG_HEART_SCROLL);
   - Id: 14364
     AegisName: Job_Manual25_Box1
     Name: JOB Battle Manual Box
@@ -32556,8 +32255,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32566,6 +32263,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX01
     Script: |
       getgroupitem(IG_BONUS_BOX01);
   - Id: 14398
@@ -32574,8 +32272,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32584,6 +32280,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX02
     Script: |
       getgroupitem(IG_BONUS_BOX02);
   - Id: 14399
@@ -32592,8 +32289,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32602,6 +32297,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX03
     Script: |
       getgroupitem(IG_BONUS_BOX03);
   - Id: 14400
@@ -32610,8 +32306,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32620,6 +32314,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX04
     Script: |
       getgroupitem(IG_BONUS_BOX04);
   - Id: 14401
@@ -32628,8 +32323,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32638,6 +32331,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX05
     Script: |
       getgroupitem(IG_BONUS_BOX05);
   - Id: 14402
@@ -32646,8 +32340,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32656,6 +32348,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX06
     Script: |
       getgroupitem(IG_BONUS_BOX06);
   - Id: 14403
@@ -32664,8 +32357,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32674,6 +32365,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX07
     Script: |
       getgroupitem(IG_BONUS_BOX07);
   - Id: 14404
@@ -32682,8 +32374,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32692,6 +32382,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX08
     Script: |
       getgroupitem(IG_BONUS_BOX08);
   - Id: 14405
@@ -32700,8 +32391,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32710,6 +32399,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX09
     Script: |
       getgroupitem(IG_BONUS_BOX09);
   - Id: 14406
@@ -32718,8 +32408,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32728,6 +32416,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BONUS_BOX10
     Script: |
       getgroupitem(IG_BONUS_BOX10);
   - Id: 14407
@@ -32736,8 +32425,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32746,6 +32433,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAS_SCROLL
     Script: |
       getgroupitem(IG_XMAS_SCROLL);
   - Id: 14408
@@ -32754,8 +32442,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32764,8 +32450,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_YEAR_SCROLL
     Script: |
-      getgroupitem(IG_New_Year_Scroll);
+      getgroupitem(IG_NEW_YEAR_SCROLL);
   - Id: 14409
     AegisName: F_Santa_Hat_1_Box
     Name: Twin Pompom By JB Box
@@ -32820,8 +32507,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32830,6 +32515,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX01
     Script: |
       getgroupitem(IG_F_BONUS_BOX01);
   - Id: 14413
@@ -32838,8 +32524,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32848,6 +32532,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX02
     Script: |
       getgroupitem(IG_F_BONUS_BOX02);
   - Id: 14414
@@ -32856,8 +32541,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32866,6 +32549,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX03
     Script: |
       getgroupitem(IG_F_BONUS_BOX03);
   - Id: 14415
@@ -32874,8 +32558,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32884,6 +32566,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX04
     Script: |
       getgroupitem(IG_F_BONUS_BOX04);
   - Id: 14416
@@ -32892,8 +32575,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32902,6 +32583,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX05
     Script: |
       getgroupitem(IG_F_BONUS_BOX05);
   - Id: 14417
@@ -32910,8 +32592,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32920,6 +32600,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX06
     Script: |
       getgroupitem(IG_F_BONUS_BOX06);
   - Id: 14418
@@ -32928,8 +32609,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32938,6 +32617,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX07
     Script: |
       getgroupitem(IG_F_BONUS_BOX07);
   - Id: 14419
@@ -32946,8 +32626,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32956,6 +32634,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX08
     Script: |
       getgroupitem(IG_F_BONUS_BOX08);
   - Id: 14420
@@ -32964,8 +32643,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32974,6 +32651,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX09
     Script: |
       getgroupitem(IG_F_BONUS_BOX09);
   - Id: 14421
@@ -32982,8 +32660,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -32992,6 +32668,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BONUS_BOX10
     Script: |
       getgroupitem(IG_F_BONUS_BOX10);
   - Id: 14422
@@ -33048,8 +32725,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33058,6 +32733,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FORTUNE_SWORD_BOX_I
     Script: |
       getgroupitem(IG_FORTUNE_SWORD_BOX_I);
   - Id: 14427
@@ -33066,8 +32742,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33076,6 +32750,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOUSE_AUGER_BOX_I
     Script: |
       getgroupitem(IG_HOUSE_AUGER_BOX_I);
   - Id: 14428
@@ -33084,8 +32759,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33094,6 +32767,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KAMAITACHI_BOX_I
     Script: |
       getgroupitem(IG_KAMAITACHI_BOX_I);
   - Id: 14429
@@ -33102,8 +32776,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33112,6 +32784,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BERSERK_GUITAR_BOX_I
     Script: |
       getgroupitem(IG_BERSERK_GUITAR_BOX_I);
   - Id: 14430
@@ -33120,8 +32793,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33130,6 +32801,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DOOM_SLAYER_BOX_I
     Script: |
       getgroupitem(IG_DOOM_SLAYER_BOX_I);
   - Id: 14431
@@ -33138,8 +32810,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33148,6 +32818,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HUUMA_BLAZE_BOX_I
     Script: |
       getgroupitem(IG_HUUMA_BLAZE_BOX_I);
   - Id: 14432
@@ -33156,8 +32827,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33166,6 +32835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ODIN_S_BLESSING_BOX_I
     Script: |
       getgroupitem(IG_ODIN_S_BLESSING_BOX_I);
   - Id: 14433
@@ -33174,8 +32844,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33184,6 +32852,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RING_OF_F_LORD_BOX_I
     Script: |
       getgroupitem(IG_RING_OF_F_LORD_BOX_I);
   - Id: 14434
@@ -33192,8 +32861,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33202,6 +32869,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RING_OF_RESON_BOX_I
     Script: |
       getgroupitem(IG_RING_OF_RESON_BOX_I);
   - Id: 14435
@@ -33210,8 +32878,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33220,6 +32886,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOY_S_CAP_BOX_I
     Script: |
       getgroupitem(IG_BOY_S_CAP_BOX_I);
   - Id: 14436
@@ -33228,8 +32895,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33238,6 +32903,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ULLE_CAP_BOX_I
     Script: |
       getgroupitem(IG_ULLE_CAP_BOX_I);
   - Id: 14437
@@ -33246,8 +32912,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33256,6 +32920,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPINX_HELM_BOX_I
     Script: |
       getgroupitem(IG_SPINX_HELM_BOX_I);
   - Id: 14438
@@ -33281,8 +32946,6 @@ Body:
     Name: Power Of Thor Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33291,6 +32954,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POWER_OF_THOR_BOX
     Script: |
       getgroupitem(IG_POWER_OF_THOR_BOX);
   - Id: 14440
@@ -33425,8 +33089,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 2000
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33435,6 +33097,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FUGIN_EGG01
     Script: |
       getgroupitem(IG_FUGIN_EGG01);
   - Id: 14450
@@ -33443,8 +33106,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 2000
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -33453,6 +33114,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FUGIN_EGG02
     Script: |
       getgroupitem(IG_FUGIN_EGG02);
   - Id: 14451
@@ -33633,8 +33295,7 @@ Body:
     AegisName: Valentine_Pledge_Box
     Name: Valentine's Emblem Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_VALENTINE_PLEDGE_BOX
     Script: |
       getgroupitem(IG_VALENTINE_PLEDGE_BOX);
   - Id: 14467
@@ -33673,10 +33334,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_OX_TAIL_SCROLL
     Script: |
-      getgroupitem(IG_Ox_Tail_Scroll);
+      getgroupitem(IG_OX_TAIL_SCROLL);
   - Id: 14470
     AegisName: T_Nightmare_Box
     Name: Nightmare Terror Exchange Coupon Box
@@ -35620,15 +35280,14 @@ Body:
     Name: Pierre's Treasure Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_PIERRE_TREASUREBOX
     Script: |
-      getgroupitem(IG_Pierre_Treasurebox);
-      getgroupitem(IG_Pierre_Treasurebox);
-      getgroupitem(IG_Pierre_Treasurebox);
-      getgroupitem(IG_Pierre_Treasurebox);
-      getgroupitem(IG_Pierre_Treasurebox);
-      getgroupitem(IG_Pierre_Treasurebox);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
+      getgroupitem(IG_PIERRE_TREASUREBOX);
   - Id: 14597
     AegisName: PhreeoniS
     Name: Phreeoni Scroll
@@ -35853,8 +35512,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -35863,8 +35520,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_SCROLL_2012
     Script: |
-      getgroupitem(IG_RWC_Scroll_2012);
+      getgroupitem(IG_RWC_SCROLL_2012);
   - Id: 14614
     AegisName: Ex_Def_Potion
     Name: Ex Def Potion
@@ -35990,8 +35648,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36000,6 +35656,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDENTREASUREBOX
     Script: |
       getgroupitem(IG_GOLDENTREASUREBOX);
   - Id: 14624
@@ -36008,27 +35665,23 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BLUE_SCROLL
     Script: |
-      getgroupitem(IG_Blue_Scroll);
+      getgroupitem(IG_BLUE_SCROLL);
   - Id: 14626
     AegisName: Indigo_Scroll
     Name: Indigo Scroll
     Type: Usable
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_INDIGO_SCROLL
     Script: |
-      getgroupitem(IG_Indigo_Scroll);
+      getgroupitem(IG_INDIGO_SCROLL);
   - Id: 14627
     AegisName: Xmax_Egg_Kr
     Name: Christmas Scroll
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36037,6 +35690,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAX_EGG_KR
     Script: |
       getgroupitem(IG_XMAX_EGG_KR);
   - Id: 14628
@@ -36045,8 +35699,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36055,6 +35707,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_FESTIVAL_TICKET
     Script: |
       getgroupitem(IG_C_FESTIVAL_TICKET);
   - Id: 14629
@@ -36063,19 +35716,17 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box);
+      getgroupitem(IG_ENCHANT_STONE_BOX);
   - Id: 14643
     AegisName: Violet_Scroll
     Name: Violet Scroll
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_VIOLET_SCROLL
     Script: |
-      getgroupitem(IG_Violet_Scroll);
+      getgroupitem(IG_VIOLET_SCROLL);
   - Id: 14645
     AegisName: Wing_Of_Baalzebub
     Name: Beelzebub Wing
@@ -36108,8 +35759,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36118,6 +35767,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_D_LORD_SCROLL
     Script: |
       getgroupitem(IG_SEALED_D_LORD_SCROLL);
   - Id: 14664
@@ -36125,45 +35775,39 @@ Body:
     Name: Bi Hwang Scroll
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_BI_HWANG_SCROLL
     Script: |
-      getgroupitem(IG_Bi_Hwang_Scroll);
+      getgroupitem(IG_BI_HWANG_SCROLL);
   - Id: 14665
     AegisName: Jung_Bi_Scroll
     Name: Jung Bi Scroll
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_JUNG_BI_SCROLL
     Script: |
-      getgroupitem(IG_Jung_Bi_Scroll);
+      getgroupitem(IG_JUNG_BI_SCROLL);
   - Id: 14666
     AegisName: Je_Un_Scroll
     Name: Je Un Scroll
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_JE_UN_SCROLL
     Script: |
-      getgroupitem(IG_Je_Un_Scroll);
+      getgroupitem(IG_JE_UN_SCROLL);
   - Id: 14667
     AegisName: Yong_Kwang_Scroll
     Name: Yong Kwang Scroll
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_YONG_KWANG_SCROLL
     Script: |
-      getgroupitem(IG_Yong_Kwang_Scroll);
+      getgroupitem(IG_YONG_KWANG_SCROLL);
   - Id: 14672
     AegisName: StealFighter_20Lv
     Name: Steel Fighter (20Lv) Egg
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36171,6 +35815,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STEALFIGHTER_20LV
     Script: |
       getgroupitem(IG_STEALFIGHTER_20LV);
   - Id: 14673
@@ -36179,8 +35824,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36188,6 +35831,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STEALFIGHTER_25LV
     Script: |
       getgroupitem(IG_STEALFIGHTER_25LV);
   - Id: 14674
@@ -36205,8 +35849,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36215,6 +35857,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_BOX2
     Script: |
       getgroupitem(IG_SHADOW_BOX2);
   - Id: 14679
@@ -36223,8 +35866,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36233,6 +35874,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_KNIGHT_WS_SCROLL
     Script: |
       getgroupitem(IG_SEALED_KNIGHT_WS_SCROLL);
   - Id: 14681
@@ -36241,18 +35883,15 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX2
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box2);
+      getgroupitem(IG_ENCHANT_STONE_BOX2);
   - Id: 14682
     AegisName: Sealed_Berz_Scroll
     Name: Sealed Beelzebub Scroll
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36261,6 +35900,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_BERZ_SCROLL
     Script: |
       getgroupitem(IG_SEALED_BERZ_SCROLL);
   - Id: 14689
@@ -36269,8 +35909,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36279,6 +35917,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_KIEL_SCROLL
     Script: |
       getgroupitem(IG_SEALED_KIEL_SCROLL);
   - Id: 14695
@@ -36287,18 +35926,15 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX3
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box3);
+      getgroupitem(IG_ENCHANT_STONE_BOX3);
   - Id: 14696
     AegisName: Sealed_Gloom_Scroll
     Name: Sealed Gloom Under Night Scroll
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36307,6 +35943,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_GLOOM_SCROLL
     Script: |
       getgroupitem(IG_SEALED_GLOOM_SCROLL);
   - Id: 14699
@@ -36316,10 +35953,9 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_GARUDA_SCROLL
     Script: |
-      getgroupitem(IG_Garuda_Scroll);
+      getgroupitem(IG_GARUDA_SCROLL);
   - Id: 14701
     AegisName: TW_13y_Lucky_Egg_06
     Name: Midgard Immortal Lucky Egg
@@ -36327,18 +35963,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_13Y_LUCKY_EGG_06
     Script: |
-      getgroupitem(IG_TW_13y_Lucky_Egg_06);
+      getgroupitem(IG_TW_13Y_LUCKY_EGG_06);
   - Id: 14704
     AegisName: Gemstone_Shadow_Box
     Name: Gemstone Shadow Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36347,6 +35980,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GEMSTONE_SHADOW_BOX
     Script: |
       getgroupitem(IG_GEMSTONE_SHADOW_BOX);
   - Id: 14705
@@ -36355,8 +35989,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36365,6 +35997,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_F_BISHOP_SCROLL
     Script: |
       getgroupitem(IG_SEALED_F_BISHOP_SCROLL);
   - Id: 14713
@@ -36373,8 +36006,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36383,6 +36014,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_IFRIT_SCROLL
     Script: |
       getgroupitem(IG_SEALED_IFRIT_SCROLL);
   - Id: 14717
@@ -36391,8 +36023,6 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36401,16 +36031,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2013_RWC_SCROLL
     Script: |
-      getgroupitem(IG_2013_RWC_Scroll);
+      getgroupitem(IG_2013_RWC_SCROLL);
   - Id: 14718
     AegisName: Sealed_TurtleG_Scroll
     Name: Sealed Turtle General Gachapon
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36419,6 +36048,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_TURTLEG_SCROLL
     Script: |
       getgroupitem(IG_SEALED_TURTLEG_SCROLL);
   - Id: 14723
@@ -36457,8 +36087,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36467,6 +36095,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_BACSOJIN_SCROLL
     Script: |
       getgroupitem(IG_SEALED_BACSOJIN_SCROLL);
   - Id: 14726
@@ -36475,8 +36104,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36485,6 +36112,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GREED_SHADOW_BOX
     Script: |
       getgroupitem(IG_GREED_SHADOW_BOX);
   - Id: 14727
@@ -36493,8 +36121,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36503,6 +36129,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HEAL_SHADOW_BOX
     Script: |
       getgroupitem(IG_HEAL_SHADOW_BOX);
   - Id: 14728
@@ -36511,8 +36138,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36521,6 +36146,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HIDING_SHADOW_BOX
     Script: |
       getgroupitem(IG_HIDING_SHADOW_BOX);
   - Id: 14729
@@ -36529,8 +36155,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36539,6 +36163,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOAKING_SHADOW_BOX
     Script: |
       getgroupitem(IG_CLOAKING_SHADOW_BOX);
   - Id: 14730
@@ -36547,8 +36172,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36557,6 +36180,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUME_FESTIVAL_BOX2
     Script: |
       getgroupitem(IG_COSTUME_FESTIVAL_BOX2);
   - Id: 14731
@@ -36565,8 +36189,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36575,6 +36197,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TELEPORT_SHADOW_BOX
     Script: |
       getgroupitem(IG_TELEPORT_SHADOW_BOX);
   - Id: 14732
@@ -36583,8 +36206,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36593,6 +36214,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STEAL_SHADOW_BOX
     Script: |
       getgroupitem(IG_STEAL_SHADOW_BOX);
   - Id: 14733
@@ -36601,8 +36223,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36611,6 +36231,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_PHARAOH_SCROLL
     Script: |
       getgroupitem(IG_SEALED_PHARAOH_SCROLL);
   - Id: 14735
@@ -36618,8 +36239,6 @@ Body:
     Name: Shapeshifter Costume
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36628,6 +36247,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG22
     Script: |
       getgroupitem(IG_COSTAMA_EGG22);
   - Id: 14739
@@ -36636,8 +36256,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36646,6 +36264,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_B_YGNIZEM_SCROLL
     Script: |
       getgroupitem(IG_SEALED_B_YGNIZEM_SCROLL);
   - Id: 14740
@@ -36654,8 +36273,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36664,6 +36281,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_APO_H_SCROLL
     Script: |
       getgroupitem(IG_SEALED_APO_H_SCROLL);
   - Id: 14741
@@ -36671,27 +36289,23 @@ Body:
     Name: Midgard Celebration Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_IMORTAL_MIDGARD_SCROLL
     Script: |
-      getgroupitem(IG_Imortal_Midgard_Scroll);
+      getgroupitem(IG_IMORTAL_MIDGARD_SCROLL);
   - Id: 14753
     AegisName: Hero_Midgard_Scroll
     Name: Hero Midgard Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HERO_MIDGARD_EGG
     Script: |
-      getgroupitem(IG_Hero_Midgard_Egg);
+      getgroupitem(IG_HERO_MIDGARD_EGG);
   - Id: 14758
     AegisName: Guarantee_Relax_Scroll
     Name: Safe To Smelting Scroll
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36700,6 +36314,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUARANTEE_RELAX_SCROLL
     Script: |
       getgroupitem(IG_GUARANTEE_RELAX_SCROLL);
   - Id: 14765
@@ -36740,8 +36355,6 @@ Body:
     Name: Soul Plunger Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36750,6 +36363,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PUMP_OF_SPIRIT_SCROLL
     Script: |
       getgroupitem(IG_PUMP_OF_SPIRIT_SCROLL);
   - Id: 14781
@@ -36757,8 +36371,6 @@ Body:
     Name: Happy Balloon Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36767,6 +36379,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HAPPY_BALLOON_SCROLL
     Script: |
       getgroupitem(IG_HAPPY_BALLOON_SCROLL);
   - Id: 14799
@@ -36791,8 +36404,6 @@ Body:
     Name: Almighty Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -36801,8 +36412,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JULY_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_July_Lucky_Scroll);
+      getgroupitem(IG_JULY_LUCKY_SCROLL);
   - Id: 14826
     AegisName: Dungeon_Ticket
     Name: Dungeon Teleport Ticket
@@ -37196,8 +36808,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37206,6 +36816,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANGRY_MOUTH_C_BOX
     Script: |
       getgroupitem(IG_ANGRY_MOUTH_C_BOX);
   - Id: 16101
@@ -37214,8 +36825,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37224,6 +36833,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KRO_LUCKY_BOX
     Script: |
       getgroupitem(IG_KRO_LUCKY_BOX);
   - Id: 16102
@@ -37232,8 +36842,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37242,6 +36850,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLAYMORE_C_BOX
     Script: |
       getgroupitem(IG_CLAYMORE_C_BOX);
   - Id: 16103
@@ -37250,8 +36859,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37260,6 +36867,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JAMADHAR_C_BOX
     Script: |
       getgroupitem(IG_JAMADHAR_C_BOX);
   - Id: 16104
@@ -37268,8 +36876,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37278,6 +36884,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TWO_HANDED_AXE_C_BOX
     Script: |
       getgroupitem(IG_TWO_HANDED_AXE_C_BOX);
   - Id: 16105
@@ -37286,8 +36893,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37296,6 +36901,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LANCE_C_BOX
     Script: |
       getgroupitem(IG_LANCE_C_BOX);
   - Id: 16106
@@ -37304,8 +36910,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37314,6 +36918,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HUUMA_GIANT_WHEEL_C_BOX
     Script: |
       getgroupitem(IG_HUUMA_GIANT_WHEEL_C_BOX);
   - Id: 16107
@@ -37322,8 +36927,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37332,6 +36935,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ORCISH_AXE_C_BOX
     Script: |
       getgroupitem(IG_ORCISH_AXE_C_BOX);
   - Id: 16108
@@ -37340,8 +36944,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37350,6 +36952,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PIKE_C_BOX
     Script: |
       getgroupitem(IG_PIKE_C_BOX);
   - Id: 16109
@@ -37358,8 +36961,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37368,6 +36969,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ENCYCLOPEDIA_C_BOX
     Script: |
       getgroupitem(IG_ENCYCLOPEDIA_C_BOX);
   - Id: 16110
@@ -37376,8 +36978,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37386,6 +36986,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FIST_C_BOX
     Script: |
       getgroupitem(IG_FIST_C_BOX);
   - Id: 16111
@@ -37394,8 +36995,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37404,6 +37003,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUITAR_C_BOX
     Script: |
       getgroupitem(IG_GUITAR_C_BOX);
   - Id: 16112
@@ -37412,8 +37012,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37422,6 +37020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RANTE_C_BOX
     Script: |
       getgroupitem(IG_RANTE_C_BOX);
   - Id: 16113
@@ -37430,8 +37029,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37440,6 +37037,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DAMASCUS_C_BOX
     Script: |
       getgroupitem(IG_DAMASCUS_C_BOX);
   - Id: 16114
@@ -37448,8 +37046,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37458,6 +37054,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FLAMBERGE_C_BOX
     Script: |
       getgroupitem(IG_FLAMBERGE_C_BOX);
   - Id: 16115
@@ -37466,8 +37063,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37476,6 +37071,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STUNNER_C_BOX
     Script: |
       getgroupitem(IG_STUNNER_C_BOX);
   - Id: 16116
@@ -37484,8 +37080,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37494,6 +37088,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_KRO_LUCKY_BOX
     Script: |
       getgroupitem(IG_F_KRO_LUCKY_BOX);
   - Id: 16117
@@ -37502,8 +37097,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37512,6 +37105,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CLAYMORE_C_BOX
     Script: |
       getgroupitem(IG_F_CLAYMORE_C_BOX);
   - Id: 16118
@@ -37520,8 +37114,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37530,6 +37122,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_JAMADHAR_C_BOX
     Script: |
       getgroupitem(IG_F_JAMADHAR_C_BOX);
   - Id: 16119
@@ -37538,8 +37131,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37548,6 +37139,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_TWO_HANDED_AXE_C_BOX
     Script: |
       getgroupitem(IG_F_TWO_HANDED_AXE_C_BOX);
   - Id: 16120
@@ -37556,8 +37148,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37566,6 +37156,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_LANCE_C_BOX
     Script: |
       getgroupitem(IG_F_LANCE_C_BOX);
   - Id: 16121
@@ -37574,8 +37165,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37584,6 +37173,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_HUUMA_GIANT_C_BOX
     Script: |
       getgroupitem(IG_F_HUUMA_GIANT_C_BOX);
   - Id: 16122
@@ -37592,8 +37182,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37602,6 +37190,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ORCISH_AXE_C_BOX
     Script: |
       getgroupitem(IG_F_ORCISH_AXE_C_BOX);
   - Id: 16123
@@ -37610,8 +37199,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37620,6 +37207,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_PIKE_C_BOX
     Script: |
       getgroupitem(IG_F_PIKE_C_BOX);
   - Id: 16124
@@ -37628,8 +37216,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37638,6 +37224,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ENCYCLOPEDIA_C_BOX
     Script: |
       getgroupitem(IG_F_ENCYCLOPEDIA_C_BOX);
   - Id: 16125
@@ -37646,8 +37233,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37656,6 +37241,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FIST_C_BOX
     Script: |
       getgroupitem(IG_F_FIST_C_BOX);
   - Id: 16126
@@ -37664,8 +37250,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37674,6 +37258,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_GUITAR_C_BOX
     Script: |
       getgroupitem(IG_F_GUITAR_C_BOX);
   - Id: 16127
@@ -37682,8 +37267,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37692,6 +37275,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RANTE_C_BOX
     Script: |
       getgroupitem(IG_F_RANTE_C_BOX);
   - Id: 16128
@@ -37700,8 +37284,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37710,6 +37292,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_DAMASCUS_C_BOX
     Script: |
       getgroupitem(IG_F_DAMASCUS_C_BOX);
   - Id: 16129
@@ -37718,8 +37301,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37728,6 +37309,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FLAMBERGE_C_BOX
     Script: |
       getgroupitem(IG_F_FLAMBERGE_C_BOX);
   - Id: 16130
@@ -37736,8 +37318,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -37746,6 +37326,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_STUNNER_C_BOX
     Script: |
       getgroupitem(IG_F_STUNNER_C_BOX);
   - Id: 16131
@@ -38606,8 +38187,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -38616,6 +38195,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ANGRY_MOUTH_C_BOX
     Script: |
       getgroupitem(IG_F_ANGRY_MOUTH_C_BOX);
   - Id: 16188
@@ -38942,8 +38522,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -38952,6 +38530,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MARIONETTE_C_BOX
     Script: |
       getgroupitem(IG_MARIONETTE_C_BOX);
   - Id: 16221
@@ -38960,8 +38539,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -38970,6 +38547,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WHISPER_C_BOX
     Script: |
       getgroupitem(IG_WHISPER_C_BOX);
   - Id: 16222
@@ -38978,8 +38556,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -38988,6 +38564,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INCUBUS_C_BOX
     Script: |
       getgroupitem(IG_INCUBUS_C_BOX);
   - Id: 16223
@@ -38996,8 +38573,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39006,6 +38581,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_MARIONETTE_C_BOX
     Script: |
       getgroupitem(IG_F_MARIONETTE_C_BOX);
   - Id: 16224
@@ -39014,8 +38590,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39024,6 +38598,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_WHISPER_C_BOX
     Script: |
       getgroupitem(IG_F_WHISPER_C_BOX);
   - Id: 16225
@@ -39032,8 +38607,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39042,6 +38615,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_INCUBUS_C_BOX
     Script: |
       getgroupitem(IG_F_INCUBUS_C_BOX);
   - Id: 16226
@@ -39344,10 +38918,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_APRIL_SCROLL
     Script: |
-      getgroupitem(IG_Tw_April_Scroll);
+      getgroupitem(IG_TW_APRIL_SCROLL);
   - Id: 16246
     AegisName: Crown_Of_Deceit_Box
     Name: Crown Of Deceit Box
@@ -39466,8 +39039,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39476,6 +39047,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACTI_POTION_BOX
     Script: |
       getgroupitem(IG_ACTI_POTION_BOX);
   - Id: 16255
@@ -39484,8 +39056,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39494,6 +39064,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ACTI_POTION_BOX
     Script: |
       getgroupitem(IG_F_ACTI_POTION_BOX);
   - Id: 16256
@@ -39502,10 +39073,9 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_RO_DS_HEADGEAR_BOX
     Script: |
       getgroupitem(IG_RO_DS_HEADGEAR_BOX);
   - Id: 16257
@@ -39514,10 +39084,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUDDAH_SCROLL
     Script: |
-      getgroupitem(IG_Buddah_Scroll);
+      getgroupitem(IG_BUDDAH_SCROLL);
   - Id: 16258
     AegisName: HD_Bradium_Box5
     Name: HD Bradium 5 Box
@@ -39526,6 +39095,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39544,6 +39114,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39562,6 +39133,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39580,6 +39152,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39596,6 +39169,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39612,6 +39187,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39628,6 +39205,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39644,6 +39223,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39669,6 +39250,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12411,10;
   - Id: 16268
@@ -39677,6 +39260,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 12412,10;
   - Id: 16269
@@ -39706,8 +39291,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39716,6 +39299,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HOCKEY_MASK_BOX1
     Script: |
       getgroupitem(IG_HOCKEY_MASK_BOX1);
   - Id: 16272
@@ -39725,8 +39309,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 35
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39735,6 +39317,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OBSERVER_BOX1
     Script: |
       getgroupitem(IG_OBSERVER_BOX1);
   - Id: 16273
@@ -39743,8 +39326,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39753,6 +39334,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALL_IN_ONE_RING_BOX1
     Script: |
       getgroupitem(IG_ALL_IN_ONE_RING_BOX1);
   - Id: 16274
@@ -39761,8 +39343,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39771,6 +39351,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPRITUAL_TUNIC_BOX1
     Script: |
       getgroupitem(IG_SPRITUAL_TUNIC_BOX1);
   - Id: 16275
@@ -39779,8 +39360,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39789,6 +39368,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RECUPERATIVE_ARMOR_BOX1
     Script: |
       getgroupitem(IG_RECUPERATIVE_ARMOR_BOX1);
   - Id: 16276
@@ -39797,8 +39377,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39807,6 +39385,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHELTER_RESIST_BOX1
     Script: |
       getgroupitem(IG_SHELTER_RESIST_BOX1);
   - Id: 16277
@@ -39815,8 +39394,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39825,6 +39402,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SYLPHID_MANTEAU_BOX1
     Script: |
       getgroupitem(IG_SYLPHID_MANTEAU_BOX1);
   - Id: 16278
@@ -39833,8 +39411,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39843,6 +39419,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFRESH_SHOES_BOX1
     Script: |
       getgroupitem(IG_REFRESH_SHOES_BOX1);
   - Id: 16279
@@ -39851,8 +39428,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39861,6 +39436,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WELL_BAKED_TOAST_BOX1
     Script: |
       getgroupitem(IG_WELL_BAKED_TOAST_BOX1);
   - Id: 16280
@@ -39869,8 +39445,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39879,6 +39453,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WASTELAND_OUTLAW_BOX1
     Script: |
       getgroupitem(IG_WASTELAND_OUTLAW_BOX1);
   - Id: 16281
@@ -39887,8 +39462,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39897,6 +39470,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVER_ACT_RIFLE_BOX1
     Script: |
       getgroupitem(IG_LEVER_ACT_RIFLE_BOX1);
   - Id: 16282
@@ -39905,8 +39479,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39915,6 +39487,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HEALING_STAFF_BOX1
     Script: |
       getgroupitem(IG_HEALING_STAFF_BOX1);
   - Id: 16283
@@ -39923,8 +39496,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39933,6 +39504,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRAXINUS_BOX1
     Script: |
       getgroupitem(IG_PRAXINUS_BOX1);
   - Id: 16284
@@ -39942,8 +39514,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39952,6 +39522,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUILD_RECRUIT_BOX1
     Script: |
       getgroupitem(IG_GUILD_RECRUIT_BOX1);
   - Id: 16285
@@ -39961,8 +39532,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39971,6 +39540,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PARTY_RECRUIT_HAT_BOX1
     Script: |
       getgroupitem(IG_PARTY_RECRUIT_HAT_BOX1);
   - Id: 16286
@@ -39980,8 +39550,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -39990,6 +39558,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BF_RECRUIT_HAT_BOX1
     Script: |
       getgroupitem(IG_BF_RECRUIT_HAT_BOX1);
   - Id: 16287
@@ -39999,8 +39568,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40009,6 +39576,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GF_RECRUIT_HAT_BOX1
     Script: |
       getgroupitem(IG_GF_RECRUIT_HAT_BOX1);
   - Id: 16288
@@ -40018,8 +39586,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40028,6 +39594,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FRIEND_RECRUIT_HAT_BOX1
     Script: |
       getgroupitem(IG_FRIEND_RECRUIT_HAT_BOX1);
   - Id: 16289
@@ -40036,8 +39603,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40046,6 +39611,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLAYMORE_C_BOX1
     Script: |
       getgroupitem(IG_CLAYMORE_C_BOX1);
   - Id: 16290
@@ -40054,8 +39620,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40064,6 +39628,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TWO_HANDED_AXE_C_BOX1
     Script: |
       getgroupitem(IG_TWO_HANDED_AXE_C_BOX1);
   - Id: 16291
@@ -40072,8 +39637,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40082,6 +39645,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LANCE_C_BOX1
     Script: |
       getgroupitem(IG_LANCE_C_BOX1);
   - Id: 16292
@@ -40090,8 +39654,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40100,6 +39662,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JAMADHAR_C_BOX1
     Script: |
       getgroupitem(IG_JAMADHAR_C_BOX1);
   - Id: 16293
@@ -40108,8 +39671,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40118,6 +39679,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HUUMA_GIANT_C_BOX1
     Script: |
       getgroupitem(IG_HUUMA_GIANT_C_BOX1);
   - Id: 16294
@@ -40126,8 +39688,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40136,6 +39696,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ORCISH_AXE_C_BOX1
     Script: |
       getgroupitem(IG_ORCISH_AXE_C_BOX1);
   - Id: 16295
@@ -40144,8 +39705,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40154,6 +39713,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PIKE_C_BOX1
     Script: |
       getgroupitem(IG_PIKE_C_BOX1);
   - Id: 16296
@@ -40162,8 +39722,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40172,6 +39730,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ENCYCLOPEDIA_C_BOX1
     Script: |
       getgroupitem(IG_ENCYCLOPEDIA_C_BOX1);
   - Id: 16297
@@ -40180,8 +39739,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40190,6 +39747,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FIST_C_BOX1
     Script: |
       getgroupitem(IG_FIST_C_BOX1);
   - Id: 16298
@@ -40198,8 +39756,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40208,6 +39764,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUITAR_C_BOX1
     Script: |
       getgroupitem(IG_GUITAR_C_BOX1);
   - Id: 16299
@@ -40216,8 +39773,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40226,6 +39781,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RANTE_C_BOX1
     Script: |
       getgroupitem(IG_RANTE_C_BOX1);
   - Id: 16300
@@ -40234,8 +39790,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40244,6 +39798,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DAMASCUS_C_BOX1
     Script: |
       getgroupitem(IG_DAMASCUS_C_BOX1);
   - Id: 16301
@@ -40252,8 +39807,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40262,6 +39815,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FLAMBERGE_C_BOX1
     Script: |
       getgroupitem(IG_FLAMBERGE_C_BOX1);
   - Id: 16302
@@ -40270,8 +39824,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40280,6 +39832,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STUNNER_C_BOX1
     Script: |
       getgroupitem(IG_STUNNER_C_BOX1);
   - Id: 16303
@@ -40288,8 +39841,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40298,6 +39849,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANGRY_MOUTH_C_BOX1
     Script: |
       getgroupitem(IG_ANGRY_MOUTH_C_BOX1);
   - Id: 16304
@@ -40306,8 +39858,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -40316,8 +39866,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVIL_INCARNATION
     Script: |
-      getgroupitem(IG_Evil_Incarnation);
+      getgroupitem(IG_EVIL_INCARNATION);
   - Id: 16305
     AegisName: Upg_Guard_Box
     Name: Upg Guard Box
@@ -41028,8 +40579,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41038,6 +40587,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHOOTING_STAR_C_BOX
     Script: |
       getgroupitem(IG_SHOOTING_STAR_C_BOX);
   - Id: 16348
@@ -41046,8 +40596,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41056,6 +40604,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_FEAR_C_BOX
     Script: |
       getgroupitem(IG_BLOODY_FEAR_C_BOX);
   - Id: 16349
@@ -41064,8 +40613,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41074,6 +40621,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AHLSPIESS_C_BOX
     Script: |
       getgroupitem(IG_AHLSPIESS_C_BOX);
   - Id: 16350
@@ -41082,8 +40630,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41092,6 +40638,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STAFF_OF_HEALING_C_BOX
     Script: |
       getgroupitem(IG_STAFF_OF_HEALING_C_BOX);
   - Id: 16351
@@ -41100,8 +40647,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41110,6 +40655,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANTI_DEMON_SHIELD_C_BOX
     Script: |
       getgroupitem(IG_ANTI_DEMON_SHIELD_C_BOX);
   - Id: 16352
@@ -41118,8 +40664,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41128,6 +40672,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SHOOTING_STAR_C_BOX
     Script: |
       getgroupitem(IG_F_SHOOTING_STAR_C_BOX);
   - Id: 16353
@@ -41136,8 +40681,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41146,6 +40689,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BLOODY_FEAR_C_BOX
     Script: |
       getgroupitem(IG_F_BLOODY_FEAR_C_BOX);
   - Id: 16354
@@ -41154,8 +40698,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41164,6 +40706,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_AHLSPIESS_C_BOX
     Script: |
       getgroupitem(IG_F_AHLSPIESS_C_BOX);
   - Id: 16355
@@ -41172,8 +40715,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41182,6 +40723,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_S_HEALING_C_BOX
     Script: |
       getgroupitem(IG_F_S_HEALING_C_BOX);
   - Id: 16356
@@ -41190,8 +40732,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41200,6 +40740,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_A_DEMON_SHIELD_C_BOX
     Script: |
       getgroupitem(IG_F_A_DEMON_SHIELD_C_BOX);
   - Id: 16357
@@ -41224,8 +40765,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41234,6 +40773,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MBL_PET_RANDOM_BOX
     Script: |
       getgroupitem(IG_MBL_PET_RANDOM_BOX);
   - Id: 16359
@@ -41242,8 +40782,7 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_7TH_ANNI_RANDOM_BOX
     Script: |
       getgroupitem(IG_7TH_ANNI_RANDOM_BOX);
   - Id: 16360
@@ -41370,8 +40909,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41380,6 +40917,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_RING_BOX
     Script: |
       getgroupitem(IG_FREYJA_RING_BOX);
   - Id: 16370
@@ -41388,8 +40926,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41398,6 +40934,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FREYJA_RING_BOX
     Script: |
       getgroupitem(IG_F_FREYJA_RING_BOX);
   - Id: 16371
@@ -41406,18 +40943,15 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_AUG_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Aug_Scroll);
+      getgroupitem(IG_TW_AUG_SCROLL);
   - Id: 16372
     AegisName: Clover_Box_Mouth
     Name: Clover Box Mouth
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41426,6 +40960,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOVER_BOX_MOUTH
     Script: |
       getgroupitem(IG_CLOVER_BOX_MOUTH);
   - Id: 16373
@@ -41434,8 +40969,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41444,6 +40977,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CLOVER_BOX_MOUTH
     Script: |
       getgroupitem(IG_F_CLOVER_BOX_MOUTH);
   - Id: 16374
@@ -41452,8 +40986,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41462,8 +40994,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOUTH_BUBBLE_GUM_BOX
     Script: |
-      getgroupitem(IG_Mouth_Bubble_Gum_Box);
+      getgroupitem(IG_MOUTH_BUBBLE_GUM_BOX);
       /*rentitem Bubble_Gum_In_Mouth,3600;*/
   - Id: 16375
     AegisName: F_BGum_Box_In_Mouth
@@ -41471,8 +41004,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41481,6 +41012,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BGUM_BOX_IN_MOUTH
     Script: |
       getgroupitem(IG_F_BGUM_BOX_IN_MOUTH);
   - Id: 16376
@@ -41555,6 +41087,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41571,6 +41105,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41619,8 +41155,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41629,6 +41163,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOVER_BOX_MOUTH2
     Script: |
       getgroupitem(IG_CLOVER_BOX_MOUTH2);
   - Id: 16386
@@ -41637,8 +41172,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41647,6 +41180,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLOVER_BOX_MOUTH4
     Script: |
       getgroupitem(IG_CLOVER_BOX_MOUTH4);
   - Id: 16387
@@ -41655,8 +41189,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41665,6 +41197,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CLOVER_BOX_MOUTH2
     Script: |
       getgroupitem(IG_F_CLOVER_BOX_MOUTH2);
   - Id: 16388
@@ -41673,8 +41206,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41683,6 +41214,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_CLOVER_BOX_MOUTH4
     Script: |
       getgroupitem(IG_F_CLOVER_BOX_MOUTH4);
   - Id: 16389
@@ -41691,8 +41223,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41701,8 +41231,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BGUM_BOX_IN_MOUTH2
     Script: |
-      getgroupitem(IG_BGum_Box_In_Mouth2);
+      getgroupitem(IG_BGUM_BOX_IN_MOUTH2);
       /*rentitem Bubble_Gum_In_Mouth,7200;*/
   - Id: 16390
     AegisName: BGum_Box_In_Mouth4
@@ -41710,8 +41241,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41720,8 +41249,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BGUM_BOX_IN_MOUTH4
     Script: |
-      getgroupitem(IG_BGum_Box_In_Mouth4);
+      getgroupitem(IG_BGUM_BOX_IN_MOUTH4);
       /*rentitem Bubble_Gum_In_Mouth,14400;*/
   - Id: 16391
     AegisName: F_BGum_Box_In_Mouth2
@@ -41729,8 +41259,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41739,6 +41267,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BGUM_BOX_IN_MOUTH2
     Script: |
       getgroupitem(IG_F_BGUM_BOX_IN_MOUTH2);
   - Id: 16392
@@ -41747,8 +41276,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41757,6 +41284,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BGUM_BOX_IN_MOUTH4
     Script: |
       getgroupitem(IG_F_BGUM_BOX_IN_MOUTH4);
   - Id: 16393
@@ -41767,6 +41295,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41785,6 +41314,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41803,6 +41333,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41821,6 +41352,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41989,8 +41521,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -41999,6 +41529,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREYJA_RING_BOX2
     Script: |
       getgroupitem(IG_FREYJA_RING_BOX2);
   - Id: 16408
@@ -42007,8 +41538,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42017,6 +41546,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_FREYJA_RING_BOX2
     Script: |
       getgroupitem(IG_F_FREYJA_RING_BOX2);
   - Id: 16409
@@ -42025,10 +41555,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_SEP_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Sep_Scroll);
+      getgroupitem(IG_TW_SEP_SCROLL);
   - Id: 16410
     AegisName: Chung_Hairband_Box
     Name: Chung Hairband Box
@@ -42095,6 +41624,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    Flags:
+      Container: true
     Script: |
       getitem 12212,500;
   - Id: 16419
@@ -42103,6 +41634,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    Flags:
+      Container: true
     Script: |
       getitem 14529,30;
   - Id: 16420
@@ -42111,6 +41644,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_PET_EGG_SCROLL9
     Script: |
       getgroupitem(IG_F_PET_EGG_SCROLL9);
   - Id: 16421
@@ -42119,6 +41653,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    Flags:
+      Container: true
     Script: |
       getitem 6026,1;
   - Id: 16422
@@ -42127,6 +41663,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_MAGESTIC_GOAT_BOX
     Script: |
       getgroupitem(IG_F_MAGESTIC_GOAT_BOX);
   - Id: 16423
@@ -42135,6 +41672,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_PET_EGG_SCROLL3
     Script: |
       getgroupitem(IG_F_PET_EGG_SCROLL3);
   - Id: 16424
@@ -42143,6 +41681,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_EXECUTIONER_BOX
     Script: |
       getgroupitem(IG_F_EXECUTIONER_BOX);
   - Id: 16425
@@ -42151,6 +41690,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_CUTLAS_BOX
     Script: |
       getgroupitem(IG_F_CUTLAS_BOX);
   - Id: 16426
@@ -42159,6 +41699,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_MOONLIGHT_SWORD_BOX
     Script: |
       getgroupitem(IG_F_MOONLIGHT_SWORD_BOX);
   - Id: 16427
@@ -42167,6 +41708,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_SPANNER_BOX
     Script: |
       getgroupitem(IG_F_SPANNER_BOX);
   - Id: 16428
@@ -42175,6 +41717,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_SOLAR_SWORD_BOX
     Script: |
       getgroupitem(IG_F_SOLAR_SWORD_BOX);
   - Id: 16429
@@ -42183,6 +41726,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_TOMAHAWK_BOX
     Script: |
       getgroupitem(IG_F_TOMAHAWK_BOX);
   - Id: 16430
@@ -42191,6 +41735,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_BOW_OF_RUDRA_BOX
     Script: |
       getgroupitem(IG_F_BOW_OF_RUDRA_BOX);
   - Id: 16431
@@ -42199,6 +41744,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_F_POLE_AXE_BOX
     Script: |
       getgroupitem(IG_F_POLE_AXE_BOX);
   - Id: 16432
@@ -42207,8 +41753,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42217,6 +41761,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BM_PACK_BOX_A
     Script: |
       getgroupitem(IG_BM_PACK_BOX_A);
   - Id: 16433
@@ -42225,8 +41770,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42235,6 +41778,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BM_PACK_BOX_A
     Script: |
       getgroupitem(IG_F_BM_PACK_BOX_A);
   - Id: 16434
@@ -42243,8 +41787,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42253,6 +41795,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BM_PACK_BOX_B
     Script: |
       getgroupitem(IG_BM_PACK_BOX_B);
   - Id: 16435
@@ -42261,8 +41804,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42271,6 +41812,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_BM_PACK_BOX_B
     Script: |
       getgroupitem(IG_F_BM_PACK_BOX_B);
   - Id: 16436
@@ -42397,10 +41939,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_OCTOBER_SCROLL
     Script: |
-      getgroupitem(IG_Tw_October_Scroll);
+      getgroupitem(IG_TW_OCTOBER_SCROLL);
   - Id: 16447
     AegisName: Scorpio_Crown_Box
     Name: Scorpio Crown Box
@@ -42549,20 +42090,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MY_SCROLL1
     Script: |
-      getgroupitem(IG_My_Scroll1);
+      getgroupitem(IG_MY_SCROLL1);
   - Id: 16457
     AegisName: Tw_Nov_Scroll
     Name: Tw Nov Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_NOV_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Nov_Scroll);
+      getgroupitem(IG_TW_NOV_SCROLL);
   - Id: 16458
     AegisName: 2009Love_Daddy_Box
     Name: Love Dad Box
@@ -42613,18 +42152,15 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MY_SCROLL2
     Script: |
-      getgroupitem(IG_My_Scroll2);
+      getgroupitem(IG_MY_SCROLL2);
   - Id: 16467
     AegisName: Xmas_Card_Box
     Name: Christmas Card Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42633,6 +42169,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAS_CARD_BOX
     Script: |
       getgroupitem(IG_XMAS_CARD_BOX);
   - Id: 16468
@@ -42641,8 +42178,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42651,6 +42186,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_XMAS_CARD_BOX
     Script: |
       getgroupitem(IG_F_XMAS_CARD_BOX);
   - Id: 16469
@@ -42659,8 +42195,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42669,6 +42203,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAS_CARD_BOX2
     Script: |
       getgroupitem(IG_XMAS_CARD_BOX2);
   - Id: 16470
@@ -42677,8 +42212,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42687,6 +42220,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_XMAS_CARD_BOX2
     Script: |
       getgroupitem(IG_F_XMAS_CARD_BOX2);
   - Id: 16481
@@ -42695,6 +42229,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42711,6 +42247,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42726,8 +42264,7 @@ Body:
     Name: Bunny Band Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_E_BUNNY_BAND_BOX
     Script: |
       getgroupitem(IG_E_BUNNY_BAND_BOX);
   - Id: 16503
@@ -42890,10 +42427,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_XMAS_BLESS
     Script: |
-      getgroupitem(IG_Xmas_Bless);
+      getgroupitem(IG_XMAS_BLESS);
   - Id: 16543
     AegisName: Snowman_Hat_Box
     Name: Snowman Hat Box
@@ -42972,6 +42508,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    Flags:
+      Container: true
     Script: |
       getitem 5245,1;
   - Id: 16555
@@ -42980,8 +42518,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -42990,8 +42526,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PR_RESET_STONE_BOX
     Script: |
-      /*getgroupitem(IG_Pr_Reset_Stone_Box);*/
+      /*getgroupitem(IG_PR_RESET_STONE_BOX);*/
       getitem 6320,1;
   - Id: 16556
     AegisName: FPr_Reset_Stone_Box
@@ -42999,10 +42536,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_FPR_RESET_STONE_BOX
     Script: |
-      /*getgroupitem(IG_FPr_Reset_Stone_Box);*/
+      /*getgroupitem(IG_FPR_RESET_STONE_BOX);*/
       getitem 6320,1;
   - Id: 16557
     AegisName: CP_Helm_Scroll10
@@ -43053,10 +42589,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAJESTIC_DEVIL_SCROLL
     Script: |
-      getgroupitem(IG_Majestic_Devil_Scroll);
+      getgroupitem(IG_MAJESTIC_DEVIL_SCROLL);
   - Id: 16563
     AegisName: BM100_Box_5
     Name: BM100 Box 5
@@ -43159,10 +42694,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ILLUSION_NOTHING
     Script: |
-      getgroupitem(IG_Illusion_Nothing);
+      getgroupitem(IG_ILLUSION_NOTHING);
   - Id: 16577
     AegisName: Dragon_Captain
     Name: Dragon Captain
@@ -43259,8 +42793,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THOUGHTFUL_HAT_BOX
     Script: |
       getgroupitem(IG_THOUGHTFUL_HAT_BOX);
   - Id: 16589
@@ -43269,8 +42802,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_F_THOUGHTFUL_HAT_BOX
     Script: |
       getgroupitem(IG_F_THOUGHTFUL_HAT_BOX);
   - Id: 16590
@@ -43279,8 +42811,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_E_THOUGHTFUL_HAT_BOX
     Script: |
       getgroupitem(IG_E_THOUGHTFUL_HAT_BOX);
   - Id: 16591
@@ -43289,8 +42820,7 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SUMMER_SCROLL2
     Script: |
       getgroupitem(IG_SUMMER_SCROLL2);
   - Id: 16592
@@ -43347,8 +42877,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43357,6 +42885,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ACTI_POTION_BOX2
     Script: |
       getgroupitem(IG_ACTI_POTION_BOX2);
   - Id: 16599
@@ -43365,8 +42894,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43375,6 +42902,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_ACTI_POTION_BOX2
     Script: |
       getgroupitem(IG_F_ACTI_POTION_BOX2);
   - Id: 16600
@@ -43491,8 +43019,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 47
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43501,6 +43027,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALF_ASPRIKA_BOX
     Script: |
       getgroupitem(IG_HALF_ASPRIKA_BOX);
   - Id: 16626
@@ -43510,8 +43037,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 47
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43520,6 +43045,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALF_MEGIN_BOX
     Script: |
       getgroupitem(IG_HALF_MEGIN_BOX);
   - Id: 16627
@@ -43529,8 +43055,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 47
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43539,6 +43063,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALF_BRYSING_BOX
     Script: |
       getgroupitem(IG_HALF_BRYSING_BOX);
   - Id: 16628
@@ -43548,8 +43073,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 47
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43558,6 +43081,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HALF_BRYNHILD_BOX
     Script: |
       getgroupitem(IG_HALF_BRYNHILD_BOX);
   - Id: 16629
@@ -43622,8 +43146,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43632,6 +43154,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIKED_SCARF_BOX2
     Script: |
       getgroupitem(IG_SPIKED_SCARF_BOX2);
   - Id: 16635
@@ -43640,8 +43163,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43650,6 +43171,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAINBOW_SCARF_BOX2
     Script: |
       getgroupitem(IG_RAINBOW_SCARF_BOX2);
   - Id: 16636
@@ -43658,8 +43180,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43668,6 +43188,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIKED_SCARF_BOX3
     Script: |
       getgroupitem(IG_SPIKED_SCARF_BOX3);
   - Id: 16637
@@ -43676,8 +43197,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43686,6 +43205,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAINBOW_SCARF_BOX3
     Script: |
       getgroupitem(IG_RAINBOW_SCARF_BOX3);
   - Id: 16638
@@ -43694,8 +43214,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43704,16 +43222,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIFE_RIBBON_BOX
     Script: |
-      getgroupitem(IG_Life_Ribbon_Box);
+      getgroupitem(IG_LIFE_RIBBON_BOX);
   - Id: 16639
     AegisName: Ribbon_Of_Life_Box2
     Name: Life Ribbon Box2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43722,16 +43239,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIFE_RIBBON_BOX2
     Script: |
-      getgroupitem(IG_Life_Ribbon_Box2);
+      getgroupitem(IG_LIFE_RIBBON_BOX2);
   - Id: 16640
     AegisName: Ribbon_Of_Life_Box3
     Name: Life Ribbon Box3
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43740,16 +43256,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIFE_RIBBON_BOX3
     Script: |
-      getgroupitem(IG_Life_Ribbon_Box3);
+      getgroupitem(IG_LIFE_RIBBON_BOX3);
   - Id: 16641
     AegisName: F_Spiked_Scarf_Box
     Name: Spiked Scarf Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43758,6 +43273,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SPIKED_SCARF_BOX
     Script: |
       getgroupitem(IG_F_SPIKED_SCARF_BOX);
   - Id: 16642
@@ -43766,8 +43282,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43776,6 +43290,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RAINBOW_SCARF_BOX
     Script: |
       getgroupitem(IG_F_RAINBOW_SCARF_BOX);
   - Id: 16643
@@ -43784,8 +43299,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43794,6 +43307,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SPIKED_SCARF_BOX2
     Script: |
       getgroupitem(IG_F_SPIKED_SCARF_BOX2);
   - Id: 16644
@@ -43802,8 +43316,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43812,6 +43324,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RAINBOW_SCARF_BOX2
     Script: |
       getgroupitem(IG_F_RAINBOW_SCARF_BOX2);
   - Id: 16645
@@ -43820,8 +43333,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43830,6 +43341,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_SPIKED_SCARF_BOX3
     Script: |
       getgroupitem(IG_F_SPIKED_SCARF_BOX3);
   - Id: 16646
@@ -43838,8 +43350,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43848,6 +43358,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RAINBOW_SCARF_BOX3
     Script: |
       getgroupitem(IG_F_RAINBOW_SCARF_BOX3);
   - Id: 16647
@@ -43856,8 +43367,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43866,6 +43375,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RIBBON_OF_LIFE_BOX
     Script: |
       getgroupitem(IG_F_RIBBON_OF_LIFE_BOX);
   - Id: 16648
@@ -43874,8 +43384,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43884,6 +43392,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RIBBON_OF_LIFE_BOX2
     Script: |
       getgroupitem(IG_F_RIBBON_OF_LIFE_BOX2);
   - Id: 16649
@@ -43892,8 +43401,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43902,6 +43409,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RIBBON_OF_LIFE_BOX3
     Script: |
       getgroupitem(IG_F_RIBBON_OF_LIFE_BOX3);
   - Id: 16650
@@ -43942,10 +43450,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_FLAME_LIGHT
     Script: |
-      getgroupitem(IG_Flame_Light);
+      getgroupitem(IG_FLAME_LIGHT);
   - Id: 16653
     AegisName: BM75_10Box
     Name: BM75 10Box
@@ -43970,8 +43477,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43980,6 +43485,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAPID_LIFE_WATER_BOX
     Script: |
       getgroupitem(IG_RAPID_LIFE_WATER_BOX);
   - Id: 16656
@@ -43988,8 +43494,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -43998,6 +43502,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_RAPID_LIFE_WATER_BOX
     Script: |
       getgroupitem(IG_F_RAPID_LIFE_WATER_BOX);
   - Id: 16657
@@ -44006,6 +43511,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44038,6 +43545,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 1
+    ItemGroup: IG_ZODIAC_DIADEM_PACK
     Script: |
       getgroupitem(IG_ZODIAC_DIADEM_PACK);
   - Id: 16660
@@ -44126,8 +43634,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44136,8 +43642,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGIC_CANDY_BOX10
     Script: |
-      getgroupitem(IG_Magic_Candy_Box10);
+      getgroupitem(IG_MAGIC_CANDY_BOX10);
       /*getitem Magic_Candy,10;*/
   - Id: 16667
     AegisName: F_Magic_Candy_Box10
@@ -44145,8 +43652,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44155,6 +43660,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_MAGIC_CANDY_BOX10
     Script: |
       getgroupitem(IG_F_MAGIC_CANDY_BOX10);
   - Id: 16668
@@ -44172,6 +43678,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 14532,10;
       if (!rand(10))
@@ -44213,15 +43721,16 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LIBRA_SCROLL
     Script: |
-      getgroupitem(IG_Libra_Scroll);
+      getgroupitem(IG_LIBRA_SCROLL);
   - Id: 16674
     AegisName: New_Insurance_Box
     Name: 10 New Life Insurance Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6413,10;
   - Id: 16675
@@ -44230,16 +43739,16 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SPLASH_SCROLL
     Script: |
-      getgroupitem(IG_Splash_Scroll);
+      getgroupitem(IG_SPLASH_SCROLL);
   - Id: 16676
     AegisName: Zodiac_Crown_Pack
     Name: Zodiac Crown Box
     Type: Usable
     Buy: 20
     Weight: 10
+    ItemGroup: IG_ZODIAC_CROWN_PACK
     Script: |
       getgroupitem(IG_ZODIAC_CROWN_PACK);
   - Id: 16677
@@ -44247,6 +43756,8 @@ Body:
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44262,6 +43773,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44277,6 +43790,8 @@ Body:
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44292,6 +43807,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44308,18 +43825,15 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BR_INDEPENDENCE_SCROLL
     Script: |
-      getgroupitem(IG_BR_Independence_Scroll);
+      getgroupitem(IG_BR_INDEPENDENCE_SCROLL);
   - Id: 16682
     AegisName: Boarding_Halter_Box
     Name: Boarding Halter Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44328,16 +43842,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOARDING_HALTER_BOX
     Script: |
-      getgroupitem(IG_Boarding_Halter_Box);
+      getgroupitem(IG_BOARDING_HALTER_BOX);
   - Id: 16683
     AegisName: B_Halter_Box_30Days
     Name: Halter Lead 30 Day Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44346,6 +43859,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_B_HALTER_BOX_30DAYS
     Script: |
       getgroupitem(IG_B_HALTER_BOX_30DAYS);
   - Id: 16684
@@ -44355,6 +43869,7 @@ Body:
     Buy: 20
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 601,10;
   - Id: 16685
@@ -44364,6 +43879,7 @@ Body:
     Buy: 20
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 601,50;
   - Id: 16686
@@ -44373,6 +43889,7 @@ Body:
     Buy: 20
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 601,100;
   - Id: 16687
@@ -44381,20 +43898,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_RWC2010_SUITCASEA
     Script: |
-      getgroupitem(IG_RWC2010_SuitcaseA);
+      getgroupitem(IG_RWC2010_SUITCASEA);
   - Id: 16688
     AegisName: RWC2010_SuitcaseB
     Name: RWC2010 SuitcaseB
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_RWC2010_SUITCASEB
     Script: |
-      getgroupitem(IG_RWC2010_SuitcaseB);
+      getgroupitem(IG_RWC2010_SUITCASEB);
   - Id: 16689
     AegisName: Garuda_Hat_Box
     Name: Garuda Hat Box
@@ -44441,6 +43956,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5137,1;
   - Id: 16693
@@ -44449,6 +43966,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5142,1;
   - Id: 16694
@@ -44457,6 +43976,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5142,1;
   - Id: 16695
@@ -44465,6 +43986,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5292,1;
   - Id: 16696
@@ -44473,6 +43996,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5292,1;
   - Id: 16697
@@ -44481,6 +44006,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5290,1;
   - Id: 16698
@@ -44489,6 +44016,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5290,1;
   - Id: 16699
@@ -44497,6 +44026,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5222,1;
   - Id: 16701
@@ -44505,6 +44036,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5221,1;
   - Id: 16702
@@ -44513,6 +44046,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5221,1;
   - Id: 16703
@@ -44521,6 +44056,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5220,1;
   - Id: 16704
@@ -44529,6 +44066,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5220,1;
   - Id: 16705
@@ -44537,6 +44076,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5139,1;
   - Id: 16706
@@ -44545,6 +44086,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5139,1;
   - Id: 16707
@@ -44553,6 +44096,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5335,1;
   - Id: 16708
@@ -44561,6 +44106,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5335,1;
   - Id: 16709
@@ -44569,6 +44116,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5291,1;
   - Id: 16710
@@ -44577,6 +44126,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5291,1;
   - Id: 16711
@@ -44585,6 +44136,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5138,1;
   - Id: 16712
@@ -44593,6 +44146,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5138,1;
   - Id: 16713
@@ -44601,6 +44156,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5226,1;
   - Id: 16714
@@ -44609,6 +44166,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5226,1;
   - Id: 16715
@@ -44617,6 +44176,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5182,1;
   - Id: 16716
@@ -44625,6 +44186,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5182,1;
   - Id: 16717
@@ -44633,6 +44196,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5133,1;
   - Id: 16718
@@ -44641,6 +44206,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5133,1;
   - Id: 16719
@@ -44649,6 +44216,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5098,1;
   - Id: 16720
@@ -44657,6 +44226,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5098,1;
   - Id: 16721
@@ -44665,6 +44236,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5629,1;
   - Id: 16722
@@ -44673,6 +44246,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5285,1;
   - Id: 16723
@@ -44681,6 +44256,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5285,1;
   - Id: 16724
@@ -44689,6 +44266,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5289,1;
   - Id: 16725
@@ -44697,6 +44276,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5289,1;
   - Id: 16726
@@ -44705,6 +44286,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5284,1;
   - Id: 16727
@@ -44713,6 +44296,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5284,1;
   - Id: 16728
@@ -44721,6 +44306,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5237,1;
   - Id: 16729
@@ -44729,6 +44316,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5237,1;
   - Id: 16730
@@ -44737,6 +44326,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5193,1;
   - Id: 16731
@@ -44745,6 +44336,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5193,1;
   - Id: 16732
@@ -44753,6 +44346,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5229,1;
   - Id: 16733
@@ -44761,6 +44356,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5229,1;
   - Id: 16734
@@ -44769,6 +44366,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5233,1;
   - Id: 16735
@@ -44777,6 +44376,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5233,1;
   - Id: 16736
@@ -44785,6 +44386,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5276,1;
   - Id: 16737
@@ -44793,6 +44396,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5276,1;
   - Id: 16738
@@ -44801,6 +44406,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5242,1;
   - Id: 16739
@@ -44809,6 +44416,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 5242,1;
   - Id: 16740
@@ -44817,8 +44426,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44827,6 +44434,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PTOTECTION_SEAGOD_BOX
     Script: |
       getgroupitem(IG_PTOTECTION_SEAGOD_BOX);
   - Id: 16741
@@ -44836,8 +44444,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44846,6 +44452,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HAIRTAIL_BOX1
     Script: |
       getgroupitem(IG_HAIRTAIL_BOX1);
   - Id: 16742
@@ -44855,8 +44462,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44865,6 +44470,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HAIRTAIL_BOX2
     Script: |
       getgroupitem(IG_HAIRTAIL_BOX2);
   - Id: 16743
@@ -44874,8 +44480,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44884,6 +44488,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPEARFISH_BOX1
     Script: |
       getgroupitem(IG_SPEARFISH_BOX1);
   - Id: 16744
@@ -44893,8 +44498,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44903,6 +44506,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPEARFISH_BOX2
     Script: |
       getgroupitem(IG_SPEARFISH_BOX2);
   - Id: 16745
@@ -44912,8 +44516,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44922,6 +44524,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAUREL_BOX1
     Script: |
       getgroupitem(IG_SAUREL_BOX1);
   - Id: 16746
@@ -44931,8 +44534,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44941,6 +44542,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SAUREL_BOX2
     Script: |
       getgroupitem(IG_SAUREL_BOX2);
   - Id: 16747
@@ -44950,8 +44552,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44960,6 +44560,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TUNA_BOX1
     Script: |
       getgroupitem(IG_TUNA_BOX1);
   - Id: 16748
@@ -44969,8 +44570,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44979,6 +44578,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TUNA_BOX2
     Script: |
       getgroupitem(IG_TUNA_BOX2);
   - Id: 16749
@@ -44988,8 +44588,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -44998,6 +44596,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MALANG_CRAB_BOX1
     Script: |
       getgroupitem(IG_MALANG_CRAB_BOX1);
   - Id: 16750
@@ -45007,8 +44606,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45017,6 +44614,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MALANG_CRAB_BOX2
     Script: |
       getgroupitem(IG_MALANG_CRAB_BOX2);
   - Id: 16751
@@ -45026,8 +44624,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45036,6 +44632,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BRINDLE_EEL_BOX1
     Script: |
       getgroupitem(IG_BRINDLE_EEL_BOX1);
   - Id: 16752
@@ -45045,8 +44642,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45055,6 +44650,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BRINDLE_EEL_BOX2
     Script: |
       getgroupitem(IG_BRINDLE_EEL_BOX2);
   - Id: 16753
@@ -45065,6 +44661,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 6438,1;
   - Id: 16754
@@ -45075,6 +44672,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 6438,1;
   - Id: 16755
@@ -45085,6 +44683,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 6439,1;
   - Id: 16756
@@ -45095,6 +44694,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 6439,1;
   - Id: 16757
@@ -45103,18 +44703,15 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HALLO_SCROLL
     Script: |
-      getgroupitem(IG_Hallo_Scroll);
+      getgroupitem(IG_HALLO_SCROLL);
   - Id: 16758
     AegisName: Umbala_Spirit_Box
     Name: Umbala Spirit Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45123,6 +44720,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UMBALA_SPIRIT_BOX
     Script: |
       getgroupitem(IG_UMBALA_SPIRIT_BOX);
   - Id: 16759
@@ -45131,8 +44729,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45141,6 +44737,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_UMBALA_SPIRIT_BOX
     Script: |
       getgroupitem(IG_F_UMBALA_SPIRIT_BOX);
   - Id: 16760
@@ -45149,8 +44746,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45159,8 +44754,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UMBALA_SPIRIT_BOX2
     Script: |
-      getgroupitem(IG_Umbala_Spirit_Box2);
+      getgroupitem(IG_UMBALA_SPIRIT_BOX2);
       /*rentitem Umbala_Spirit,604800;*/
   - Id: 16761
     AegisName: F_Umbala_Spirit_Box2
@@ -45168,8 +44764,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45178,8 +44772,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_F_UMBALA_SPIRIT_BOX2
     Script: |
-      getgroupitem(IG_F_Umbala_Spirit_Box2);
+      getgroupitem(IG_F_UMBALA_SPIRIT_BOX2);
       /*rentitem Umbala_Spirit,604800;*/
   - Id: 16762
     AegisName: Umbala_Spirit_Box_7day
@@ -45187,8 +44782,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45197,6 +44790,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UMBALA_SPIRIT_BOX_7DAY
     Script: |
       getgroupitem(IG_UMBALA_SPIRIT_BOX_7DAY);
   - Id: 16763
@@ -45205,8 +44799,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45215,6 +44807,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PTOTECTION_SEAGOD_BOX2
     Script: |
       getgroupitem(IG_PTOTECTION_SEAGOD_BOX2);
   - Id: 16764
@@ -45223,8 +44816,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45233,6 +44824,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PTOTECTION_SEAGOD_BOX3
     Script: |
       getgroupitem(IG_PTOTECTION_SEAGOD_BOX3);
   - Id: 16765
@@ -45241,8 +44833,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45251,6 +44841,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OCTO_HSTICK_BOX
     Script: |
       getgroupitem(IG_OCTO_HSTICK_BOX);
   - Id: 16766
@@ -45259,8 +44850,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45269,6 +44858,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OCTO_HSTICK_BOX2
     Script: |
       getgroupitem(IG_OCTO_HSTICK_BOX2);
   - Id: 16767
@@ -45277,8 +44867,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45287,6 +44875,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OCTO_HSTICK_BOX3
     Script: |
       getgroupitem(IG_OCTO_HSTICK_BOX3);
   - Id: 16770
@@ -45295,8 +44884,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45305,6 +44892,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_FRUIT_BOX10
     Script: |
       getgroupitem(IG_SILVERVINE_FRUIT_BOX10);
   - Id: 16771
@@ -45313,8 +44901,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45323,6 +44909,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_FRUIT_BOX40
     Script: |
       getgroupitem(IG_SILVERVINE_FRUIT_BOX40);
   - Id: 16774
@@ -45331,25 +44918,25 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ASGARD_SCROLL
     Script: |
-      getgroupitem(IG_Asgard_Scroll);
+      getgroupitem(IG_ASGARD_SCROLL);
   - Id: 16775
     AegisName: Sagittarius_Scroll
     Name: Sagittarius Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SAGITTARIUS_SCROLL
     Script: |
-      getgroupitem(IG_Sagittarius_Scroll);
+      getgroupitem(IG_SAGITTARIUS_SCROLL);
   - Id: 16776
     AegisName: C_Vending_Scroll2_Box10
     Name: Universal Catalog Gold 10 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45365,6 +44952,8 @@ Body:
     Name: Universal Catalog Gold 50 Box
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45573,8 +45162,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45583,6 +45170,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_INSURANCE_PACKAGE
     Script: |
       getgroupitem(IG_C_INSURANCE_PACKAGE);
   - Id: 16791
@@ -45591,8 +45179,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45601,6 +45187,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_INSURANCE_PACKAGE50
     Script: |
       getgroupitem(IG_C_INSURANCE_PACKAGE50);
   - Id: 16792
@@ -45641,8 +45228,6 @@ Body:
     Type: Cash
     Sell: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45651,6 +45236,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_GIANT_FLY_WING_BOX
     Script: |
       getgroupitem(IG_C_GIANT_FLY_WING_BOX);
   - Id: 16795
@@ -45659,8 +45245,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45669,6 +45253,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_GIANT_FLY_WING_BOX100
     Script: |
       getgroupitem(IG_C_GIANT_FLY_WING_BOX100);
   - Id: 16796
@@ -45677,8 +45262,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45687,6 +45270,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SIEGFRIED_BOX5
     Script: |
       getgroupitem(IG_C_SIEGFRIED_BOX5);
   - Id: 16797
@@ -45695,8 +45279,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45705,6 +45287,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SIEGFRIED_BOX20
     Script: |
       getgroupitem(IG_C_SIEGFRIED_BOX20);
   - Id: 16798
@@ -45729,8 +45312,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45739,6 +45320,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CONVEX_MIRROR_BOX30
     Script: |
       getgroupitem(IG_C_CONVEX_MIRROR_BOX30);
   - Id: 16800
@@ -45763,8 +45345,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45773,6 +45353,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BLESSING_10_BOX50
     Script: |
       getgroupitem(IG_C_BLESSING_10_BOX50);
   - Id: 16802
@@ -45797,8 +45378,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45807,6 +45386,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_INC_AGI_10_BOX50
     Script: |
       getgroupitem(IG_C_INC_AGI_10_BOX50);
   - Id: 16804
@@ -45863,8 +45443,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45873,6 +45451,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ASPERSIO_5_BOX50
     Script: |
       getgroupitem(IG_C_ASPERSIO_5_BOX50);
   - Id: 16808
@@ -45881,8 +45460,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45891,6 +45468,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BATTLE_MANUAL_BOX
     Script: |
       getgroupitem(IG_C_BATTLE_MANUAL_BOX);
   - Id: 16809
@@ -45899,8 +45477,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45909,6 +45485,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BATTLE_MANUAL_BOX10
     Script: |
       getgroupitem(IG_C_BATTLE_MANUAL_BOX10);
   - Id: 16810
@@ -45917,8 +45494,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45927,6 +45502,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BUBBLE_GUM_BOX
     Script: |
       getgroupitem(IG_C_BUBBLE_GUM_BOX);
   - Id: 16811
@@ -45935,8 +45511,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45945,6 +45519,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BUBBLE_GUM_BOX10
     Script: |
       getgroupitem(IG_C_BUBBLE_GUM_BOX10);
   - Id: 16812
@@ -45969,8 +45544,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45979,6 +45552,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MEGAPHONE_BOX10
     Script: |
       getgroupitem(IG_C_MEGAPHONE_BOX10);
   - Id: 16814
@@ -45987,8 +45561,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -45997,6 +45569,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ENRICHED_ELUNIUM_BOX
     Script: |
       getgroupitem(IG_C_ENRICHED_ELUNIUM_BOX);
   - Id: 16815
@@ -46005,8 +45578,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46015,6 +45586,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ENRICHED_ELUNIUM_BOX5
     Script: |
       getgroupitem(IG_C_ENRICHED_ELUNIUM_BOX5);
   - Id: 16816
@@ -46023,8 +45595,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46033,6 +45603,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ENRICHED_ORIDECON_BOX
     Script: |
       getgroupitem(IG_C_ENRICHED_ORIDECON_BOX);
   - Id: 16817
@@ -46041,8 +45612,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46051,6 +45620,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ENC_ORIDECON_BOX5
     Script: |
       getgroupitem(IG_C_ENC_ORIDECON_BOX5);
   - Id: 16818
@@ -46059,8 +45629,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46069,6 +45637,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_NEURALIZER_BOX
     Script: |
       getgroupitem(IG_C_NEURALIZER_BOX);
   - Id: 16819
@@ -46093,8 +45662,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46103,6 +45670,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ABRASIVE_BOX10
     Script: |
       getgroupitem(IG_C_ABRASIVE_BOX10);
   - Id: 16821
@@ -46139,8 +45707,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46149,6 +45715,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MAX_WEIGHT_UP_BOX
     Script: |
       getgroupitem(IG_C_MAX_WEIGHT_UP_BOX);
   - Id: 16824
@@ -46173,8 +45740,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46183,6 +45748,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_REGENERATION_BOX10
     Script: |
       getgroupitem(IG_C_REGENERATION_BOX10);
   - Id: 16826
@@ -46191,10 +45757,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SAGITTARIUS_SCR_BOX
     Script: |
-      getgroupitem(IG_Sagittarius_Scr_Box);
+      getgroupitem(IG_SAGITTARIUS_SCR_BOX);
   - Id: 16827
     AegisName: C_Small_Life_Potion_Box
     Name: Small Life Potion Box(10)
@@ -46217,8 +45782,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46227,6 +45790,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_S_LIFE_POTION_BOX50
     Script: |
       getgroupitem(IG_C_S_LIFE_POTION_BOX50);
   - Id: 16829
@@ -46251,8 +45815,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46261,6 +45823,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MED_LIFE_POTION_BOX50
     Script: |
       getgroupitem(IG_C_MED_LIFE_POTION_BOX50);
   - Id: 16831
@@ -46317,8 +45880,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46327,6 +45888,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_S_ARMORBOX10
     Script: |
       getgroupitem(IG_C_S_ARMORBOX10);
   - Id: 16835
@@ -46351,8 +45913,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46361,6 +45921,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HOLY_ARMOR_S_BOX30
     Script: |
       getgroupitem(IG_C_HOLY_ARMOR_S_BOX30);
   - Id: 16837
@@ -46429,8 +45990,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46439,6 +45998,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_REPAIR_SCROLL_BOX
     Script: |
       getgroupitem(IG_C_REPAIR_SCROLL_BOX);
   - Id: 16842
@@ -46447,8 +46007,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46457,6 +46015,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_REPAIR_SCROLL_BOX10
     Script: |
       getgroupitem(IG_C_REPAIR_SCROLL_BOX10);
   - Id: 16843
@@ -46465,8 +46024,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46475,6 +46032,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_NEW_STYLE_BOX
     Script: |
       getgroupitem(IG_C_NEW_STYLE_BOX);
   - Id: 16844
@@ -46499,8 +46057,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46509,6 +46065,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ALICE_SCROLL_BOX10
     Script: |
       getgroupitem(IG_C_ALICE_SCROLL_BOX10);
   - Id: 16846
@@ -46533,8 +46090,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46543,6 +46098,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MIMIC_SCROLL_BOX10
     Script: |
       getgroupitem(IG_C_MIMIC_SCROLL_BOX10);
   - Id: 16848
@@ -46567,8 +46123,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46577,6 +46131,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_DISGUISE_CROLL_BOX10
     Script: |
       getgroupitem(IG_C_DISGUISE_CROLL_BOX10);
   - Id: 16850
@@ -46601,8 +46156,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46611,6 +46164,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MP_SCROLL_BOX50
     Script: |
       getgroupitem(IG_C_MP_SCROLL_BOX50);
   - Id: 16852
@@ -46651,8 +46205,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46661,6 +46213,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CCLOTH_DYE_COUPON_BOX
     Script: |
       getgroupitem(IG_CCLOTH_DYE_COUPON_BOX);
   - Id: 16855
@@ -46669,8 +46222,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46679,6 +46230,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CCLOTH_DYE_COUPON2_BOX
     Script: |
       getgroupitem(IG_CCLOTH_DYE_COUPON2_BOX);
   - Id: 16856
@@ -46735,8 +46287,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46745,6 +46295,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MENTAL_POTION50_BOX
     Script: |
       getgroupitem(IG_C_MENTAL_POTION50_BOX);
   - Id: 16860
@@ -46785,8 +46336,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46795,6 +46344,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_JOB_MANUAL25_BOX1
     Script: |
       getgroupitem(IG_C_JOB_MANUAL25_BOX1);
   - Id: 16863
@@ -46803,8 +46353,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46813,6 +46361,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_JOB_MANUAL25_BOX10
     Script: |
       getgroupitem(IG_C_JOB_MANUAL25_BOX10);
   - Id: 16864
@@ -46821,8 +46370,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46831,6 +46378,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SIEGE_SCROLL_BOX1_10
     Script: |
       getgroupitem(IG_C_SIEGE_SCROLL_BOX1_10);
   - Id: 16865
@@ -46839,8 +46387,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46849,6 +46395,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SIEGE_SCROLL_BOX1_30
     Script: |
       getgroupitem(IG_C_SIEGE_SCROLL_BOX1_30);
   - Id: 16866
@@ -46873,8 +46420,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46883,6 +46428,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SIEGE_SCROLL_BOX2_30
     Script: |
       getgroupitem(IG_C_SIEGE_SCROLL_BOX2_30);
   - Id: 16868
@@ -46891,8 +46437,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46901,6 +46445,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_BRADIUM_BOX5
     Script: |
       getgroupitem(IG_C_HD_BRADIUM_BOX5);
   - Id: 16869
@@ -46909,8 +46454,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46919,6 +46462,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_BRADIUM_BOX10
     Script: |
       getgroupitem(IG_C_HD_BRADIUM_BOX10);
   - Id: 16870
@@ -46927,8 +46471,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46937,6 +46479,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_CARNIUM_BOX5
     Script: |
       getgroupitem(IG_C_HD_CARNIUM_BOX5);
   - Id: 16871
@@ -46945,8 +46488,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46955,6 +46496,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_CARNIUM_BOX10
     Script: |
       getgroupitem(IG_C_HD_CARNIUM_BOX10);
   - Id: 16872
@@ -46963,8 +46505,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46973,6 +46513,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_ORI_BOX5
     Script: |
       getgroupitem(IG_C_HD_ORI_BOX5);
   - Id: 16873
@@ -46981,8 +46522,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -46991,6 +46530,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_ORI_BOX10
     Script: |
       getgroupitem(IG_C_HD_ORI_BOX10);
   - Id: 16874
@@ -46999,8 +46539,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47009,6 +46547,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_ELU_BOX5
     Script: |
       getgroupitem(IG_C_HD_ELU_BOX5);
   - Id: 16875
@@ -47017,8 +46556,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47027,6 +46564,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HD_ELU_BOX10
     Script: |
       getgroupitem(IG_C_HD_ELU_BOX10);
   - Id: 16876
@@ -47035,8 +46573,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47045,6 +46581,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RAPID_LIFE_WATER_BOX2
     Script: |
       getgroupitem(IG_C_RAPID_LIFE_WATER_BOX2);
   - Id: 16877
@@ -47069,8 +46606,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47079,6 +46614,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_UMBALA_SPIRIT_BOX2
     Script: |
       getgroupitem(IG_C_UMBALA_SPIRIT_BOX2);
   - Id: 16879
@@ -47087,8 +46623,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47097,6 +46631,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MURAMASA_BOX
     Script: |
       getgroupitem(IG_C_MURAMASA_BOX);
   - Id: 16880
@@ -47105,8 +46640,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47115,6 +46648,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_EXCALIBUR_BOX
     Script: |
       getgroupitem(IG_C_EXCALIBUR_BOX);
   - Id: 16881
@@ -47123,8 +46657,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47133,6 +46665,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_COMBAT_KNIFE_BOX
     Script: |
       getgroupitem(IG_C_COMBAT_KNIFE_BOX);
   - Id: 16882
@@ -47141,8 +46674,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47151,6 +46682,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_COUNTER_DAGGER_BOX
     Script: |
       getgroupitem(IG_C_COUNTER_DAGGER_BOX);
   - Id: 16883
@@ -47159,8 +46691,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47169,6 +46699,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MIGHTY_STAFF_BOX
     Script: |
       getgroupitem(IG_C_MIGHTY_STAFF_BOX);
   - Id: 16884
@@ -47177,8 +46708,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47187,6 +46716,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RIGHT_EPSILON_BOX
     Script: |
       getgroupitem(IG_C_RIGHT_EPSILON_BOX);
   - Id: 16885
@@ -47195,8 +46725,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47205,6 +46733,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BALISTAR_BOX
     Script: |
       getgroupitem(IG_C_BALISTAR_BOX);
   - Id: 16886
@@ -47213,8 +46742,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47223,6 +46750,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_D_GREAT_SAGE_BOX
     Script: |
       getgroupitem(IG_C_D_GREAT_SAGE_BOX);
   - Id: 16887
@@ -47231,8 +46759,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47241,6 +46767,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ASURA_BOX
     Script: |
       getgroupitem(IG_C_ASURA_BOX);
   - Id: 16888
@@ -47249,8 +46776,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47259,6 +46784,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BROOCH_BOX
     Script: |
       getgroupitem(IG_C_BROOCH_BOX);
   - Id: 16889
@@ -47267,8 +46793,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47277,6 +46801,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SAFETY_RING_BOX
     Script: |
       getgroupitem(IG_C_SAFETY_RING_BOX);
   - Id: 16890
@@ -47285,8 +46810,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47295,6 +46818,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_PECOPECO_HAIRBAND_BOX
     Script: |
       getgroupitem(IG_C_PECOPECO_HAIRBAND_BOX);
   - Id: 16891
@@ -47303,8 +46827,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47313,6 +46835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_NAGAN_BOX
     Script: |
       getgroupitem(IG_C_NAGAN_BOX);
   - Id: 16892
@@ -47321,8 +46844,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47331,6 +46852,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SKEWER_BOX
     Script: |
       getgroupitem(IG_C_SKEWER_BOX);
   - Id: 16893
@@ -47339,8 +46861,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47349,6 +46869,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_QUADRILLE_BOX
     Script: |
       getgroupitem(IG_C_QUADRILLE_BOX);
   - Id: 16894
@@ -47357,8 +46878,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47367,6 +46886,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_FIRE_BRAND_BOX
     Script: |
       getgroupitem(IG_C_FIRE_BRAND_BOX);
   - Id: 16895
@@ -47375,8 +46895,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47385,6 +46903,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MASQUERADE_BOX
     Script: |
       getgroupitem(IG_C_MASQUERADE_BOX);
   - Id: 16896
@@ -47393,8 +46912,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47403,6 +46920,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ORC_HERO_HELM_BOX
     Script: |
       getgroupitem(IG_C_ORC_HERO_HELM_BOX);
   - Id: 16897
@@ -47411,8 +46929,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47421,6 +46937,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_KRO_D_KITTY_BOX
     Script: |
       getgroupitem(IG_C_KRO_D_KITTY_BOX);
   - Id: 16898
@@ -47429,8 +46946,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47439,6 +46954,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BLOODY_IRON_BALL_BOX
     Script: |
       getgroupitem(IG_C_BLOODY_IRON_BALL_BOX);
   - Id: 16899
@@ -47448,8 +46964,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47458,6 +46972,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_HOCKEY_MASK_BOX
     Script: |
       getgroupitem(IG_C_HOCKEY_MASK_BOX);
   - Id: 16900
@@ -47467,8 +46982,6 @@ Body:
     Buy: 20
     Weight: 10
     EquipLevelMin: 35
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47477,6 +46990,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_OBSERVER_BOX
     Script: |
       getgroupitem(IG_C_OBSERVER_BOX);
   - Id: 16901
@@ -47485,8 +46999,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47495,6 +47007,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ALL_IN_ONE_RING_BOX
     Script: |
       getgroupitem(IG_C_ALL_IN_ONE_RING_BOX);
   - Id: 16902
@@ -47503,8 +47016,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47513,6 +47024,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SPIRITUAL_TUNIC_BOX
     Script: |
       getgroupitem(IG_C_SPIRITUAL_TUNIC_BOX);
   - Id: 16903
@@ -47521,8 +47033,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47531,6 +47041,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RECUP_ARMOR_BOX
     Script: |
       getgroupitem(IG_C_RECUP_ARMOR_BOX);
   - Id: 16904
@@ -47539,8 +47050,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47549,6 +47058,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SHELTER_RESIST_BOX
     Script: |
       getgroupitem(IG_C_SHELTER_RESIST_BOX);
   - Id: 16905
@@ -47557,8 +47067,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47567,6 +47075,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SYLPHID_MANTEAU_BOX
     Script: |
       getgroupitem(IG_C_SYLPHID_MANTEAU_BOX);
   - Id: 16906
@@ -47575,8 +47084,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47585,6 +47092,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_REFRESH_SHOES_BOX
     Script: |
       getgroupitem(IG_C_REFRESH_SHOES_BOX);
   - Id: 16907
@@ -47593,8 +47101,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47603,6 +47109,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WASTELAND_OUTLAW_BOX
     Script: |
       getgroupitem(IG_C_WASTELAND_OUTLAW_BOX);
   - Id: 16908
@@ -47611,8 +47118,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47621,6 +47126,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_LEVER_ACT_RIFLE_BOX
     Script: |
       getgroupitem(IG_C_LEVER_ACT_RIFLE_BOX);
   - Id: 16909
@@ -47629,8 +47135,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47639,6 +47143,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CLAYMORE_C_BOX
     Script: |
       getgroupitem(IG_C_CLAYMORE_C_BOX);
   - Id: 16910
@@ -47647,8 +47152,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47657,6 +47160,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_JAMADHAR_C_BOX
     Script: |
       getgroupitem(IG_C_JAMADHAR_C_BOX);
   - Id: 16911
@@ -47665,8 +47169,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47675,6 +47177,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_TWO_HANDED_AXE_C_BOX
     Script: |
       getgroupitem(IG_C_TWO_HANDED_AXE_C_BOX);
   - Id: 16912
@@ -47683,8 +47186,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47693,6 +47194,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_LANCE_C_BOX
     Script: |
       getgroupitem(IG_C_LANCE_C_BOX);
   - Id: 16913
@@ -47701,8 +47203,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47711,6 +47211,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ORCISH_AXE_C_BOX
     Script: |
       getgroupitem(IG_C_ORCISH_AXE_C_BOX);
   - Id: 16914
@@ -47719,8 +47220,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47729,6 +47228,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ENCYCLOPEDIA_C_BOX
     Script: |
       getgroupitem(IG_C_ENCYCLOPEDIA_C_BOX);
   - Id: 16915
@@ -47737,8 +47237,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47747,6 +47245,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_PIKE_C_BOX
     Script: |
       getgroupitem(IG_C_PIKE_C_BOX);
   - Id: 16916
@@ -47755,8 +47254,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47765,6 +47262,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_FIST_C_BOX
     Script: |
       getgroupitem(IG_C_FIST_C_BOX);
   - Id: 16917
@@ -47773,8 +47271,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47783,6 +47279,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_DAMASCUS_C_BOX
     Script: |
       getgroupitem(IG_C_DAMASCUS_C_BOX);
   - Id: 16918
@@ -47791,8 +47288,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47801,6 +47296,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_FLAMBERGE_C_BOX
     Script: |
       getgroupitem(IG_C_FLAMBERGE_C_BOX);
   - Id: 16919
@@ -47809,8 +47305,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47819,6 +47313,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_STUNNER_C_BOX
     Script: |
       getgroupitem(IG_C_STUNNER_C_BOX);
   - Id: 16920
@@ -47843,8 +47338,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47853,6 +47346,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SHOOTING_STAR_C_BOX
     Script: |
       getgroupitem(IG_C_SHOOTING_STAR_C_BOX);
   - Id: 16922
@@ -47861,8 +47355,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47871,6 +47363,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BLOODY_FEAR_C_BOX
     Script: |
       getgroupitem(IG_C_BLOODY_FEAR_C_BOX);
   - Id: 16923
@@ -47879,8 +47372,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47889,6 +47380,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_STAFF_HEALING_C_BOX
     Script: |
       getgroupitem(IG_C_STAFF_HEALING_C_BOX);
   - Id: 16924
@@ -47897,8 +47389,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47907,6 +47397,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CLOVER_BOX_MOUTH
     Script: |
       getgroupitem(IG_C_CLOVER_BOX_MOUTH);
   - Id: 16925
@@ -47915,8 +47406,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47925,6 +47414,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CLOVER_BOX_MOUTH2
     Script: |
       getgroupitem(IG_C_CLOVER_BOX_MOUTH2);
   - Id: 16926
@@ -47933,8 +47423,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47943,6 +47431,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CLOVER_BOX_MOUTH4
     Script: |
       getgroupitem(IG_C_CLOVER_BOX_MOUTH4);
   - Id: 16927
@@ -47951,8 +47440,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47961,6 +47448,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BGUM_BOX_IN_MOUTH
     Script: |
       getgroupitem(IG_C_BGUM_BOX_IN_MOUTH);
   - Id: 16928
@@ -47969,8 +47457,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47979,6 +47465,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BGUM_BOX_IN_MOUTH2
     Script: |
       getgroupitem(IG_C_BGUM_BOX_IN_MOUTH2);
   - Id: 16929
@@ -47987,8 +47474,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -47997,6 +47482,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BGUM_BOX_IN_MOUTH4
     Script: |
       getgroupitem(IG_C_BGUM_BOX_IN_MOUTH4);
   - Id: 16930
@@ -48005,8 +47491,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48015,6 +47499,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SPIKED_SCARF_BOX
     Script: |
       getgroupitem(IG_C_SPIKED_SCARF_BOX);
   - Id: 16931
@@ -48023,8 +47508,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48033,6 +47516,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SPIKED_SCARF_BOX2
     Script: |
       getgroupitem(IG_C_SPIKED_SCARF_BOX2);
   - Id: 16932
@@ -48041,8 +47525,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48051,6 +47533,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SPIKED_SCARF_BOX3
     Script: |
       getgroupitem(IG_C_SPIKED_SCARF_BOX3);
   - Id: 16933
@@ -48059,8 +47542,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48069,6 +47550,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RAINBOW_SCARF_BOX
     Script: |
       getgroupitem(IG_C_RAINBOW_SCARF_BOX);
   - Id: 16934
@@ -48077,8 +47559,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48087,6 +47567,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RAINBOW_SCARF_BOX2
     Script: |
       getgroupitem(IG_C_RAINBOW_SCARF_BOX2);
   - Id: 16935
@@ -48095,8 +47576,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48105,6 +47584,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RAINBOW_SCARF_BOX3
     Script: |
       getgroupitem(IG_C_RAINBOW_SCARF_BOX3);
   - Id: 16936
@@ -48113,8 +47593,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48123,6 +47601,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RIBBON_OF_LIFE_BOX
     Script: |
       getgroupitem(IG_C_RIBBON_OF_LIFE_BOX);
   - Id: 16937
@@ -48131,8 +47610,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48141,6 +47618,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RIBBON_OF_LIFE_BOX2
     Script: |
       getgroupitem(IG_C_RIBBON_OF_LIFE_BOX2);
   - Id: 16938
@@ -48149,8 +47627,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48159,6 +47635,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_RIBBON_OF_LIFE_BOX3
     Script: |
       getgroupitem(IG_C_RIBBON_OF_LIFE_BOX3);
   - Id: 16939
@@ -48167,8 +47644,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48177,6 +47652,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_LOVE_ANGEL_BOX
     Script: |
       getgroupitem(IG_C_LOVE_ANGEL_BOX);
   - Id: 16940
@@ -48185,8 +47661,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48195,6 +47669,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_LOVE_ANGEL_BOX_1M
     Script: |
       getgroupitem(IG_C_LOVE_ANGEL_BOX_1M);
   - Id: 16941
@@ -48203,8 +47678,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48213,6 +47686,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SQUIRREL_BOX
     Script: |
       getgroupitem(IG_C_SQUIRREL_BOX);
   - Id: 16942
@@ -48221,8 +47695,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48231,6 +47703,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_SQUIRREL_BOX_1M
     Script: |
       getgroupitem(IG_C_SQUIRREL_BOX_1M);
   - Id: 16943
@@ -48239,8 +47712,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48249,6 +47720,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_PICTURE_DIARY_BOX
     Script: |
       getgroupitem(IG_C_PICTURE_DIARY_BOX);
   - Id: 16944
@@ -48257,8 +47729,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48267,6 +47737,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_PICTURE_DIARY_BOX_1M
     Script: |
       getgroupitem(IG_C_PICTURE_DIARY_BOX_1M);
   - Id: 16945
@@ -48275,8 +47746,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48285,6 +47754,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MINI_HEART_BOX
     Script: |
       getgroupitem(IG_C_MINI_HEART_BOX);
   - Id: 16946
@@ -48293,8 +47763,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48303,6 +47771,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MINI_HEART_BOX_1M
     Script: |
       getgroupitem(IG_C_MINI_HEART_BOX_1M);
   - Id: 16947
@@ -48311,8 +47780,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48321,6 +47788,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_NEWCOMER_BOX
     Script: |
       getgroupitem(IG_C_NEWCOMER_BOX);
   - Id: 16948
@@ -48329,8 +47797,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48339,6 +47805,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_NEWCOMER_BOX_1M
     Script: |
       getgroupitem(IG_C_NEWCOMER_BOX_1M);
   - Id: 16949
@@ -48347,8 +47814,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48357,6 +47822,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_KID_BOX
     Script: |
       getgroupitem(IG_C_KID_BOX);
   - Id: 16950
@@ -48365,8 +47831,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48375,6 +47839,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_KID_BOX_1M
     Script: |
       getgroupitem(IG_C_KID_BOX_1M);
   - Id: 16951
@@ -48383,8 +47848,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48393,6 +47856,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MAGIC_CASTLE_BOX
     Script: |
       getgroupitem(IG_C_MAGIC_CASTLE_BOX);
   - Id: 16952
@@ -48401,8 +47865,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48411,6 +47873,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MAGIC_CASTLE_BOX_1M
     Script: |
       getgroupitem(IG_C_MAGIC_CASTLE_BOX_1M);
   - Id: 16953
@@ -48419,8 +47882,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48429,6 +47890,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BULGING_HEAD_BOX
     Script: |
       getgroupitem(IG_C_BULGING_HEAD_BOX);
   - Id: 16954
@@ -48437,8 +47899,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48447,6 +47907,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BULGING_HEAD_BOX_1M
     Script: |
       getgroupitem(IG_C_BULGING_HEAD_BOX_1M);
   - Id: 16955
@@ -48727,8 +48188,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48737,6 +48196,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WEATHER_REPORT_BOX
     Script: |
       getgroupitem(IG_WEATHER_REPORT_BOX);
   - Id: 16973
@@ -48763,8 +48223,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48773,6 +48231,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMIN_ACTOR_BOX
     Script: |
       getgroupitem(IG_COMIN_ACTOR_BOX);
   - Id: 16975
@@ -48799,8 +48258,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48809,6 +48266,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HEN_SET_BOX
     Script: |
       getgroupitem(IG_HEN_SET_BOX);
   - Id: 16977
@@ -48851,8 +48309,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48861,6 +48317,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_FRUIT_BOX4
     Script: |
       getgroupitem(IG_SILVERVINE_FRUIT_BOX4);
   - Id: 16990
@@ -48869,20 +48326,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SAGITTAR_DIADEM_SCROLL
     Script: |
-      getgroupitem(IG_Sagittar_Diadem_Scroll);
+      getgroupitem(IG_SAGITTAR_DIADEM_SCROLL);
   - Id: 16991
     AegisName: Sagittar_Di_Scroll_Box
     Name: Sagittar Di Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SAGITTAR_DI_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Sagittar_Di_Scroll_Box);
+      getgroupitem(IG_SAGITTAR_DI_SCROLL_BOX);
   - Id: 16992
     AegisName: Butterfly_Wing_Box20
     Name: Butterfly Wing Box20
@@ -48907,8 +48362,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48917,6 +48370,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OLD_HAT_BOX
     Script: |
       getgroupitem(IG_OLD_HAT_BOX);
   - Id: 16996
@@ -48925,28 +48379,24 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CAPRI_CROWN_SCROLL
     Script: |
-      getgroupitem(IG_Capri_Crown_Scroll);
+      getgroupitem(IG_CAPRI_CROWN_SCROLL);
   - Id: 16997
     AegisName: Capri_Crown_Scroll_Box
     Name: Capri Crown Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CAPRI_CROWN_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Capri_Crown_Scroll_Box);
+      getgroupitem(IG_CAPRI_CROWN_SCROLL_BOX);
   - Id: 16998
     AegisName: Archangel_Wing_Box
     Name: Archangel Wing Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -48955,6 +48405,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ARCHANGEL_WING_BOX
     Script: |
       getgroupitem(IG_ARCHANGEL_WING_BOX);
   - Id: 16999
@@ -49081,28 +48532,24 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CAPRICON_DI_SCROLL
     Script: |
-      getgroupitem(IG_Capricon_Di_Scroll);
+      getgroupitem(IG_CAPRICON_DI_SCROLL);
   - Id: 17012
     AegisName: Capricon_Di_Scroll_Box
     Name: Capricon Di Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CAPRICON_DI_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Capricon_Di_Scroll_Box);
+      getgroupitem(IG_CAPRICON_DI_SCROLL_BOX);
   - Id: 17013
     AegisName: Malang_Woe_Encard_Box
     Name: Malangdo Woe Encard Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49111,6 +48558,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MALANG_WOE_ENCARD_BOX
     Script: |
       getgroupitem(IG_MALANG_WOE_ENCARD_BOX);
   - Id: 17014
@@ -49151,20 +48599,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_AQUARIUS_DIADEM_SCROLL
     Script: |
-      getgroupitem(IG_Aquarius_Diadem_Scroll);
+      getgroupitem(IG_AQUARIUS_DIADEM_SCROLL);
   - Id: 17017
     AegisName: Aquarius_Di_Scroll_Box
     Name: Aquarius Di Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_AQUARIUS_DI_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Aquarius_Di_Scroll_Box);
+      getgroupitem(IG_AQUARIUS_DI_SCROLL_BOX);
   - Id: 17018
     AegisName: Libra_Scroll2
     Name: Libra Scroll2
@@ -49187,78 +48633,69 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_NOV_SCROLL2
     Script: |
-      getgroupitem(IG_Tw_Nov_Scroll2);
+      getgroupitem(IG_TW_NOV_SCROLL2);
   - Id: 17021
     AegisName: Summer_Scroll3
     Name: Summer Scroll3
     Type: Usable
     Buy: 20
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SUMMER_SCROLL3
     Script: |
-      getgroupitem(IG_Summer_Scroll3);
+      getgroupitem(IG_SUMMER_SCROLL3);
   - Id: 17022
     AegisName: Super_Pet_Egg1_2
     Name: Super Pet Egg1 2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SUPER_PET_EGG1_2
     Script: |
-      getgroupitem(IG_Super_Pet_Egg1_2);
+      getgroupitem(IG_SUPER_PET_EGG1_2);
   - Id: 17023
     AegisName: Super_Pet_Egg4_2
     Name: Super Pet Egg4 2
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SUPER_PET_EGG4_2
     Script: |
-      getgroupitem(IG_Super_Pet_Egg4_2);
+      getgroupitem(IG_SUPER_PET_EGG4_2);
   - Id: 17024
     AegisName: Lovely_Aquarius_Scroll
     Name: Lovely Aquarius Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LOVELY_AQUARIUS_SCROLL
     Script: |
-      getgroupitem(IG_Lovely_Aquarius_Scroll);
+      getgroupitem(IG_LOVELY_AQUARIUS_SCROLL);
   - Id: 17025
     AegisName: Lovely_Aquarius_Box
     Name: Lovely Aquarius Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LOVELY_AQUARIUS_BOX
     Script: |
-      getgroupitem(IG_Lovely_Aquarius_Box);
+      getgroupitem(IG_LOVELY_AQUARIUS_BOX);
   - Id: 17026
     AegisName: Boitata_Scroll
     Name: Boitata Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BOITATA_SCROLL
     Script: |
-      getgroupitem(IG_Boitata_Scroll);
+      getgroupitem(IG_BOITATA_SCROLL);
   - Id: 17027
     AegisName: Refine_Ore_Box
     Name: Enriched Ores Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49267,6 +48704,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX);
   - Id: 17028
@@ -49275,20 +48713,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_PISCES_DIADEM_SCROLL
     Script: |
-      getgroupitem(IG_Pisces_Diadem_Scroll);
+      getgroupitem(IG_PISCES_DIADEM_SCROLL);
   - Id: 17029
     AegisName: Pisces_Diadem_S_Box
     Name: Pisces Diadem Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_PISCES_DIADEM_BOX
     Script: |
-      getgroupitem(IG_Pisces_Diadem_Box);
+      getgroupitem(IG_PISCES_DIADEM_BOX);
   - Id: 17030
     AegisName: St_Pat_Hat_box
     Name: St Pat Hat box
@@ -49305,28 +48741,24 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENERGETIC_PISCES_SCROLL
     Script: |
-      getgroupitem(IG_Energetic_Pisces_Scroll);
+      getgroupitem(IG_ENERGETIC_PISCES_SCROLL);
   - Id: 17036
     AegisName: Energetic_Pisces_Box
     Name: Energetic Pisces Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENERGETIC_PISCES_BOX
     Script: |
-      getgroupitem(IG_Energetic_Pisces_Box);
+      getgroupitem(IG_ENERGETIC_PISCES_BOX);
   - Id: 17037
     AegisName: Trans_Box_Devi
     Name: Transform Deviruchi 10pcs Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49335,6 +48767,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_DEVI
     Script: |
       getgroupitem(IG_TRANS_BOX_DEVI);
   - Id: 17038
@@ -49343,8 +48776,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49353,6 +48784,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_RAY_ARCH
     Script: |
       getgroupitem(IG_TRANS_BOX_RAY_ARCH);
   - Id: 17039
@@ -49361,8 +48793,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49371,6 +48801,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_MAVKA
     Script: |
       getgroupitem(IG_TRANS_BOX_MAVKA);
   - Id: 17040
@@ -49379,8 +48810,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49389,6 +48818,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_MARDUK
     Script: |
       getgroupitem(IG_TRANS_BOX_MARDUK);
   - Id: 17041
@@ -49397,8 +48827,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49407,6 +48835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_BANSHEE
     Script: |
       getgroupitem(IG_TRANS_BOX_BANSHEE);
   - Id: 17042
@@ -49433,8 +48862,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49443,6 +48870,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_BOX_GOLEM
     Script: |
       getgroupitem(IG_TRANS_BOX_GOLEM);
   - Id: 17044
@@ -49483,8 +48911,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -49493,6 +48919,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ATTEND_C_BOX
     Script: |
       getgroupitem(IG_ATTEND_C_BOX);
   - Id: 17050
@@ -49501,20 +48928,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ARIES_SCROLL
     Script: |
-      getgroupitem(IG_Aries_Scroll);
+      getgroupitem(IG_ARIES_SCROLL);
   - Id: 17051
     AegisName: Aries_Scroll_box
     Name: Aries Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ARIES_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Aries_Scroll_Box);
+      getgroupitem(IG_ARIES_SCROLL_BOX);
   - Id: 17052
     AegisName: Holy_Mom_Blaze_Box
     Name: Holy Mom Blaze Box
@@ -49579,20 +49004,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TAURUS_DIADEM_SCROLL
     Script: |
-      getgroupitem(IG_Taurus_Diadem_Scroll);
+      getgroupitem(IG_TAURUS_DIADEM_SCROLL);
   - Id: 17063
     AegisName: Taurus_Di_Scroll_Box
     Name: Taurus Di Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TAURUS_DI_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Taurus_Di_Scroll_Box);
+      getgroupitem(IG_TAURUS_DI_SCROLL_BOX);
   - Id: 17064
     AegisName: Tw_Sagitt_Scroll
     Name: Tw Sagitt Scroll
@@ -49645,6 +49068,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+    ItemGroup: IG_ACIDBOMB_BOX50
     Script: |
       getgroupitem(IG_ACIDBOMB_BOX50);
   - Id: 17069
@@ -49655,6 +49079,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 7135,100;
       getitem 7136,100;
@@ -49666,6 +49091,7 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+      Container: true
     Script: |
       getitem 7135,500;
       getitem 7136,500;
@@ -49735,20 +49161,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TAURUS_CROWN_SCROLL
     Script: |
-      getgroupitem(IG_Taurus_Crown_Scroll);
+      getgroupitem(IG_TAURUS_CROWN_SCROLL);
   - Id: 17078
     AegisName: Taurus_Crown_Scroll_Box
     Name: Taurus Crown Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TAURUS_CROWN_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Taurus_Crown_Scroll_Box);
+      getgroupitem(IG_TAURUS_CROWN_SCROLL_BOX);
   - Id: 17079
     AegisName: Indonesian_Box2
     Name: Indonesia Box2
@@ -49796,20 +49220,18 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMI_DIADEM_SCROLL
     Script: |
-      getgroupitem(IG_Gemi_Diadem_Scroll);
+      getgroupitem(IG_GEMI_DIADEM_SCROLL);
   - Id: 17083
     AegisName: Gemi_Diadem_Scroll_Box
     Name: Gemi Diadem Scroll Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMI_DIADEM_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Gemi_Diadem_Scroll_Box);
+      getgroupitem(IG_GEMI_DIADEM_SCROLL_BOX);
   - Id: 17084
     AegisName: Upg_Katar_Box
     Name: Upg Katar Box
@@ -49996,8 +49418,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50006,6 +49426,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_KATAR_BOX2
     Script: |
       getgroupitem(IG_UPG_KATAR_BOX2);
   - Id: 17095
@@ -50014,8 +49435,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50024,6 +49443,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_TWO_HANDED_AXE_BOX2
     Script: |
       getgroupitem(IG_UPG_TWO_HANDED_AXE_BOX2);
   - Id: 17096
@@ -50032,8 +49452,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50042,6 +49460,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_LANCE_BOX2
     Script: |
       getgroupitem(IG_UPG_LANCE_BOX2);
   - Id: 17097
@@ -50050,8 +49469,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50060,6 +49477,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_BOOK_BOX2
     Script: |
       getgroupitem(IG_UPG_BOOK_BOX2);
   - Id: 17098
@@ -50068,8 +49486,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50078,6 +49494,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_STAFF_BOX2
     Script: |
       getgroupitem(IG_UPG_STAFF_BOX2);
   - Id: 17099
@@ -50086,8 +49503,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50096,6 +49511,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_DAGGER_BOX2
     Script: |
       getgroupitem(IG_UPG_DAGGER_BOX2);
   - Id: 17100
@@ -50104,8 +49520,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50114,6 +49528,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_REVOLVER_BOX2
     Script: |
       getgroupitem(IG_UPG_REVOLVER_BOX2);
   - Id: 17101
@@ -50122,8 +49537,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50132,6 +49545,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_MACE_BOX2
     Script: |
       getgroupitem(IG_UPG_MACE_BOX2);
   - Id: 17102
@@ -50140,8 +49554,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50150,6 +49562,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_BOW_BOX2
     Script: |
       getgroupitem(IG_UPG_BOW_BOX2);
   - Id: 17103
@@ -50158,8 +49571,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50168,6 +49579,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UPG_TWOHAND_SWORD_BOX2
     Script: |
       getgroupitem(IG_UPG_TWOHAND_SWORD_BOX2);
   - Id: 17104
@@ -50214,20 +49626,18 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMI_CROWN_SCROLL
     Script: |
-      getgroupitem(IG_Gemi_Crown_Scroll);
+      getgroupitem(IG_GEMI_CROWN_SCROLL);
   - Id: 17108
     AegisName: Gemi_Crown_Scroll_Box
     Name: Gemi Crown Scroll Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMI_CROWN_SCROLL_BOX
     Script: |
-      getgroupitem(IG_Gemi_Crown_Scroll_Box);
+      getgroupitem(IG_GEMI_CROWN_SCROLL_BOX);
   - Id: 17109
     AegisName: Capri_Scroll
     Name: Capri Scroll
@@ -50296,8 +49706,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50306,6 +49714,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASPD_POTION_BOX10
     Script: |
       getgroupitem(IG_ASPD_POTION_BOX10);
   - Id: 17120
@@ -50419,8 +49828,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50429,6 +49836,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_A_SET
     Script: |
       getgroupitem(IG_TRANS_A_SET);
   - Id: 17136
@@ -50437,8 +49845,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50447,6 +49853,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_B_SET
     Script: |
       getgroupitem(IG_TRANS_B_SET);
   - Id: 17137
@@ -50455,8 +49862,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50465,6 +49870,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TRANS_C_SET
     Script: |
       getgroupitem(IG_TRANS_C_SET);
   - Id: 17138
@@ -50473,58 +49879,51 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MS_CANCER_SCROLL
     Script: |
-      getgroupitem(IG_Ms_Cancer_Scroll);
+      getgroupitem(IG_MS_CANCER_SCROLL);
   - Id: 17139
     AegisName: Ms_RWC_Super_Scroll
     Name: RWC Super Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_RWC_SUPER_SCROLL
     Script: |
-      getgroupitem(IG_RWC_Super_Scroll);
+      getgroupitem(IG_RWC_SUPER_SCROLL);
   - Id: 17140
     AegisName: Ms_Leo_Scroll
     Name: Leo Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LEO_SCROLL
     Script: |
-      getgroupitem(IG_Leo_Scroll);
+      getgroupitem(IG_LEO_SCROLL);
   - Id: 17141
     AegisName: Ms_Virgo_Scroll
     Name: Ms Virgo Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MS_VIRGO_SCROLL
     Script: |
-      getgroupitem(IG_Ms_Virgo_Scroll);
+      getgroupitem(IG_MS_VIRGO_SCROLL);
   - Id: 17143
     AegisName: Ms_Scorpio_Scroll
     Name: Ms Scorpio Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MS_SCORPIO_SCROLL
     Script: |
-      getgroupitem(IG_Ms_Scorpio_Scroll);
+      getgroupitem(IG_MS_SCORPIO_SCROLL);
   - Id: 17144
     AegisName: Made_Dish_Set
     Name: Assorted Cuisine Set
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50533,6 +49932,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MADE_DISH_SET
     Script: |
       getgroupitem(IG_MADE_DISH_SET);
   - Id: 17145
@@ -50541,10 +49941,9 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
+    ItemGroup: IG_MADE_DISH_BOX
     Script: |
       getgroupitem(IG_MADE_DISH_BOX);
   - Id: 17146
@@ -50599,8 +49998,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50609,6 +50006,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RED_BOOSTER_BOX20_2
     Script: |
       getgroupitem(IG_RED_BOOSTER_BOX20_2);
   - Id: 17155
@@ -50617,6 +50015,7 @@ Body:
     Type: Usable
     Flags:
       UniqueId: true
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50632,10 +50031,9 @@ Body:
     Name: Bossnia Ticket Scroll
     Type: Usable
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_TCG_CARD_SCROLL
     Script: |
-      getgroupitem(IG_TCG_Card_Scroll);
+      getgroupitem(IG_TCG_CARD_SCROLL);
   - Id: 17157
     AegisName: Vital_Flower_Box
     Name: Vital Flower Box
@@ -50662,8 +50060,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50672,6 +50068,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHANGE_NAME_CARD_BOX
     Script: |
       getgroupitem(IG_CHANGE_NAME_CARD_BOX);
   - Id: 17160
@@ -50680,8 +50077,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50690,6 +50085,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHANGE_NAME_CARD_BOX2
     Script: |
       getgroupitem(IG_CHANGE_NAME_CARD_BOX2);
   - Id: 17162
@@ -50698,7 +50094,6 @@ Body:
     Type: Cash
     Weight: 10
     Flags:
-      Container: true
       UniqueId: true
     Trade:
       NoDrop: true
@@ -50708,6 +50103,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOARDING_HALTER_BOX7
     Script: |
       getgroupitem(IG_BOARDING_HALTER_BOX7);
   - Id: 17163
@@ -50732,8 +50128,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50742,6 +50136,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTIC_POWDER_BOX30_2
     Script: |
       getgroupitem(IG_MYSTIC_POWDER_BOX30_2);
   - Id: 17165
@@ -50750,10 +50145,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHALLENGE_KIT
     Script: |
-      getgroupitem(IG_Challenge_Kit);
+      getgroupitem(IG_CHALLENGE_KIT);
       /*getitem Blessing_10_Scroll,20; getitem Inc_Agi_10_Scroll,20;*/
   - Id: 17166
     AegisName: Hellomother_Hat_Box
@@ -50777,8 +50171,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50787,6 +50179,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EC_BATTLE_MANUAL_BOX
     Script: |
       getgroupitem(IG_EC_BATTLE_MANUAL_BOX);
   - Id: 17172
@@ -50795,8 +50188,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50805,6 +50196,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EC_JOB_MANUAL25_BOX10
     Script: |
       getgroupitem(IG_EC_JOB_MANUAL25_BOX10);
   - Id: 17173
@@ -50813,8 +50205,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50823,6 +50213,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GLOBAL_HAT_FES_BOX
     Script: |
       getgroupitem(IG_GLOBAL_HAT_FES_BOX);
   - Id: 17174
@@ -50831,8 +50222,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50841,6 +50230,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GLOBAL_HAT_FES_5_BOX
     Script: |
       getgroupitem(IG_GLOBAL_HAT_FES_5_BOX);
   - Id: 17175
@@ -50849,8 +50239,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50859,6 +50247,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GLOBAL_HAT_FES_BOX2
     Script: |
       getgroupitem(IG_GLOBAL_HAT_FES_BOX2);
   - Id: 17176
@@ -50867,8 +50256,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50877,6 +50264,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOARDING_HALTER_BOX3
     Script: |
       getgroupitem(IG_BOARDING_HALTER_BOX3);
   - Id: 17177
@@ -50885,8 +50273,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50895,6 +50281,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MADE_DISH_BOX1
     Script: |
       getgroupitem(IG_MADE_DISH_BOX1);
   - Id: 17178
@@ -50903,8 +50290,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50913,6 +50298,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_WATER_BOX50
     Script: |
       getgroupitem(IG_MYSTERIOUS_WATER_BOX50);
   - Id: 17179
@@ -50921,8 +50307,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50931,6 +50315,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_MYST_WATER_BOX50
     Script: |
       getgroupitem(IG_C_MYST_WATER_BOX50);
   - Id: 17180
@@ -50939,8 +50324,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50949,6 +50332,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_WATER_BOX50_
     Script: |
       getgroupitem(IG_MYSTERIOUS_WATER_BOX50_);
   - Id: 17181
@@ -50989,8 +50373,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -50999,6 +50381,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX2
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX2);
   - Id: 17194
@@ -51006,8 +50389,6 @@ Body:
     Name: RG Red Potion Box
     Type: Cash
     Weight: 400
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51016,6 +50397,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RED_POTION_RG_BOX
     Script: |
       getgroupitem(IG_RED_POTION_RG_BOX);
   - Id: 17195
@@ -51023,8 +50405,6 @@ Body:
     Name: RG Blue Potion Box
     Type: Cash
     Weight: 900
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51033,6 +50413,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLUE_POTION_RG_BOX
     Script: |
       getgroupitem(IG_BLUE_POTION_RG_BOX);
   - Id: 17196
@@ -51040,8 +50421,6 @@ Body:
     Name: RG Golden Apple Slice Box
     Type: Cash
     Weight: 3000
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51050,6 +50429,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDENAPPLE_P_RG_BOX
     Script: |
       getgroupitem(IG_GOLDENAPPLE_P_RG_BOX);
   - Id: 17197
@@ -51057,8 +50437,6 @@ Body:
     Name: RG Golden Apple Box
     Type: Cash
     Weight: 3000
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51067,6 +50445,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDENAPPLE_RG_BOX
     Script: |
       getgroupitem(IG_GOLDENAPPLE_RG_BOX);
   - Id: 17198
@@ -51074,8 +50453,6 @@ Body:
     Name: RG Golden Potion Box
     Type: Cash
     Weight: 300
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51084,6 +50461,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDEN_POTION_RG_BOX
     Script: |
       getgroupitem(IG_GOLDEN_POTION_RG_BOX);
   - Id: 17200
@@ -51147,8 +50525,6 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51157,16 +50533,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHINING_EGG
     Script: |
-      getgroupitem(IG_Shining_Egg);
+      getgroupitem(IG_SHINING_EGG);
   - Id: 17205
     AegisName: Special_Po_Box
     Name: Poring's Special Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51175,6 +50550,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPECIAL_PO_BOX
     Script: |
       getgroupitem(IG_SPECIAL_PO_BOX);
   - Id: 17206
@@ -51182,8 +50558,6 @@ Body:
     Name: Battle Manual Limit Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51192,6 +50566,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BATTLE_MANUAL_LIMIT_BOX
     Script: |
       getgroupitem(IG_BATTLE_MANUAL_LIMIT_BOX);
   - Id: 17207
@@ -51202,48 +50577,45 @@ Body:
     Weight: 10
     Flags:
       UniqueId: true
+    ItemGroup: IG_IDN_HEART_SCROLL
     Script: |
-      getgroupitem(IG_Idn_Heart_Scroll);
+      getgroupitem(IG_IDN_HEART_SCROLL);
   - Id: 17209
     AegisName: Tw_Rainbow_Scroll
     Name: Tw Rainbow Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_RAINBOW_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Rainbow_Scroll);
+      getgroupitem(IG_TW_RAINBOW_SCROLL);
   - Id: 17210
     AegisName: Tw_Red_Scroll
     Name: Tw Red Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_RED_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Red_Scroll);
+      getgroupitem(IG_TW_RED_SCROLL);
   - Id: 17211
     AegisName: Tw_Orange_Scroll
     Name: Tw Orange Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_ORANGE_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Orange_Scroll);
+      getgroupitem(IG_TW_ORANGE_SCROLL);
   - Id: 17212
     AegisName: Tw_Yellow_Scroll
     Name: Tw Yellow Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TW_YELLOW_SCROLL
     Script: |
-      getgroupitem(IG_Tw_Yellow_Scroll);
+      getgroupitem(IG_TW_YELLOW_SCROLL);
   - Id: 17224
     AegisName: Almighty_Box
     Name: Almighty Box
@@ -51274,6 +50646,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CENTER_POT_BOX
     Script: |
       getgroupitem(IG_C_CENTER_POT_BOX);
   - Id: 17227
@@ -51290,6 +50663,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_AWAKENING_POT_BOX
     Script: |
       getgroupitem(IG_C_AWAKENING_POT_BOX);
   - Id: 17228
@@ -51306,6 +50680,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BERSERK_POT_BOX
     Script: |
       getgroupitem(IG_C_BERSERK_POT_BOX);
   - Id: 17229
@@ -51314,8 +50689,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51324,6 +50697,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WING_OF_FLY_BOX
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_BOX);
   - Id: 17230
@@ -51333,16 +50707,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
+    ItemGroup: IG_VALERIAN_SCROLL
     Script: |
-      getgroupitem(IG_Valerian_Scroll);
+      getgroupitem(IG_VALERIAN_SCROLL);
   - Id: 17231
     AegisName: Refine_Ore_Box3
     Name: Refining Ore Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51351,6 +50724,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX3
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX3);
   - Id: 17232
@@ -51359,8 +50733,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51369,6 +50741,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUARANTEE7_BOX
     Script: |
       getgroupitem(IG_GUARANTEE7_BOX);
   - Id: 17233
@@ -51377,86 +50750,80 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_DEATH
     Script: |
-      getgroupitem(IG_Scroll_Of_Death);
+      getgroupitem(IG_SCROLL_OF_DEATH);
   - Id: 17234
     AegisName: Scroll_Of_Life
     Name: Scroll Of Life
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_LIFE
     Script: |
-      getgroupitem(IG_Scroll_Of_Life);
+      getgroupitem(IG_SCROLL_OF_LIFE);
   - Id: 17235
     AegisName: Scroll_Of_Magic
     Name: Scroll Of Magic
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_MAGIC
     Script: |
-      getgroupitem(IG_Scroll_Of_Magic);
+      getgroupitem(IG_SCROLL_OF_MAGIC);
   - Id: 17236
     AegisName: Scroll_Of_Thews
     Name: Scroll Of Thews
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_THEWS
     Script: |
-      getgroupitem(IG_Scroll_Of_Thews);
+      getgroupitem(IG_SCROLL_OF_THEWS);
   - Id: 17237
     AegisName: Scroll_Of_Darkness
     Name: Scroll Of Darkness
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_DARKNESS
     Script: |
-      getgroupitem(IG_Scroll_Of_Darkness);
+      getgroupitem(IG_SCROLL_OF_DARKNESS);
   - Id: 17238
     AegisName: Scroll_Of_Holiness
     Name: Scroll Of Holiness
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SCROLL_OF_HOLINESS
     Script: |
-      getgroupitem(IG_Scroll_Of_Holiness);
+      getgroupitem(IG_SCROLL_OF_HOLINESS);
   - Id: 17239
     AegisName: Horned_Scroll
     Name: Horned Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HORNED_SCROLL
     Script: |
-      getgroupitem(IG_Horned_Scroll);
+      getgroupitem(IG_HORNED_SCROLL);
   - Id: 17240
     AegisName: Mercury_Scroll
     Name: Mercury Scroll
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MERCURY_SCROLL
     Script: |
-      getgroupitem(IG_Mercury_Scroll);
+      getgroupitem(IG_MERCURY_SCROLL);
   - Id: 17241
     AegisName: Amistr_Cap_Box
     Name: Amistir Cap Box
     Type: Usable
     Buy: 10
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51474,16 +50841,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
+    ItemGroup: IG_IMMORTAL_EGG
     Script: |
-      getgroupitem(IG_Immortal_Egg);
+      getgroupitem(IG_IMMORTAL_EGG);
   - Id: 17244
     AegisName: Almighty_Box2
     Name: Event Almighty Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51492,6 +50858,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_BOX2
     Script: |
       getgroupitem(IG_ALMIGHTY_BOX2);
   - Id: 17245
@@ -51507,8 +50874,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51517,6 +50882,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_ELUNIUM_BOX30
     Script: |
       getgroupitem(IG_HD_ELUNIUM_BOX30);
   - Id: 17247
@@ -51525,8 +50891,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51535,6 +50899,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_ORIDECON_BOX30
     Script: |
       getgroupitem(IG_HD_ORIDECON_BOX30);
   - Id: 17251
@@ -51543,8 +50908,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51553,16 +50916,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WING_OF_FLY_3DAY_BOX
     Script: |
-      getgroupitem(IG_C_Wing_Of_Fly_3Day_Box);
+      getgroupitem(IG_C_WING_OF_FLY_3DAY_BOX);
   - Id: 17252
     AegisName: RWC_2012_Set_Box
     Name: RWC 2012 Set Box
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51571,8 +50933,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RWC_2012_SET_BOX
     Script: |
-      getgroupitem(IG_RWC_2012_Set_Box);
+      getgroupitem(IG_RWC_2012_SET_BOX);
   - Id: 17253
     AegisName: RWC_2012_Ring_Box
     Name: RWC 2012 Ring Box
@@ -51616,33 +50979,30 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
+    ItemGroup: IG_SAPPHIRE_EGG
     Script: |
-      getgroupitem(IG_Sapphire_Egg);
+      getgroupitem(IG_SAPPHIRE_EGG);
   - Id: 17256
     AegisName: Good_Student_Gift_Box
     Name: Good Student Gift Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_GOOD_STUDENT_GIFT_BOX
     Script: |
-      getgroupitem(IG_Good_Student_Gift_Box);
+      getgroupitem(IG_GOOD_STUDENT_GIFT_BOX);
   - Id: 17257
     AegisName: Bad_Student_Gift_Box
     Name: Bad Student Gift Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
+    ItemGroup: IG_BAD_STUDENT_GIFT_BOX
     Script: |
-      getgroupitem(IG_Bad_Student_Gift_Box);
+      getgroupitem(IG_BAD_STUDENT_GIFT_BOX);
   - Id: 17262
     AegisName: Ex_Def_Potion_Box
     Name: Special Defense Potion Box
     Type: Cash
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51651,8 +51011,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EX_DEF_POTION_BOX
     Script: |
-      getgroupitem(IG_Ex_Def_Potion_Box);
+      getgroupitem(IG_EX_DEF_POTION_BOX);
       /*getitem Ex_Def_Potion,5; getitem RWC_Scroll_2012,1;*/
   - Id: 17263
     AegisName: C_Center_Pot_3d_Box
@@ -51660,8 +51021,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51670,6 +51029,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_CENTER_POT_3D_BOX
     Script: |
       getgroupitem(IG_C_CENTER_POT_3D_BOX);
   - Id: 17264
@@ -51678,8 +51038,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51688,6 +51046,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_AWAKENING_POT_3D_BOX
     Script: |
       getgroupitem(IG_C_AWAKENING_POT_3D_BOX);
   - Id: 17265
@@ -51696,8 +51055,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51706,6 +51063,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_BERSERK_POT_3D_BOX
     Script: |
       getgroupitem(IG_C_BERSERK_POT_3D_BOX);
   - Id: 17266
@@ -51714,8 +51072,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51724,6 +51080,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BM_LIMIT_PACK
     Script: |
       getgroupitem(IG_BM_LIMIT_PACK);
   - Id: 17270
@@ -51836,8 +51193,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51846,16 +51201,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX
     Script: |
-      getgroupitem(IG_Unlimited_Box);
+      getgroupitem(IG_UNLIMITED_BOX);
   - Id: 17278
     AegisName: Unlimited_10_Box
     Name: Unlimited Set of 10 boxes
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51864,6 +51218,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_10_BOX
     Script: |
       getgroupitem(IG_UNLIMITED_10_BOX);
   - Id: 17279
@@ -51872,8 +51227,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51882,6 +51235,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_20_BOX
     Script: |
       getgroupitem(IG_UNLIMITED_20_BOX);
   - Id: 17281
@@ -51890,8 +51244,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51900,6 +51252,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX4
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX4);
   - Id: 17282
@@ -51908,8 +51261,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51918,6 +51269,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX4_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX4_SET10);
   - Id: 17283
@@ -51926,8 +51278,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -51936,6 +51286,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX4_SET20
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX4_SET20);
   - Id: 17284
@@ -52006,8 +51357,6 @@ Body:
     Name: Customization Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52016,6 +51365,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CUSTOMIZING_BOX
     Script: |
       getgroupitem(IG_CUSTOMIZING_BOX);
   - Id: 17289
@@ -52033,6 +51383,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WING_OF_BAALZEBUB_BOX
     Script: |
       getgroupitem(IG_WING_OF_BAALZEBUB_BOX);
   - Id: 17290
@@ -52056,8 +51407,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52066,6 +51415,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_BOX
     Script: |
       getgroupitem(IG_SHADOW_BOX);
   - Id: 17293
@@ -52074,8 +51424,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52084,6 +51432,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PHYSICAL_S_PACKAGE
     Script: |
       getgroupitem(IG_PHYSICAL_S_PACKAGE);
   - Id: 17294
@@ -52092,8 +51441,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52102,6 +51449,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAGICAL_S_PACKAGE
     Script: |
       getgroupitem(IG_MAGICAL_S_PACKAGE);
   - Id: 17298
@@ -52110,8 +51458,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52120,16 +51466,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE
     Script: |
-      getgroupitem(IG_Support_Package);
+      getgroupitem(IG_SUPPORT_PACKAGE);
   - Id: 17299
     AegisName: Vigorgra_Package_Set
     Name: Support Package(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52138,8 +51483,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE_10
     Script: |
-      getgroupitem(IG_Support_Package_10);
+      getgroupitem(IG_SUPPORT_PACKAGE_10);
   - Id: 17302
     AegisName: Shadow_Box2_Box
     Name: Shadow Box II
@@ -52189,8 +51535,6 @@ Body:
     Name: Status Reset Coupon Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52199,6 +51543,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STATUS_RESET_COUPON_BOX
     Script: |
       getgroupitem(IG_STATUS_RESET_COUPON_BOX);
   - Id: 17307
@@ -52208,16 +51553,17 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_MIDGARD_SCROLL
     Script: |
-      getgroupitem(IG_Midgard_Scroll);
+      getgroupitem(IG_MIDGARD_SCROLL);
   - Id: 17308
     AegisName: Half_Asprika_Box_1
     Name: Half Asprika box1
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 2566,86400;
   - Id: 17311
@@ -52226,6 +51572,8 @@ Body:
     Type: Usable
     Buy: 20
     EquipLevelMin: 47
+    Flags:
+      Container: true
     Script: |
       rentitem 15023,86400;
   - Id: 17314
@@ -52234,8 +51582,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52244,6 +51590,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WING_OF_FLY_1DAY_BOX
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_1DAY_BOX);
   - Id: 17315
@@ -52252,8 +51599,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52262,6 +51607,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_BOX10_
     Script: |
       getgroupitem(IG_SILVERVINE_BOX10_);
   - Id: 17316
@@ -52270,8 +51616,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52280,6 +51624,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_BOX110
     Script: |
       getgroupitem(IG_SILVERVINE_BOX110);
   - Id: 17317
@@ -52289,10 +51634,9 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_SWEET_MIDGARD_SCROLL
     Script: |
-      getgroupitem(IG_Sweet_Midgard_Scroll);
+      getgroupitem(IG_SWEET_MIDGARD_SCROLL);
   - Id: 17320
     AegisName: Brithday_IdRO10th_Scr
     Name: Birthday IdRO10th Scroll
@@ -52300,18 +51644,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_IDRO10TH_SCROLL
     Script: |
-      getgroupitem(IG_IdRO10th_Scroll);
+      getgroupitem(IG_IDRO10TH_SCROLL);
   - Id: 17321
     AegisName: 3_Life_Potion_pack
     Name: Three Master Package
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52320,6 +51661,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK);
   - Id: 17322
@@ -52328,8 +51670,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52338,6 +51678,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK);
   - Id: 17326
@@ -52347,18 +51688,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_REQUIEM_SCROLL
     Script: |
-      getgroupitem(IG_Requiem_Scroll);
+      getgroupitem(IG_REQUIEM_SCROLL);
   - Id: 17331
     AegisName: Almighty_Box3
     Name: Event Almighty Box
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52367,16 +51705,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVENT_ALMIGHTY_BOX
     Script: |
-      getgroupitem(IG_Event_Almighty_Box);
+      getgroupitem(IG_EVENT_ALMIGHTY_BOX);
   - Id: 17332
     AegisName: Almighty100_Box
     Name: Event Almighty Box (100)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52385,8 +51722,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVENT_ALMIGHTY_BOX_100
     Script: |
-      getgroupitem(IG_Event_Almighty_Box_100);
+      getgroupitem(IG_EVENT_ALMIGHTY_BOX_100);
   - Id: 17336
     AegisName: J_Shop_Coupon_Box
     Name: Cash Hair Coupon Box
@@ -52410,18 +51748,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_HOLY_SPIRIT_SCROLL
     Script: |
-      getgroupitem(IG_Holy_Spirit_Scroll);
+      getgroupitem(IG_HOLY_SPIRIT_SCROLL);
   - Id: 17338
     AegisName: Refine_Ore_Box5
     Name: Ore Box V
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52430,6 +51765,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX5
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX5);
   - Id: 17339
@@ -52438,8 +51774,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52448,6 +51782,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX5_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX5_SET10);
   - Id: 17394
@@ -52456,8 +51791,7 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_OLD_HAT_BOX_
     Script: |
       getgroupitem(IG_OLD_HAT_BOX_);
   - Id: 17396
@@ -52466,6 +51800,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 5887,86400;
   - Id: 17397
@@ -52474,6 +51810,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 5887,604800;
   - Id: 17398
@@ -52482,6 +51820,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1439,86400;
   - Id: 17399
@@ -52490,6 +51830,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1439,604800;
   - Id: 17400
@@ -52498,6 +51840,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1597,86400;
   - Id: 17401
@@ -52506,6 +51850,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1597,604800;
   - Id: 17402
@@ -52514,6 +51860,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1673,86400;
   - Id: 17403
@@ -52522,6 +51870,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1673,604800;
   - Id: 17404
@@ -52530,6 +51880,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1674,86400;
   - Id: 17405
@@ -52538,6 +51890,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1674,604800;
   - Id: 17406
@@ -52546,6 +51900,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1838,86400;
   - Id: 17407
@@ -52554,6 +51910,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 1838,604800;
   - Id: 17408
@@ -52562,6 +51920,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13096,86400;
   - Id: 17409
@@ -52570,6 +51930,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13096,604800;
   - Id: 17410
@@ -52578,6 +51940,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13321,86400;
   - Id: 17411
@@ -52586,6 +51950,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13321,604800;
   - Id: 17412
@@ -52594,6 +51960,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13445,86400;
   - Id: 17413
@@ -52602,6 +51970,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 13445,604800;
   - Id: 17414
@@ -52610,6 +51980,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 16034,86400;
   - Id: 17415
@@ -52618,6 +51990,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 16034,604800;
   - Id: 17416
@@ -52626,6 +52000,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 16035,86400;
   - Id: 17417
@@ -52634,6 +52010,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 16035,604800;
   - Id: 17418
@@ -52642,6 +52020,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 18124,86400;
   - Id: 17419
@@ -52650,6 +52030,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 18124,604800;
   - Id: 17420
@@ -52658,6 +52040,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28002,86400;
   - Id: 17421
@@ -52666,6 +52050,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28002,604800;
   - Id: 17422
@@ -52674,6 +52060,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28102,86400;
   - Id: 17423
@@ -52682,6 +52070,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28102,604800;
   - Id: 17424
@@ -52690,6 +52080,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28203,86400;
   - Id: 17425
@@ -52698,6 +52090,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28203,604800;
   - Id: 17426
@@ -52706,6 +52100,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28204,86400;
   - Id: 17427
@@ -52714,6 +52110,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       rentitem 28204,604800;
   - Id: 17429
@@ -52722,8 +52120,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52732,6 +52128,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_BOX3
     Script: |
       getgroupitem(IG_SHADOW_BOX3);
   - Id: 17430
@@ -52740,8 +52137,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52750,6 +52145,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_11TH_S_PACKAGE
     Script: |
       getgroupitem(IG_11TH_S_PACKAGE);
   - Id: 17431
@@ -52759,18 +52155,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_THANKS_GIVING_SCROLL
     Script: |
-      getgroupitem(IG_Thanks_Giving_Scroll);
+      getgroupitem(IG_THANKS_GIVING_SCROLL);
   - Id: 17432
     AegisName: Silvervine_Box10_2
     Name: Lucky Silvervine Fruit Box II(10)
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52779,6 +52172,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_BOX10_2
     Script: |
       getgroupitem(IG_SILVERVINE_BOX10_2);
   - Id: 17433
@@ -52787,8 +52181,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52797,6 +52189,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SILVERVINE_BOX110_2
     Script: |
       getgroupitem(IG_SILVERVINE_BOX110_2);
   - Id: 17435
@@ -52806,18 +52199,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_IDN_LEGEND_HERO_SCROLL
     Script: |
-      getgroupitem(IG_Idn_Legend_Hero_Scroll);
+      getgroupitem(IG_IDN_LEGEND_HERO_SCROLL);
   - Id: 17438
     AegisName: 3_Life_Potion_pack2
     Name: Three Master Package II
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52826,6 +52216,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK2
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK2);
   - Id: 17439
@@ -52834,8 +52225,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52844,6 +52233,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK2
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK2);
   - Id: 17440
@@ -52883,8 +52273,6 @@ Body:
     Name: Emperium G Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52893,6 +52281,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_EMPELIUM_BOX
     Script: |
       getgroupitem(IG_LI_EMPELIUM_BOX);
   - Id: 17443
@@ -52900,8 +52289,6 @@ Body:
     Name: Reinforcement Buckler Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52910,6 +52297,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_UPG_BUCKLER_BOX
     Script: |
       getgroupitem(IG_LI_UPG_BUCKLER_BOX);
   - Id: 17447
@@ -52918,17 +52306,14 @@ Body:
     Type: Cash
     Buy: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_BLESSING_MIDGARD_SCROLL
     Script: |
-      getgroupitem(IG_Blessing_Midgard_Scroll);
+      getgroupitem(IG_BLESSING_MIDGARD_SCROLL);
   - Id: 17449
     AegisName: Biscuit_Stick_Set
     Name: Set Bar Cookies
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52937,6 +52322,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BISCUIT_STICK_SET
     Script: |
       getgroupitem(IG_BISCUIT_STICK_SET);
   - Id: 17455
@@ -52945,8 +52331,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52955,6 +52339,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PREMIUM_BOOK_BOX
     Script: |
       getgroupitem(IG_PREMIUM_BOOK_BOX);
   - Id: 17456
@@ -52963,8 +52348,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52973,16 +52356,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE_II
     Script: |
-      getgroupitem(IG_Support_Package_II);
+      getgroupitem(IG_SUPPORT_PACKAGE_II);
   - Id: 17457
     AegisName: Vigorgra_Package_Set_V2
     Name: Support Package II(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -52991,15 +52373,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE_II_10
     Script: |
-      getgroupitem(IG_Support_Package_II_10);
+      getgroupitem(IG_SUPPORT_PACKAGE_II_10);
   - Id: 17461
     AegisName: Costama_Egg18
     Name: Frozen Egg Costume
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53008,8 +52389,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG18
     Script: |
-      getgroupitem(IG_Costama_Egg18);
+      getgroupitem(IG_COSTAMA_EGG18);
   - Id: 17464
     AegisName: Winter_Midgard_Scroll
     Name: Winter Midgard Egg
@@ -53017,18 +52399,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_WINTER_MIDGARD_SCROLL
     Script: |
-      getgroupitem(IG_Winter_Midgard_Scroll);
+      getgroupitem(IG_WINTER_MIDGARD_SCROLL);
   - Id: 17465
     AegisName: Refine_Ore_Box6
     Name: Refine Ore Box VI
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53037,6 +52416,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX6
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX6);
   - Id: 17466
@@ -53045,8 +52425,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53055,6 +52433,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX6_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX6_SET10);
   - Id: 17467
@@ -53079,6 +52458,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53095,6 +52476,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53110,8 +52493,6 @@ Body:
     Name: Headgear Costume Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53120,8 +52501,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG19
     Script: |
-      getgroupitem(IG_Costama_Egg19);
+      getgroupitem(IG_COSTAMA_EGG19);
   - Id: 17471
     AegisName: Spring_Festival_Scroll
     Name: Spring Festival Lucky Egg
@@ -53129,18 +52511,15 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_SPRING_FESTIVAL_SCROLL
     Script: |
-      getgroupitem(IG_Spring_Festival_Scroll);
+      getgroupitem(IG_SPRING_FESTIVAL_SCROLL);
   - Id: 17472
     AegisName: Vigorgra_Package_v3
     Name: Support Package III
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53149,16 +52528,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE_III
     Script: |
-      getgroupitem(IG_Support_Package_III);
+      getgroupitem(IG_SUPPORT_PACKAGE_III);
   - Id: 17473
     AegisName: Vigorgra_Package_Set_V3
     Name: Support Package III(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53167,16 +52545,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPPORT_PACKAGE_III_10
     Script: |
-      getgroupitem(IG_Support_Package_III_10);
+      getgroupitem(IG_SUPPORT_PACKAGE_III_10);
   - Id: 17474
     AegisName: C_Wing_Of_Fly_5Day_Box
     Name: Unlimited Fly Wing 5 Day Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53185,6 +52562,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WING_OF_FLY_5DAY_BOX
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_5DAY_BOX);
   - Id: 17475
@@ -53209,8 +52587,6 @@ Body:
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53219,16 +52595,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX_II
     Script: |
-      getgroupitem(IG_Unlimited_Box_II);
+      getgroupitem(IG_UNLIMITED_BOX_II);
   - Id: 17478
     AegisName: Unlimited_10_Box2
     Name: Unlimited Box II(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53237,25 +52612,23 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX_II_10
     Script: |
-      getgroupitem(IG_Unlimited_Box_II_10);
+      getgroupitem(IG_UNLIMITED_BOX_II_10);
   - Id: 17479
     AegisName: Midgard_Fes_Scroll
     Name: Midgard Festival Egg
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MIDGARD_FES_SCROLL
     Script: |
-      getgroupitem(IG_Midgard_Fes_Scroll);
+      getgroupitem(IG_MIDGARD_FES_SCROLL);
   - Id: 17481
     AegisName: Costama_Egg21
     Name: Flower Blossom Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53264,6 +52637,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG21
     Script: |
       getgroupitem(IG_COSTAMA_EGG21);
   - Id: 17482
@@ -53272,18 +52646,15 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SOLARIS_FESTIVAL_SCROLL
     Script: |
-      getgroupitem(IG_Solaris_Festival_Scroll);
+      getgroupitem(IG_SOLARIS_FESTIVAL_SCROLL);
   - Id: 17483
     AegisName: 3_Life_Potion_pack3
     Name: Three Master Package III
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53292,16 +52663,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_THREE_MASTER_PACKAGE_III
     Script: |
-      getgroupitem(IG_Three_Master_Package_III);
+      getgroupitem(IG_THREE_MASTER_PACKAGE_III);
   - Id: 17484
     AegisName: 3_Life_Potion_10pack3
     Name: Three Master Package III(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53310,26 +52680,24 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_THREE_MASTER_PACKAGE_III_10
     Script: |
-      getgroupitem(IG_Three_Master_Package_III_10);
+      getgroupitem(IG_THREE_MASTER_PACKAGE_III_10);
   - Id: 17490
     AegisName: Time_Travel_Scroll
     Name: Time Travel Lucky Egg
     Type: Usable
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_TIME_TRAVEL_SCROLL
     Script: |
-      getgroupitem(IG_Time_Travel_Scroll);
+      getgroupitem(IG_TIME_TRAVEL_SCROLL);
   - Id: 17491
     AegisName: Refine_Ore_Box7
     Name: Smelting Ore Box VII
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53338,6 +52706,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX7
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX7);
   - Id: 17492
@@ -53346,8 +52715,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53356,6 +52723,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX7_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX7_SET10);
   - Id: 17493
@@ -53363,8 +52731,6 @@ Body:
     Name: Burning Feather Costume Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53373,26 +52739,24 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG23
     Script: |
-      getgroupitem(IG_Costama_Egg23);
+      getgroupitem(IG_COSTAMA_EGG23);
   - Id: 17494
     AegisName: Happy_Time_Scroll
     Name: Rise Midgard Lucky Egg
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HAPPY_TIME_SCROLL
     Script: |
-      getgroupitem(IG_Happy_Time_Scroll);
+      getgroupitem(IG_HAPPY_TIME_SCROLL);
   - Id: 17495
     AegisName: Silvervine_Box10_3
     Name: Lucky Silvervine Fruit Box III(10)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53401,16 +52765,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_SILVERVINE_FRUIT_BOX_III10
     Script: |
-      getgroupitem(IG_Lucky_Silvervine_Fruit_Box_III10);
+      getgroupitem(IG_LUCKY_SILVERVINE_FRUIT_BOX_III10);
   - Id: 17496
     AegisName: Silvervine_Box110_3
     Name: Lucky Silvervine Fruit Box III(110)
     Type: Cash
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53419,15 +52782,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUCKY_SILVERVINE_FRUIT_BOX_III110
     Script: |
-      getgroupitem(IG_Lucky_Silvervine_Fruit_Box_III110);
+      getgroupitem(IG_LUCKY_SILVERVINE_FRUIT_BOX_III110);
   - Id: 17497
     AegisName: Costama_Egg24
     Name: Seaside Costume Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53436,16 +52798,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG24
     Script: |
-      getgroupitem(IG_Costama_Egg24);
+      getgroupitem(IG_COSTAMA_EGG24);
   - Id: 17498
     AegisName: 3_Life_Potion_pack4
     Name: Three Master Package IV
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53454,6 +52815,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK4
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK4);
   - Id: 17499
@@ -53462,8 +52824,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53472,6 +52832,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK4
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK4);
   - Id: 17501
@@ -53480,8 +52841,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53490,6 +52849,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE_V4
     Script: |
       getgroupitem(IG_VIGORGRA_PACKAGE_V4);
   - Id: 17502
@@ -53498,8 +52858,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53508,6 +52866,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE_SET_V4
     Script: |
       getgroupitem(IG_VIGORGRA_PACKAGE_SET_V4);
   - Id: 17507
@@ -53515,8 +52874,6 @@ Body:
     Name: Kit Costume Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53525,6 +52882,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX4
     Script: |
       getgroupitem(IG_NYANGVINE_BOX4);
   - Id: 17508
@@ -53532,8 +52890,6 @@ Body:
     Name: Kitcoin Purse
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53542,6 +52898,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX10
     Script: |
       getgroupitem(IG_NYANGVINE_BOX10);
   - Id: 17509
@@ -53549,8 +52906,6 @@ Body:
     Name: Nyangvine 40 Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53559,6 +52914,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX40
     Script: |
       getgroupitem(IG_NYANGVINE_BOX40);
   - Id: 17510
@@ -53567,8 +52923,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53577,6 +52931,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX8
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX8);
   - Id: 17511
@@ -53585,8 +52940,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53595,6 +52948,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX8_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX8_SET10);
   - Id: 17512
@@ -53603,8 +52957,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53613,6 +52965,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ELUNIUM_BOX30
     Script: |
       getgroupitem(IG_LI_HD_ELUNIUM_BOX30);
   - Id: 17513
@@ -53621,8 +52974,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53631,6 +52982,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ORIDECON_BOX30
     Script: |
       getgroupitem(IG_LI_HD_ORIDECON_BOX30);
   - Id: 17515
@@ -53639,8 +52991,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53649,6 +52999,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX3
     Script: |
       getgroupitem(IG_UNLIMITED_BOX3);
   - Id: 17516
@@ -53657,8 +53008,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53667,6 +53016,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_10_BOX3
     Script: |
       getgroupitem(IG_UNLIMITED_10_BOX3);
   - Id: 17517
@@ -53674,8 +53024,6 @@ Body:
     Name: Animal Costume Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53684,24 +53032,22 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG28
     Script: |
-      getgroupitem(IG_Costama_Egg28);
+      getgroupitem(IG_COSTAMA_EGG28);
   - Id: 17519
     AegisName: Epic_Heroes_Scroll
     Name: Epic Heroes Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EPIC_HEROES_LUCKY_EGG
     Script: |
-      getgroupitem(IG_Epic_Heroes_Lucky_Egg);
+      getgroupitem(IG_EPIC_HEROES_LUCKY_EGG);
   - Id: 17520
     AegisName: Limit_Manual_Box
     Name: Limited Edition Manual Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53710,6 +53056,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_MANUAL_BOX
     Script: |
       getgroupitem(IG_LIMIT_MANUAL_BOX);
   - Id: 17521
@@ -53718,8 +53065,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53728,6 +53073,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK5
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK5);
   - Id: 17522
@@ -53736,8 +53082,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53746,6 +53090,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK5
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK5);
   - Id: 17523
@@ -53753,8 +53098,6 @@ Body:
     Name: Mystical Costume Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53763,16 +53106,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTAMA_EGG29
     Script: |
-      getgroupitem(IG_Costama_Egg29);
+      getgroupitem(IG_COSTAMA_EGG29);
   - Id: 17524
     AegisName: Limit_Power_Booster_Box
     Name: Limited Power Booster Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53781,6 +53123,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_POWER_BOOSTER_BOX
     Script: |
       getgroupitem(IG_LIMIT_POWER_BOOSTER_BOX);
   - Id: 17525
@@ -53789,8 +53132,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53799,6 +53140,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_POWER_BOOSTER100
     Script: |
       getgroupitem(IG_LIMIT_POWER_BOOSTER100);
   - Id: 17526
@@ -53806,17 +53148,14 @@ Body:
     Name: Majestic Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAJESTIC_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Majestic_Lucky_Scroll);
+      getgroupitem(IG_MAJESTIC_LUCKY_SCROLL);
   - Id: 17527
     AegisName: Nyangvine_Box200
     Name: Silvervine Cat Fruit Box(200)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53825,6 +53164,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX200
     Script: |
       getgroupitem(IG_NYANGVINE_BOX200);
   - Id: 17532
@@ -53832,18 +53172,15 @@ Body:
     Name: Blessing Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BLESSING_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Blessing_Lucky_Scroll);
+      getgroupitem(IG_BLESSING_LUCKY_SCROLL);
   - Id: 17544
     AegisName: Refine_Ore_Box9
     Name: Refining Ore Box IX
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53852,6 +53189,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX9
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX9);
   - Id: 17545
@@ -53860,8 +53198,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53870,6 +53206,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX9_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX9_SET10);
   - Id: 17547
@@ -53878,6 +53215,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53894,6 +53233,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53910,6 +53251,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53926,6 +53269,8 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53941,18 +53286,15 @@ Body:
     Name: Garnet Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GARNET_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Garnet_Lucky_Scroll);
+      getgroupitem(IG_GARNET_LUCKY_SCROLL);
   - Id: 17567
     AegisName: Almighty_Box4
     Name: Event Almighty Box
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53961,6 +53303,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_BOX4
     Script: |
       getgroupitem(IG_ALMIGHTY_BOX4);
   - Id: 17568
@@ -53969,8 +53312,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53979,6 +53320,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY100_BOX2
     Script: |
       getgroupitem(IG_ALMIGHTY100_BOX2);
   - Id: 17569
@@ -53987,8 +53329,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -53997,6 +53337,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DUN_VOUCHER_BOX1
     Script: |
       getgroupitem(IG_DUN_VOUCHER_BOX1);
   - Id: 17570
@@ -54005,8 +53346,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54015,6 +53354,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DUN_VOUCHER_BOX2
     Script: |
       getgroupitem(IG_DUN_VOUCHER_BOX2);
   - Id: 17572
@@ -54022,18 +53362,15 @@ Body:
     Name: Erzulie Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ERZULIE_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Erzulie_Lucky_Scroll);
+      getgroupitem(IG_ERZULIE_LUCKY_SCROLL);
   - Id: 17573
     AegisName: Nyangvine_Box10_
     Name: Lucky Silvervine Cat Fruit Box (10)
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54042,6 +53379,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX10_
     Script: |
       getgroupitem(IG_NYANGVINE_BOX10_);
   - Id: 17574
@@ -54050,8 +53388,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54060,6 +53396,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX100
     Script: |
       getgroupitem(IG_NYANGVINE_BOX100);
   - Id: 17575
@@ -54068,8 +53405,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54078,6 +53413,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE30_M_01_BOX
     Script: |
       getgroupitem(IG_SERVICE30_M_01_BOX);
   - Id: 17576
@@ -54086,8 +53422,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54096,6 +53430,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE30_F_01_BOX
     Script: |
       getgroupitem(IG_SERVICE30_F_01_BOX);
   - Id: 17582
@@ -54104,8 +53439,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54114,6 +53447,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK6
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK6);
   - Id: 17583
@@ -54122,8 +53456,6 @@ Body:
     Type: Cash
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54132,6 +53464,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK6
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK6);
   - Id: 17584
@@ -54139,17 +53472,14 @@ Body:
     Name: Venus Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VENUS_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Venus_Lucky_Scroll);
+      getgroupitem(IG_VENUS_LUCKY_SCROLL);
   - Id: 17586
     AegisName: Refine_Ore_Box10
     Name: Smelting Ore Box X
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54158,6 +53488,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX10);
   - Id: 17587
@@ -54165,8 +53496,6 @@ Body:
     Name: Smelting Ore Box X (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54175,6 +53504,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX10_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX10_SET10);
   - Id: 17588
@@ -54182,17 +53512,14 @@ Body:
     Name: Amora Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_AMORA_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Amora_Lucky_Scroll);
+      getgroupitem(IG_AMORA_LUCKY_SCROLL);
   - Id: 17590
     AegisName: Service30P_M_01_Box
     Name: Edward Zonda Service Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54201,6 +53528,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE30P_M_01_BOX
     Script: |
       getgroupitem(IG_SERVICE30P_M_01_BOX);
   - Id: 17591
@@ -54208,8 +53536,6 @@ Body:
     Name: Elysee Zonda Owner EX Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54218,6 +53544,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE30P_F_01_BOX
     Script: |
       getgroupitem(IG_SERVICE30P_F_01_BOX);
   - Id: 17592
@@ -54225,8 +53552,6 @@ Body:
     Name: Cheer Up Package V
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54235,6 +53560,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE_V5
     Script: |
       getgroupitem(IG_VIGORGRA_PACKAGE_V5);
   - Id: 17593
@@ -54242,8 +53568,6 @@ Body:
     Name: Cheer Up Package V (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54252,6 +53576,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PACKAGE_SET_V5
     Script: |
       getgroupitem(IG_VIGORGRA_PACKAGE_SET_V5);
   - Id: 17598
@@ -54259,17 +53584,14 @@ Body:
     Name: Sograt Lucky Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SOGRAT_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Sograt_Lucky_Scroll);
+      getgroupitem(IG_SOGRAT_LUCKY_SCROLL);
   - Id: 17599
     AegisName: C_Greed_1Hour_Box
     Name: Endless Greed Scroll Box (1h)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54278,6 +53600,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_GREED_1HOUR_BOX
     Script: |
       getgroupitem(IG_C_GREED_1HOUR_BOX);
   - Id: 17600
@@ -54285,8 +53608,7 @@ Body:
     Name: Infinite Cat's Hand Ticket Box (1 day)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_CATPAW_1DAY_BOX
     Script: |
       getgroupitem(IG_C_CATPAW_1DAY_BOX);
   - Id: 17601
@@ -54294,8 +53616,6 @@ Body:
     Name: Unlimited Box IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54304,6 +53624,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX4
     Script: |
       getgroupitem(IG_UNLIMITED_BOX4);
   - Id: 17602
@@ -54311,8 +53632,6 @@ Body:
     Name: Unlimited Box IV (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54321,6 +53640,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_10_BOX4
     Script: |
       getgroupitem(IG_UNLIMITED_10_BOX4);
   - Id: 17607
@@ -54328,17 +53648,15 @@ Body:
     Name: Sanctuary Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SANCTUARY_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Sanctuary_Lucky_Scroll);
+      getgroupitem(IG_SANCTUARY_LUCKY_SCROLL);
   - Id: 17608
     AegisName: C_Giant_Fly_1Day_Box
     Name: Infinite Giant Fly Wing Box 1Day
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_GIANT_FLY_1DAY_BOX
     Script: |
       getgroupitem(IG_C_GIANT_FLY_1DAY_BOX);
   - Id: 17609
@@ -54346,8 +53664,6 @@ Body:
     Name: Refine Ore Box XI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54356,6 +53672,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX11
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX11);
   - Id: 17610
@@ -54363,8 +53680,6 @@ Body:
     Name: Refine Ore Box XI(10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54373,6 +53688,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX11_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX11_SET10);
   - Id: 17613
@@ -54380,17 +53696,14 @@ Body:
     Name: Chronosian Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHRONOSIAN_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Chronosian_Lucky_Scroll);
+      getgroupitem(IG_CHRONOSIAN_LUCKY_SCROLL);
   - Id: 17616
     AegisName: 3_Life_Potion_pack7
     Name: Three Master Package VII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54399,6 +53712,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK7
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK7);
   - Id: 17617
@@ -54406,8 +53720,6 @@ Body:
     Name: Three Master Package VII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54416,6 +53728,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK7
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK7);
   - Id: 17628
@@ -54423,17 +53736,14 @@ Body:
     Name: Cyborg Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CYBORG_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Cyborg_Lucky_Scroll);
+      getgroupitem(IG_CYBORG_LUCKY_SCROLL);
   - Id: 17631
     AegisName: Almighty_Plus_Box
     Name: Almighty Plus Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54442,6 +53752,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_PLUS_BOX
     Script: |
       getgroupitem(IG_ALMIGHTY_PLUS_BOX);
   - Id: 17632
@@ -54449,8 +53760,6 @@ Body:
     Name: Almighty Plus Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54459,6 +53768,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY100_PLUSBOX
     Script: |
       getgroupitem(IG_ALMIGHTY100_PLUSBOX);
   - Id: 17633
@@ -54466,17 +53776,14 @@ Body:
     Name: Undine Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_UNDINE_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Undine_Lucky_Scroll);
+      getgroupitem(IG_UNDINE_LUCKY_SCROLL);
   - Id: 17639
     AegisName: Limit_Power_Booster2
     Name: Limited Power Booster Box 2
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54485,6 +53792,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_POWER_BOOSTER2
     Script: |
       getgroupitem(IG_LIMIT_POWER_BOOSTER2);
   - Id: 17640
@@ -54492,8 +53800,6 @@ Body:
     Name: Limited Power Booster Box 2 (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54502,6 +53808,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMITPOWERBOOSTER2_100
     Script: |
       getgroupitem(IG_LIMITPOWERBOOSTER2_100);
   - Id: 17646
@@ -54509,8 +53816,6 @@ Body:
     Name: Halter Lead Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54519,6 +53824,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LC_BOARDING_HALTER_BOX
     Script: |
       getgroupitem(IG_LC_BOARDING_HALTER_BOX);
   - Id: 17648
@@ -54526,8 +53832,6 @@ Body:
     Name: Smithy Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54536,15 +53840,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SMITHY_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Smithy_Lucky_Scroll);
+      getgroupitem(IG_SMITHY_LUCKY_SCROLL);
   - Id: 17650
     AegisName: Refine_Ore_Box12
     Name: Refining Ore Box XII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54553,6 +53856,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX12
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX12);
   - Id: 17651
@@ -54560,8 +53864,6 @@ Body:
     Name: Refining Ore Box XII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54570,6 +53872,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX12_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX12_SET10);
   - Id: 17659
@@ -54577,8 +53880,6 @@ Body:
     Name: Ganymede Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54587,15 +53888,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GANYMEDE_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Ganymede_Lucky_Scroll);
+      getgroupitem(IG_GANYMEDE_LUCKY_SCROLL);
   - Id: 17662
     AegisName: Vigorgra_Plus_Package
     Name: Cheer Up Plus Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54604,6 +53904,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_PACKAGE
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_PACKAGE);
   - Id: 17663
@@ -54611,8 +53912,6 @@ Body:
     Name: Cheer Up Plus Package (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54621,6 +53920,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_SET
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_SET);
   - Id: 17665
@@ -54628,8 +53928,6 @@ Body:
     Name: LastAngel LuckyScroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54638,15 +53936,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LASTANGEL_LUCKYSCROLL
     Script: |
-      getgroupitem(IG_LastAngel_LuckyScroll);
+      getgroupitem(IG_LASTANGEL_LUCKYSCROLL);
   - Id: 17668
     AegisName: 3_Life_Potion_pack8
     Name: Three Master Package VIII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54655,6 +53952,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK8
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK8);
   - Id: 17669
@@ -54662,8 +53960,6 @@ Body:
     Name: Three Master Package VIII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54672,6 +53968,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK8
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK8);
   - Id: 17671
@@ -54679,8 +53976,6 @@ Body:
     Name: Valkyrie Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54689,15 +53984,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VALKYRIE_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Valkyrie_Lucky_Scroll);
+      getgroupitem(IG_VALKYRIE_LUCKY_SCROLL);
   - Id: 17672
     AegisName: Unlimited_Box5
     Name: Unlimited Box V
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54706,6 +54000,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX5
     Script: |
       getgroupitem(IG_UNLIMITED_BOX5);
   - Id: 17673
@@ -54713,8 +54008,6 @@ Body:
     Name: Ultimate Box V (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54723,6 +54016,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_10_BOX5
     Script: |
       getgroupitem(IG_UNLIMITED_10_BOX5);
   - Id: 17674
@@ -54730,8 +54024,6 @@ Body:
     Name: Splash Rainbow Lucky Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54740,15 +54032,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPLASH_RAINBOW_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Splash_Rainbow_Lucky_Scroll);
+      getgroupitem(IG_SPLASH_RAINBOW_LUCKY_SCROLL);
   - Id: 17675
     AegisName: Refine_Ore_Box13
     Name: Refining Ore Box XIII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54757,6 +54048,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX13
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX13);
   - Id: 17676
@@ -54764,8 +54056,6 @@ Body:
     Name: Refining Ore Box XIII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54774,6 +54064,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX13_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX13_SET10);
   - Id: 17677
@@ -54781,8 +54072,6 @@ Body:
     Name: HD Refining Ore Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54791,6 +54080,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX);
   - Id: 17681
@@ -54798,8 +54088,6 @@ Body:
     Name: Midgard Lucky Scroll
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54808,15 +54096,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MIDGARD_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Midgard_Lucky_Scroll);
+      getgroupitem(IG_MIDGARD_LUCKY_SCROLL);
   - Id: 17683
     AegisName: Nyangvine_Box10_2
     Name: Lucky Silvervine Cat Fruit Box II (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54825,6 +54112,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX10_2
     Script: |
       getgroupitem(IG_NYANGVINE_BOX10_2);
   - Id: 17684
@@ -54832,8 +54120,6 @@ Body:
     Name: Lucky Silvervine Cat Fruit Box II (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54842,6 +54128,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX100_2
     Script: |
       getgroupitem(IG_NYANGVINE_BOX100_2);
   - Id: 17689
@@ -54849,8 +54136,6 @@ Body:
     Name: Premium Buff Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54859,6 +54144,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AID_BUFF_BOX
     Script: |
       getgroupitem(IG_AID_BUFF_BOX);
   - Id: 17690
@@ -54866,8 +54152,6 @@ Body:
     Name: Cheer Up Plus Package II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54876,6 +54160,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_PACKAGE2
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_PACKAGE2);
   - Id: 17691
@@ -54883,8 +54168,6 @@ Body:
     Name: Cheer Up Plus Package II (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54893,6 +54176,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_SET2
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_SET2);
   - Id: 17692
@@ -54900,8 +54184,6 @@ Body:
     Name: Blessing Scarlet Egg
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54910,15 +54192,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLESSING_SCARLET_SCROLL
     Script: |
-      getgroupitem(IG_Blessing_Scarlet_Scroll);
+      getgroupitem(IG_BLESSING_SCARLET_SCROLL);
   - Id: 17712
     AegisName: 3_Life_Potion_pack9
     Name: Three Master Package IX
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54927,6 +54208,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK9
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK9);
   - Id: 17713
@@ -54934,8 +54216,6 @@ Body:
     Name: Three Master Package IX (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54944,6 +54224,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK9
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK9);
   - Id: 17716
@@ -54951,8 +54232,6 @@ Body:
     Name: Refining Ore Box XIV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54961,6 +54240,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX14
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX14);
   - Id: 17717
@@ -54968,8 +54248,6 @@ Body:
     Name: Refining Ore Box XIV (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54978,6 +54256,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX14_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX14_SET10);
   - Id: 17718
@@ -54985,8 +54264,6 @@ Body:
     Name: HD Refining Ore Box II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -54995,6 +54272,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX2
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX2);
   - Id: 17726
@@ -55002,8 +54280,6 @@ Body:
     Name: Almighty Plus Box II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55012,6 +54288,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_PLUS_BOX2
     Script: |
       getgroupitem(IG_ALMIGHTY_PLUS_BOX2);
   - Id: 17727
@@ -55019,8 +54296,6 @@ Body:
     Name: Almighty Plus Box II (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55029,6 +54304,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY100_PLUSBOX2
     Script: |
       getgroupitem(IG_ALMIGHTY100_PLUSBOX2);
   - Id: 17742
@@ -55036,8 +54312,6 @@ Body:
     Name: Defense Scroll Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55046,6 +54320,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX);
   - Id: 17743
@@ -55053,8 +54328,6 @@ Body:
     Name: Defense Scroll Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55063,6 +54336,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX_SET
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX_SET);
   - Id: 17748
@@ -55070,8 +54344,6 @@ Body:
     Name: Limited Power Booster 3
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55080,6 +54352,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_POWER_BOOSTER3
     Script: |
       getgroupitem(IG_LIMIT_POWER_BOOSTER3);
   - Id: 17749
@@ -55087,8 +54360,6 @@ Body:
     Name: Limited Power Booster 3 (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55097,6 +54368,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMITPOWERBOOSTER3_100
     Script: |
       getgroupitem(IG_LIMITPOWERBOOSTER3_100);
   - Id: 17756
@@ -55104,8 +54376,6 @@ Body:
     Name: HD Refine Ore Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55114,6 +54384,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_HIGH_REFINE_BOX
     Script: |
       getgroupitem(IG_HD_HIGH_REFINE_BOX);
   - Id: 17759
@@ -55121,8 +54392,6 @@ Body:
     Name: Refine Ore XV Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55131,6 +54400,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX15_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX15_SET10);
   - Id: 17760
@@ -55138,8 +54408,6 @@ Body:
     Name: Refine Ore XV Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55148,6 +54416,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX15
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX15);
   - Id: 17761
@@ -55155,8 +54424,6 @@ Body:
     Name: HD Refine Ore Box III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55165,6 +54432,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX3
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX3);
   - Id: 17764
@@ -55172,8 +54440,6 @@ Body:
     Name: Cheer Up Plus Package III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55182,6 +54448,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_PACKAGE3
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_PACKAGE3);
   - Id: 17765
@@ -55189,8 +54456,6 @@ Body:
     Name: Cheer Up Plus Package III (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55199,6 +54464,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIGORGRA_PLUS_SET3
     Script: |
       getgroupitem(IG_VIGORGRA_PLUS_SET3);
   - Id: 17766
@@ -55206,8 +54472,7 @@ Body:
     Name: Infinite Cat's Hand Ticket Box (7 days)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_CATPAW_7DAY_BOX
     Script: |
       getgroupitem(IG_C_CATPAW_7DAY_BOX);
   - Id: 17774
@@ -55215,8 +54480,6 @@ Body:
     Name: Almighty Plus Box III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55225,6 +54488,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_PLUS_BOX3
     Script: |
       getgroupitem(IG_ALMIGHTY_PLUS_BOX3);
   - Id: 17775
@@ -55232,8 +54496,6 @@ Body:
     Name: Almighty Plus Box III (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55242,6 +54504,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY100_PLUSBOX3
     Script: |
       getgroupitem(IG_ALMIGHTY100_PLUSBOX3);
   - Id: 17776
@@ -55249,8 +54512,6 @@ Body:
     Name: Three Master Package X
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55259,6 +54520,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK10
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK10);
   - Id: 17777
@@ -55266,8 +54528,6 @@ Body:
     Name: Three Master Package X (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55276,6 +54536,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK10
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK10);
   - Id: 17780
@@ -55298,8 +54559,6 @@ Body:
     Name: Unlimited Box VI (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55308,6 +54567,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_10_BOX6
     Script: |
       getgroupitem(IG_UNLIMITED_10_BOX6);
   - Id: 17784
@@ -55315,8 +54575,6 @@ Body:
     Name: Unlimited Box VI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55325,6 +54583,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_UNLIMITED_BOX6
     Script: |
       getgroupitem(IG_UNLIMITED_BOX6);
   - Id: 17792
@@ -55332,8 +54591,6 @@ Body:
     Name: Refining Ore Box XVI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55342,6 +54599,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX16
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX16);
   - Id: 17793
@@ -55349,8 +54607,6 @@ Body:
     Name: Refining Ore Box XVI (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55359,6 +54615,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX16_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX16_SET10);
   - Id: 17794
@@ -55366,8 +54623,6 @@ Body:
     Name: HD Refining Ore Box IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55376,6 +54631,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX4
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX4);
   - Id: 17795
@@ -55383,8 +54639,6 @@ Body:
     Name: HD Refine Ore Box II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55393,6 +54647,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_HIGH_REFINE_BOX2
     Script: |
       getgroupitem(IG_HD_HIGH_REFINE_BOX2);
   - Id: 17799
@@ -55400,8 +54655,6 @@ Body:
     Name: Defense Scroll Box II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55410,6 +54663,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX2
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX2);
   - Id: 17800
@@ -55417,8 +54671,6 @@ Body:
     Name: Defense Scroll Box II (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55427,6 +54679,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX_SET2
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX_SET2);
   - Id: 17832
@@ -55434,8 +54687,6 @@ Body:
     Name: Three Master Package XI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55444,6 +54695,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK11
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK11);
   - Id: 17833
@@ -55451,8 +54703,6 @@ Body:
     Name: Three Master Package XI (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55461,6 +54711,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK11
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK11);
   - Id: 17881
@@ -55468,8 +54719,6 @@ Body:
     Name: 2017 Ragnarok RTC Participaton Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55479,6 +54728,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RTC_ANNIV_BOX
     Script: |
       getgroupitem(IG_RTC_ANNIV_BOX);
   - Id: 17882
@@ -55486,8 +54736,6 @@ Body:
     Name: Refining Ore Box XVII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55496,6 +54744,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX17_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX17_SET10);
   - Id: 17883
@@ -55503,8 +54752,6 @@ Body:
     Name: Refining Ore Box XVII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55513,6 +54760,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX17
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX17);
   - Id: 17884
@@ -55520,8 +54768,6 @@ Body:
     Name: HD Refining Ore Box V
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55530,6 +54776,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX5
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX5);
   - Id: 17885
@@ -55537,8 +54784,6 @@ Body:
     Name: HD Refine Ore Box III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55547,6 +54792,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_HIGH_REFINE_BOX3
     Script: |
       getgroupitem(IG_HD_HIGH_REFINE_BOX3);
   - Id: 17886
@@ -55554,8 +54800,6 @@ Body:
     Name: Infinity Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55564,6 +54808,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFINITY_BOX
     Script: |
       getgroupitem(IG_INFINITY_BOX);
   - Id: 17887
@@ -55571,8 +54816,6 @@ Body:
     Name: Infinity Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55581,6 +54824,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFINITY_10_BOX
     Script: |
       getgroupitem(IG_INFINITY_10_BOX);
   - Id: 17888
@@ -55595,8 +54839,6 @@ Body:
     Name: New Cheer Up Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55605,6 +54847,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_VIGORGRA_PACKAGE
     Script: |
       getgroupitem(IG_NEW_VIGORGRA_PACKAGE);
   - Id: 17895
@@ -55612,8 +54855,6 @@ Body:
     Name: New Cheer Up Package (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55622,6 +54863,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_VIGORGRA_SET
     Script: |
       getgroupitem(IG_NEW_VIGORGRA_SET);
   - Id: 17901
@@ -55629,8 +54871,6 @@ Body:
     Name: Limited Power Booster IV (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55639,6 +54879,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMITPOWERBOOSTER4_100
     Script: |
       getgroupitem(IG_LIMITPOWERBOOSTER4_100);
   - Id: 17902
@@ -55646,8 +54887,6 @@ Body:
     Name: Limited Power Booster IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55656,6 +54895,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIMIT_POWER_BOOSTER4
     Script: |
       getgroupitem(IG_LIMIT_POWER_BOOSTER4);
   - Id: 17914
@@ -55663,8 +54903,6 @@ Body:
     Name: G-STAR 2017 Ragnarok Memorial Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55673,14 +54911,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2017_GSTAR_COSTUMEBOX
     Script: |
       getgroupitem(IG_2017_GSTAR_COSTUMEBOX);
   - Id: 17920
     AegisName: Zero_Merchant_Bell_Box
     Name: Tool Dealer Bell Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55689,14 +54926,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ZERO_MERCHANT_BELL_BOX
     Script: |
       getgroupitem(IG_ZERO_MERCHANT_BELL_BOX);
   - Id: 17921
     AegisName: Zero_Kafra_Bell_Box
     Name: Kafra Storage Bell Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55705,6 +54941,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ZERO_KAFRA_BELL_BOX
     Script: |
       getgroupitem(IG_ZERO_KAFRA_BELL_BOX);
   - Id: 17923
@@ -55712,8 +54949,6 @@ Body:
     Name: Refining Ore Box XVIII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55722,6 +54957,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX18
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX18);
   - Id: 17924
@@ -55729,8 +54965,6 @@ Body:
     Name: Refining Ore Box XVIII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55739,6 +54973,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX18_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX18_SET10);
   - Id: 17925
@@ -55746,8 +54981,6 @@ Body:
     Name: HD Refining Ore Box VI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55756,6 +54989,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX6
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX6);
   - Id: 17926
@@ -55763,8 +54997,6 @@ Body:
     Name: HD Refine Ore Box IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55773,6 +55005,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_HIGH_REFINE_BOX4
     Script: |
       getgroupitem(IG_HD_HIGH_REFINE_BOX4);
   - Id: 17935
@@ -55780,8 +55013,6 @@ Body:
     Name: New Three Master Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55790,6 +55021,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_3_POTION_PACK
     Script: |
       getgroupitem(IG_NEW_3_POTION_PACK);
   - Id: 17936
@@ -55797,8 +55029,6 @@ Body:
     Name: New Three Master Package (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55807,6 +55037,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_3_POTION_10PACK
     Script: |
       getgroupitem(IG_NEW_3_POTION_10PACK);
   - Id: 17940
@@ -55814,8 +55045,6 @@ Body:
     Name: Lucky Silvervine Cat Fruit Box III (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55824,6 +55053,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX10_3
     Script: |
       getgroupitem(IG_NYANGVINE_BOX10_3);
   - Id: 17941
@@ -55831,8 +55061,6 @@ Body:
     Name: Lucky Silvervine Cat Fruit Box III (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55841,6 +55069,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NYANGVINE_BOX100_3
     Script: |
       getgroupitem(IG_NYANGVINE_BOX100_3);
   - Id: 17944
@@ -55848,8 +55077,6 @@ Body:
     Name: Almighty Plus Box IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55858,6 +55085,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY_PLUS_BOX4
     Script: |
       getgroupitem(IG_ALMIGHTY_PLUS_BOX4);
   - Id: 17945
@@ -55865,8 +55093,6 @@ Body:
     Name: Almighty Plus Box IV (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55875,6 +55101,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ALMIGHTY100_PLUSBOX4
     Script: |
       getgroupitem(IG_ALMIGHTY100_PLUSBOX4);
   - Id: 17948
@@ -55882,8 +55109,6 @@ Body:
     Name: Refining Ore Box XIX (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55892,6 +55117,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX19_SET10
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX19_SET10);
   - Id: 17949
@@ -55899,8 +55125,6 @@ Body:
     Name: Refining Ore Box XIX
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55909,6 +55133,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_ORE_BOX19
     Script: |
       getgroupitem(IG_REFINE_ORE_BOX19);
   - Id: 17950
@@ -55916,8 +55141,6 @@ Body:
     Name: HD Refining Ore Box VII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55926,6 +55149,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_REFINE_ORE_BOX7
     Script: |
       getgroupitem(IG_HD_REFINE_ORE_BOX7);
   - Id: 17951
@@ -55933,8 +55157,6 @@ Body:
     Name: HD Refine Ore Box V
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55943,6 +55165,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HD_HIGH_REFINE_BOX5
     Script: |
       getgroupitem(IG_HD_HIGH_REFINE_BOX5);
   - Id: 17959
@@ -55950,8 +55173,6 @@ Body:
     Name: Defense Scroll Box III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55960,6 +55181,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX3
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX3);
   - Id: 17960
@@ -55967,8 +55189,6 @@ Body:
     Name: Defense Scroll Box III (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55977,6 +55197,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEF_SCROLL_BOX_SET3
     Script: |
       getgroupitem(IG_DEF_SCROLL_BOX_SET3);
   - Id: 17961
@@ -55984,8 +55205,6 @@ Body:
     Name: Three Master Package XII
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -55994,6 +55213,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_PACK12
     Script: |
       getgroupitem(IG_3_LIFE_POTION_PACK12);
   - Id: 17962
@@ -56001,8 +55221,6 @@ Body:
     Name: Three Master Package XII (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56011,6 +55229,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_3_LIFE_POTION_10PACK12
     Script: |
       getgroupitem(IG_3_LIFE_POTION_10PACK12);
   - Id: 17967
@@ -56018,8 +55237,6 @@ Body:
     Name: Infinity Box II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56028,6 +55245,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFINITY_BOX2
     Script: |
       getgroupitem(IG_INFINITY_BOX2);
   - Id: 17968
@@ -56035,8 +55253,6 @@ Body:
     Name: Infinity Box II 10 sets    # !todo check english name
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56045,6 +55261,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFINITY_10_BOX2
     Script: |
       getgroupitem(IG_INFINITY_10_BOX2);
   - Id: 17969
@@ -56052,8 +55269,6 @@ Body:
     Name: Cheer Up Package (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56062,6 +55277,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_VIGORGRA_SET
     Script: |
       getgroupitem(IG_A_VIGORGRA_SET);
   - Id: 17970
@@ -56069,8 +55285,6 @@ Body:
     Name: Cheer Up Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56079,6 +55293,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_VIGORGRA_PACKAGE
     Script: |
       getgroupitem(IG_A_VIGORGRA_PACKAGE);
   - Id: 17971
@@ -56086,8 +55301,6 @@ Body:
     Name: Life Potion Sampler 10 Crate
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56096,6 +55309,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_3_LIFE_POTION_10PACK
     Script: |
       getgroupitem(IG_A_3_LIFE_POTION_10PACK);
   - Id: 17972
@@ -56103,8 +55317,6 @@ Body:
     Name: Life Potion Sampler Crate
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56113,6 +55325,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_3_LIFE_POTION_PACK
     Script: |
       getgroupitem(IG_A_3_LIFE_POTION_PACK);
   - Id: 17973
@@ -56120,8 +55333,6 @@ Body:
     Name: Almighty package 10set
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56130,6 +55341,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_ALMIGHTY100_BOX
     Script: |
       getgroupitem(IG_A_ALMIGHTY100_BOX);
   - Id: 17974
@@ -56137,8 +55349,6 @@ Body:
     Name: Almighty package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56147,6 +55357,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_ALMIGHTY_BOX
     Script: |
       getgroupitem(IG_A_ALMIGHTY_BOX);
   - Id: 17975
@@ -56154,8 +55365,6 @@ Body:
     Name: Enriched ore package 10 set
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56164,6 +55373,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_REFINE_ORE_BOX_SET
     Script: |
       getgroupitem(IG_A_REFINE_ORE_BOX_SET);
   - Id: 17976
@@ -56171,8 +55381,6 @@ Body:
     Name: Enriched ore package set
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56181,6 +55389,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_REFINE_ORE_BOX
     Script: |
       getgroupitem(IG_A_REFINE_ORE_BOX);
   - Id: 17977
@@ -56188,8 +55397,6 @@ Body:
     Name: HD ore package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56198,6 +55405,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_REFINE_ORE_BOX
     Script: |
       getgroupitem(IG_A_HD_REFINE_ORE_BOX);
   - Id: 17978
@@ -56205,8 +55413,6 @@ Body:
     Name: High density ore package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56215,6 +55421,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_HIGH_REFINE_BOX
     Script: |
       getgroupitem(IG_A_HD_HIGH_REFINE_BOX);
   - Id: 17979
@@ -56222,8 +55429,6 @@ Body:
     Name: Limit Power Booster Package 10 set
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56232,6 +55437,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_LIMITPOWERBOOSTER_100
     Script: |
       getgroupitem(IG_A_LIMITPOWERBOOSTER_100);
   - Id: 17980
@@ -56239,8 +55445,6 @@ Body:
     Name: LimitPowerBooster package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56249,6 +55453,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_LIMITPOWERBOOSTER
     Script: |
       getgroupitem(IG_A_LIMITPOWERBOOSTER);
   - Id: 17981
@@ -56256,8 +55461,6 @@ Body:
     Name: Infinity Drink 200 Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56266,6 +55469,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_INFINITY_10_BOX
     Script: |
       getgroupitem(IG_A_INFINITY_10_BOX);
   - Id: 17982
@@ -56273,8 +55477,6 @@ Body:
     Name: Infinity Drink 20 Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56283,6 +55485,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_INFINITY_BOX
     Script: |
       getgroupitem(IG_A_INFINITY_BOX);
   - Id: 17983
@@ -56290,8 +55493,6 @@ Body:
     Name: Defense Scroll Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56300,6 +55501,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_DEF_SCROLL_BOX_SET
     Script: |
       getgroupitem(IG_A_DEF_SCROLL_BOX_SET);
   - Id: 17984
@@ -56307,8 +55509,6 @@ Body:
     Name: Defense Scroll Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56317,6 +55517,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_DEF_SCROLL_BOX
     Script: |
       getgroupitem(IG_A_DEF_SCROLL_BOX);
   - Id: 17985
@@ -56324,8 +55525,6 @@ Body:
     Name: Unlimited Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56334,6 +55533,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_UNLIMITED_10_BOX
     Script: |
       getgroupitem(IG_A_UNLIMITED_10_BOX);
   - Id: 17986
@@ -56341,8 +55541,6 @@ Body:
     Name: Unlimited Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56351,6 +55549,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_UNLIMITED_BOX
     Script: |
       getgroupitem(IG_A_UNLIMITED_BOX);
   - Id: 17999
@@ -56358,8 +55557,6 @@ Body:
     Name: Inventory Expansion Voucher Box(1)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56368,6 +55565,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INVENTORY_EX_BOX
     Script: |
       getgroupitem(IG_INVENTORY_EX_BOX);
   - Id: 22507
@@ -56403,8 +55601,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56413,6 +55609,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_WOLFKING_SCROLL
     Script: |
       getgroupitem(IG_WOLFKING_SCROLL);
   - Id: 22511
@@ -56436,8 +55633,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56446,6 +55641,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KINGS_GIFT
     Script: |
       getgroupitem(IG_KINGS_GIFT);
   - Id: 22514
@@ -56454,12 +55650,11 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CANDY_HOLDER
     Script: |
-      getgroupitem(IG_Candy_Holder);
-      getgroupitem(IG_Candy_Holder);
-      getgroupitem(IG_Candy_Holder);
+      getgroupitem(IG_CANDY_HOLDER);
+      getgroupitem(IG_CANDY_HOLDER);
+      getgroupitem(IG_CANDY_HOLDER);
   - Id: 22515
     AegisName: Key_Of_Twisted_Time
     Name: Twisted Key of Time
@@ -56500,15 +55695,14 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
+    ItemGroup: IG_IDN_WISDOM_EGG
     Script: |
-      getgroupitem(IG_Idn_Wisdom_Egg);
+      getgroupitem(IG_IDN_WISDOM_EGG);
   - Id: 22521
     AegisName: 80LVUP
     Name: Level Up Box (80)
     Type: Usable
     EquipLevelMin: 80
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56518,6 +55712,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_80LVUP
     Script: |
       getgroupitem(IG_80LVUP);
   - Id: 22522
@@ -56526,8 +55721,6 @@ Body:
     Type: Cash
     Buy: 10
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56537,16 +55730,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX100
     Script: |
-      getgroupitem(IG_Level_Up_Box100);
+      getgroupitem(IG_LEVEL_UP_BOX100);
   - Id: 22523
     AegisName: 120LVUP
     Name: Level Up Box (120)
     Type: Cash
     Buy: 10
     EquipLevelMin: 120
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56556,16 +55748,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX120
     Script: |
-      getgroupitem(IG_Level_Up_Box120);
+      getgroupitem(IG_LEVEL_UP_BOX120);
   - Id: 22524
     AegisName: 130LVUP
     Name: Level Up Box (130)
     Type: Cash
     Buy: 10
     EquipLevelMin: 130
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56575,16 +55766,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX130
     Script: |
-      getgroupitem(IG_Level_Up_Box130);
+      getgroupitem(IG_LEVEL_UP_BOX130);
   - Id: 22525
     AegisName: 140LVUP
     Name: Level Up Box (140)
     Type: Cash
     Buy: 10
     EquipLevelMin: 140
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56594,16 +55784,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX140
     Script: |
-      getgroupitem(IG_Level_Up_Box140);
+      getgroupitem(IG_LEVEL_UP_BOX140);
   - Id: 22526
     AegisName: 150LVUP
     Name: Level Up Box (150)
     Type: Cash
     Buy: 10
     EquipLevelMin: 150
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56613,16 +55802,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX150
     Script: |
-      getgroupitem(IG_Level_Up_Box150);
+      getgroupitem(IG_LEVEL_UP_BOX150);
   - Id: 22527
     AegisName: 160LVUP
     Name: Level Up Box (160)
     Type: Cash
     Buy: 10
     EquipLevelMin: 160
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56632,8 +55820,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LEVEL_UP_BOX160
     Script: |
-      getgroupitem(IG_Level_Up_Box160);
+      getgroupitem(IG_LEVEL_UP_BOX160);
   - Id: 22528
     AegisName: Pet_Ticket_Box
     Name: Pet Exchange Ticket Box
@@ -56666,8 +55855,9 @@ Body:
     Buy: 10
     Weight: 200
     EquipLevelMin: 1
+    ItemGroup: IG_CHRISTMAS_BOX
     Script: |
-      getgroupitem(IG_Christmas_Box);
+      getgroupitem(IG_CHRISTMAS_BOX);
   - Id: 22531
     AegisName: Special_Christmas_Box
     Name: Special Christmas Box
@@ -56675,8 +55865,9 @@ Body:
     Buy: 10
     Weight: 200
     EquipLevelMin: 1
+    ItemGroup: IG_SPECIAL_CHRISTMAS_BOX
     Script: |
-      getgroupitem(IG_Special_Christmas_Box);
+      getgroupitem(IG_SPECIAL_CHRISTMAS_BOX);
   - Id: 22532
     AegisName: Santa_Gift
     Name: Santa Gift
@@ -56684,14 +55875,13 @@ Body:
     Buy: 10
     Weight: 200
     EquipLevelMin: 1
+    ItemGroup: IG_SANTA_GIFT
     Script: |
-      getgroupitem(IG_Santa_Gift);
+      getgroupitem(IG_SANTA_GIFT);
   - Id: 22533
     AegisName: New_Year_Gift_Box
     Name: New Year Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56701,6 +55891,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_YEAR_GIFT_BOX
     Script: |
       getgroupitem(IG_NEW_YEAR_GIFT_BOX);
   - Id: 22534
@@ -56712,7 +55903,7 @@ Body:
     EquipLevelMin: 1
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLOSEDMIND_BOX
     Script: |
       getgroupitem(IG_CLOSEDMIND_BOX);
   - Id: 22535
@@ -56753,10 +55944,9 @@ Body:
     Type: Usable
     Weight: 100
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_PRIZEOFHERO
     Script: |
-      getgroupitem(IG_PrizeOfHero);
+      getgroupitem(IG_PRIZEOFHERO);
   - Id: 22538
     AegisName: Hanbok_bag
     Name: Hanbok bag
@@ -56768,8 +55958,6 @@ Body:
     AegisName: Made_Dish_Box2
     Name: Special Box of Cooked Dishes
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56777,6 +55965,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MADE_DISH_BOX2
     Script: |
       getgroupitem(IG_MADE_DISH_BOX2);
   - Id: 22540
@@ -56807,8 +55996,6 @@ Body:
     Name: PC Room Coupon Box VI
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56817,6 +56004,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PCBANG_COUPON_BOX6
     Script: |
       getgroupitem(IG_PCBANG_COUPON_BOX6);
   - Id: 22542
@@ -56988,8 +56176,6 @@ Body:
     Name: Cookie Bag
     Type: Usable
     Weight: 70
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -56998,6 +56184,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COOKIE_BAG_B
     Script: |
       getgroupitem(IG_COOKIE_BAG_B);
   - Id: 22551
@@ -57051,8 +56238,6 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57060,6 +56245,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FIRST_AID_KIT_B
     Script: |
       getgroupitem(IG_FIRST_AID_KIT_B);
   - Id: 22555
@@ -57095,10 +56281,9 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LUCKY_BAG
     Script: |
-      getgroupitem(IG_Lucky_Bag);
+      getgroupitem(IG_LUCKY_BAG);
   - Id: 22559
     AegisName: Mock_Strawberry
     Name: Mock Strawberry
@@ -57133,11 +56318,10 @@ Body:
     Type: Usable
     Buy: 5000
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SQUAD_PRIZE2
     Script: |
-      getgroupitem(IG_Squad_Prize1);
-      getgroupitem(IG_Squad_Prize2);
+      getgroupitem(IG_SQUAD_PRIZE1);
+      getgroupitem(IG_SQUAD_PRIZE2);
   - Id: 22568
     AegisName: Nyd_Summon_Scroll
     Name: Nidhoggur Summon Scroll
@@ -57152,8 +56336,6 @@ Body:
     Type: Usable
     Buy: 20
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57162,6 +56344,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KINGS_GIFT2
     Script: |
       getgroupitem(IG_KINGS_GIFT2);
   - Id: 22571
@@ -57170,16 +56353,13 @@ Body:
     Type: DelayConsume
     Buy: 10
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EASTER_EGG
     Script: |
       getgroupitem(IG_EASTER_EGG);
   - Id: 22592
     AegisName: Happy_Call_Box
     Name: Happy Call Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57189,6 +56369,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HAPPY_CALL_BOX
     Script: |
       getgroupitem(IG_HAPPY_CALL_BOX);
   - Id: 22605
@@ -57203,6 +56384,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57286,8 +56469,6 @@ Body:
     Name: Clear Box S
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57296,6 +56477,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CLEARBOX_S
     Script: |
       getgroupitem(IG_CLEARBOX_S);
   - Id: 22618
@@ -57332,7 +56514,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MEMORIAL_BOX
     Script: |
       getgroupitem(IG_MEMORIAL_BOX);
   - Id: 22621
@@ -57382,8 +56564,6 @@ Body:
     AegisName: JanuaryGiftBox_
     Name: January Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57392,14 +56572,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JANUARYGIFTBOX_
     Script: |
       getgroupitem(IG_JANUARYGIFTBOX_);
   - Id: 22627
     AegisName: FebruaryGiftBox_
     Name: February Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57408,6 +56587,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FEBRUARYGIFTBOX_
     Script: |
       getgroupitem(IG_FEBRUARYGIFTBOX_);
   - Id: 22628
@@ -57559,7 +56739,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ANGELING_PACKAGE
     Script: |
       getgroupitem(IG_ANGELING_PACKAGE);
   - Id: 22649
@@ -57570,7 +56750,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_DEVILING_PACKAGE
     Script: |
       getgroupitem(IG_DEVILING_PACKAGE);
   - Id: 22652
@@ -57594,8 +56774,7 @@ Body:
     Name: Wet Card Album
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_WET_CARDALBUM
     Script: |
       getgroupitem(IG_WET_CARDALBUM);
   - Id: 22654
@@ -57603,8 +56782,7 @@ Body:
     Name: Golden Seal Card
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_GOLDEN_CARD
     Script: |
       getgroupitem(IG_GOLDEN_CARD);
   - Id: 22657
@@ -57651,6 +56829,8 @@ Body:
     Name: Guyak Pudding Box
     Type: Usable
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57666,8 +56846,7 @@ Body:
     Name: Halloween Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_HALLOWEEN_G_BOX
     Script: |
       getgroupitem(IG_HALLOWEEN_G_BOX);
   - Id: 22670
@@ -57694,8 +56873,6 @@ Body:
     AegisName: MarchGiftBox_
     Name: March Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57704,14 +56881,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MARCHGIFTBOX_
     Script: |
       getgroupitem(IG_MARCHGIFTBOX_);
   - Id: 22672
     AegisName: AprilGiftBox_
     Name: April Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57720,14 +56896,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_APRILGIFTBOX_
     Script: |
       getgroupitem(IG_APRILGIFTBOX_);
   - Id: 22673
     AegisName: MayGiftBox_
     Name: May Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57736,14 +56911,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAYGIFTBOX_
     Script: |
       getgroupitem(IG_MAYGIFTBOX_);
   - Id: 22674
     AegisName: JuneGiftBox_
     Name: June Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57752,6 +56926,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JUNEGIFTBOX_
     Script: |
       getgroupitem(IG_JUNEGIFTBOX_);
   - Id: 22675
@@ -57767,8 +56942,7 @@ Body:
     Name: Hangul Day Event Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HANGULDAY_BOX
     Script: |
       getgroupitem(IG_HANGULDAY_BOX);
   - Id: 22679
@@ -57778,14 +56952,13 @@ Body:
     EquipLevelMin: 170
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem rand(6814,6819),1;
   - Id: 22685
     AegisName: Solo_Christmas_Gift
     Name: Single Union Christmas Gift
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57793,8 +56966,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SOLO_CHRISTMAS_GIFT
     Script: |
-      getgroupitem(IG_Solo_Christmas_Gift);
+      getgroupitem(IG_SOLO_CHRISTMAS_GIFT);
   - Id: 22686
     AegisName: Solo_Cookie
     Name: Single Cookie
@@ -57904,8 +57078,6 @@ Body:
     AegisName: Jumping_Kit_Box
     Name: Jumping Support Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57915,6 +57087,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JUMPING_KIT_BOX
     Script: |
       getgroupitem(IG_JUMPING_KIT_BOX);
   - Id: 22701
@@ -57972,8 +57145,6 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -57982,14 +57153,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PITAPAT_BOX
     Script: |
       getgroupitem(IG_PITAPAT_BOX);
   - Id: 22721
     AegisName: Question_Box
     Name: "? Box"
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_QUESTION_BOX
     Script: |
       getgroupitem(IG_QUESTION_BOX);
   - Id: 22734
@@ -58016,8 +57187,6 @@ Body:
     Name: Sealed Moonlight Flower Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58026,14 +57195,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_M_FLOWER_SCROLL
     Script: |
       getgroupitem(IG_SEALED_M_FLOWER_SCROLL);
   - Id: 22736
     AegisName: JulyGiftBox_
     Name: July Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58042,6 +57210,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JULYGIFTBOX_
     Script: |
       getgroupitem(IG_JULYGIFTBOX_);
   - Id: 22737
@@ -58050,6 +57219,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13222,500;
   - Id: 22738
@@ -58058,6 +57229,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13221,500;
   - Id: 22739
@@ -58066,6 +57239,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 350
+    Flags:
+      Container: true
     Script: |
       getitem 13224,500;
   - Id: 22740
@@ -58074,6 +57249,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 350
+    Flags:
+      Container: true
     Script: |
       getitem 13226,500;
   - Id: 22741
@@ -58082,6 +57259,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 350
+    Flags:
+      Container: true
     Script: |
       getitem 13225,500;
   - Id: 22742
@@ -58090,6 +57269,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 350
+    Flags:
+      Container: true
     Script: |
       getitem 13227,500;
   - Id: 22743
@@ -58098,6 +57279,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 350
+    Flags:
+      Container: true
     Script: |
       getitem 13223,500;
   - Id: 22744
@@ -58106,6 +57289,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13215,500;
   - Id: 22745
@@ -58114,6 +57299,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13216,500;
   - Id: 22746
@@ -58122,6 +57309,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13217,500;
   - Id: 22747
@@ -58130,6 +57319,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13218,500;
   - Id: 22748
@@ -58138,6 +57329,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13219,500;
   - Id: 22749
@@ -58146,6 +57339,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13220,500;
   - Id: 22750
@@ -58200,8 +57395,6 @@ Body:
     AegisName: AugustGiftBox_
     Name: August Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58210,6 +57403,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AUGUSTGIFTBOX_
     Script: |
       getgroupitem(IG_AUGUSTGIFTBOX_);
   - Id: 22757
@@ -58291,8 +57485,6 @@ Body:
     Name: Pet Exchange Ticket Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58301,6 +57493,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PETTRADETICKET_BOX
     Script: |
       getgroupitem(IG_PETTRADETICKET_BOX);
   - Id: 22770
@@ -58380,8 +57573,6 @@ Body:
     Buy: 10
     Weight: 100
     EquipLevelMin: 1
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58390,15 +57581,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GIFT_BUFF_SET
     Script: |
-      getgroupitem(IG_Gift_Buff_Set);
+      getgroupitem(IG_GIFT_BUFF_SET);
   - Id: 22781
     AegisName: PC_NomalBox
     Name: PC Bang Normal Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58407,6 +57597,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_NOMALBOX
     Script: |
       getgroupitem(IG_PC_NOMALBOX);
   - Id: 22782
@@ -58414,8 +57605,6 @@ Body:
     Name: PC Bang Wooden Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58424,6 +57613,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_WOODENBOX
     Script: |
       getgroupitem(IG_PC_WOODENBOX);
   - Id: 22783
@@ -58431,8 +57621,6 @@ Body:
     Name: PC Bang Golden Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58441,6 +57629,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_GOLDENBOX
     Script: |
       getgroupitem(IG_PC_GOLDENBOX);
   - Id: 22784
@@ -58448,8 +57637,6 @@ Body:
     Name: PC Bang Platinum Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58458,6 +57645,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PC_PLATINUMBOX
     Script: |
       getgroupitem(IG_PC_PLATINUMBOX);
   - Id: 22808
@@ -58468,6 +57656,8 @@ Body:
     Weight: 100
     Classes:
       All: false
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58486,8 +57676,6 @@ Body:
     Name: Sealed Dracula Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58496,6 +57684,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_DRACULA_SCROLL
     Script: |
       getgroupitem(IG_SEALED_DRACULA_SCROLL);
   - Id: 22813
@@ -58503,8 +57692,6 @@ Body:
     Name: Bearer's Shadow Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58513,6 +57700,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BEARERS_SHADOW_BOX
     Script: |
       getgroupitem(IG_BEARERS_SHADOW_BOX);
   - Id: 22814
@@ -58617,8 +57805,6 @@ Body:
     Name: Sealed Sniper Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58627,14 +57813,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_B_SHECIL_SCROLL
     Script: |
       getgroupitem(IG_SEALED_B_SHECIL_SCROLL);
   - Id: 22825
     AegisName: Costume_Set1_Kr
     Name: Heidam Fellow
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_COSTUME_SET1_KR
     Script: |
       getgroupitem(IG_COSTUME_SET1_KR);
   - Id: 22826
@@ -58642,17 +57828,15 @@ Body:
     Name: Costume Enchant Stone Box 4
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX4
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box4);
+      getgroupitem(IG_ENCHANT_STONE_BOX4);
   - Id: 22827
     AegisName: Shadow_Cube
     Name: Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE
     Script: |
       getgroupitem(IG_SHADOW_CUBE);
   - Id: 22828
@@ -58662,8 +57846,6 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58672,6 +57854,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_SCROLL
     Script: |
       getgroupitem(IG_SEALED_SCROLL);
   - Id: 22829
@@ -58679,8 +57862,6 @@ Body:
     Name: Sealed Card Album
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58689,6 +57870,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_CARD
     Script: |
       getgroupitem(IG_SEALED_CARD);
   - Id: 22837
@@ -58698,6 +57880,8 @@ Body:
     Buy: 10
     Weight: 50
     EquipLevelMin: 50
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58716,10 +57900,9 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
+    ItemGroup: IG_SOMETHING_CANDY_HOLDER
     Script: |
-      getgroupitem(IG_Something_Candy_Holder);
+      getgroupitem(IG_SOMETHING_CANDY_HOLDER);
   - Id: 22839
     AegisName: Happy_Box_J
     Name: Happy Box
@@ -58727,8 +57910,9 @@ Body:
     Buy: 10
     Weight: 200
     EquipLevelMin: 1
+    ItemGroup: IG_HAPPY_BOX_J
     Script: |
-      getgroupitem(IG_Happy_Box_J);
+      getgroupitem(IG_HAPPY_BOX_J);
   - Id: 22841
     AegisName: Pumpkin_Candy
     Name: Pumpkin Candy
@@ -58741,8 +57925,6 @@ Body:
     Name: Sealed Dracula Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58751,6 +57933,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_DRACULA_SCROLL2
     Script: |
       getgroupitem(IG_SEALED_DRACULA_SCROLL2);
   - Id: 22843
@@ -58766,8 +57949,6 @@ Body:
     Name: Sealed Dracula Card Album
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58776,6 +57957,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_DRACULA_ALBUM
     Script: |
       getgroupitem(IG_SEALED_DRACULA_ALBUM);
   - Id: 22845
@@ -58783,8 +57965,6 @@ Body:
     Name: Sealed Fortune Egg
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58793,6 +57973,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_MYSTERIOUS_EGG
     Script: |
       getgroupitem(IG_SEALED_MYSTERIOUS_EGG);
   - Id: 22846
@@ -58846,6 +58027,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58862,6 +58045,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58893,8 +58078,6 @@ Body:
     Name: April Gift Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58903,6 +58086,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_APRILGIFTBOX
     Script: |
       getgroupitem(IG_APRILGIFTBOX);
   - Id: 22854
@@ -58911,6 +58095,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58943,6 +58129,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58959,6 +58147,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58974,8 +58164,6 @@ Body:
     Name: September Gift Box
     Type: Cash
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -58984,6 +58172,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEPTEMBERGIFTBOX
     Script: |
       getgroupitem(IG_SEPTEMBERGIFTBOX);
   - Id: 22859
@@ -58992,6 +58181,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59007,8 +58198,6 @@ Body:
     Name: November Gift Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59017,6 +58206,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NOVEMBERGIFTBOX
     Script: |
       getgroupitem(IG_NOVEMBERGIFTBOX);
   - Id: 22861
@@ -59025,6 +58215,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59040,10 +58232,9 @@ Body:
     Name: Costume Enchant Stone Box 5
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX5
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box5);
+      getgroupitem(IG_ENCHANT_STONE_BOX5);
   - Id: 22869
     AegisName: LuckyRouletteTickets
     Name: Lucky Roulette Ticket
@@ -59067,8 +58258,6 @@ Body:
     Name: Christmas Package
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59076,6 +58265,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_XMAS_PACKAGE_14
     Script: |
       getgroupitem(IG_XMAS_PACKAGE_14);
   - Id: 22873
@@ -59083,8 +58273,6 @@ Body:
     Name: Sealed Beelzebub Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59093,6 +58281,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_BERZ_SCROLL2
     Script: |
       getgroupitem(IG_SEALED_BERZ_SCROLL2);
   - Id: 22874
@@ -59100,8 +58289,6 @@ Body:
     Name: Sealed Beelzebub Card Album
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59110,6 +58297,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_BERZ_ALBUM
     Script: |
       getgroupitem(IG_SEALED_BERZ_ALBUM);
   - Id: 22876
@@ -59145,8 +58333,6 @@ Body:
     AegisName: SeptemberGiftBox_
     Name: September Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59155,14 +58341,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEPTEMBERGIFTBOX_
     Script: |
       getgroupitem(IG_SEPTEMBERGIFTBOX_);
   - Id: 22884
     AegisName: OctoberGiftBox_
     Name: October Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59171,14 +58356,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_OCTOBERGIFTBOX_
     Script: |
       getgroupitem(IG_OCTOBERGIFTBOX_);
   - Id: 22885
     AegisName: NovemberGiftBox_
     Name: November Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59187,14 +58371,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NOVEMBERGIFTBOX_
     Script: |
       getgroupitem(IG_NOVEMBERGIFTBOX_);
   - Id: 22886
     AegisName: DecemberGiftBox_
     Name: December Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59203,6 +58386,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DECEMBERGIFTBOX_
     Script: |
       getgroupitem(IG_DECEMBERGIFTBOX_);
   - Id: 22887
@@ -59210,8 +58394,6 @@ Body:
     Name: Gold PC Cafe Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59221,6 +58403,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2015GOLDPCBOX
     Script: |
       getgroupitem(IG_2015GOLDPCBOX);
   - Id: 22888
@@ -59228,8 +58411,6 @@ Body:
     Name: New Year's Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59238,6 +58419,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2015_NEW_YEAR_SCROLL
     Script: |
       getgroupitem(IG_2015_NEW_YEAR_SCROLL);
   - Id: 22893
@@ -59245,8 +58427,6 @@ Body:
     Name: New Year Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59255,6 +58435,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_YEAR_SHADOW_CUBE
     Script: |
       getgroupitem(IG_NEW_YEAR_SHADOW_CUBE);
   - Id: 22894
@@ -59318,8 +58499,6 @@ Body:
     Name: Mysterious Blue Box
     Type: Usable
     Buy: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59328,6 +58507,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLUEBOXOFQUESTIONS
     Script: |
       getgroupitem(IG_BLUEBOXOFQUESTIONS);
   - Id: 22902
@@ -59335,8 +58515,6 @@ Body:
     Name: Sealed Seal Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59345,6 +58523,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_SCROLL2
     Script: |
       getgroupitem(IG_SEALED_SCROLL2);
   - Id: 22905
@@ -59352,17 +58531,14 @@ Body:
     Name: Costume Enchant Stone Box 6
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX6
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box6);
+      getgroupitem(IG_ENCHANT_STONE_BOX6);
   - Id: 22906
     AegisName: Sealed_Scroll3
     Name: Sealed Seal Scroll III
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59371,6 +58547,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_SCROLL3
     Script: |
       getgroupitem(IG_SEALED_SCROLL3);
   - Id: 22907
@@ -59408,6 +58585,8 @@ Body:
     Name: +5 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6456,1; /* +5 Weapon Refine Ticket */
   - Id: 22910
@@ -59415,6 +58594,8 @@ Body:
     Name: +6 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6231,1; /* +6 Weapon Refine Ticket */
   - Id: 22911
@@ -59422,6 +58603,8 @@ Body:
     Name: Weapon +7 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6230,1; /* Safe to 7 Weapon Certificate */
   - Id: 22912
@@ -59429,6 +58612,8 @@ Body:
     Name: Weapon +8 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6229,1; /* +8 Weapon Refine Ticket */
   - Id: 22913
@@ -59436,6 +58621,8 @@ Body:
     Name: Weapon +9 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6228,1; /* +9 Weapon refine deed */
   - Id: 22914
@@ -59458,6 +58645,8 @@ Body:
     Name: Weapon +11 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6238,1; /* +11 Weapon refine deed */
   - Id: 22916
@@ -59465,6 +58654,8 @@ Body:
     Name: Weapon +12 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6584,1; /* +12 Weapon Certificate */
   - Id: 22917
@@ -59472,6 +58663,8 @@ Body:
     Name: +13 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6870,1; /* Safe to 13 Weapon Certificate */
   - Id: 22918
@@ -59479,6 +58672,8 @@ Body:
     Name: +14 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6871,1; /* Safe to 14 Weapon Certificate */
   - Id: 22919
@@ -59486,6 +58681,8 @@ Body:
     Name: +15 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6872,1; /* Safe to 15 Weapon Certificate */
   - Id: 22920
@@ -59493,6 +58690,8 @@ Body:
     Name: +16 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6873,1; /* Safe to 16 Weapon Certificate */
   - Id: 22921
@@ -59500,6 +58699,8 @@ Body:
     Name: +17 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6874,1; /* Safe to 17 Weapon Certificate */
   - Id: 22922
@@ -59507,6 +58708,8 @@ Body:
     Name: +18 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6875,1; /* Safe to 18 Weapon Certificate */
   - Id: 22923
@@ -59514,6 +58717,8 @@ Body:
     Name: +19 Weapon Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6864,1; /* Safe to 19 Weapon Certificate */
   - Id: 22924
@@ -59521,6 +58726,8 @@ Body:
     Name: +5 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6457,1; /* +5 Armor Refine Ticket */
   - Id: 22925
@@ -59528,6 +58735,8 @@ Body:
     Name: +6 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6235,1; /* +6 Armor Refine Ticket */
   - Id: 22926
@@ -59535,6 +58744,8 @@ Body:
     Name: Armor +7 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6234,1; /* Safe to 7 Body Armor Certificate */
   - Id: 22927
@@ -59542,6 +58753,8 @@ Body:
     Name: Armor +8 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6233,1; /* +8 Armor Refine Ticket */
   - Id: 22928
@@ -59549,6 +58762,8 @@ Body:
     Name: Armor +9 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6232,1; /* +9 Armor refine deed */
   - Id: 22929
@@ -59571,6 +58786,8 @@ Body:
     Name: Armor +11 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6239,1; /* +11 Armor refine deed */
   - Id: 22931
@@ -59578,6 +58795,8 @@ Body:
     Name: Armor +12 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6585,1; /* +12 Armor Certificate */
   - Id: 22932
@@ -59585,6 +58804,8 @@ Body:
     Name: +13 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6876,1; /* Safe to 13 Armor Certificate */
   - Id: 22933
@@ -59592,6 +58813,8 @@ Body:
     Name: +14 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6877,1; /* Safe to 14 Armor Certificate */
   - Id: 22934
@@ -59599,6 +58822,8 @@ Body:
     Name: +15 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6878,1; /* Safe to 15 Armor Certificate */
   - Id: 22935
@@ -59606,6 +58831,8 @@ Body:
     Name: +16 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6879,1; /* Safe to 16 Armor Certificate */
   - Id: 22936
@@ -59613,6 +58840,8 @@ Body:
     Name: +17 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6880,1; /* Safe to 17 Armor Certificate */
   - Id: 22937
@@ -59620,6 +58849,8 @@ Body:
     Name: +18 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6881,1; /* Safe to 18 Armor Certificate */
   - Id: 22938
@@ -59627,6 +58858,8 @@ Body:
     Name: +19 Armor Upgrade Certificate
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6865,1; /* Safe to 19 Armor Certificate */
   - Id: 22943
@@ -59634,6 +58867,8 @@ Body:
     Name: Armor +10 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6994,1; /* +10 Armor Certificate */
   - Id: 22944
@@ -59641,6 +58876,8 @@ Body:
     Name: Weapon +10 Refine Ticket
     Type: Usable
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 6993,1; /* +10 Weapon Certificate */
   - Id: 22945
@@ -59656,8 +58893,6 @@ Body:
     Name: Stats Reduction Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59666,6 +58901,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STATUS_DECREASE_SCROLL
     Script: |
       getgroupitem(IG_STATUS_DECREASE_SCROLL);
   - Id: 22947
@@ -59763,17 +58999,14 @@ Body:
     Name: Costume Enchant Stone Box 7
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX7
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box7);
+      getgroupitem(IG_ENCHANT_STONE_BOX7);
   - Id: 22971
     AegisName: Mad_Bunny_Scroll
     Name: Mad Bunny Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59782,6 +59015,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAD_BUNNY_SCROLL
     Script: |
       getgroupitem(IG_MAD_BUNNY_SCROLL);
   - Id: 22972
@@ -59789,8 +59023,6 @@ Body:
     Name: Sealed Hat Box I
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59799,6 +59031,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_HAT_BOX
     Script: |
       getgroupitem(IG_SEALED_HAT_BOX);
   - Id: 22973
@@ -59808,7 +59041,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_WEAPON
     Script: |
       getgroupitem(IG_SHADOW_CUBE_WEAPON);
   - Id: 22974
@@ -59818,7 +59051,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_ARMOR
     Script: |
       getgroupitem(IG_SHADOW_CUBE_ARMOR);
   - Id: 22975
@@ -59828,7 +59061,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_SHIELD
     Script: |
       getgroupitem(IG_SHADOW_CUBE_SHIELD);
   - Id: 22976
@@ -59838,7 +59071,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_SHOES
     Script: |
       getgroupitem(IG_SHADOW_CUBE_SHOES);
   - Id: 22977
@@ -59848,7 +59081,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_PENDANT
     Script: |
       getgroupitem(IG_SHADOW_CUBE_PENDANT);
   - Id: 22978
@@ -59858,7 +59091,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_CUBE_EARING
     Script: |
       getgroupitem(IG_SHADOW_CUBE_EARING);
   - Id: 22979
@@ -59934,8 +59167,6 @@ Body:
     Name: Sealed Hat Box II
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59944,6 +59175,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_HAT_BOX2
     Script: |
       getgroupitem(IG_SEALED_HAT_BOX2);
   - Id: 22989
@@ -59951,8 +59183,6 @@ Body:
     Name: Improved PC Cafe Normal Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -59961,6 +59191,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMPROVED_NOMALBOX
     Script: |
       getgroupitem(IG_IMPROVED_NOMALBOX);
   - Id: 22991
@@ -60021,7 +59252,7 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_COMP_TRANS_SCROLL
     Script: |
       getgroupitem(IG_COMP_TRANS_SCROLL);
   - Id: 23001
@@ -60029,17 +59260,14 @@ Body:
     Name: Costume Enchant Stone Box 8
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX8
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box8);
+      getgroupitem(IG_ENCHANT_STONE_BOX8);
   - Id: 23007
     AegisName: Improved_WoodenBox
     Name: Improved PC Cafe Wooden Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60048,6 +59276,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMPROVED_WOODENBOX
     Script: |
       getgroupitem(IG_IMPROVED_WOODENBOX);
   - Id: 23008
@@ -60117,8 +59346,6 @@ Body:
     Name: Improved PC Cafe Golden Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60127,6 +59354,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMPROVED_GOLDENBOX
     Script: |
       getgroupitem(IG_IMPROVED_GOLDENBOX);
   - Id: 23014
@@ -60134,8 +59362,6 @@ Body:
     Name: Improved PC Cafe Platinum Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60144,6 +59370,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_IMPROVED_PLATINUMBOX
     Script: |
       getgroupitem(IG_IMPROVED_PLATINUMBOX);
   - Id: 23015
@@ -60176,8 +59403,6 @@ Body:
     Name: 15th Anniversary Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60187,6 +59412,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_13THCELEBRATEBOX
     Script: |
       getgroupitem(IG_13THCELEBRATEBOX);
   - Id: 23022
@@ -60194,8 +59420,6 @@ Body:
     Name: Cross Event Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60205,6 +59429,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CROSSEVENTBOX
     Script: |
       getgroupitem(IG_CROSSEVENTBOX);
   - Id: 23023
@@ -60227,8 +59452,6 @@ Body:
     Name: Piamette Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60237,6 +59460,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PIAMETTE_SCROLL
     Script: |
       getgroupitem(IG_PIAMETTE_SCROLL);
   - Id: 23025
@@ -60305,8 +59529,7 @@ Body:
     Name: Ponytail Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_COWLICK_BOX
     Script: |
       getgroupitem(IG_COWLICK_BOX);
   - Id: 23030
@@ -60314,8 +59537,7 @@ Body:
     Name: Straight Pony Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_STRAIGHT_PONY_BOX
     Script: |
       getgroupitem(IG_STRAIGHT_PONY_BOX);
   - Id: 23031
@@ -60323,24 +59545,21 @@ Body:
     Name: Loose Wave Twintail Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LOOSE_WAVE_TWIN_BOX
     Script: |
       getgroupitem(IG_LOOSE_WAVE_TWIN_BOX);
   - Id: 23032
     AegisName: Minus_Status_Box
     Name: Stats Soul Potion Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_MINUS_STATUS_BOX
     Script: |
       getgroupitem(IG_MINUS_STATUS_BOX);
   - Id: 23033
     AegisName: Invisible_Box
     Name: Invisible Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_INVISIBLE_BOX
     Script: |
       getgroupitem(IG_INVISIBLE_BOX);
   - Id: 23034
@@ -60348,8 +59567,6 @@ Body:
     Name: Invisible Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60358,6 +59575,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INVISIBLE_SCROLL
     Script: |
       getgroupitem(IG_INVISIBLE_SCROLL);
   - Id: 23036
@@ -60398,6 +59616,8 @@ Body:
     AegisName: White_Slim_Potion_Box_
     Name: "[Sale] Slim White Potion Box"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60412,6 +59632,8 @@ Body:
     AegisName: Mastela_Fruit_Box_
     Name: "[NotForSale] Mastela Fruit Box"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60438,6 +59660,8 @@ Body:
     AegisName: Royal_Jelly_Box2_
     Name: "[NotForSale] Royal Jelly Box"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60470,6 +59694,8 @@ Body:
     AegisName: Yggdrasil_Seed_Box_
     Name: "[Sale] Yggdrasil Seed Box"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60485,10 +59711,10 @@ Body:
     Name: Elvira Candy
     Type: Usable
     Weight: 10
-    Delay:
-      Duration: 60000
     Flags:
       BuyingStore: true
+    Delay:
+      Duration: 60000
     Script: |
       specialeffect2 EF_HEAL3;
       sc_end SC_CURSEDCIRCLE;
@@ -60599,8 +59825,6 @@ Body:
     Name: Liberty Cap Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60609,6 +59833,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_HAT_SCROLL
     Script: |
       getgroupitem(IG_NEW_HAT_SCROLL);
   - Id: 23052
@@ -60616,8 +59841,6 @@ Body:
     Name: Liberty Statue Hat Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60626,6 +59849,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_HAT_BOX
     Script: |
       getgroupitem(IG_NEW_HAT_BOX);
   - Id: 23058
@@ -60633,16 +59857,17 @@ Body:
     Name: Costume Enchant Stone Box 9
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX9
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box9);
+      getgroupitem(IG_ENCHANT_STONE_BOX9);
   - Id: 23061
     AegisName: Incisive_Arrow_Cntr
     Name: Sharp Arrow Quiver
     Type: Usable
     Buy: 20
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 1764,500; /* Sharp Arrow */
   - Id: 23062
@@ -60650,8 +59875,6 @@ Body:
     Name: Cooking Open Memorial Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60660,14 +59883,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COKINGOPENBOX
     Script: |
       getgroupitem(IG_COKINGOPENBOX);
   - Id: 23063
     AegisName: Freeze_Dream
     Name: Frozen Dream
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60677,6 +59899,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FREEZE_DREAM
     Script: |
       getgroupitem(IG_FREEZE_DREAM);
   - Id: 23069
@@ -60684,8 +59907,6 @@ Body:
     Name: 2015 Special Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60694,6 +59915,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2015_SPECIAL_SCROLL
     Script: |
       getgroupitem(IG_2015_SPECIAL_SCROLL);
   - Id: 23070
@@ -60701,8 +59923,6 @@ Body:
     Name: 2015 Special Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60711,6 +59931,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2015_SPECIAL_BOX
     Script: |
       getgroupitem(IG_2015_SPECIAL_BOX);
   - Id: 23072
@@ -60718,8 +59939,6 @@ Body:
     Name: Angel Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60728,6 +59947,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2015_ANGEL_SCROLL
     Script: |
       getgroupitem(IG_2015_ANGEL_SCROLL);
   - Id: 23073
@@ -60735,8 +59955,6 @@ Body:
     Name: Angel Poring Shoes Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60745,6 +59963,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANGELPORING_BOX
     Script: |
       getgroupitem(IG_ANGELPORING_BOX);
   - Id: 23074
@@ -60752,8 +59971,6 @@ Body:
     Name: December Gift Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60762,6 +59979,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DECEMBERGIFTBOX_2016
     Script: |
       getgroupitem(IG_DECEMBERGIFTBOX_2016);
   - Id: 23075
@@ -60769,8 +59987,6 @@ Body:
     Name: November Gift Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60779,6 +59995,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NOVEMBERGIFTBOX_2016
     Script: |
       getgroupitem(IG_NOVEMBERGIFTBOX_2016);
   - Id: 23076
@@ -60827,7 +60044,7 @@ Body:
     Weight: 500
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CRYSTAL_OF_GRUDGE
     Script: |
       getgroupitem(IG_CRYSTAL_OF_GRUDGE);
   - Id: 23081
@@ -60835,8 +60052,7 @@ Body:
     Name: Kunai Scroll of Flame
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_OF_FLAME
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_OF_FLAME);
   - Id: 23082
@@ -60844,8 +60060,7 @@ Body:
     Name: Kunai Scroll of Icicle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_OF_ICICLE
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_OF_ICICLE);
   - Id: 23083
@@ -60853,8 +60068,7 @@ Body:
     Name: Kunai Scroll of Storm
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_OF_WIND
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_OF_WIND);
   - Id: 23084
@@ -60862,8 +60076,7 @@ Body:
     Name: Kunai Scroll of Sand
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_OF_SOIL
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_OF_SOIL);
   - Id: 23085
@@ -60871,8 +60084,7 @@ Body:
     Name: Kunai Scroll of Poison
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_OF_POISON
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_OF_POISON);
   - Id: 23086
@@ -60880,14 +60092,15 @@ Body:
     Name: Costume Enchant Stone Box 10
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX10
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box10);
+      getgroupitem(IG_ENCHANT_STONE_BOX10);
   - Id: 23087
     AegisName: Small_Leather_Bag
     Name: Small Leather Bag
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60927,8 +60140,6 @@ Body:
     Name: Poring Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60937,6 +60148,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PORING_SCROLL
     Script: |
       getgroupitem(IG_PORING_SCROLL);
   - Id: 23096
@@ -60944,8 +60156,6 @@ Body:
     Name: MOBI Support Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60954,14 +60164,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOBI_SUPPORT_BOX
     Script: |
       getgroupitem(IG_MOBI_SUPPORT_BOX);
   - Id: 23097
     AegisName: Time_Guardian_Box2
     Name: Greater Time Guardian Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60971,14 +60180,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TIME_GUARDIAN_BOX2
     Script: |
       getgroupitem(IG_TIME_GUARDIAN_BOX2);
   - Id: 23098
     AegisName: Assorted_ShdowBox
     Name: Shadow Assortment Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -60988,6 +60196,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ASSORTED_SHDOWBOX
     Script: |
       getgroupitem(IG_ASSORTED_SHDOWBOX);
   - Id: 23100
@@ -61002,8 +60211,6 @@ Body:
     Name: Amistr Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61012,6 +60219,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AMISTR_SCROLL
     Script: |
       getgroupitem(IG_AMISTR_SCROLL);
   - Id: 23107
@@ -61019,8 +60227,7 @@ Body:
     Name: Amistr Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_AMISTR_BOX
     Script: |
       getgroupitem(IG_AMISTR_BOX);
   - Id: 23115
@@ -61030,7 +60237,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_CUBE);
   - Id: 23116
@@ -61038,8 +60245,6 @@ Body:
     Name: Shadow Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61048,6 +60253,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_SCROLL
     Script: |
       getgroupitem(IG_SHADOW_SCROLL);
   - Id: 23119
@@ -61055,8 +60261,6 @@ Body:
     Name: Soul Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61065,6 +60269,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPIRIT_SCROLL
     Script: |
       getgroupitem(IG_SPIRIT_SCROLL);
   - Id: 23120
@@ -61072,8 +60277,6 @@ Body:
     Name: Sealed Hat Box III
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61082,6 +60285,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_HAT_BOX3
     Script: |
       getgroupitem(IG_SEALED_HAT_BOX3);
   - Id: 23123
@@ -61090,6 +60294,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13228,500;
   - Id: 23124
@@ -61098,6 +60304,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13229,500;
   - Id: 23125
@@ -61106,6 +60314,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13230,500;
   - Id: 23126
@@ -61114,6 +60324,8 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13231,500;
   - Id: 23127
@@ -61122,54 +60334,50 @@ Body:
     Type: Usable
     Buy: 10
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem 13232,500;
   - Id: 23128
     AegisName: Cachua_Weapon
     Name: Kachua Weapon
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_WEAPON
     Script: |
       getgroupitem(IG_CACHUA_WEAPON,true);
   - Id: 23129
     AegisName: Cachua_Robe
     Name: Kachua Garment
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_ROBE
     Script: |
       getgroupitem(IG_CACHUA_ROBE,true);
   - Id: 23130
     AegisName: Cachua_Mail
     Name: Kachua Armor
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_MAIL
     Script: |
       getgroupitem(IG_CACHUA_MAIL,true);
   - Id: 23131
     AegisName: Cachua_Shoes
     Name: Kachua Shoes
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_SHOES
     Script: |
       getgroupitem(IG_CACHUA_SHOES,true);
   - Id: 23132
     AegisName: Cachua_Shield
     Name: Kachua Shield
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_SHIELD
     Script: |
       getgroupitem(IG_CACHUA_SHIELD,true);
   - Id: 23133
     AegisName: Cachua_Helm
     Name: Kachua Helm
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_CACHUA_HELM
     Script: |
       getgroupitem(IG_CACHUA_HELM,true);
   - Id: 23134
@@ -61177,8 +60385,6 @@ Body:
     Name: Balloon Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61187,6 +60393,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BALLOON_SCROLL
     Script: |
       getgroupitem(IG_BALLOON_SCROLL);
   - Id: 23135
@@ -61196,7 +60403,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_PORING_BALLOON_BOX
     Script: |
       getgroupitem(IG_PORING_BALLOON_BOX);
   - Id: 23136
@@ -61207,6 +60414,7 @@ Body:
     Weight: 20
     Flags:
       BuyingStore: true
+      Container: true
     Script: |
       getitem 12507,3;
       getitem 12508,3;
@@ -61217,8 +60425,6 @@ Body:
     Name: Rebellion Jumping Support Box
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61228,12 +60434,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RIBEL_JUMPING_BOX
     Script: |
       getgroupitem(IG_RIBEL_JUMPING_BOX);
   - Id: 23142
     AegisName: EXPUP_Potion1
     Name: Minor Growth Elixir
     Type: Usable
+    Buy: 2
+    Weight: 10
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61242,14 +60451,14 @@ Body:
       NoMail: true
       NoAuction: true
       Override: 100
-    Buy: 2
-    Weight: 10
     Script: |
       getexp (BaseLevel < 100)?15000:1500,0;
   - Id: 23143
     AegisName: JEXPUP_Potion1
     Name: Minor Job Elixir
     Type: Usable
+    Buy: 2
+    Weight: 10
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61258,8 +60467,6 @@ Body:
       NoMail: true
       NoAuction: true
       Override: 100
-    Buy: 2
-    Weight: 10
     Script: |
       getexp 0,(BaseLevel < 100)?15000:1500;
   - Id: 23144
@@ -61268,6 +60475,8 @@ Body:
     Type: Usable
     Buy: 2
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 23142,5;
   - Id: 23145
@@ -61276,6 +60485,8 @@ Body:
     Type: Usable
     Buy: 2
     Weight: 10
+    Flags:
+      Container: true
     Script: |
       getitem 23143,5;
   - Id: 23148
@@ -61313,8 +60524,7 @@ Body:
     Name: Lapine Big Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LAPINE_DDUKDDAKBOX
     Script: |
       getgroupitem(IG_LAPINE_DDUKDDAKBOX);
   - Id: 23151
@@ -61351,6 +60561,8 @@ Body:
     AegisName: Poison_Pack2
     Name: Poison Bottle Pack
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61379,8 +60591,7 @@ Body:
     Name: Gunslinger Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GUNSLINGER_BOX
     Script: |
       getgroupitem(IG_GUNSLINGER_BOX);
   - Id: 23162
@@ -61388,8 +60599,6 @@ Body:
     Name: Gunslinger Scoll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61398,6 +60607,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GUNSLINGER_SCROLL
     Script: |
       getgroupitem(IG_GUNSLINGER_SCROLL);
   - Id: 23165
@@ -61419,8 +60629,6 @@ Body:
     Name: July Green Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61429,6 +60637,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GREEN_SCROLL_K
     Script: |
       getgroupitem(IG_GREEN_SCROLL_K);
   - Id: 23168
@@ -61438,7 +60647,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MINI_FAN_BOX
     Script: |
       getgroupitem(IG_MINI_FAN_BOX);
   - Id: 23169
@@ -61448,7 +60657,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ALCHEMIST_BOX
     Script: |
       getgroupitem(IG_ALCHEMIST_BOX);
   - Id: 23170
@@ -61505,10 +60714,9 @@ Body:
     Name: Costume Enchant Stone Box 11
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX11
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box11);
+      getgroupitem(IG_ENCHANT_STONE_BOX11);
   - Id: 23175
     AegisName: Suit_Upgrade_Kit
     Name: Uniform Repair Kit
@@ -61521,8 +60729,6 @@ Body:
     Name: Kafra Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61531,6 +60737,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KAFRA_SCROLL
     Script: |
       getgroupitem(IG_KAFRA_SCROLL);
   - Id: 23177
@@ -61556,7 +60763,7 @@ Body:
     Weight: 510
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_KAFRA_BOX
     Script: |
       getgroupitem(IG_KAFRA_BOX);
   - Id: 23187
@@ -61617,8 +60824,7 @@ Body:
     Name: Sigrun Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SIGRUN_SCROLL
     Script: |
       getgroupitem(IG_SIGRUN_SCROLL);
   - Id: 23196
@@ -61628,8 +60834,6 @@ Body:
     Buy: 10
     Weight: 10
     EquipLevelMin: 1
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61638,15 +60842,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AGUST_LUCKY_SCROLL
     Script: |
-      getgroupitem(IG_Agust_Lucky_Scroll);
+      getgroupitem(IG_AGUST_LUCKY_SCROLL);
   - Id: 23198
     AegisName: PremiumWoodenBox
     Name: Premium Wooden Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61655,6 +60858,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PREMIUMWOODENBOX
     Script: |
       getgroupitem(IG_PREMIUMWOODENBOX);
   - Id: 23199
@@ -61662,8 +60866,6 @@ Body:
     Name: Premium Golden Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61672,6 +60874,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PREMIUMGOLDENBOX
     Script: |
       getgroupitem(IG_PREMIUMGOLDENBOX);
   - Id: 23200
@@ -61679,8 +60882,6 @@ Body:
     Name: Premium Platinum Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61689,6 +60890,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PREMIUMPLATINUMBOX
     Script: |
       getgroupitem(IG_PREMIUMPLATINUMBOX);
   - Id: 23201
@@ -61696,8 +60898,6 @@ Body:
     Name: Premium Normal Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61706,6 +60906,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PREMIUMNOMALBOX
     Script: |
       getgroupitem(IG_PREMIUMNOMALBOX);
   - Id: 23202
@@ -61761,8 +60962,7 @@ Body:
     Name: New Hat Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_NEW_HAT_SCROLL2
     Script: |
       getgroupitem(IG_NEW_HAT_SCROLL2);
   - Id: 23206
@@ -61770,8 +60970,6 @@ Body:
     Name: New Hat Box II
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61780,6 +60978,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_HAT_BOX2
     Script: |
       getgroupitem(IG_NEW_HAT_BOX2);
   - Id: 23207
@@ -61922,8 +61121,6 @@ Body:
     Name: 2016 Special Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61932,6 +61129,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2016_SPECIAL_SCROLL
     Script: |
       getgroupitem(IG_2016_SPECIAL_SCROLL);
   - Id: 23218
@@ -61939,8 +61137,6 @@ Body:
     Name: 2016 Special Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -61949,6 +61145,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2016_SPECIAL_BOX
     Script: |
       getgroupitem(IG_2016_SPECIAL_BOX);
   - Id: 23221
@@ -62017,7 +61214,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BISCUIT_STICK_2SET
     Script: |
       getgroupitem(IG_BISCUIT_STICK_2SET);
   - Id: 23228
@@ -62041,8 +61238,7 @@ Body:
     AegisName: Racing_Exchange
     Name: Mysterious Medal Crane
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_RACING_EXCHANGE
     Script: |
       getgroupitem(IG_RACING_EXCHANGE);
   - Id: 23235
@@ -62050,8 +61246,6 @@ Body:
     Name: Mad Bunny Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62060,6 +61254,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CANDLELIGHT_SCROLL
     Script: |
       getgroupitem(IG_CANDLELIGHT_SCROLL);
   - Id: 23236
@@ -62123,8 +61318,6 @@ Body:
     Name: Lapine Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62133,6 +61326,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LAPINE_SCROLL
     Script: |
       getgroupitem(IG_LAPINE_SCROLL);
   - Id: 23246
@@ -62140,8 +61334,7 @@ Body:
     Name: "[Limited] Lapine's Thump Box"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LI_LAPINE_DDUKDDAKBOX
     Script: |
       getgroupitem(IG_LI_LAPINE_DDUKDDAKBOX);
   - Id: 23247
@@ -62178,8 +61371,6 @@ Body:
     AegisName: Rose_Bundle_A
     Name: Rose Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62188,14 +61379,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ROSE_BUNDLE_A
     Script: |
       getgroupitem(IG_ROSE_BUNDLE_A);
   - Id: 23252
     AegisName: Orleans_Bundle_A
     Name: Orleans's Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62204,14 +61394,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ORLEANS_BUNDLE_A
     Script: |
       getgroupitem(IG_ORLEANS_BUNDLE_A);
   - Id: 23253
     AegisName: Black_Shiba_Bundle_A
     Name: Black Shiba Inu Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62220,14 +61409,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLACK_SHIBA_BUNDLE_A
     Script: |
       getgroupitem(IG_BLACK_SHIBA_BUNDLE_A);
   - Id: 23254
     AegisName: Valkyrie_Bundle_A
     Name: Valkyrie Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62236,14 +61424,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VALKYRIE_BUNDLE_A
     Script: |
       getgroupitem(IG_VALKYRIE_BUNDLE_A);
   - Id: 23255
     AegisName: Kardui_Bundle_A
     Name: Kardui Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62252,6 +61439,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KARDUI_BUNDLE_A
     Script: |
       getgroupitem(IG_KARDUI_BUNDLE_A);
   - Id: 23256
@@ -62312,8 +61500,7 @@ Body:
     Name: Tango Hair Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HAIR_BUN_BOX
     Script: |
       getgroupitem(IG_HAIR_BUN_BOX);
   - Id: 23263
@@ -62321,8 +61508,7 @@ Body:
     Name: Roll Twin Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ROLL_TWIN_BOX
     Script: |
       getgroupitem(IG_ROLL_TWIN_BOX);
   - Id: 23264
@@ -62330,16 +61516,13 @@ Body:
     Name: Long Pony Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_LONG_PONY_BOX
     Script: |
       getgroupitem(IG_LONG_PONY_BOX);
   - Id: 23265
     AegisName: Sprint_Bundle_A
     Name: Sprint Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62348,14 +61531,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPRINT_BUNDLE_A
     Script: |
       getgroupitem(IG_SPRINT_BUNDLE_A);
   - Id: 23266
     AegisName: Etran_Bundle_A
     Name: Etran Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62364,14 +61546,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ETRAN_BUNDLE_A
     Script: |
       getgroupitem(IG_ETRAN_BUNDLE_A);
   - Id: 23267
     AegisName: 1LVUP
     Name: Level Up Box (1)
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62381,6 +61562,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_1LVUP
     Script: |
       getgroupitem(IG_1LVUP);
   - Id: 23268
@@ -62388,8 +61570,6 @@ Body:
     Name: Level Up Box (10)
     Type: Usable
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62399,6 +61579,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_10LVUP
     Script: |
       getgroupitem(IG_10LVUP);
   - Id: 23269
@@ -62406,8 +61587,6 @@ Body:
     Name: Level Up Box (20)
     Type: Usable
     EquipLevelMin: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62417,6 +61596,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_20LVUP
     Script: |
       getgroupitem(IG_20LVUP);
   - Id: 23270
@@ -62424,8 +61604,6 @@ Body:
     Name: Level Up Box (30)
     Type: Usable
     EquipLevelMin: 30
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62435,6 +61613,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_30LVUP
     Script: |
       getgroupitem(IG_30LVUP);
   - Id: 23271
@@ -62442,8 +61621,6 @@ Body:
     Name: Level Up Box (40)
     Type: Usable
     EquipLevelMin: 40
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62453,6 +61630,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_40LVUP
     Script: |
       getgroupitem(IG_40LVUP);
   - Id: 23272
@@ -62460,8 +61638,6 @@ Body:
     Name: Level Up Box (50)
     Type: Usable
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62471,6 +61647,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_50LVUP
     Script: |
       getgroupitem(IG_50LVUP);
   - Id: 23273
@@ -62478,8 +61655,6 @@ Body:
     Name: Level Up Box (60)
     Type: Usable
     EquipLevelMin: 60
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62489,6 +61664,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_60LVUP
     Script: |
       getgroupitem(IG_60LVUP);
   - Id: 23274
@@ -62496,8 +61672,6 @@ Body:
     Name: Level Up Box (70)
     Type: Usable
     EquipLevelMin: 70
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62507,6 +61681,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_70LVUP
     Script: |
       getgroupitem(IG_70LVUP);
   - Id: 23275
@@ -62514,8 +61689,6 @@ Body:
     Name: Level Up Box (90)
     Type: Usable
     EquipLevelMin: 90
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62525,6 +61698,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_90LVUP
     Script: |
       getgroupitem(IG_90LVUP);
   - Id: 23276
@@ -62532,8 +61706,6 @@ Body:
     Name: Level Up Box (175)
     Type: Usable
     EquipLevelMin: 175
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62543,6 +61715,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_175LVUP
     Script: |
       getgroupitem(IG_175LVUP);
   - Id: 23277
@@ -62608,7 +61781,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BISCUIT_STICK_2SET_
     Script: |
       getgroupitem(IG_BISCUIT_STICK_2SET_);
   - Id: 23283
@@ -62616,8 +61789,6 @@ Body:
     Name: Love Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62626,6 +61797,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LOVE_SCROLL
     Script: |
       getgroupitem(IG_LOVE_SCROLL);
   - Id: 23284
@@ -62633,8 +61805,7 @@ Body:
     Name: Premium Taming Gift Set
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_ADVANCED_TAIMING_ITEM
     Script: |
       getgroupitem(IG_ADVANCED_TAIMING_ITEM);
   - Id: 23285
@@ -62642,8 +61813,7 @@ Body:
     Name: Candy Pouch Box(Physical)
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CANDY_BOX_MELEE
     Script: |
       getgroupitem(IG_CANDY_BOX_MELEE);
   - Id: 23286
@@ -62651,8 +61821,7 @@ Body:
     Name: Candy Pouch Box(Ranged)
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CANDY_BOX_RANGE
     Script: |
       getgroupitem(IG_CANDY_BOX_RANGE);
   - Id: 23287
@@ -62660,8 +61829,7 @@ Body:
     Name: Candy Pouch Box(Magic)
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CANDY_BOX_MAGIC
     Script: |
       getgroupitem(IG_CANDY_BOX_MAGIC);
   - Id: 23288
@@ -62697,8 +61865,6 @@ Body:
     AegisName: Pororoca_Shoes_Bundle_A
     Name: Pororoca Shoes Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62707,14 +61873,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POROROCA_SHOES_BUNDLE_A
     Script: |
       getgroupitem(IG_POROROCA_SHOES_BUNDLE_A);
   - Id: 23295
     AegisName: Lian_Bundle_B
     Name: Lian Bundle A
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62723,6 +61888,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LIAN_BUNDLE_B
     Script: |
       getgroupitem(IG_LIAN_BUNDLE_B);
   - Id: 23296
@@ -62743,8 +61909,7 @@ Body:
     AegisName: Lovely_Egg_Box
     Name: Lovely Egg Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_LOVELY_EGG_BOX
     Script: |
       getgroupitem(IG_LOVELY_EGG_BOX);
   - Id: 23299
@@ -62752,18 +61917,16 @@ Body:
     Name: Costume Enchant Stone Box 12
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX12
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box12);
+      getgroupitem(IG_ENCHANT_STONE_BOX12);
   - Id: 23302
     AegisName: PoringsPreciousBox
     Name: Poring Treasure Box
     Type: Usable
     Weight: 200
     EquipLevelMin: 30
-    Flags:
-      Container: true
+    ItemGroup: IG_PORINGSPRECIOUSBOX
     Script: |
       getgroupitem(IG_PORINGSPRECIOUSBOX);
   - Id: 23303
@@ -62771,8 +61934,7 @@ Body:
     Name: Infinite Cat Hand Ticket Box (1 Day)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_CATPAW_1DAY_PARA
     Script: |
       getgroupitem(IG_C_CATPAW_1DAY_PARA);
   - Id: 23304
@@ -62780,8 +61942,7 @@ Body:
     Name: Infinite Fly Wing Box (1 Day)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_WING_OF_FLY_1DAY_PARA
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_1DAY_PARA);
   - Id: 23305
@@ -62789,8 +61950,6 @@ Body:
     Name: Cat Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62799,6 +61958,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CAT_SCROLL
     Script: |
       getgroupitem(IG_CAT_SCROLL);
   - Id: 23307
@@ -62829,8 +61989,7 @@ Body:
     Name: Magical Booster Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAGICAL_BOOSTER_BOX
     Script: |
       getgroupitem(IG_MAGICAL_BOOSTER_BOX);
   - Id: 23310
@@ -62840,7 +61999,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CAT_HEAD_DRESS_BASKET
     Script: |
       getgroupitem(IG_CAT_HEAD_DRESS_BASKET);
   - Id: 23311
@@ -62855,8 +62014,7 @@ Body:
     Name: Chemical Bag
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CHEMICALS_BAG
     Script: |
       getgroupitem(IG_CHEMICALS_BAG);
   - Id: 23317
@@ -62878,8 +62036,6 @@ Body:
     Name: Shadow Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62888,6 +62044,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_SCROLL2
     Script: |
       getgroupitem(IG_SHADOW_SCROLL2);
   - Id: 23320
@@ -62921,8 +62078,7 @@ Body:
     Name: Unlimited Wing Of Fly 3D Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_WING_OF_FLY_3DAY_BOX_
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_3DAY_BOX_);
   - Id: 23324
@@ -62937,8 +62093,6 @@ Body:
     Name: Beginner Level Up Package
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -62948,6 +62102,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MOBILE_NOVICE_BOX
     Script: |
       getgroupitem(IG_MOBILE_NOVICE_BOX);
   - Id: 23328
@@ -62971,7 +62126,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_C_WING_OF_FLY_5DAY_BOX_
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_5DAY_BOX_);
   - Id: 23330
@@ -62981,7 +62136,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_C_GIANT_FLY_1DAY_BOX_
     Script: |
       getgroupitem(IG_C_GIANT_FLY_1DAY_BOX_);
   - Id: 23331
@@ -62989,8 +62144,7 @@ Body:
     Name: Infinite Fly Wing Box (1 Week)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_WING_OF_FLY_BOX_
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_BOX_);
   - Id: 23332
@@ -62998,8 +62152,6 @@ Body:
     Name: May's Golden Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63008,6 +62160,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAY_GOLD_SCROLL
     Script: |
       getgroupitem(IG_MAY_GOLD_SCROLL);
   - Id: 23333
@@ -63015,8 +62168,6 @@ Body:
     Name: New Hat Box III
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63025,6 +62176,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_NEW_HAT_BOX3
     Script: |
       getgroupitem(IG_NEW_HAT_BOX3);
   - Id: 23334
@@ -63032,8 +62184,7 @@ Body:
     Name: Exchange Shadow Thump Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EXSHADOW_DDUKDDAKBOX
     Script: |
       getgroupitem(IG_EXSHADOW_DDUKDDAKBOX);
   - Id: 23335
@@ -63043,7 +62194,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MATERIAL_SHADOW_CUBE
     Script: |
       getgroupitem(IG_MATERIAL_SHADOW_CUBE);
   - Id: 23336
@@ -63053,7 +62204,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MYSTERIOUS_MEDAL_BOX
     Script: |
       getgroupitem(IG_MYSTERIOUS_MEDAL_BOX);
   - Id: 23338
@@ -63070,7 +62221,7 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-       itemskill "AL_TELEPORT",1;
+      itemskill "AL_TELEPORT",1;
   - Id: 23340
     AegisName: Comp_Megaphone
     Name: "[Sale] Megaphone"
@@ -63091,8 +62242,7 @@ Body:
     Name: "[1 Day] Consignment Merchant Envelope Lv1"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT1_1LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT1_1LV);
   - Id: 23343
@@ -63100,8 +62250,7 @@ Body:
     Name: "[1 Day] Consignment Merchant Envelope Lv2"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT1_2LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT1_2LV);
   - Id: 23344
@@ -63109,8 +62258,7 @@ Body:
     Name: "[1 Day] Consignment Merchant Envelope Lv3"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT1_3LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT1_3LV);
   - Id: 23345
@@ -63118,8 +62266,7 @@ Body:
     Name: "[1 Day] Personal Shopper Envelope Lv1"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT1_1LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT1_1LV);
   - Id: 23346
@@ -63127,8 +62274,7 @@ Body:
     Name: "[1 Day] Personal Shopper Envelope Lv2"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT1_2LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT1_2LV);
   - Id: 23347
@@ -63136,8 +62282,7 @@ Body:
     Name: "[1 Day] Personal Shopper Envelope Lv3"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT1_3LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT1_3LV);
   - Id: 23348
@@ -63235,8 +62380,7 @@ Body:
     Name: "[3 Day] Consignment Merchant Envelope Lv1"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT3_1LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT3_1LV);
   - Id: 23355
@@ -63244,8 +62388,7 @@ Body:
     Name: Consignment Merchant Envelope
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT3_2LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT3_2LV);
   - Id: 23356
@@ -63253,8 +62396,7 @@ Body:
     Name: "[3 Day] Consignment Merchant Envelope Lv3"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_VEND_ARBEIT3_3LV
     Script: |
       getgroupitem(IG_VEND_ARBEIT3_3LV);
   - Id: 23357
@@ -63262,8 +62404,7 @@ Body:
     Name: "[3 Day] Personal Shopper Envelope Lv1"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT3_1LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT3_1LV);
   - Id: 23358
@@ -63271,8 +62412,7 @@ Body:
     Name: Personal Shopper Envelope
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT3_2LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT3_2LV);
   - Id: 23359
@@ -63280,8 +62420,7 @@ Body:
     Name: "[3 Day] Personal Shopper Envelope Lv3"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BUY_ARBEIT3_3LV
     Script: |
       getgroupitem(IG_BUY_ARBEIT3_3LV);
   - Id: 23360
@@ -63290,10 +62429,10 @@ Body:
     Type: DelayConsume
     Weight: 10
     EquipLevelMin: 100
-    NoUse:
-      Sitting: true
     Flags:
       BuyingStore: true
+    NoUse:
+      Sitting: true
     Script: |
       itemskill "WM_GLOOMYDAY",5;
   - Id: 23361
@@ -63361,8 +62500,6 @@ Body:
     AegisName: Cryptura_Giftbox
     Name: Critatura Souvenir Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63371,6 +62508,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CRYPTURA_GIFTBOX
     Script: |
       getgroupitem(IG_CRYPTURA_GIFTBOX);
   - Id: 23367
@@ -63424,8 +62562,6 @@ Body:
     Name: Warlord's Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63434,6 +62570,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GENERAL_SCROLL
     Script: |
       getgroupitem(IG_GENERAL_SCROLL);
   - Id: 23388
@@ -63456,8 +62593,6 @@ Body:
     Name: July Green Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63466,6 +62601,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GREEN_SCROLL_K2
     Script: |
       getgroupitem(IG_GREEN_SCROLL_K2);
   - Id: 23436
@@ -63484,7 +62620,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_SHADOW_CUBE
     Script: |
       getgroupitem(IG_NEW_SHADOW_CUBE);
   - Id: 23440
@@ -63492,8 +62628,6 @@ Body:
     Name: Sentimental Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63502,6 +62636,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SENTIMENTAL_SCROLL
     Script: |
       getgroupitem(IG_SENTIMENTAL_SCROLL);
   - Id: 23444
@@ -63509,8 +62644,6 @@ Body:
     Name: July Payment Event Special Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63519,6 +62652,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_JULY_HAIR_BOX
     Script: |
       getgroupitem(IG_JULY_HAIR_BOX);
   - Id: 23445
@@ -63547,8 +62681,6 @@ Body:
     Name: Infinity Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63557,6 +62689,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INFINITY_SCROLL
     Script: |
       getgroupitem(IG_INFINITY_SCROLL);
   - Id: 23474
@@ -63587,6 +62720,8 @@ Body:
     Name: First aid Box (5)
     Type: Usable
     EquipLevelMin: 5
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63606,6 +62741,8 @@ Body:
     Name: First aid Box (10)
     Type: Usable
     EquipLevelMin: 10
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63625,6 +62762,8 @@ Body:
     Name: First aid Box (15)
     Type: Usable
     EquipLevelMin: 15
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63644,6 +62783,8 @@ Body:
     Name: First aid Box (20)
     Type: Usable
     EquipLevelMin: 20
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63663,6 +62804,8 @@ Body:
     Name: First aid Box (25)
     Type: Usable
     EquipLevelMin: 25
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63682,6 +62825,8 @@ Body:
     Name: First aid Box (30)
     Type: Usable
     EquipLevelMin: 30
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63701,6 +62846,8 @@ Body:
     Name: First aid Box (35)
     Type: Usable
     EquipLevelMin: 35
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63719,6 +62866,8 @@ Body:
     Name: First aid Box (40)
     Type: Usable
     EquipLevelMin: 40
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63737,6 +62886,8 @@ Body:
     Name: First aid Box (45)
     Type: Usable
     EquipLevelMin: 45
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63755,6 +62906,8 @@ Body:
     Name: First aid Box (50)
     Type: Usable
     EquipLevelMin: 50
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63773,6 +62926,8 @@ Body:
     Name: First aid Box (55)
     Type: Usable
     EquipLevelMin: 55
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63791,6 +62946,8 @@ Body:
     Name: First aid Box (60)
     Type: Usable
     EquipLevelMin: 60
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63808,6 +62965,8 @@ Body:
     Name: First aid Box (65)
     Type: Usable
     EquipLevelMin: 65
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63825,6 +62984,8 @@ Body:
     Name: First aid Box (70)
     Type: Usable
     EquipLevelMin: 70
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63842,6 +63003,8 @@ Body:
     Name: First aid Box (75)
     Type: Usable
     EquipLevelMin: 75
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63859,6 +63022,8 @@ Body:
     Name: First aid Box (80)
     Type: Usable
     EquipLevelMin: 80
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63876,6 +63041,8 @@ Body:
     Name: First aid Box (85)
     Type: Usable
     EquipLevelMin: 85
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63894,6 +63061,8 @@ Body:
     Name: First aid Box (90)
     Type: Usable
     EquipLevelMin: 90
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63912,6 +63081,8 @@ Body:
     Name: First aid Box (95)
     Type: Usable
     EquipLevelMin: 95
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63928,6 +63099,8 @@ Body:
     AegisName: Red_Potion_B_20
     Name: "[Not For Sale] Crate of 20 Red Potions"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63942,6 +63115,8 @@ Body:
     AegisName: Orange_Potion_B_20
     Name: "[Not For Sale] Crate of 20 Orange Potions"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63956,6 +63131,8 @@ Body:
     AegisName: Yellow_Potion_B_20
     Name: "[Not For Sale] Crate of 20 Yellow Potions"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63970,6 +63147,8 @@ Body:
     AegisName: White_Potion_B_20
     Name: "[Not For Sale] Box of 20 White Potion"
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -63985,10 +63164,9 @@ Body:
     Name: Costume Enchant Stone Box 13
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX13
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box13);
+      getgroupitem(IG_ENCHANT_STONE_BOX13);
   - Id: 23533
     AegisName: Vote_Rose
     Name: Rose of Choice
@@ -64002,8 +63180,6 @@ Body:
     Name: Bloody Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64012,6 +63188,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLOODY_SCROLL
     Script: |
       getgroupitem(IG_BLOODY_SCROLL);
   - Id: 23538
@@ -64021,7 +63198,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BLOODYKNIGHT_SHIELD_BOX
     Script: |
       getgroupitem(IG_BLOODYKNIGHT_SHIELD_BOX);
   - Id: 23545
@@ -64090,8 +63267,7 @@ Body:
     Name: Snow Flower Festival Giftbox
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SNOW_FESTA_BOX
     Script: |
       getgroupitem(IG_SNOW_FESTA_BOX);
   - Id: 23554
@@ -64099,8 +63275,7 @@ Body:
     Name: Snow Festa Card Pack
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_SNOW_FESTA_CARDPACK
     Script: |
       getgroupitem(IG_SNOW_FESTA_CARDPACK);
   - Id: 23556
@@ -64114,6 +63289,8 @@ Body:
     Name: Adventurer Box (1)
     Type: Usable
     Weight: 0
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64132,8 +63309,10 @@ Body:
     AegisName: Adventurer_Box_15
     Name: Adventurer Box (15)
     Type: Usable
-    EquipLevelMin: 15
     Weight: 0
+    EquipLevelMin: 15
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64150,8 +63329,10 @@ Body:
     AegisName: Adventurer_Box_30
     Name: Adventurer Box (30)
     Type: Usable
-    EquipLevelMin: 30
     Weight: 0
+    EquipLevelMin: 30
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64168,8 +63349,10 @@ Body:
     AegisName: Adventurer_Box_45
     Name: Adventurer Box (45)
     Type: Usable
-    EquipLevelMin: 45
     Weight: 0
+    EquipLevelMin: 45
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64186,8 +63369,10 @@ Body:
     AegisName: Adventurer_Box_60
     Name: Adventurer Box (60)
     Type: Usable
-    EquipLevelMin: 60
     Weight: 0
+    EquipLevelMin: 60
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64204,8 +63389,10 @@ Body:
     AegisName: Adventurer_Box_75
     Name: Adventurer Box (75)
     Type: Usable
-    EquipLevelMin: 75
     Weight: 0
+    EquipLevelMin: 75
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64222,8 +63409,10 @@ Body:
     AegisName: Adventurer_Box_90
     Name: Adventurer Box (90)
     Type: Usable
-    EquipLevelMin: 90
     Weight: 0
+    EquipLevelMin: 90
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64239,8 +63428,6 @@ Body:
     AegisName: E_Wing_Of_Fly_3Day_Box
     Name: "[Gift] Unlimited Fly Wing 3 Day Box"
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64249,6 +63436,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_WING_OF_FLY_3DAY_BOX
     Script: |
       getgroupitem(IG_E_WING_OF_FLY_3DAY_BOX);
   - Id: 23583
@@ -64256,8 +63444,6 @@ Body:
     Name: Beginner's Armor Box
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64266,6 +63452,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REBEGINER_BOX
     Script: |
       getgroupitem(IG_REBEGINER_BOX);
   - Id: 23584
@@ -64273,8 +63460,6 @@ Body:
     Name: Beginner's Shadow Box
     Type: Usable
     EquipLevelMin: 120
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64283,6 +63468,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REBEGINER_S_BOX
     Script: |
       getgroupitem(IG_REBEGINER_S_BOX);
   - Id: 23585
@@ -64290,6 +63476,8 @@ Body:
     Name: Beginner Support Box (100)
     Type: Usable
     EquipLevelMin: 100
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64309,6 +63497,8 @@ Body:
     Name: Beginner Support Box (110)
     Type: Usable
     EquipLevelMin: 110
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64327,6 +63517,8 @@ Body:
     Name: Beginner Support Box (120)
     Type: Usable
     EquipLevelMin: 120
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64406,8 +63598,6 @@ Body:
     Name: 2017 Special Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64416,6 +63606,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2017_SPECIAL_SCROLL
     Script: |
       getgroupitem(IG_2017_SPECIAL_SCROLL);
   - Id: 23619
@@ -64423,8 +63614,6 @@ Body:
     Name: 2017 Special Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64433,6 +63622,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2017_SPECIAL_BOX
     Script: |
       getgroupitem(IG_2017_SPECIAL_BOX);
   - Id: 23629
@@ -64440,10 +63630,9 @@ Body:
     Name: Costume Enchant Stone Box 14
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX14
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box14);
+      getgroupitem(IG_ENCHANT_STONE_BOX14);
   - Id: 23647
     AegisName: Zero_Merchant_Bell
     Name: Tool Dealer Bell
@@ -64479,8 +63668,6 @@ Body:
     Name: Ice Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64489,6 +63676,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ICE_SCROLL
     Script: |
       getgroupitem(IG_ICE_SCROLL);
   - Id: 23660
@@ -64503,8 +63691,6 @@ Body:
     Name: 2018 New Year Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64513,6 +63699,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2018_NEW_YEAR_SCROLL
     Script: |
       getgroupitem(IG_2018_NEW_YEAR_SCROLL);
   - Id: 23662
@@ -64520,8 +63707,7 @@ Body:
     Name: New Year Shadow Cube 2018
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_2018_YEAR_SHADOW_CUBE
     Script: |
       getgroupitem(IG_2018_YEAR_SHADOW_CUBE);
   - Id: 23663
@@ -64529,8 +63715,7 @@ Body:
     Name: 2018 Material Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_2018_MATERIAL_CUBE
     Script: |
       getgroupitem(IG_2018_MATERIAL_CUBE);
   - Id: 23664
@@ -64538,8 +63723,7 @@ Body:
     Name: "[Limited] Lapine's Thump Box 2018"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_2018_LAPINE_DDUKDDAKBOX
     Script: |
       getgroupitem(IG_2018_LAPINE_DDUKDDAKBOX);
   - Id: 23665
@@ -64582,8 +63766,7 @@ Body:
     Name: Sweets Festival Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_SWEETS_EVT_BOX
     Script: |
       getgroupitem(IG_SWEETS_EVT_BOX);
   - Id: 23675
@@ -64632,17 +63815,14 @@ Body:
     Name: Costume Enchant Stone Box 15
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX15
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box15);
+      getgroupitem(IG_ENCHANT_STONE_BOX15);
   - Id: 23683
     AegisName: EVT_JAN02KR
     Name: Lucky Bag
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64651,14 +63831,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_JAN02KR
     Script: |
       getgroupitem(IG_EVT_JAN02KR);
   - Id: 23684
     AegisName: 2018_Visionary_Card
     Name: Phantom's Spirit
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_2018_VISIONARY_CARD
     Script: |
       getgroupitem(IG_2018_VISIONARY_CARD);
   - Id: 23700
@@ -64666,8 +63846,6 @@ Body:
     Name: New Year Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64676,6 +63854,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LUNAR_NEW_YEAR_SCROLL
     Script: |
       getgroupitem(IG_LUNAR_NEW_YEAR_SCROLL);
   - Id: 23706
@@ -64697,8 +63876,7 @@ Body:
     Name: February Special Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_FEBRUARY_HAIR_BOX
     Script: |
       getgroupitem(IG_FEBRUARY_HAIR_BOX);
   - Id: 23710
@@ -64706,8 +63884,6 @@ Body:
     Name: Spring's Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64716,6 +63892,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2018_SPRING_SCROLL
     Script: |
       getgroupitem(IG_2018_SPRING_SCROLL);
   - Id: 23711
@@ -64725,6 +63902,8 @@ Body:
     Buy: 20
     Sell: 0
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem "Booby_Trap",500;
   - Id: 23718
@@ -64732,8 +63911,6 @@ Body:
     Name: Spring Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64742,6 +63919,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2018_SAKURA_SCROLL
     Script: |
       getgroupitem(IG_2018_SAKURA_SCROLL);
   - Id: 23719
@@ -64749,8 +63927,6 @@ Body:
     Name: Sealed Card Album II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64759,6 +63935,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_CARD2
     Script: |
       getgroupitem(IG_SEALED_CARD2);
   - Id: 23720
@@ -64782,8 +63959,7 @@ Body:
     Name: Memorial Egg
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_CELEBRATE_EGG
     Script: |
       getgroupitem(IG_CELEBRATE_EGG);
   - Id: 23725
@@ -64877,8 +64053,7 @@ Body:
     Name: Festa Commemorative Can
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_NOODLE_FESTA_CAN
     Script: |
       getgroupitem(IG_NOODLE_FESTA_CAN);
   - Id: 23744
@@ -64892,8 +64067,6 @@ Body:
     AegisName: Comp_AID_Buff_Box
     Name: "[Not For Sale] Premium Buff Box"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64902,14 +64075,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMP_AID_BUFF_BOX
     Script: |
       getgroupitem(IG_COMP_AID_BUFF_BOX);
   - Id: 23752
     AegisName: Comp_Box
     Name: Gift of Apology
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64918,14 +64090,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMP_BOX
     Script: |
       getgroupitem(IG_COMP_BOX);
   - Id: 23754
     AegisName: Comp_All_Ring_Box
     Name: Apology Ring Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64934,6 +64105,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMP_ALL_RING_BOX
     Script: |
       getgroupitem(IG_COMP_ALL_RING_BOX);
   - Id: 23761
@@ -64941,8 +64113,7 @@ Body:
     Name: Premium Taming Gift Set II
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_ADVANCED_TAIMING_ITEM2
     Script: |
       getgroupitem(IG_ADVANCED_TAIMING_ITEM2);
   - Id: 23763
@@ -64950,8 +64121,6 @@ Body:
     Name: Mysterious Egg III
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64960,14 +64129,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_EGG3
     Script: |
       getgroupitem(IG_MYSTERIOUS_EGG3);
   - Id: 23764
     AegisName: Comp_Box2
     Name: A gift with an Apple Heart
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64976,6 +64144,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMP_BOX2
     Script: |
       getgroupitem(IG_COMP_BOX2);
   - Id: 23765
@@ -64983,8 +64152,6 @@ Body:
     Name: May's Rainbow Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -64993,6 +64160,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAY_RAINBOW_SCROLL
     Script: |
       getgroupitem(IG_MAY_RAINBOW_SCROLL);
   - Id: 23766
@@ -65002,7 +64170,7 @@ Body:
     Weight: 2000
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_OVERWHELM_ARMOR_BOX
     Script: |
       getgroupitem(IG_OVERWHELM_ARMOR_BOX);
   - Id: 23767
@@ -65010,8 +64178,7 @@ Body:
     Name: Strong Helmet Box
     Type: Usable
     Weight: 800
-    Flags:
-      Container: true
+    ItemGroup: IG_POWERFUL_HELM_BOX
     Script: |
       getgroupitem(IG_POWERFUL_HELM_BOX);
   - Id: 23770
@@ -65019,16 +64186,13 @@ Body:
     Name: Costume Enchant Stone Box 16
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX16
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box16);
+      getgroupitem(IG_ENCHANT_STONE_BOX16);
   - Id: 23771
     AegisName: Mysterious_Plastic
     Name: Mysterious Plastic Bag
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65037,6 +64201,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MYSTERIOUS_PLASTIC
     Script: |
       getgroupitem(IG_MYSTERIOUS_PLASTIC);
   - Id: 23772
@@ -65053,8 +64218,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-    Flags:
-      Container: true
+    ItemGroup: IG_EP17_1_SPC01
     Script: |
       getgroupitem(IG_EP17_1_SPC01);
   - Id: 23773
@@ -65071,8 +64235,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-    Flags:
-      Container: true
+    ItemGroup: IG_EP17_1_SPC02
     Script: |
       getgroupitem(IG_EP17_1_SPC02);
   - Id: 23774
@@ -65089,8 +64252,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-    Flags:
-      Container: true
+    ItemGroup: IG_EP17_1_SPC03
     Script: |
       getgroupitem(IG_EP17_1_SPC03);
   - Id: 23775
@@ -65107,8 +64269,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-    Flags:
-      Container: true
+    ItemGroup: IG_EP17_1_SPC04
     Script: |
       getgroupitem(IG_EP17_1_SPC04);
   - Id: 23776
@@ -65158,8 +64319,6 @@ Body:
     Name: Sweet Candy Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65168,6 +64327,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SWEET_CANDY_BOX
     Script: |
       getgroupitem(IG_SWEET_CANDY_BOX);
   - Id: 23804
@@ -65175,8 +64335,6 @@ Body:
     Name: Soul Plunger Scroll II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65185,6 +64343,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PUMP_OF_SPIRIT_SCROLL2
     Script: |
       getgroupitem(IG_PUMP_OF_SPIRIT_SCROLL2);
   - Id: 23805
@@ -65192,8 +64351,7 @@ Body:
     Name: Soul Hat Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SPIRIT_HAT_BOX
     Script: |
       getgroupitem(IG_SPIRIT_HAT_BOX);
   - Id: 23806
@@ -65203,7 +64361,7 @@ Body:
     Weight: 2000
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HERO_WEAPON_BOX
     Script: |
       getgroupitem(IG_HERO_WEAPON_BOX);
   - Id: 23815
@@ -65220,7 +64378,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BS_MAKING_S
     Script: |
       getgroupitem(IG_BS_MAKING_S);
   - Id: 23818
@@ -65768,8 +64926,6 @@ Body:
     Name: Star and Soul Scroll
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65778,6 +64934,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STARSOUL_SCROLL
     Script: |
       getgroupitem(IG_STARSOUL_SCROLL);
   - Id: 23879
@@ -65928,8 +65085,6 @@ Body:
     AegisName: Comp_ConnectError
     Name: Recertification Thank You Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65938,14 +65093,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COMP_CONNECTERROR
     Script: |
       getgroupitem(IG_COMP_CONNECTERROR);
   - Id: 23897
     AegisName: 2018_Jump_Thx_Box
     Name: 2018 Jumping Reservation Appreciation Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -65955,6 +65109,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2018_JUMP_THX_BOX
     Script: |
       getgroupitem(IG_2018_JUMP_THX_BOX);
   - Id: 23898
@@ -65999,8 +65154,6 @@ Body:
     AegisName: Time_Overload_Box
     Name: Temporal Transcendence Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66009,6 +65162,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TIME_OVERLOAD_BOX
     Script: |
       getgroupitem(IG_TIME_OVERLOAD_BOX);
   - Id: 23901
@@ -66016,8 +65170,6 @@ Body:
     Name: Level Up Box (110)
     Type: Usable
     EquipLevelMin: 110
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66027,14 +65179,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_110LVUP
     Script: |
       getgroupitem(IG_110LVUP);
   - Id: 23905
     AegisName: Season_Evt_Reward_3
     Name: March Event Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66044,14 +65195,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD_3
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_3);
   - Id: 23906
     AegisName: Season_Evt_Reward_4
     Name: April Event Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66061,14 +65211,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD_4
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_4);
   - Id: 23907
     AegisName: Season_Evt_Reward_5
     Name: Melon Festival Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66078,6 +65227,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD_5
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_5);
   - Id: 23913
@@ -66085,8 +65235,7 @@ Body:
     Name: Class Enchant Stone Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_JOB_ENCHANT_STONE_BOX
     Script: |
       getgroupitem(IG_JOB_ENCHANT_STONE_BOX);
   - Id: 23914
@@ -66094,8 +65243,6 @@ Body:
     Name: Kachua's Secret Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66104,6 +65251,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAIN_LUCKY_BOX
     Script: |
       getgroupitem(IG_MAIN_LUCKY_BOX,true);
   - Id: 23919
@@ -66124,8 +65272,6 @@ Body:
     AegisName: Season_Evt_Reward
     Name: Event Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66135,6 +65281,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD);
   - Id: 23922
@@ -66144,7 +65291,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CANDY_BOX
     Script: |
       getgroupitem(IG_CANDY_BOX);
   - Id: 23923
@@ -66154,7 +65301,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_PORING_SUNGLASSES_BOX
     Script: |
       getgroupitem(IG_PORING_SUNGLASSES_BOX);
   - Id: 23924
@@ -66162,8 +65309,7 @@ Body:
     Name: Sigrun Shadow Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SIGRUN_SHADOW_BOX
     Script: |
       getgroupitem(IG_SIGRUN_SHADOW_BOX);
   - Id: 23925
@@ -66173,7 +65319,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MAD_BUNNY_BOX
     Script: |
       getgroupitem(IG_MAD_BUNNY_BOX);
   - Id: 23926
@@ -66190,8 +65336,7 @@ Body:
     Name: Level Achievement Box
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_LEVEL_ACHIEVEMENT_BOX
     Script: |
       getgroupitem(IG_LEVEL_ACHIEVEMENT_BOX);
   - Id: 23952
@@ -66201,7 +65346,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SILLIT_PONG_BOX
     Script: |
       getgroupitem(IG_SILLIT_PONG_BOX);
   - Id: 23962
@@ -66238,8 +65383,6 @@ Body:
     Name: Dragon Treasure
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66248,6 +65391,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ABYSS_ITEMBOX
     Script: |
       getgroupitem(IG_ABYSS_ITEMBOX);
   - Id: 23986
@@ -66255,8 +65399,6 @@ Body:
     Name: Odin Relic
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66265,6 +65407,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ODIN_ITEMBOX
     Script: |
       getgroupitem(IG_ODIN_ITEMBOX);
   - Id: 23992
@@ -66272,8 +65415,7 @@ Body:
     Name: Experimental Weapon Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BIO_W_BOX
     Script: |
       getgroupitem(IG_BIO_W_BOX);
   - Id: 23993
@@ -66281,8 +65423,7 @@ Body:
     Name: Bio Lab Material Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BIO_DOCU_BOX
     Script: |
       getgroupitem(IG_BIO_DOCU_BOX);
   - Id: 23994
@@ -66290,8 +65431,7 @@ Body:
     Name: Bio Reactor Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_BIO_REACTANT_BOX
     Script: |
       getgroupitem(IG_BIO_REACTANT_BOX);
   - Id: 100000
@@ -66307,8 +65447,7 @@ Body:
     AegisName: PayPromotion_Box
     Name: Payment Promotion Reward Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_PAYPROMOTION_BOX
     Script: |
       getgroupitem(IG_PAYPROMOTION_BOX);
   - Id: 100003
@@ -66401,17 +65540,15 @@ Body:
     Name: Costume Enchant Stone Box 18
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX18
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box18);
+      getgroupitem(IG_ENCHANT_STONE_BOX18);
   - Id: 100020
     AegisName: E_Bcrystal_Box
     Name: Don Cristal Chino Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_E_BCRYSTAL_BOX
     Script: |
       getgroupitem(IG_E_BCRYSTAL_BOX);
   - Id: 100021
@@ -66419,8 +65556,7 @@ Body:
     Name: Family Crystal Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_E_MCRYSTAL_BOX
     Script: |
       getgroupitem(IG_E_MCRYSTAL_BOX);
   - Id: 100022
@@ -66428,8 +65564,7 @@ Body:
     Name: Minions Crystal Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_E_SCRYSTAL_BOX
     Script: |
       getgroupitem(IG_E_SCRYSTAL_BOX);
   - Id: 100023
@@ -66466,8 +65601,6 @@ Body:
     AegisName: Booster_Pack_1
     Name: Booster Pack(1)
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66477,6 +65610,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_1
     Script: |
       getgroupitem(IG_BOOSTER_PACK_1,true);
   - Id: 100030
@@ -66484,8 +65618,6 @@ Body:
     Name: Booster Pack (15)
     Type: Usable
     EquipLevelMin: 15
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66495,6 +65627,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_15
     Script: |
       getgroupitem(IG_BOOSTER_PACK_15);
   - Id: 100031
@@ -66502,8 +65635,6 @@ Body:
     Name: Booster Pack(30)
     Type: Usable
     EquipLevelMin: 30
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66513,6 +65644,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_30
     Script: |
       getgroupitem(IG_BOOSTER_PACK_30);
   - Id: 100032
@@ -66520,8 +65652,6 @@ Body:
     Name: Booster Pack(45)
     Type: Usable
     EquipLevelMin: 45
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66531,6 +65661,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_45
     Script: |
       getgroupitem(IG_BOOSTER_PACK_45);
   - Id: 100033
@@ -66538,8 +65669,6 @@ Body:
     Name: Booster Pack(60)
     Type: Usable
     EquipLevelMin: 60
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66549,6 +65678,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_60
     Script: |
       getgroupitem(IG_BOOSTER_PACK_60);
   - Id: 100034
@@ -66556,8 +65686,6 @@ Body:
     Name: Booster Pack(75)
     Type: Usable
     EquipLevelMin: 75
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66567,6 +65695,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_75
     Script: |
       getgroupitem(IG_BOOSTER_PACK_75);
   - Id: 100035
@@ -66574,8 +65703,6 @@ Body:
     Name: Booster Pack(90)
     Type: Usable
     EquipLevelMin: 90
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66585,6 +65712,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_90
     Script: |
       getgroupitem(IG_BOOSTER_PACK_90);
   - Id: 100036
@@ -66592,8 +65720,6 @@ Body:
     Name: Booster Pack(100)
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66603,6 +65729,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_100
     Script: |
       getgroupitem(IG_BOOSTER_PACK_100,true);
   - Id: 100037
@@ -66610,8 +65737,6 @@ Body:
     Name: Booster Pack(115)
     Type: Usable
     EquipLevelMin: 115
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66621,6 +65746,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_115
     Script: |
       getgroupitem(IG_BOOSTER_PACK_115);
   - Id: 100038
@@ -66628,8 +65754,6 @@ Body:
     Name: Booster Pack(130)
     Type: Usable
     EquipLevelMin: 130
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66639,6 +65763,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_130
     Script: |
       getgroupitem(IG_BOOSTER_PACK_130);
   - Id: 100039
@@ -66646,8 +65771,6 @@ Body:
     Name: Booster Pack(145)
     Type: Usable
     EquipLevelMin: 145
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66657,6 +65780,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_145
     Script: |
       getgroupitem(IG_BOOSTER_PACK_145);
   - Id: 100040
@@ -66664,8 +65788,6 @@ Body:
     Name: Booster Pack(160)
     Type: Usable
     EquipLevelMin: 160
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66675,6 +65797,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_160
     Script: |
       getgroupitem(IG_BOOSTER_PACK_160);
   - Id: 100041
@@ -66682,8 +65805,6 @@ Body:
     Name: Booster Pack(175)
     Type: Usable
     EquipLevelMin: 175
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66693,6 +65814,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_175
     Script: |
       getgroupitem(IG_BOOSTER_PACK_175);
   - Id: 100043
@@ -66727,8 +65849,6 @@ Body:
     AegisName: Stater_A_Box
     Name: Starter Armor Crate
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66737,6 +65857,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STATER_A_BOX
     Script: |
       getgroupitem(IG_STATER_A_BOX,true);
   - Id: 100046
@@ -66744,8 +65865,6 @@ Body:
     Name: Attacker Booster Armor Crate
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66754,6 +65873,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOST_ATK_BOX
     Script: |
       getgroupitem(IG_BOOST_ATK_BOX);
   - Id: 100047
@@ -66761,8 +65881,6 @@ Body:
     Name: Ranged Booster Crate
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66771,6 +65889,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOST_RAN_BOX
     Script: |
       getgroupitem(IG_BOOST_RAN_BOX);
   - Id: 100048
@@ -66778,8 +65897,6 @@ Body:
     Name: Elemental Booster Crate
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66788,6 +65905,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOST_ELE_BOX
     Script: |
       getgroupitem(IG_BOOST_ELE_BOX);
   - Id: 100049
@@ -66795,8 +65913,6 @@ Body:
     Name: Defiant Booster Crate
     Type: Usable
     EquipLevelMin: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66805,14 +65921,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOST_DEFN_BOX
     Script: |
       getgroupitem(IG_BOOST_DEFN_BOX);
   - Id: 100050
     AegisName: Goal_Gift_Box
     Name: Goal Achievement Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66821,6 +65936,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOAL_GIFT_BOX
     Script: |
       getgroupitem(IG_GOAL_GIFT_BOX);
   - Id: 100051
@@ -66828,8 +65944,6 @@ Body:
     Name: Booster Promotion Thank you Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66839,6 +65953,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_PREORDER
     Script: |
       getgroupitem(IG_BOOSTER_PACK_PREORDER);
   - Id: 100052
@@ -66846,10 +65961,9 @@ Body:
     Name: Costume Enchant Stone Box 19
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX19
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box19);
+      getgroupitem(IG_ENCHANT_STONE_BOX19);
   - Id: 100053
     AegisName: Piercing_Mix
     Name: Piercing Shadow SynthesisBox
@@ -66861,8 +65975,6 @@ Body:
     AegisName: Time_Over_S_Box
     Name: Shadow Transcendental Time Crate
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -66871,6 +65983,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TIME_OVER_S_BOX
     Script: |
       getgroupitem(IG_TIME_OVER_S_BOX,true);
   - Id: 100058
@@ -67101,8 +66214,6 @@ Body:
     AegisName: Boarding_Halter_Box30_Z
     Name: "[Not For Sale] Boarding Halter (30 Days)"
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67111,6 +66222,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOARDING_HALTER_BOX30_Z
     Script: |
       getgroupitem(IG_BOARDING_HALTER_BOX30_Z);
   - Id: 100098
@@ -67127,7 +66239,7 @@ Body:
     Weight: 100
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_TEMPORAL_MANTEAU_BOX
     Script: |
       getgroupitem(IG_TEMPORAL_MANTEAU_BOX);
   - Id: 100109
@@ -67137,7 +66249,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LAPINE_DDUKDDAKBOX2
     Script: |
       getgroupitem(IG_LAPINE_DDUKDDAKBOX2);
   - Id: 100125
@@ -67158,8 +66270,6 @@ Body:
     AegisName: Kr_B_Special02
     Name: 17th Anniversary Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67168,6 +66278,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL02
     Script: |
       getgroupitem(IG_KR_B_SPECIAL02);
   - Id: 100128
@@ -67449,8 +66560,6 @@ Body:
     Name: Gold PC Room Sield Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67459,6 +66568,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDPCBANG_SHIELDBOX
     Script: |
       getgroupitem(IG_GOLDPCBANG_SHIELDBOX);
   - Id: 100153
@@ -67466,8 +66576,7 @@ Body:
     Name: Taming Gift Set II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SET_OF_TAIMING_ITEM2
     Script: |
       getgroupitem(IG_SET_OF_TAIMING_ITEM2);
   - Id: 100158
@@ -67491,8 +66600,6 @@ Body:
     AegisName: Auto_M_Box
     Name: Automatic Module Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67502,14 +66609,13 @@ Body:
       NoMail: true
       NoAuction: true
       NoGuildStorage: true
+    ItemGroup: IG_AUTOMATIC_MODULE_MIX
     Script: |
       getgroupitem(IG_AUTOMATIC_MODULE_MIX);
   - Id: 100161
     AegisName: Epic_M_Box
     Name: Epic Module Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67519,14 +66625,13 @@ Body:
       NoMail: true
       NoAuction: true
       NoGuildStorage: true
+    ItemGroup: IG_EPIC_MODULE_MIX
     Script: |
       getgroupitem(IG_EPIC_MODULE_MIX);
   - Id: 100162
     AegisName: Auto_M_I_Box_A
     Name: Automatic Improvement Device Physical
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67536,14 +66641,13 @@ Body:
       NoMail: true
       NoAuction: true
       NoGuildStorage: true
+    ItemGroup: IG_AUTO_M_I_BOX_A
     Script: |
       getgroupitem(IG_AUTO_M_I_BOX_A);
   - Id: 100163
     AegisName: Auto_M_I_Box_B
     Name: Automatic Improvement Device Magical
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67553,6 +66657,7 @@ Body:
       NoMail: true
       NoAuction: true
       NoGuildStorage: true
+    ItemGroup: IG_AUTO_M_I_BOX_B
     Script: |
       getgroupitem(IG_AUTO_M_I_BOX_B);
   - Id: 100164
@@ -67596,8 +66701,6 @@ Body:
     Name: PC Room Mileage Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -67606,6 +66709,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GOLDPCBANG_MILEAGEBOX
     Script: |
       getgroupitem(IG_GOLDPCBANG_MILEAGEBOX);
   - Id: 100171
@@ -67613,8 +66717,7 @@ Body:
     Name: Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BALL_BOX
     Script: |
       getgroupitem(IG_CANNON_BALL_BOX);
   - Id: 100172
@@ -67622,8 +66725,7 @@ Body:
     Name: Iron Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_IRON_CANNON_BALL_BOX
     Script: |
       getgroupitem(IG_IRON_CANNON_BALL_BOX);
   - Id: 100173
@@ -67631,8 +66733,7 @@ Body:
     Name: Soul Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SOUL_CANNON_BALL_BOX
     Script: |
       getgroupitem(IG_SOUL_CANNON_BALL_BOX);
   - Id: 100174
@@ -67642,6 +66743,8 @@ Body:
     Buy: 20
     Sell: 0
     Weight: 250
+    Flags:
+      Container: true
     Script: |
       getitem "Poison_Arrow",500;
   - Id: 100176
@@ -67649,8 +66752,7 @@ Body:
     Name: Dark Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_DARK_CANNON_BALL_BOX
     Script: |
       getgroupitem(IG_DARK_CANNON_BALL_BOX);
   - Id: 100177
@@ -67658,8 +66760,7 @@ Body:
     Name: Holy Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_HOLY_CANNON_BALL_BOX
     Script: |
       getgroupitem(IG_HOLY_CANNON_BALL_BOX);
   - Id: 100178
@@ -67667,8 +66768,7 @@ Body:
     Name: Liquid Condensed Bullet Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_6
     Script: |
       getgroupitem(IG_CANNON_BOX_6);
   - Id: 100179
@@ -67676,8 +66776,7 @@ Body:
     Name: Large Madogear Fuel Tank
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_MAGIC_GEAR_FUEL_BOX
     Script: |
       getgroupitem(IG_MAGIC_GEAR_FUEL_BOX);
   - Id: 100180
@@ -67685,8 +66784,7 @@ Body:
     Name: Repair A Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_REPAIRA_BOX
     Script: |
       getgroupitem(IG_REPAIRA_BOX);
   - Id: 100181
@@ -67694,8 +66792,7 @@ Body:
     Name: Repair B Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_REPAIRB_BOX
     Script: |
       getgroupitem(IG_REPAIRB_BOX);
   - Id: 100182
@@ -67703,8 +66800,7 @@ Body:
     Name: Repair C Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_REPAIRC_BOX
     Script: |
       getgroupitem(IG_REPAIRC_BOX);
   - Id: 100183
@@ -67712,8 +66808,7 @@ Body:
     Name: Flame Stone Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_FLAME_STONE_BUNDLE
     Script: |
       getgroupitem(IG_FLAME_STONE_BUNDLE);
   - Id: 100184
@@ -67721,8 +66816,7 @@ Body:
     Name: Ice Stone Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_ICE_STONE_BUNDLE
     Script: |
       getgroupitem(IG_ICE_STONE_BUNDLE);
   - Id: 100185
@@ -67730,8 +66824,7 @@ Body:
     Name: Wind Stone Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_WIND_STONE_BUNDLE
     Script: |
       getgroupitem(IG_WIND_STONE_BUNDLE);
   - Id: 100186
@@ -67739,8 +66832,7 @@ Body:
     Name: Shadow Orb Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SHADOW_ORB_BUNDLE
     Script: |
       getgroupitem(IG_SHADOW_ORB_BUNDLE);
   - Id: 100187
@@ -67748,8 +66840,7 @@ Body:
     Name: Fire Charm Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CHARM_FIRE_BUNDLE
     Script: |
       getgroupitem(IG_CHARM_FIRE_BUNDLE);
   - Id: 100188
@@ -67757,8 +66848,7 @@ Body:
     Name: Ice Charm Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CHARM_ICE_BUNDLE
     Script: |
       getgroupitem(IG_CHARM_ICE_BUNDLE);
   - Id: 100189
@@ -67766,8 +66856,7 @@ Body:
     Name: Wind Charm Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CHARM_WIND_BUNDLE
     Script: |
       getgroupitem(IG_CHARM_WIND_BUNDLE);
   - Id: 100190
@@ -67775,8 +66864,7 @@ Body:
     Name: Earth Charm Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CHARM_EARTH_BUNDLE
     Script: |
       getgroupitem(IG_CHARM_EARTH_BUNDLE);
   - Id: 100191
@@ -67784,8 +66872,7 @@ Body:
     Name: Explosive Kunai Scroll
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_EXPLOSIVE
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_EXPLOSIVE);
   - Id: 100192
@@ -67793,8 +66880,7 @@ Body:
     Name: Blue Gemstone Pouch
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMSTONE_BLUE
     Script: |
       getgroupitem(IG_GEMSTONE_BLUE);
   - Id: 100193
@@ -67802,8 +66888,7 @@ Body:
     Name: Yellow Gemstone Pouch
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMSTONE_YL
     Script: |
       getgroupitem(IG_GEMSTONE_YL);
   - Id: 100194
@@ -67811,8 +66896,7 @@ Body:
     Name: Red Gemstone Pouch
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_GEMSTONE_RED
     Script: |
       getgroupitem(IG_GEMSTONE_RED);
   - Id: 100195
@@ -67820,8 +66904,7 @@ Body:
     Name: Full Metal Jacket Case
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_BULLET_CASE_FULL
     Script: |
       getgroupitem(IG_BULLET_CASE_FULL);
   - Id: 100196
@@ -67829,8 +66912,7 @@ Body:
     Name: Projectile Mine Case
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_BULLET_CASE_MINE
     Script: |
       getgroupitem(IG_BULLET_CASE_MINE);
   - Id: 100197
@@ -67838,8 +66920,7 @@ Body:
     Name: Dragon Tail Missile Case
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_BULLET_CASE_TAIL
     Script: |
       getgroupitem(IG_BULLET_CASE_TAIL);
   - Id: 100198
@@ -67849,7 +66930,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SKILL_SHADOW_CUBE
     Script: |
       getgroupitem(IG_SKILL_SHADOW_CUBE);
   - Id: 100202
@@ -67857,10 +66938,9 @@ Body:
     Name: Costume Enchant Stone Box 20
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX20
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box20);
+      getgroupitem(IG_ENCHANT_STONE_BOX20);
   - Id: 100205
     AegisName: Class_Sha_R_M_Melee
     Name: Class Shadow Spellbook (Melee)
@@ -67939,7 +67019,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOWDECON_ORE_BOX
     Script: |
       getgroupitem(IG_SHADOWDECON_ORE_BOX);
   - Id: 100215
@@ -67949,7 +67029,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ZELUNIUM_ORE_BOX
     Script: |
       getgroupitem(IG_ZELUNIUM_ORE_BOX);
   - Id: 100231
@@ -68009,8 +67089,6 @@ Body:
     Name: G STAR Event Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -68020,6 +67098,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GSTAR2019BOX
     Script: |
       getgroupitem(IG_GSTAR2019BOX);
   - Id: 100268
@@ -68105,10 +67184,9 @@ Body:
     Name: Costume Enchant Stone Box 21
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX21
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box21);
+      getgroupitem(IG_ENCHANT_STONE_BOX21);
   - Id: 100316
     AegisName: G_Tyrs_Blessing
     Name: True Tyr's Blessing
@@ -68141,8 +67219,7 @@ Body:
     AegisName: Exotic_Bob_Box
     Name: Himelmez's Wig Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_EXOTIC_BOB_BOX
     Script: |
       getgroupitem(IG_EXOTIC_BOB_BOX);
   - Id: 100321
@@ -68168,8 +67245,7 @@ Body:
     Name: Rune Knight Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_RUNEKNIGHT_S_CUBE
     Script: |
       getgroupitem(IG_RUNEKNIGHT_S_CUBE);
   - Id: 100324
@@ -68177,8 +67253,7 @@ Body:
     Name: Guillotine Cross Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GUILLOTINECROSS_S_CUBE
     Script: |
       getgroupitem(IG_GUILLOTINECROSS_S_CUBE);
   - Id: 100325
@@ -68186,8 +67261,7 @@ Body:
     Name: Archbishop Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ARCHBISHOP_S_CUBE
     Script: |
       getgroupitem(IG_ARCHBISHOP_S_CUBE);
   - Id: 100326
@@ -68195,8 +67269,7 @@ Body:
     Name: Sura Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SURA_S_CUBE
     Script: |
       getgroupitem(IG_SURA_S_CUBE);
   - Id: 100327
@@ -68239,8 +67312,6 @@ Body:
     Name: Chrismas Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -68249,6 +67320,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2019_CHRISMAS_PRESENT
     Script: |
       getgroupitem(IG_2019_CHRISMAS_PRESENT);
   - Id: 100333
@@ -68272,8 +67344,6 @@ Body:
     Name: Booster Pack(190)
     Type: Usable
     EquipLevelMin: 190
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -68283,6 +67353,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_190
     Script: |
       getgroupitem(IG_BOOSTER_PACK_190);
   - Id: 100336
@@ -68290,8 +67361,6 @@ Body:
     Name: Booster Pack(200)
     Type: Usable
     EquipLevelMin: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -68301,6 +67370,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_200
     Script: |
       getgroupitem(IG_BOOSTER_PACK_200);
   - Id: 100337
@@ -68457,8 +67527,6 @@ Body:
     AegisName: 2020_Goal_Gift_Box
     Name: 2021 Booster Goal Achievement Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -68467,6 +67535,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2020_GOAL_GIFT_BOX
     Script: |
       getgroupitem(IG_2020_GOAL_GIFT_BOX);
   - Id: 100351
@@ -68510,8 +67579,7 @@ Body:
     Name: Ranger Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_RANGER_S_CUBE
     Script: |
       getgroupitem(IG_RANGER_S_CUBE);
   - Id: 100357
@@ -68519,8 +67587,7 @@ Body:
     Name: Warlock Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_WARLOCK_S_CUBE
     Script: |
       getgroupitem(IG_WARLOCK_S_CUBE);
   - Id: 100358
@@ -68528,8 +67595,7 @@ Body:
     Name: Sorcerer Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SORCERER_S_CUBE
     Script: |
       getgroupitem(IG_SORCERER_S_CUBE);
   - Id: 100359
@@ -68537,8 +67603,7 @@ Body:
     Name: Minstrel Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_WANDERMINS_S_CUBE
     Script: |
       getgroupitem(IG_WANDERMINS_S_CUBE);
   - Id: 100360
@@ -68641,8 +67706,7 @@ Body:
     Name: Royal Guard Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ROYALGUARD_S_CUBE
     Script: |
       getgroupitem(IG_ROYALGUARD_S_CUBE);
   - Id: 100373
@@ -68650,8 +67714,7 @@ Body:
     Name: Shadow Chaser Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SHADOWCHASER_S_CUBE
     Script: |
       getgroupitem(IG_SHADOWCHASER_S_CUBE);
   - Id: 100374
@@ -68659,8 +67722,7 @@ Body:
     Name: Mechanic Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MECHANIC_S_CUBE
     Script: |
       getgroupitem(IG_MECHANIC_S_CUBE);
   - Id: 100375
@@ -68668,8 +67730,7 @@ Body:
     Name: Genetic Shadow Cube
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_GENETIC_S_CUBE
     Script: |
       getgroupitem(IG_GENETIC_S_CUBE);
   - Id: 100376
@@ -69003,8 +68064,7 @@ Body:
     Name: Costume Signon Princess Wave Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_SIGNON_PRIN_WAVE_BOX
     Script: |
       getgroupitem(IG_SIGNON_PRIN_WAVE_BOX);
   - Id: 100433
@@ -69030,7 +68090,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HERO_WEAPON_CUBE
     Script: |
       getgroupitem(IG_HERO_WEAPON_CUBE);
   - Id: 100442
@@ -69040,7 +68100,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_WEAPON_CUBE
     Script: |
       getgroupitem(IG_NEW_S_WEAPON_CUBE);
   - Id: 100443
@@ -69050,7 +68110,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_SHIELD_CUBE
     Script: |
       getgroupitem(IG_NEW_S_SHIELD_CUBE);
   - Id: 100444
@@ -69060,7 +68120,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_ARMOR_CUBE
     Script: |
       getgroupitem(IG_NEW_S_ARMOR_CUBE);
   - Id: 100445
@@ -69070,7 +68130,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_SHOES_CUBE
     Script: |
       getgroupitem(IG_NEW_S_SHOES_CUBE);
   - Id: 100446
@@ -69080,7 +68140,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_EARRING_CUBE
     Script: |
       getgroupitem(IG_NEW_S_EARRING_CUBE);
   - Id: 100447
@@ -69090,7 +68150,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_NEW_S_PENDANT_CUBE
     Script: |
       getgroupitem(IG_NEW_S_PENDANT_CUBE);
   - Id: 100452
@@ -69152,8 +68212,7 @@ Body:
     Name: Contaminated Card Book
     Type: Usable
     Weight: 15
-    Flags:
-      Container: true
+    ItemGroup: IG_MD_AIRBOAT_REWARD
     Script: |
       getgroupitem(IG_MD_AIRBOAT_REWARD);
   - Id: 100465
@@ -69161,8 +68220,7 @@ Body:
     Name: 3rd/Expanded Stone (Garment) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_GARMENT_BOX
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_GARMENT_BOX);
   - Id: 100466
@@ -69193,7 +68251,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_OS_HELM_BOX
     Script: |
       getgroupitem(IG_OS_HELM_BOX);
   - Id: 100470
@@ -69203,15 +68261,14 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FAMOUS_HAT_BOX
     Script: |
       getgroupitem(IG_FAMOUS_HAT_BOX);
   - Id: 100475
     AegisName: MD_Airboat_Expbox
     Name: Purple Special Storage Device
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_MD_AIRBOAT_EXPBOX
     Script: |
       getgroupitem(IG_MD_AIRBOAT_EXPBOX);
   - Id: 100476
@@ -69232,8 +68289,6 @@ Body:
     AegisName: Poenetentia_Box1
     Name: Poenitentia Gladius Set Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69241,14 +68296,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POENETENTIA_BOX1
     Script: |
       getgroupitem(IG_POENETENTIA_BOX1);
   - Id: 100478
     AegisName: Poenetentia_Box2
     Name: Poenitentia Asta Set Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69256,6 +68310,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POENETENTIA_BOX2
     Script: |
       getgroupitem(IG_POENETENTIA_BOX2);
   - Id: 100479
@@ -69324,8 +68379,7 @@ Body:
     Name: 3rd/Expanded Stone II (Garment) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_GARMENT_BOX2
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_GARMENT_BOX2);
   - Id: 100496
@@ -69333,8 +68387,7 @@ Body:
     Name: Rebirth/Expanded Stone (Top) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_TOP_BOX
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_TOP_BOX);
   - Id: 100497
@@ -69342,8 +68395,7 @@ Body:
     Name: Rebirth/Expanded Stone II (Top) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_TOP_BOX2
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_TOP_BOX2);
   - Id: 100498
@@ -69351,8 +68403,7 @@ Body:
     Name: Rebirth/Expanded Stone (Middle) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_MIDDLE_BOX
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_MIDDLE_BOX);
   - Id: 100499
@@ -69360,8 +68411,7 @@ Body:
     Name: Rebirth/Expanded Stone II (Middle) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_MIDDLE_BOX2
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_MIDDLE_BOX2);
   - Id: 100500
@@ -69369,8 +68419,7 @@ Body:
     Name: Rebirth/Expanded Stone (Bottom) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_BOTTOM_BOX
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_BOTTOM_BOX);
   - Id: 100501
@@ -69378,8 +68427,7 @@ Body:
     Name: Rebirth/Expanded Stone II (Bottom) Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_THIRD_JOB_STONE_BOTTOM_BOX2
     Script: |
       getgroupitem(IG_THIRD_JOB_STONE_BOTTOM_BOX2);
   - Id: 100502
@@ -69387,10 +68435,9 @@ Body:
     Name: Costume Enchant Stone Box 22
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX22
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box22);
+      getgroupitem(IG_ENCHANT_STONE_BOX22);
   - Id: 100508
     AegisName: Exp_Up_1_S
     Name: Special Growth Potion (Lower)
@@ -69461,15 +68508,13 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_EX_SKILL_SHADOW_CUBE
     Script: |
       getgroupitem(IG_EX_SKILL_SHADOW_CUBE);
   - Id: 100515
     AegisName: Cachua_Costume_Box
     Name: Kachua's Costume Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69478,6 +68523,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CACHUA_COSTUME_BOX
     Script: |
       getgroupitem(IG_CACHUA_COSTUME_BOX);
   - Id: 100516
@@ -69549,8 +68595,6 @@ Body:
     Name: 18th Anniversary Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69559,6 +68603,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL03
     Script: |
       getgroupitem(IG_KR_B_SPECIAL03);
   - Id: 100537
@@ -69568,7 +68613,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_WP_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_WP_CUBE);
   - Id: 100538
@@ -69578,7 +68623,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_AM_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_AM_CUBE);
   - Id: 100539
@@ -69588,7 +68633,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_SU_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_SU_CUBE);
   - Id: 100540
@@ -69598,7 +68643,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_SD_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_SD_CUBE);
   - Id: 100541
@@ -69608,7 +68653,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_PD_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_PD_CUBE);
   - Id: 100542
@@ -69618,7 +68663,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CLASS_SHADOW_EA_CUBE
     Script: |
       getgroupitem(IG_CLASS_SHADOW_EA_CUBE);
   - Id: 100547
@@ -69628,7 +68673,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BIOWEAPON_HELM_BOX
     Script: |
       getgroupitem(IG_BIOWEAPON_HELM_BOX);
   - Id: 100553
@@ -69638,7 +68683,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_TREE_OF_SPROUT_BOX
     Script: |
       getgroupitem(IG_TREE_OF_SPROUT_BOX);
   - Id: 100569
@@ -69646,8 +68691,6 @@ Body:
     Name: Special Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69656,6 +68699,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPECIAL_COSTUME_BOX
     Script: |
       getgroupitem(IG_SPECIAL_COSTUME_BOX);
   - Id: 100570
@@ -69663,8 +68707,6 @@ Body:
     Name: Special Costume Box+
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69673,6 +68715,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SPECIAL_COSTUME_BOX_
     Script: |
       getgroupitem(IG_SPECIAL_COSTUME_BOX_);
   - Id: 100572
@@ -69689,8 +68732,6 @@ Body:
     Name: Ragnarok Inven Event Support Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69699,6 +68740,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RAG_INVEN_BOX
     Script: |
       getgroupitem(IG_RAG_INVEN_BOX);
   - Id: 100574
@@ -69778,7 +68820,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_THANATOS_PENDANT_BOX
     Script: |
       getgroupitem(IG_THANATOS_PENDANT_BOX);
   - Id: 100591
@@ -69836,7 +68878,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LAPINE_DDUKDDAKBOX3
     Script: |
       getgroupitem(IG_LAPINE_DDUKDDAKBOX3);
   - Id: 100616
@@ -69844,8 +68886,6 @@ Body:
     Name: Donation Participaton Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -69855,6 +68895,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_AUCTION_PROMOTION
     Script: |
       getgroupitem(IG_AUCTION_PROMOTION);
   - Id: 100619
@@ -69980,7 +69021,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_BLUE_PRINTS_SCROLL
     Script: |
       getgroupitem(IG_BLUE_PRINTS_SCROLL);
   - Id: 100661
@@ -70008,7 +69049,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MATERIAL_SHADOW_CUBEII
     Script: |
       getgroupitem(IG_MATERIAL_SHADOW_CUBEII);
   - Id: 100691
@@ -70053,7 +69094,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ANCIENT_HERO_WILL
     Script: |
       getgroupitem(IG_ANCIENT_HERO_WILL);
   - Id: 100707
@@ -70063,7 +69104,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_MAMMOTH_SHADOW_BOX
     Script: |
       getgroupitem(IG_MAMMOTH_SHADOW_BOX);
   - Id: 100708
@@ -70073,7 +69114,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_R_M_BOX
     Script: |
       getgroupitem(IG_SHADOW_R_M_BOX);
   - Id: 100709
@@ -70083,7 +69124,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_ALL_SHADOW_CUBE
     Script: |
       getgroupitem(IG_ALL_SHADOW_CUBE);
   - Id: 100710
@@ -70098,8 +69139,7 @@ Body:
     Name: Semi-Long Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_FLUFFY_SEMI_LONG_BOX
     Script: |
       getgroupitem(IG_FLUFFY_SEMI_LONG_BOX);
   - Id: 100721
@@ -70107,10 +69147,9 @@ Body:
     Name: Costume Enchant Stone Box 23
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX23
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box23);
+      getgroupitem(IG_ENCHANT_STONE_BOX23);
   - Id: 100722
     AegisName: Booster_RandomOpt_P
     Name: Booster Modification Stone(Physical)
@@ -70150,8 +69189,6 @@ Body:
     Name: Booster Pack(215)
     Type: Usable
     EquipLevelMin: 215
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70161,6 +69198,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_215
     Script: |
       getgroupitem(IG_BOOSTER_PACK_215);
   - Id: 100727
@@ -70168,8 +69206,6 @@ Body:
     Name: Booster Pack(230)
     Type: Usable
     EquipLevelMin: 230
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70179,6 +69215,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_230
     Script: |
       getgroupitem(IG_BOOSTER_PACK_230);
   - Id: 100728
@@ -70186,8 +69223,6 @@ Body:
     Name: Angel Poring Boots Stone Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70196,6 +69231,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ANGELPORINGJEWEL_BOX
     Script: |
       getgroupitem(IG_ANGELPORINGJEWEL_BOX);
   - Id: 100742
@@ -70205,7 +69241,7 @@ Body:
     Weight: 2000
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_UP_HERO_WEAPON_BOX
     Script: |
       getgroupitem(IG_UP_HERO_WEAPON_BOX);
   - Id: 100744
@@ -70251,7 +69287,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HIGH_REFINE_GUARANTEE
     Script: |
       getgroupitem(IG_HIGH_REFINE_GUARANTEE);
   - Id: 100751
@@ -70261,7 +69297,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_REFINE_GUARANTEE
     Script: |
       getgroupitem(IG_REFINE_GUARANTEE);
   - Id: 100752
@@ -70271,7 +69307,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SPECIAL_REFINE_CUBE
     Script: |
       getgroupitem(IG_SPECIAL_REFINE_CUBE);
   - Id: 100753
@@ -70287,8 +69323,6 @@ Body:
     AegisName: Kr_B_Special04
     Name: Brilliant Soda
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70296,6 +69330,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL04
     Script: |
       getgroupitem(IG_KR_B_SPECIAL04);
   - Id: 100783
@@ -70323,7 +69358,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_AUTOSPELL_SHADOW_BOX
     Script: |
       getgroupitem(IG_AUTOSPELL_SHADOW_BOX);
   - Id: 100786
@@ -70346,8 +69381,6 @@ Body:
     Name: Broadcast Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70356,6 +69389,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROADCASTBOX_
     Script: |
       getgroupitem(IG_BROADCASTBOX_);
   - Id: 100816
@@ -70510,8 +69544,6 @@ Body:
     AegisName: S_Enchant_Stone_Box
     Name: Special Costume Enchant Stone Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70520,6 +69552,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ENCHANT_STONE_BOX
     Script: |
       getgroupitem(IG_S_ENCHANT_STONE_BOX);
   - Id: 100874
@@ -70527,8 +69560,6 @@ Body:
     Name: Infinite Giant Fly Wings Daily Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70538,6 +69569,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_GIANT_FLY_1DAY_BOX__
     Script: |
       getgroupitem(IG_C_GIANT_FLY_1DAY_BOX__);
   - Id: 100875
@@ -70545,8 +69577,6 @@ Body:
     Name: ?nfinite Fly Wings Box (3 Days)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70555,6 +69585,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_WING_OF_FLY_3DAY_B__
     Script: |
       getgroupitem(IG_C_WING_OF_FLY_3DAY_B__);
   - Id: 100880
@@ -70573,7 +69604,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_PHYMAG_SHADOW_BOX
     Script: |
       getgroupitem(IG_PHYMAG_SHADOW_BOX);
   - Id: 100887
@@ -70584,7 +69615,7 @@ Body:
     Flags:
       BuyingStore: true
     Script: |
-     laphine_synthesis();
+      laphine_synthesis();
   - Id: 100888
     AegisName: PhysicalShadow_Mix
     Name: Durable Shadow Pick-Up Box
@@ -70718,8 +69749,6 @@ Body:
     AegisName: S_Dual_Stone_Box
     Name: Special Dual Enchant Stone Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70728,14 +69757,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_DUAL_STONE_BOX
     Script: |
       getgroupitem(IG_S_DUAL_STONE_BOX);
   - Id: 100911
     AegisName: S_Costume_Box
     Name: Special Outfit Package
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70744,6 +69772,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_COSTUME_BOX
     Script: |
       getgroupitem(IG_S_COSTUME_BOX);
   - Id: 100913
@@ -70795,16 +69824,13 @@ Body:
     Name: Costume Enchant Stone Box 24
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX24
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box24);
+      getgroupitem(IG_ENCHANT_STONE_BOX24);
   - Id: 100929
     AegisName: GM_Lost_Bagpack
     Name: GM Bigfoot Bag
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70813,6 +69839,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GM_LOST_BAGPACK
     Script: |
       getgroupitem(IG_GM_LOST_BAGPACK);
   - Id: 100933
@@ -70820,8 +69847,6 @@ Body:
     Name: "[Gift] Potion Box"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70830,6 +69855,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_POTION_BOX
     Script: |
       getgroupitem(IG_E_POTION_BOX);
   - Id: 100934
@@ -70837,8 +69863,6 @@ Body:
     Name: "[Not For Sale] Buff Scroll Box"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70847,6 +69871,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BUFF_SCROLL_BOX
     Script: |
       getgroupitem(IG_BUFF_SCROLL_BOX);
   - Id: 100938
@@ -70867,8 +69892,7 @@ Body:
     AegisName: Season_Evt_Reward_9
     Name: Thanksgiving Package
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_SEASON_EVT_REWARD_9
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_9);
   - Id: 100949
@@ -70890,8 +69914,6 @@ Body:
     AegisName: Evt_RagFes_Box
     Name: Ragfest Commemorative Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70900,6 +69922,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_RAGFES_BOX
     Script: |
       getgroupitem(IG_EVT_RAGFES_BOX);
   - Id: 100951
@@ -70907,8 +69930,6 @@ Body:
     Name: Ignition Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70917,15 +69938,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_IGNITION_CUBE
     Script: |
-      getgroupitem(IG_S_Ignition_Cube);
+      getgroupitem(IG_S_IGNITION_CUBE);
   - Id: 100952
     AegisName: S_W_Breath_Cube
     Name: Cold Breath Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70934,15 +69954,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_W_BREATH_CUBE
     Script: |
-      getgroupitem(IG_S_W_Breath_Cube);
+      getgroupitem(IG_S_W_BREATH_CUBE);
   - Id: 100954
     AegisName: S_F_Breath_Cube
     Name: Fire Breath Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70951,15 +69970,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_F_BREATH_CUBE
     Script: |
-      getgroupitem(IG_S_F_Breath_Cube);
+      getgroupitem(IG_S_F_BREATH_CUBE);
   - Id: 100955
     AegisName: S_Sonic_Cube
     Name: Sonic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70968,15 +69986,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SONIC_CUBE
     Script: |
-      getgroupitem(IG_S_Sonic_Cube);
+      getgroupitem(IG_S_SONIC_CUBE);
   - Id: 100956
     AegisName: S_Banish_Cannon_Cube
     Name: Vanishing Cannon Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -70985,15 +70002,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BANISH_CANNON_CUBE
     Script: |
-      getgroupitem(IG_S_Banish_Cannon_Cube);
+      getgroupitem(IG_S_BANISH_CANNON_CUBE);
   - Id: 100957
     AegisName: S_Brand_Cube
     Name: Brand Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71002,15 +70018,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BRAND_CUBE
     Script: |
-      getgroupitem(IG_S_Brand_Cube);
+      getgroupitem(IG_S_BRAND_CUBE);
   - Id: 100958
     AegisName: S_Genesis_Cube
     Name: Genesis Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71019,15 +70034,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GENESIS_CUBE
     Script: |
-      getgroupitem(IG_S_Genesis_Cube);
+      getgroupitem(IG_S_GENESIS_CUBE);
   - Id: 100959
     AegisName: S_Chain_Press_Cube
     Name: Chain Press Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71036,15 +70050,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CHAIN_PRESS_CUBE
     Script: |
-      getgroupitem(IG_S_Chain_Press_Cube);
+      getgroupitem(IG_S_CHAIN_PRESS_CUBE);
   - Id: 100960
     AegisName: S_Strain_Cube
     Name: Strain Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71053,15 +70066,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_STRAIN_CUBE
     Script: |
-      getgroupitem(IG_S_Strain_Cube);
+      getgroupitem(IG_S_STRAIN_CUBE);
   - Id: 100961
     AegisName: S_Jack_Cube
     Name: Jack Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71070,15 +70082,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_JACK_CUBE
     Script: |
-      getgroupitem(IG_S_Jack_Cube);
+      getgroupitem(IG_S_JACK_CUBE);
   - Id: 100962
     AegisName: S_Chain_Cube
     Name: Chain Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71087,15 +70098,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CHAIN_CUBE
     Script: |
-      getgroupitem(IG_S_Chain_Cube);
+      getgroupitem(IG_S_CHAIN_CUBE);
   - Id: 100963
     AegisName: S_Crimson_Cube
     Name: Crimson Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71104,15 +70114,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CRIMSON_CUBE
     Script: |
-      getgroupitem(IG_S_Crimson_Cube);
+      getgroupitem(IG_S_CRIMSON_CUBE);
   - Id: 100964
     AegisName: S_Grave_Cube
     Name: Grave Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71121,15 +70130,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GRAVE_CUBE
     Script: |
-      getgroupitem(IG_S_Grave_Cube);
+      getgroupitem(IG_S_GRAVE_CUBE);
   - Id: 100965
     AegisName: S_Dust_Cube
     Name: Dust Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71138,15 +70146,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_DUST_CUBE
     Script: |
-      getgroupitem(IG_S_Dust_Cube);
+      getgroupitem(IG_S_DUST_CUBE);
   - Id: 100966
     AegisName: S_Varetyr_Cube
     Name: Varetyr Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71155,15 +70162,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_VARETYR_CUBE
     Script: |
-      getgroupitem(IG_S_Varetyr_Cube);
+      getgroupitem(IG_S_VARETYR_CUBE);
   - Id: 100967
     AegisName: S_Psychic_Cube
     Name: Psychic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71172,15 +70178,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_PSYCHIC_CUBE
     Script: |
-      getgroupitem(IG_S_Psychic_Cube);
+      getgroupitem(IG_S_PSYCHIC_CUBE);
   - Id: 100968
     AegisName: S_Vulcan_Cube
     Name: Vulcan Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71189,15 +70194,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_VULCAN_CUBE
     Script: |
-      getgroupitem(IG_S_Vulcan_Cube);
+      getgroupitem(IG_S_VULCAN_CUBE);
   - Id: 100969
     AegisName: S_Boomerang_Cube
     Name: Boomerang Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71206,15 +70210,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BOOMERANG_CUBE
     Script: |
-      getgroupitem(IG_S_Boomerang_Cube);
+      getgroupitem(IG_S_BOOMERANG_CUBE);
   - Id: 100970
     AegisName: S_Arms_Cube
     Name: Arm Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71223,15 +70226,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ARMS_CUBE
     Script: |
-      getgroupitem(IG_S_Arms_Cube);
+      getgroupitem(IG_S_ARMS_CUBE);
   - Id: 100971
     AegisName: S_Tornado_Cube
     Name: Tornado Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71240,15 +70242,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TORNADO_CUBE
     Script: |
-      getgroupitem(IG_S_Tornado_Cube);
+      getgroupitem(IG_S_TORNADO_CUBE);
   - Id: 100972
     AegisName: S_Spore_Bomb_Cube
     Name: Spore Bomb Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71257,15 +70258,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SPORE_BOMB_CUBE
     Script: |
-      getgroupitem(IG_S_Spore_Bomb_Cube);
+      getgroupitem(IG_S_SPORE_BOMB_CUBE);
   - Id: 100973
     AegisName: S_Cannon_Cart_Cube
     Name: Cannon Cart Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71274,15 +70274,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CANNON_CART_CUBE
     Script: |
-      getgroupitem(IG_S_Cannon_Cart_Cube);
+      getgroupitem(IG_S_CANNON_CART_CUBE);
   - Id: 100974
     AegisName: S_Crazy_Cube
     Name: Crazy Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71291,15 +70290,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CRAZY_CUBE
     Script: |
-      getgroupitem(IG_S_Crazy_Cube);
+      getgroupitem(IG_S_CRAZY_CUBE);
   - Id: 100975
     AegisName: S_Cart_Tornado_Cube
     Name: Tornado Cart Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71308,15 +70306,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CART_TORNADO_CUBE
     Script: |
-      getgroupitem(IG_S_Cart_Tornado_Cube);
+      getgroupitem(IG_S_CART_TORNADO_CUBE);
   - Id: 100976
     AegisName: S_Duplelight_Cube
     Name: Duple Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71325,15 +70322,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_DUPLELIGHT_CUBE
     Script: |
-      getgroupitem(IG_S_Duplelight_Cube);
+      getgroupitem(IG_S_DUPLELIGHT_CUBE);
   - Id: 100977
     AegisName: S_Magnus_Cube
     Name: Magnus Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71342,15 +70338,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MAGNUS_CUBE
     Script: |
-      getgroupitem(IG_S_Magnus_Cube);
+      getgroupitem(IG_S_MAGNUS_CUBE);
   - Id: 100978
     AegisName: S_Adoramus_Cube
     Name: Adora Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71359,15 +70354,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ADORAMUS_CUBE
     Script: |
-      getgroupitem(IG_S_Adoramus_Cube);
+      getgroupitem(IG_S_ADORAMUS_CUBE);
   - Id: 100979
     AegisName: S_Judex_Cube
     Name: Judex Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71376,15 +70370,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_JUDEX_CUBE
     Script: |
-      getgroupitem(IG_S_Judex_Cube);
+      getgroupitem(IG_S_JUDEX_CUBE);
   - Id: 100980
     AegisName: S_Knucklearrow_Cube
     Name: Knuckle Arrow Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71393,15 +70386,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_KNUCKLEARROW_CUBE
     Script: |
-      getgroupitem(IG_S_Knucklearrow_Cube);
+      getgroupitem(IG_S_KNUCKLEARROW_CUBE);
   - Id: 100981
     AegisName: S_Skynetblow_Cube
     Name: Sky Blow Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71410,15 +70402,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SKYNETBLOW_CUBE
     Script: |
-      getgroupitem(IG_S_Skynetblow_Cube);
+      getgroupitem(IG_S_SKYNETBLOW_CUBE);
   - Id: 100982
     AegisName: S_Rampage_Cube
     Name: Rampage Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71427,15 +70418,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_RAMPAGE_CUBE
     Script: |
-      getgroupitem(IG_S_Rampage_Cube);
+      getgroupitem(IG_S_RAMPAGE_CUBE);
   - Id: 100983
     AegisName: S_TigerCannon_Cube
     Name: Tiger Cannon Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71444,15 +70434,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TIGERCANNON_CUBE
     Script: |
-      getgroupitem(IG_S_TigerCannon_Cube);
+      getgroupitem(IG_S_TIGERCANNON_CUBE);
   - Id: 100984
     AegisName: S_Rolling_Cube
     Name: Rolling Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71461,15 +70450,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ROLLING_CUBE
     Script: |
-      getgroupitem(IG_S_Rolling_Cube);
+      getgroupitem(IG_S_ROLLING_CUBE);
   - Id: 100985
     AegisName: S_Ripper_Cube
     Name: Ripper Slasher Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71478,15 +70466,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_RIPPER_CUBE
     Script: |
-      getgroupitem(IG_S_Ripper_Cube);
+      getgroupitem(IG_S_RIPPER_CUBE);
   - Id: 100986
     AegisName: S_Slash_Cube
     Name: Slash Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71495,15 +70482,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SLASH_CUBE
     Script: |
-      getgroupitem(IG_S_Slash_Cube);
+      getgroupitem(IG_S_SLASH_CUBE);
   - Id: 100987
     AegisName: S_Katar_Cube
     Name: Katar Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71512,15 +70498,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_KATAR_CUBE
     Script: |
-      getgroupitem(IG_S_Katar_Cube);
+      getgroupitem(IG_S_KATAR_CUBE);
   - Id: 100988
     AegisName: S_Menace_Cube
     Name: Menace Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71529,15 +70514,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MENACE_CUBE
     Script: |
-      getgroupitem(IG_S_Menace_Cube);
+      getgroupitem(IG_S_MENACE_CUBE);
   - Id: 100989
     AegisName: S_Shadowspell_Cube
     Name: Shadow Spell Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71546,15 +70530,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SHADOWSPELL_CUBE
     Script: |
-      getgroupitem(IG_S_Shadowspell_Cube);
+      getgroupitem(IG_S_SHADOWSPELL_CUBE);
   - Id: 100990
     AegisName: S_Triangle_Cube
     Name: Triangle Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71563,15 +70546,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TRIANGLE_CUBE
     Script: |
-      getgroupitem(IG_S_Triangle_Cube);
+      getgroupitem(IG_S_TRIANGLE_CUBE);
   - Id: 100991
     AegisName: S_Paint_Cube
     Name: Feint Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71580,15 +70562,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_PAINT_CUBE
     Script: |
-      getgroupitem(IG_S_Paint_Cube);
+      getgroupitem(IG_S_PAINT_CUBE);
   - Id: 100992
     AegisName: S_Shooting_Cube
     Name: Katar Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71597,15 +70578,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SHOOTING_CUBE
     Script: |
-      getgroupitem(IG_S_Shooting_Cube);
+      getgroupitem(IG_S_SHOOTING_CUBE);
   - Id: 100994
     AegisName: S_Arrow_Cube
     Name: Arrow Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71614,15 +70594,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ARROW_CUBE
     Script: |
-      getgroupitem(IG_S_Arrow_Cube);
+      getgroupitem(IG_S_ARROW_CUBE);
   - Id: 100995
     AegisName: S_Aimed_Cube
     Name: Aimed Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71631,15 +70610,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_AIMED_CUBE
     Script: |
-      getgroupitem(IG_S_Aimed_Cube);
+      getgroupitem(IG_S_AIMED_CUBE);
   - Id: 100996
     AegisName: S_Cluster_Cube
     Name: Cluster Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71648,15 +70626,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CLUSTER_CUBE
     Script: |
-      getgroupitem(IG_S_Cluster_Cube);
+      getgroupitem(IG_S_CLUSTER_CUBE);
   - Id: 100997
     AegisName: S_Rainstorm_Cube
     Name: Rainstorm Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71665,15 +70642,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_RAINSTORM_CUBE
     Script: |
-      getgroupitem(IG_S_Rainstorm_Cube);
+      getgroupitem(IG_S_RAINSTORM_CUBE);
   - Id: 100998
     AegisName: S_Metalic_Cube
     Name: Metallic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71682,15 +70658,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_METALIC_CUBE
     Script: |
-      getgroupitem(IG_S_Metalic_Cube);
+      getgroupitem(IG_S_METALIC_CUBE);
   - Id: 100999
     AegisName: S_Arrowvulcan_Cube
     Name: Arrow Vulcan Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71699,15 +70674,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ARROWVULCAN_CUBE
     Script: |
-      getgroupitem(IG_S_Arrowvulcan_Cube);
+      getgroupitem(IG_S_ARROWVULCAN_CUBE);
   - Id: 101000
     AegisName: S_Reverberation_Cube
     Name: Reverberation Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71716,15 +70690,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_REVERBERATION_CUBE
     Script: |
-      getgroupitem(IG_S_Reverberation_Cube);
+      getgroupitem(IG_S_REVERBERATION_CUBE);
   - Id: 101001
     AegisName: S_Moonlight_Cube
     Name: Moonlight Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71733,15 +70706,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MOONLIGHT_CUBE
     Script: |
-      getgroupitem(IG_S_Moonlight_Cube);
+      getgroupitem(IG_S_MOONLIGHT_CUBE);
   - Id: 101002
     AegisName: S_Sunshine_Cube
     Name: Sunshine Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71750,15 +70722,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SUNSHINE_CUBE
     Script: |
-      getgroupitem(IG_S_Sunshine_Cube);
+      getgroupitem(IG_S_SUNSHINE_CUBE);
   - Id: 101003
     AegisName: S_Stardust_Cube
     Name: Stardust Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71767,15 +70738,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_STARDUST_CUBE
     Script: |
-      getgroupitem(IG_S_Stardust_Cube);
+      getgroupitem(IG_S_STARDUST_CUBE);
   - Id: 101004
     AegisName: S_S_Cube
     Name: Es Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71784,15 +70754,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_S_CUBE
     Script: |
-      getgroupitem(IG_S_S_Cube);
+      getgroupitem(IG_S_S_CUBE);
   - Id: 101005
     AegisName: S_Evilcurse_Cube
     Name: Evil Curse Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71801,15 +70770,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_EVILCURSE_CUBE
     Script: |
-      getgroupitem(IG_S_Evilcurse_Cube);
+      getgroupitem(IG_S_EVILCURSE_CUBE);
   - Id: 101006
     AegisName: S_Syuriken_Cube
     Name: Cross Shuriken Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71818,15 +70786,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SYURIKEN_CUBE
     Script: |
-      getgroupitem(IG_S_Syuriken_Cube);
+      getgroupitem(IG_S_SYURIKEN_CUBE);
   - Id: 101007
     AegisName: S_Kunai_Cube
     Name: Kunai Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71835,15 +70802,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_KUNAI_CUBE
     Script: |
-      getgroupitem(IG_S_Kunai_Cube);
+      getgroupitem(IG_S_KUNAI_CUBE);
   - Id: 101008
     AegisName: S_Huusouka_Cube
     Name: Wind Spear Petal Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71852,15 +70818,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_HUUSOUKA_CUBE
     Script: |
-      getgroupitem(IG_S_Huusouka_Cube);
+      getgroupitem(IG_S_HUUSOUKA_CUBE);
   - Id: 101009
     AegisName: S_Kamaenraku_Cube
     Name: First Exploding Draft Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71869,15 +70834,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_KAMAENRAKU_CUBE
     Script: |
-      getgroupitem(IG_S_Kamaenraku_Cube);
+      getgroupitem(IG_S_KAMAENRAKU_CUBE);
   - Id: 101010
     AegisName: S_God_Hammer_Cube
     Name: God Hammer Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71886,15 +70850,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GOD_HAMMER_CUBE
     Script: |
-      getgroupitem(IG_S_God_Hammer_Cube);
+      getgroupitem(IG_S_GOD_HAMMER_CUBE);
   - Id: 101011
     AegisName: S_Shatter_Buster_Cube
     Name: Shatter Buster Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71903,15 +70866,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SHATTER_BUSTER_CUBE
     Script: |
-      getgroupitem(IG_S_Shatter_Buster_Cube);
+      getgroupitem(IG_S_SHATTER_BUSTER_CUBE);
   - Id: 101012
     AegisName: S_Tail_Dragon_Cube
     Name: Tail Dragon Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71920,15 +70882,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TAIL_DRAGON_CUBE
     Script: |
-      getgroupitem(IG_S_Tail_Dragon_Cube);
+      getgroupitem(IG_S_TAIL_DRAGON_CUBE);
   - Id: 101013
     AegisName: S_Trip_Cube
     Name: Trip Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71937,15 +70898,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TRIP_CUBE
     Script: |
-      getgroupitem(IG_S_Trip_Cube);
+      getgroupitem(IG_S_TRIP_CUBE);
   - Id: 101014
     AegisName: S_Flare_Dance_Cube
     Name: Flare Dance Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71954,15 +70914,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_FLARE_DANCE_CUBE
     Script: |
-      getgroupitem(IG_S_Flare_Dance_Cube);
+      getgroupitem(IG_S_FLARE_DANCE_CUBE);
   - Id: 101015
     AegisName: S_Super_Magic_Cube
     Name: Super Magic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71971,15 +70930,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SUPER_MAGIC_CUBE
     Script: |
-      getgroupitem(IG_S_Super_Magic_Cube);
+      getgroupitem(IG_S_SUPER_MAGIC_CUBE);
   - Id: 101016
     AegisName: S_Super_Power_Cube
     Name: Super Power Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -71988,15 +70946,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SUPER_POWER_CUBE
     Script: |
-      getgroupitem(IG_S_Super_Power_Cube);
+      getgroupitem(IG_S_SUPER_POWER_CUBE);
   - Id: 101017
     AegisName: S_Silvervine_Cube
     Name: Silvervine Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72005,15 +70962,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SILVERVINE_CUBE
     Script: |
-      getgroupitem(IG_S_Silvervine_Cube);
+      getgroupitem(IG_S_SILVERVINE_CUBE);
   - Id: 101018
     AegisName: S_Catnip_Cube
     Name: Catnip Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72022,15 +70978,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_CATNIP_CUBE
     Script: |
-      getgroupitem(IG_S_Catnip_Cube);
+      getgroupitem(IG_S_CATNIP_CUBE);
   - Id: 101019
     AegisName: S_SavageRabbit_Cube
     Name: Savage Rabbit Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72039,15 +70994,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SAVAGERABBIT_CUBE
     Script: |
-      getgroupitem(IG_S_SavageRabbit_Cube);
+      getgroupitem(IG_S_SAVAGERABBIT_CUBE);
   - Id: 101020
     AegisName: S_Pickyrush_Cube
     Name: Picky Rush Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72056,15 +71010,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_PICKYRUSH_CUBE
     Script: |
-      getgroupitem(IG_S_Pickyrush_Cube);
+      getgroupitem(IG_S_PICKYRUSH_CUBE);
   - Id: 101021
     AegisName: S_RuneKnight_Cube
     Name: Rune Knight Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72073,15 +71026,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_RUNEKNIGHT_CUBE
     Script: |
-      getgroupitem(IG_S_RuneKnight_Cube);
+      getgroupitem(IG_S_RUNEKNIGHT_CUBE);
   - Id: 101022
     AegisName: S_RoyalGuard_Cube
     Name: Royal Guard Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72090,15 +71042,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ROYALGUARD_CUBE
     Script: |
-      getgroupitem(IG_S_RoyalGuard_Cube);
+      getgroupitem(IG_S_ROYALGUARD_CUBE);
   - Id: 101023
     AegisName: S_Warlock_Cube
     Name: Warlock Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72107,15 +71058,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_WARLOCK_CUBE
     Script: |
-      getgroupitem(IG_S_Warlock_Cube);
+      getgroupitem(IG_S_WARLOCK_CUBE);
   - Id: 101024
     AegisName: S_Sorcerer_Cube
     Name: Sorcerer Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72124,15 +71074,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SORCERER_CUBE
     Script: |
-      getgroupitem(IG_S_Sorcerer_Cube);
+      getgroupitem(IG_S_SORCERER_CUBE);
   - Id: 101025
     AegisName: S_Mechanic_Cube
     Name: Mechanic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72141,15 +71090,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MECHANIC_CUBE
     Script: |
-      getgroupitem(IG_S_Mechanic_Cube);
+      getgroupitem(IG_S_MECHANIC_CUBE);
   - Id: 101026
     AegisName: S_Generic_Cube
     Name: Genetic Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72158,15 +71106,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GENERIC_CUBE
     Script: |
-      getgroupitem(IG_S_Generic_Cube);
+      getgroupitem(IG_S_GENERIC_CUBE);
   - Id: 101027
     AegisName: S_ArchBishop_Cube
     Name: Arch Bishop Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72175,15 +71122,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ARCHBISHOP_CUBE
     Script: |
-      getgroupitem(IG_S_ArchBishop_Cube);
+      getgroupitem(IG_S_ARCHBISHOP_CUBE);
   - Id: 101028
     AegisName: S_Sura_Cube
     Name: Sura Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72192,15 +71138,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SURA_CUBE
     Script: |
-      getgroupitem(IG_S_Sura_Cube);
+      getgroupitem(IG_S_SURA_CUBE);
   - Id: 101029
     AegisName: S_GuillotineCross_Cube
     Name: Guillotine Cross Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72209,15 +71154,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GUILLOTINECROSS_CUBE
     Script: |
-      getgroupitem(IG_S_GuillotineCross_Cube);
+      getgroupitem(IG_S_GUILLOTINECROSS_CUBE);
   - Id: 101030
     AegisName: S_ShadowChaser_Cube
     Name: Shadow Chaser Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72226,15 +71170,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SHADOWCHASER_CUBE
     Script: |
-      getgroupitem(IG_S_ShadowChaser_Cube);
+      getgroupitem(IG_S_SHADOWCHASER_CUBE);
   - Id: 101031
     AegisName: S_Ranger_Cube
     Name: Ranger Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72243,15 +71186,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_RANGER_CUBE
     Script: |
-      getgroupitem(IG_S_Ranger_Cube);
+      getgroupitem(IG_S_RANGER_CUBE);
   - Id: 101032
     AegisName: S_Wanderer_Cube
     Name: Wanderer Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72260,15 +71202,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_WANDERER_CUBE
     Script: |
-      getgroupitem(IG_S_Wanderer_Cube);
+      getgroupitem(IG_S_WANDERER_CUBE);
   - Id: 101033
     AegisName: S_Minstrel_Cube
     Name: Minstrel Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72277,15 +71218,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MINSTREL_CUBE
     Script: |
-      getgroupitem(IG_S_Minstrel_Cube);
+      getgroupitem(IG_S_MINSTREL_CUBE);
   - Id: 101034
     AegisName: S_Star_Emperor_Cube
     Name: Star Emperor Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72294,15 +71234,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_STAR_EMPEROR_CUBE
     Script: |
-      getgroupitem(IG_S_Star_Emperor_Cube);
+      getgroupitem(IG_S_STAR_EMPEROR_CUBE);
   - Id: 101035
     AegisName: S_Soul_Reaper_Cube
     Name: Soul Reaper Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72311,15 +71250,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SOUL_REAPER_CUBE
     Script: |
-      getgroupitem(IG_S_Soul_Reaper_Cube);
+      getgroupitem(IG_S_SOUL_REAPER_CUBE);
   - Id: 101036
     AegisName: S_Kagerou_Cube
     Name: Kagerou Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72328,15 +71266,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_KAGEROU_CUBE
     Script: |
-      getgroupitem(IG_S_Kagerou_Cube);
+      getgroupitem(IG_S_KAGEROU_CUBE);
   - Id: 101037
     AegisName: S_Oboro_Cube
     Name: Oboro Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72345,15 +71282,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_OBORO_CUBE
     Script: |
-      getgroupitem(IG_S_Oboro_Cube);
+      getgroupitem(IG_S_OBORO_CUBE);
   - Id: 101038
     AegisName: S_Rebellion_Cube
     Name: Rebellion Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72362,15 +71298,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_REBELLION_CUBE
     Script: |
-      getgroupitem(IG_S_Rebellion_Cube);
+      getgroupitem(IG_S_REBELLION_CUBE);
   - Id: 101039
     AegisName: S_SuperNovice_Cube
     Name: Super Novice Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72379,15 +71314,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_SUPERNOVICE_CUBE
     Script: |
-      getgroupitem(IG_S_SuperNovice_Cube);
+      getgroupitem(IG_S_SUPERNOVICE_CUBE);
   - Id: 101040
     AegisName: S_Doram_Cube
     Name: Doram Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72396,15 +71330,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_DORAM_CUBE
     Script: |
-      getgroupitem(IG_S_Doram_Cube);
+      getgroupitem(IG_S_DORAM_CUBE);
   - Id: 101041
     AegisName: S_Mammoth_Cube
     Name: Mammoth Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72413,15 +71346,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_MAMMOTH_CUBE
     Script: |
-      getgroupitem(IG_S_Mammoth_Cube);
+      getgroupitem(IG_S_MAMMOTH_CUBE);
   - Id: 101042
     AegisName: S_Gemstone_Cube
     Name: Gemstone Shadow Cube
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72430,15 +71362,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_GEMSTONE_CUBE
     Script: |
-      getgroupitem(IG_S_Gemstone_Cube);
+      getgroupitem(IG_S_GEMSTONE_CUBE);
   - Id: 101043
     AegisName: S_Pene1_Cube
     Name: Penetration Shadow Cube I
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72447,15 +71378,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_PENE1_CUBE
     Script: |
-      getgroupitem(IG_S_Pene1_Cube);
+      getgroupitem(IG_S_PENE1_CUBE);
   - Id: 101044
     AegisName: S_Pene2_Cube
     Name: Penetration Shadow Cube II
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72464,15 +71394,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_PENE2_CUBE
     Script: |
-      getgroupitem(IG_S_Pene2_Cube);
+      getgroupitem(IG_S_PENE2_CUBE);
   - Id: 101045
     AegisName: S_Temp1_Cube
     Name: Tempest Shadow Cube I
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72481,15 +71410,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TEMP1_CUBE
     Script: |
-      getgroupitem(IG_S_Temp1_Cube);
+      getgroupitem(IG_S_TEMP1_CUBE);
   - Id: 101046
     AegisName: S_Temp2_Cube
     Name: Tempest Shadow Cube II
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72498,15 +71426,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_TEMP2_CUBE
     Script: |
-      getgroupitem(IG_S_Temp2_Cube);
+      getgroupitem(IG_S_TEMP2_CUBE);
   - Id: 101047
     AegisName: Blacksmith_Bless_Box_3
     Name: Blacksmith Blessing Box 3
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72515,15 +71442,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLACKSMITH_BLESS_BOX_3
     Script: |
-      getgroupitem(IG_Blacksmith_Bless_Box_3);
+      getgroupitem(IG_BLACKSMITH_BLESS_BOX_3);
   - Id: 101048
     AegisName: Shadow_Hammer_Box_3
     Name: Holgren's Shadow Smelting Hammer Box 3
     Type: Usable
     Weight: 0
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72532,8 +71458,9 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SHADOW_HAMMER_BOX_3
     Script: |
-      getgroupitem(IG_Shadow_Hammer_Box_3);
+      getgroupitem(IG_SHADOW_HAMMER_BOX_3);
   - Id: 101060
     AegisName: Select_Example1
     Name: TestA
@@ -72551,8 +71478,6 @@ Body:
     Name: Varmundt's Rune Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72560,14 +71485,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BARMUND_RUNE_BOX
     Script: |
       getgroupitem(IG_BARMUND_RUNE_BOX);
   - Id: 101070
     AegisName: Chuseog_Present_Box
     Name: Chuseok Event Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72576,6 +71500,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHUSEOG_PRESENT_BOX
     Script: |
       getgroupitem(IG_CHUSEOG_PRESENT_BOX);
   - Id: 101074
@@ -72583,8 +71508,6 @@ Body:
     Name: Sealed Seal Card III
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72593,6 +71516,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEALED_CARD3
     Script: |
       getgroupitem(IG_SEALED_CARD3);
   - Id: 101075
@@ -72641,8 +71565,6 @@ Body:
     AegisName: Poenetentia_Box3
     Name: Poenitentia Two Swords Set Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72651,14 +71573,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POENETENTIA_BOX3
     Script: |
       getgroupitem(IG_POENETENTIA_BOX3);
   - Id: 101101
     AegisName: Poenetentia_Box4
     Name: Poenitentia Firearm Set Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72667,6 +71588,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_POENETENTIA_BOX4
     Script: |
       getgroupitem(IG_POENETENTIA_BOX4);
   - Id: 101103
@@ -72674,17 +71596,15 @@ Body:
     Name: Costume Enchant Stone Box 25
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX25
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box25);
+      getgroupitem(IG_ENCHANT_STONE_BOX25);
   - Id: 101107
     AegisName: Cannon_Box_Ice
     Name: Ice Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_ICE
     Script: |
       getgroupitem(IG_CANNON_BOX_ICE);
   - Id: 101108
@@ -72692,8 +71612,7 @@ Body:
     Name: Lightning Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_LIGHTNING
     Script: |
       getgroupitem(IG_CANNON_BOX_LIGHTNING);
   - Id: 101109
@@ -72701,8 +71620,7 @@ Body:
     Name: Stone Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_STONE
     Script: |
       getgroupitem(IG_CANNON_BOX_STONE);
   - Id: 101110
@@ -72710,8 +71628,7 @@ Body:
     Name: Flare Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_FLARE
     Script: |
       getgroupitem(IG_CANNON_BOX_FLARE);
   - Id: 101111
@@ -72719,8 +71636,7 @@ Body:
     Name: Poisoning Cannon Ball Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_CANNON_BOX_POISONING
     Script: |
       getgroupitem(IG_CANNON_BOX_POISONING);
   - Id: 101112
@@ -72728,8 +71644,7 @@ Body:
     Name: Kunai Summon Scroll
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL
     Script: |
       getgroupitem(IG_KUNAI_SCROLL);
   - Id: 101113
@@ -72737,8 +71652,7 @@ Body:
     Name: Formless Kunai Summon Scroll
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_NOTHING
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_NOTHING);
   - Id: 101114
@@ -72746,8 +71660,7 @@ Body:
     Name: Shadow Kunai Summon Scroll
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_SHADOW
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_SHADOW);
   - Id: 101115
@@ -72755,8 +71668,7 @@ Body:
     Name: Hamaya Kunai Summon Scroll
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_KUNAI_SCROLL_HAMAYA
     Script: |
       getgroupitem(IG_KUNAI_SCROLL_HAMAYA);
   - Id: 101116
@@ -72764,8 +71676,7 @@ Body:
     Name: Throwing Grenade Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_NW_GRENADE_BOX
     Script: |
       getgroupitem(IG_NW_GRENADE_BOX);
   - Id: 101117
@@ -72773,8 +71684,7 @@ Body:
     Name: Soul Talisman Bundle
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SOA_CHARM_BUNDLE
     Script: |
       getgroupitem(IG_SOA_CHARM_BUNDLE);
   - Id: 101118
@@ -72782,8 +71692,7 @@ Body:
     Name: Haze of Pitch Darkness Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SS_CHARM_BOX
     Script: |
       getgroupitem(IG_SS_CHARM_BOX);
   - Id: 101119
@@ -72791,8 +71700,7 @@ Body:
     Name: Haze of Prominence Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SS_CHARM_F_BOX
     Script: |
       getgroupitem(IG_SS_CHARM_F_BOX);
   - Id: 101120
@@ -72800,8 +71708,7 @@ Body:
     Name: Haze of Icy Snow Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SS_CHARM_W_BOX
     Script: |
       getgroupitem(IG_SS_CHARM_W_BOX);
   - Id: 101121
@@ -72809,8 +71716,7 @@ Body:
     Name: Haze of Mother Earth Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SS_CHARM_G_BOX
     Script: |
       getgroupitem(IG_SS_CHARM_G_BOX);
   - Id: 101122
@@ -72818,8 +71724,7 @@ Body:
     Name: Haze of North Wind Box
     Type: Usable
     Weight: 250
-    Flags:
-      Container: true
+    ItemGroup: IG_SS_CHARM_L_BOX
     Script: |
       getgroupitem(IG_SS_CHARM_L_BOX);
   - Id: 101123
@@ -72827,8 +71732,6 @@ Body:
     Name: RO Live Shop Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72838,6 +71741,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_LIVE_SHOP_BOX
     Script: |
       getgroupitem(IG_RO_LIVE_SHOP_BOX);
   - Id: 101124
@@ -72845,8 +71749,6 @@ Body:
     Name: RO Live Shop Luxury Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72856,6 +71758,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_LIVE_SHOP_EX_BOX
     Script: |
       getgroupitem(IG_RO_LIVE_SHOP_EX_BOX);
   - Id: 101126
@@ -72869,8 +71772,7 @@ Body:
     AegisName: Season_Evt_Reward_11
     Name: Royal Reward Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_SEASON_EVT_REWARD_11
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_11);
   - Id: 101129
@@ -72878,8 +71780,6 @@ Body:
     Name: Random Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72889,6 +71789,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PAYMENT_COSTUME_BOX1
     Script: |
       getgroupitem(IG_PAYMENT_COSTUME_BOX1);
   - Id: 101130
@@ -72896,8 +71797,6 @@ Body:
     Name: Confirmed Costume Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72907,6 +71806,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PAYMENT_COSTUME_BOX2
     Script: |
       getgroupitem(IG_PAYMENT_COSTUME_BOX2);
   - Id: 101139
@@ -72914,8 +71814,6 @@ Body:
     Name: Riding Halter Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72924,14 +71822,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_BOARDING_HALTER_BOX
     Script: |
       getgroupitem(IG_E_BOARDING_HALTER_BOX);
   - Id: 101148
     AegisName: Security_Campaign_Box
     Name: "[Security Campaign Reward Box]"
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72940,6 +71837,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SECURITY_CAMPAIGN_BOX
     Script: |
       getgroupitem(IG_SECURITY_CAMPAIGN_BOX);
   - Id: 101159
@@ -72947,16 +71845,14 @@ Body:
     Name: Costume Pigtails Half Up Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_C_BRAID_HALF_UP_BOX
     Script: |
       getgroupitem(IG_C_BRAID_HALF_UP_BOX);
   - Id: 101161
     AegisName: Season_Evt_Reward_12
     Name: Snowflake Reward Box
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_SEASON_EVT_REWARD_12
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_12);
   - Id: 101162
@@ -72979,8 +71875,6 @@ Body:
     AegisName: Kr_B_Special05
     Name: G-Star RO Shop Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -72989,14 +71883,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL05
     Script: |
       getgroupitem(IG_KR_B_SPECIAL05);
   - Id: 101167
     AegisName: Kr_B_Special06
     Name: 2021 G-Star Commemorative Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73005,6 +71898,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL06
     Script: |
       getgroupitem(IG_KR_B_SPECIAL06);
   - Id: 101168
@@ -73024,8 +71918,6 @@ Body:
     AegisName: Kr_B_Special09
     Name: Exhibition Hall Movement Scroll
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73034,14 +71926,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL09
     Script: |
       getgroupitem(IG_KR_B_SPECIAL09);
   - Id: 101170
     AegisName: Kr_B_Special08
     Name: 2021 Quiz Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73050,6 +71941,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KR_B_SPECIAL08
     Script: |
       getgroupitem(IG_KR_B_SPECIAL08);
   - Id: 101177
@@ -73110,8 +72002,6 @@ Body:
     AegisName: Ice_F_Stone_Box
     Name: Snow Flower Manastone Extractor
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73121,6 +72011,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ICE_F_STONE_BOX
     Script: |
       getgroupitem(IG_ICE_F_STONE_BOX);
   - Id: 101184
@@ -73217,7 +72108,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HERO_TOKEN_BOX
     Script: |
       getgroupitem(IG_HERO_TOKEN_BOX);
   - Id: 101200
@@ -73297,8 +72188,6 @@ Body:
     Name: Booster Pack(120)    # !todo check english name
     Type: Usable
     EquipLevelMin: 120
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73308,6 +72197,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_120
     Script: |
       getgroupitem(IG_BOOSTER_PACK_120);
   - Id: 101236
@@ -73315,8 +72205,6 @@ Body:
     Name: Booster Pack(150)    # !todo check english name
     Type: Usable
     EquipLevelMin: 150
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73326,6 +72214,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_150
     Script: |
       getgroupitem(IG_BOOSTER_PACK_150);
   - Id: 101238
@@ -73347,8 +72236,6 @@ Body:
     AegisName: Season_Evt_Reward_1
     Name: January Event's Reward Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73358,6 +72245,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SEASON_EVT_REWARD_1
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_1);
   - Id: 101241
@@ -73439,8 +72327,6 @@ Body:
     AegisName: 2021_Winter_Event_Box1
     Name: Winter Event Costume Basket
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73449,14 +72335,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2021_WINTER_EVENT_BOX1
     Script: |
       getgroupitem(IG_2021_WINTER_EVENT_BOX1);
   - Id: 101269
     AegisName: 2021_Winter_Event_Box2
     Name: Winter Event Costume Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73465,6 +72350,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2021_WINTER_EVENT_BOX2
     Script: |
       getgroupitem(IG_2021_WINTER_EVENT_BOX2);
   - Id: 101271
@@ -73472,10 +72358,9 @@ Body:
     Name: Costume Enchant Stone Box 26
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX26
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box26);
+      getgroupitem(IG_ENCHANT_STONE_BOX26);
   - Id: 101276
     AegisName: New_Year_Rice_Soup
     Name: New Year Rice Soup
@@ -73494,8 +72379,6 @@ Body:
     AegisName: 2022_LunarNewYears_box
     Name: New Year Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73503,6 +72386,7 @@ Body:
       NoCart: true
       NoGuildStorage: true
       NoAuction: true
+    ItemGroup: IG_2022_LUNARNEWYEARS_BOX
     Script: |
       getgroupitem(IG_2022_LUNARNEWYEARS_BOX);
   - Id: 101306
@@ -73566,7 +72450,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HELM_OF_FAITH_BOX
     Script: |
       getgroupitem(IG_HELM_OF_FAITH_BOX);
   - Id: 101321
@@ -73574,8 +72458,6 @@ Body:
     Name: Event Error Compensation Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73585,6 +72467,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2020_REWARD_BOX
     Script: |
       getgroupitem(IG_2020_REWARD_BOX);
   - Id: 101322
@@ -73830,8 +72713,7 @@ Body:
     Name: Enchantment Ticket Envelope
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_TICKET_3
     Script: |
       getgroupitem(IG_ENCHANT_TICKET_3);
   - Id: 101404
@@ -73875,10 +72757,9 @@ Body:
     Name: Costume Enchant Stone Box 27
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX27
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box27);
+      getgroupitem(IG_ENCHANT_STONE_BOX27);
   - Id: 101423
     AegisName: Boost_Armor_Box
     Name: Boost Armor Box    # !todo check english name
@@ -73985,8 +72866,6 @@ Body:
     AegisName: P_Booster230_Gift
     Name: Premium Booster Gift Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -73995,6 +72874,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_P_BOOSTER230_GIFT
     Script: |
       getgroupitem(IG_P_BOOSTER230_GIFT);
   - Id: 101461
@@ -74004,13 +72884,15 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FAN_GREED_1HOUR_BOX
     Script: |
       getgroupitem(IG_FAN_GREED_1HOUR_BOX);
   - Id: 101463
     AegisName: HD_Elunium_10Box_MSP
     Name: (Limited) HD Elunium 10 Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74026,6 +72908,8 @@ Body:
     AegisName: HD_Oridecon_10Box_MSP
     Name: (Limited) HD Oridecon 10 Box
     Type: Usable
+    Flags:
+      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74096,8 +72980,6 @@ Body:
     AegisName: Booster230_Gift
     Name: Booster Gift Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74107,6 +72989,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER230_GIFT
     Script: |
       getgroupitem(IG_BOOSTER230_GIFT);
   - Id: 101482
@@ -74128,8 +73011,6 @@ Body:
     Name: Booster Pack(10)    # !todo check english name
     Type: Usable
     EquipLevelMin: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74139,6 +73020,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_10
     Script: |
       getgroupitem(IG_BOOSTER_PACK_10);
   - Id: 101491
@@ -74146,8 +73028,6 @@ Body:
     Name: Booster Pack(20)    # !todo check english name
     Type: Usable
     EquipLevelMin: 20
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74157,6 +73037,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_20
     Script: |
       getgroupitem(IG_BOOSTER_PACK_20);
   - Id: 101492
@@ -74164,8 +73045,6 @@ Body:
     Name: Booster Pack(40)    # !todo check english name
     Type: Usable
     EquipLevelMin: 40
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74175,6 +73054,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_40
     Script: |
       getgroupitem(IG_BOOSTER_PACK_40);
   - Id: 101493
@@ -74182,8 +73062,6 @@ Body:
     Name: Booster Pack(50)    # !todo check english name
     Type: Usable
     EquipLevelMin: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74193,6 +73071,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_50
     Script: |
       getgroupitem(IG_BOOSTER_PACK_50);
   - Id: 101494
@@ -74200,8 +73079,6 @@ Body:
     Name: Booster Pack(70)    # !todo check english name
     Type: Usable
     EquipLevelMin: 70
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74211,6 +73088,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_70
     Script: |
       getgroupitem(IG_BOOSTER_PACK_70);
   - Id: 101495
@@ -74218,8 +73096,6 @@ Body:
     Name: Booster Pack (80)    # !todo check english name
     Type: Usable
     EquipLevelMin: 80
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74229,6 +73105,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_80
     Script: |
       getgroupitem(IG_BOOSTER_PACK_80);
   - Id: 101496
@@ -74236,8 +73113,6 @@ Body:
     Name: Booster Pack(110)    # !todo check english name
     Type: Usable
     EquipLevelMin: 110
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74247,6 +73122,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_110
     Script: |
       getgroupitem(IG_BOOSTER_PACK_110);
   - Id: 101497
@@ -74254,8 +73130,6 @@ Body:
     Name: Booster Pack(140)    # !todo check english name
     Type: Usable
     EquipLevelMin: 140
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74265,6 +73139,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_140
     Script: |
       getgroupitem(IG_BOOSTER_PACK_140);
   - Id: 101498
@@ -74272,8 +73147,6 @@ Body:
     Name: Booster Pack(170)    # !todo check english name
     Type: Usable
     EquipLevelMin: 170
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74283,6 +73156,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_170
     Script: |
       getgroupitem(IG_BOOSTER_PACK_170);
   - Id: 101499
@@ -74290,8 +73164,6 @@ Body:
     Name: Booster Pack (180)    # !todo check english name
     Type: Usable
     EquipLevelMin: 180
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74301,6 +73173,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_180
     Script: |
       getgroupitem(IG_BOOSTER_PACK_180);
   - Id: 101500
@@ -74308,8 +73181,6 @@ Body:
     Name: Booster Pack(210)    # !todo check english name
     Type: Usable
     EquipLevelMin: 210
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74319,6 +73190,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_210
     Script: |
       getgroupitem(IG_BOOSTER_PACK_210);
   - Id: 101501
@@ -74326,8 +73198,6 @@ Body:
     Name: Booster Pack(220)    # !todo check english name
     Type: Usable
     EquipLevelMin: 220
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74337,6 +73207,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_220
     Script: |
       getgroupitem(IG_BOOSTER_PACK_220);
   - Id: 101502
@@ -74344,8 +73215,6 @@ Body:
     Name: Booster Pack(240)    # !todo check english name
     Type: Usable
     EquipLevelMin: 240
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74355,6 +73224,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_240
     Script: |
       getgroupitem(IG_BOOSTER_PACK_240);
   - Id: 101503
@@ -74362,8 +73232,6 @@ Body:
     Name: Booster Pack (250)    # !todo check english name
     Type: Usable
     EquipLevelMin: 250
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74373,6 +73241,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_PACK_250
     Script: |
       getgroupitem(IG_BOOSTER_PACK_250);
   - Id: 101512
@@ -74380,10 +73249,9 @@ Body:
     Name: Ancient Hero Box 1    # !todo check english name
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_ANCIENT_HERO_BOX_1
     Script: |
-      getgroupitem(IG_Ancient_Hero_Box_1);
+      getgroupitem(IG_ANCIENT_HERO_BOX_1);
   - Id: 101513
     AegisName: aegis_101513
     Name: "[Scroll] STR Biscuit Stick"
@@ -74465,8 +73333,6 @@ Body:
     Name: Booster box    # !todo check english name
     Type: Usable
     EquipLevelMax: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74475,6 +73341,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BOOSTER_CALL_PACKAGE
     Script: |
       getgroupitem(IG_BOOSTER_CALL_PACKAGE);
   - Id: 101542
@@ -74489,8 +73356,7 @@ Body:
     Name: Full Penetration Shadow Earring Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLPENE_EARRING
     Script: |
       getgroupitem(IG_S_FULLPENE_EARRING,true);
   - Id: 101544
@@ -74498,8 +73364,7 @@ Body:
     Name: Full Penetration Shadow Pendant Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLPENE_PENDANT
     Script: |
       getgroupitem(IG_S_FULLPENE_PENDANT,true);
   - Id: 101545
@@ -74507,8 +73372,7 @@ Body:
     Name: Full Penetration Shadow Armor Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLPENE_ARMOR
     Script: |
       getgroupitem(IG_S_FULLPENE_ARMOR,true);
   - Id: 101546
@@ -74516,8 +73380,7 @@ Body:
     Name: Full Penetration Shadow Shoes Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLPENE_SHOES
     Script: |
       getgroupitem(IG_S_FULLPENE_SHOES,true);
   - Id: 101547
@@ -74532,8 +73395,7 @@ Body:
     Name: Full Tempest Shadow Earring Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLTEMP_EARRING
     Script: |
       getgroupitem(IG_S_FULLTEMP_EARRING,true);
   - Id: 101549
@@ -74541,8 +73403,7 @@ Body:
     Name: Full Tempest Shadow Pendant Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLTEMP_PENDANT
     Script: |
       getgroupitem(IG_S_FULLTEMP_PENDANT,true);
   - Id: 101550
@@ -74550,8 +73411,7 @@ Body:
     Name: Full Tempest Shadow Armor Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLTEMP_ARMOR
     Script: |
       getgroupitem(IG_S_FULLTEMP_ARMOR,true);
   - Id: 101551
@@ -74559,8 +73419,7 @@ Body:
     Name: Full Tempest Shadow Shoes Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_FULLTEMP_SHOES
     Script: |
       getgroupitem(IG_S_FULLTEMP_SHOES,true);
   - Id: 101552
@@ -74575,8 +73434,7 @@ Body:
     Name: Durable Shadow Weapon Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_DURABLE_WEAPON
     Script: |
       getgroupitem(IG_S_DURABLE_WEAPON,true);
   - Id: 101554
@@ -74584,8 +73442,7 @@ Body:
     Name: Durable Shadow Shield Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_DURABLE_SHIELD
     Script: |
       getgroupitem(IG_S_DURABLE_SHIELD,true);
   - Id: 101555
@@ -74600,8 +73457,7 @@ Body:
     Name: Clever Shadow Weapon Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_CLEVER_WEAPON
     Script: |
       getgroupitem(IG_S_CLEVER_WEAPON,true);
   - Id: 101557
@@ -74609,8 +73465,7 @@ Body:
     Name: Clever Shadow Shield Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_CLEVER_SHIELD
     Script: |
       getgroupitem(IG_S_CLEVER_SHIELD,true);
   - Id: 101563
@@ -74640,8 +73495,6 @@ Body:
     AegisName: KAKAO_Plus_Box
     Name: Gravity Fluffy Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74650,6 +73503,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_KAKAO_PLUS_BOX
     Script: |
       getgroupitem(IG_KAKAO_PLUS_BOX,true);
   - Id: 101589
@@ -74657,8 +73511,6 @@ Body:
     Name: "[Not for Sale] Boarding Rein Box"    # !todo check english name
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74667,6 +73519,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_BOARDING_HALTER_BOX2
     Script: |
       getgroupitem(IG_E_BOARDING_HALTER_BOX2);
   - Id: 101596
@@ -74702,8 +73555,6 @@ Body:
     Name: "[Event] Equipment Crafting Material Box"    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74712,6 +73563,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_MAKINGMATERIALS_BOX
     Script: |
       getgroupitem(IG_EVT_MAKINGMATERIALS_BOX);
   - Id: 101600
@@ -74719,8 +73571,6 @@ Body:
     Name: Merit Box (Platinum Class)    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74730,6 +73580,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_WHITEGOLD
     Script: |
       getgroupitem(IG_EVT_20TH_WHITEGOLD);
   - Id: 101601
@@ -74737,8 +73588,6 @@ Body:
     Name: Merit Box (Gold Class)    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74748,6 +73597,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_GOLD
     Script: |
       getgroupitem(IG_EVT_20TH_GOLD);
   - Id: 101602
@@ -74755,8 +73605,6 @@ Body:
     Name: Merit Box (Silver grade)    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74766,6 +73614,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_SILVER
     Script: |
       getgroupitem(IG_EVT_20TH_SILVER);
   - Id: 101603
@@ -74773,8 +73622,6 @@ Body:
     Name: Merit Box (Equivalent level)    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74784,6 +73631,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_BRONZE
     Script: |
       getgroupitem(IG_EVT_20TH_BRONZE);
   - Id: 101604
@@ -74791,8 +73639,6 @@ Body:
     Name: Commander's Return    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74802,6 +73648,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_RETURN
     Script: |
       getgroupitem(IG_EVT_20TH_RETURN);
   - Id: 101605
@@ -74809,8 +73656,6 @@ Body:
     Name: Commander's Advanced Answers    # !todo check english name
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -74820,6 +73665,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EVT_20TH_RETURN2
     Script: |
       getgroupitem(IG_EVT_20TH_RETURN2);
   - Id: 101637
@@ -74884,7 +73730,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_VIVA_ADUL_HAT_BOX_11
     Script: |
       getgroupitem(IG_VIVA_ADUL_HAT_BOX_11,true);
   - Id: 101654
@@ -74899,8 +73745,7 @@ Body:
     Name: Almighty Shadow Earring Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_ALLMIGHTY_EARRING
     Script: |
       getgroupitem(IG_S_ALLMIGHTY_EARRING,true);
   - Id: 101656
@@ -74908,8 +73753,7 @@ Body:
     Name: Almighty Shadow Pendant Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_ALLMIGHTY_PENDANT
     Script: |
       getgroupitem(IG_S_ALLMIGHTY_PENDANT,true);
   - Id: 101657
@@ -74924,8 +73768,7 @@ Body:
     Name: True Gemstone Shadow Earring Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_TRUEGEM_EARRING
     Script: |
       getgroupitem(IG_S_TRUEGEM_EARRING,true);
   - Id: 101659
@@ -74933,8 +73776,7 @@ Body:
     Name: True Gemstone Shadow Pendant Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_TRUEGEM_PENDANT
     Script: |
       getgroupitem(IG_S_TRUEGEM_PENDANT,true);
   - Id: 101660
@@ -74942,8 +73784,7 @@ Body:
     Name: True Gemstone Shadow Shoes Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_TRUEGEM_SHOES
     Script: |
       getgroupitem(IG_S_TRUEGEM_SHOES,true);
   - Id: 101661
@@ -74951,8 +73792,7 @@ Body:
     Name: True Gemstone Shadow Armor Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_TRUEGEM_ARMOR
     Script: |
       getgroupitem(IG_S_TRUEGEM_ARMOR,true);
   - Id: 101662
@@ -74967,8 +73807,7 @@ Body:
     Name: Perfect Size Shadow Weapon Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_PERFECTSIZE_WEAPON
     Script: |
       getgroupitem(IG_S_PERFECTSIZE_WEAPON,true);
   - Id: 101664
@@ -74976,8 +73815,7 @@ Body:
     Name: Perfect Size Shadow Armor Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_PERFECTSIZE_ARMOR
     Script: |
       getgroupitem(IG_S_PERFECTSIZE_ARMOR,true);
   - Id: 101665
@@ -74996,7 +73834,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_UP_BOX
     Script: |
       getgroupitem(IG_SHADOW_UP_BOX);
   - Id: 101675
@@ -75004,10 +73842,9 @@ Body:
     Name: Costume Enchant Stone Box 28
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX28
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box28);
+      getgroupitem(IG_ENCHANT_STONE_BOX28);
   - Id: 101705
     AegisName: F_VR_Book006
     Name: Fantasy Series 006    # !todo check english name
@@ -75043,8 +73880,7 @@ Body:
     Name: Maximum Mammoth Shadow Earring Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_M_MAMMOTH_EARRING
     Script: |
       getgroupitem(IG_S_M_MAMMOTH_EARRING,true);
   - Id: 101718
@@ -75052,8 +73888,7 @@ Body:
     Name: Maximum Mammoth Shadow Pendant Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_M_MAMMOTH_PENDANT
     Script: |
       getgroupitem(IG_S_M_MAMMOTH_PENDANT,true);
   - Id: 101719
@@ -75061,8 +73896,7 @@ Body:
     Name: Maximum Mammoth Shadow Armor Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_M_MAMMOTH_ARMOR
     Script: |
       getgroupitem(IG_S_M_MAMMOTH_ARMOR,true);
   - Id: 101720
@@ -75070,8 +73904,7 @@ Body:
     Name: Maximum Mammoth Shadow Shoes Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_M_MAMMOTH_SHOES
     Script: |
       getgroupitem(IG_S_M_MAMMOTH_SHOES,true);
   - Id: 101721
@@ -75079,8 +73912,7 @@ Body:
     Name: Spell Caster Shadow Earring Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_SPELLCASTER_EARRING
     Script: |
       getgroupitem(IG_S_SPELLCASTER_EARRING,true);
   - Id: 101722
@@ -75088,8 +73920,7 @@ Body:
     Name: Spell Caster Shadow Pendant Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_SPELLCASTER_PENDANT
     Script: |
       getgroupitem(IG_S_SPELLCASTER_PENDANT,true);
   - Id: 101723
@@ -75097,8 +73928,7 @@ Body:
     Name: Spell Caster Shadow Armor Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_SPELLCASTER_ARMOR
     Script: |
       getgroupitem(IG_S_SPELLCASTER_ARMOR,true);
   - Id: 101724
@@ -75106,8 +73936,7 @@ Body:
     Name: Spell Caster Shadow Shoes Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_SPELLCASTER_SHOES
     Script: |
       getgroupitem(IG_S_SPELLCASTER_SHOES,true);
   - Id: 101725
@@ -75115,8 +73944,7 @@ Body:
     Name: Absorb Shadow Weapon Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_ABSORB_WEAPON
     Script: |
       getgroupitem(IG_S_ABSORB_WEAPON,true);
   - Id: 101726
@@ -75124,8 +73952,7 @@ Body:
     Name: Absorb Shadow Shield Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_S_ABSORB_SHIELD
     Script: |
       getgroupitem(IG_S_ABSORB_SHIELD,true);
   - Id: 101727
@@ -75153,8 +73980,6 @@ Body:
     AegisName: E_Cloth_Dye_Box
     Name: "[Non-sale] Clothes dyeing Coupon Box"    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75163,6 +73988,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_E_CLOTH_DYE_BOX
     Script: |
       getgroupitem(IG_E_CLOTH_DYE_BOX);
   - Id: 101745
@@ -75184,15 +74010,13 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_HEROSRIA_GIFT
     Script: |
       getgroupitem(IG_HEROSRIA_GIFT,true);
   - Id: 101752
     AegisName: RO_Festival_Box
     Name: Ragnarok Festival Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75201,6 +74025,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_FESTIVAL_BOX
     Script: |
       getgroupitem(IG_RO_FESTIVAL_BOX);
   - Id: 101753
@@ -75252,8 +74077,6 @@ Body:
     AegisName: Plain_Rune_Box5
     Name: Plain Rune 5ea Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75262,14 +74085,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PLAIN_RUNE_BOX5
     Script: |
       getgroupitem(IG_PLAIN_RUNE_BOX5);
   - Id: 101760
     AegisName: Flame_Rune_Box5
     Name: Flame Rune 5ea Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75278,14 +74100,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_FLAME_RUNE_BOX5
     Script: |
       getgroupitem(IG_FLAME_RUNE_BOX5);
   - Id: 101761
     AegisName: Ice_Rune_Box5
     Name: Ice Rune 5ea Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75294,14 +74115,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_ICE_RUNE_BOX5
     Script: |
       getgroupitem(IG_ICE_RUNE_BOX5);
   - Id: 101762
     AegisName: Death_Rune_Box5
     Name: Death Rune 5ea Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75310,6 +74130,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_DEATH_RUNE_BOX5
     Script: |
       getgroupitem(IG_DEATH_RUNE_BOX5);
   - Id: 101765
@@ -75436,8 +74257,6 @@ Body:
     AegisName: Service1_M_01_Box
     Name: Edward Zonda Owner's Box (1 Day)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75446,14 +74265,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_M_01_BOX
     Script: |
       getgroupitem(IG_SERVICE1_M_01_BOX);
   - Id: 101775
     AegisName: Service1_M_05_Box
     Name: Edward Zonda Owner's Box (5 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75462,14 +74280,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_M_05_BOX
     Script: |
       getgroupitem(IG_SERVICE1_M_05_BOX);
   - Id: 101776
     AegisName: Service1_M_07_Box
     Name: Edward Zonda Your Own Box (7 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75478,14 +74295,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_M_07_BOX
     Script: |
       getgroupitem(IG_SERVICE1_M_07_BOX);
   - Id: 101777
     AegisName: Service1_M_10_Box
     Name: Edward Zonda Owner's Box (10 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75494,14 +74310,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_M_10_BOX
     Script: |
       getgroupitem(IG_SERVICE1_M_10_BOX);
   - Id: 101778
     AegisName: Service1P_M_01_Box
     Name: Edward Zonda Ownerra EX Box (1 Day)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75510,14 +74325,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_M_01_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_M_01_BOX);
   - Id: 101779
     AegisName: Service1P_M_05_Box
     Name: Edward Zonda Owra EX Box (5 days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75526,14 +74340,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_M_05_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_M_05_BOX);
   - Id: 101780
     AegisName: Service1P_M_07_Box
     Name: Edward Zonda Ownerra EX Box (7 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75542,14 +74355,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_M_07_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_M_07_BOX);
   - Id: 101781
     AegisName: Service1P_M_10_Box
     Name: Edward Zonda Ownerra EX Box (10 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75558,14 +74370,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_M_10_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_M_10_BOX);
   - Id: 101782
     AegisName: Service1_F_01_Box
     Name: Elysee Zonda Come on Box (1 day)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75574,14 +74385,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_F_01_BOX
     Script: |
       getgroupitem(IG_SERVICE1_F_01_BOX);
   - Id: 101783
     AegisName: Service1_F_05_Box
     Name: Elise Zonda Come Box (5 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75590,14 +74400,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_F_05_BOX
     Script: |
       getgroupitem(IG_SERVICE1_F_05_BOX);
   - Id: 101784
     AegisName: Service1_F_07_Box
     Name: Elysee Zonda Come Box (7 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75606,14 +74415,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_F_07_BOX
     Script: |
       getgroupitem(IG_SERVICE1_F_07_BOX);
   - Id: 101785
     AegisName: Service1_F_10_Box
     Name: Elysee Zonda Come Box (10 Days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75622,14 +74430,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1_F_10_BOX
     Script: |
       getgroupitem(IG_SERVICE1_F_10_BOX);
   - Id: 101786
     AegisName: Service1P_F_01_Box
     Name: Elysee Zonda Own EX Box (1 day)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75638,14 +74445,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_F_01_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_F_01_BOX);
   - Id: 101787
     AegisName: Service1P_F_05_Box
     Name: Elysee Zonda Own EX Box (5 days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75654,14 +74460,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_F_05_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_F_05_BOX);
   - Id: 101788
     AegisName: Service1P_F_07_Box
     Name: Elysee Zonda Own EX Box (7 days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75670,14 +74475,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_F_07_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_F_07_BOX);
   - Id: 101789
     AegisName: Service1P_F_10_Box
     Name: Elysee Zonda Own EX Box (10 days)    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75686,6 +74490,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SERVICE1P_F_10_BOX
     Script: |
       getgroupitem(IG_SERVICE1P_F_10_BOX);
   - Id: 101792
@@ -75709,8 +74514,7 @@ Body:
     Name: Rod Bearers Earring Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_R_BEARERS_EARRING_BOX
     Script: |
       getgroupitem(IG_R_BEARERS_EARRING_BOX,true);
   - Id: 101803
@@ -75718,8 +74522,7 @@ Body:
     Name: Rod Bearers Pendant Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_R_BEARERS_PENDANT_BOX
     Script: |
       getgroupitem(IG_R_BEARERS_PENDANT_BOX,true);
   - Id: 101804
@@ -75727,8 +74530,7 @@ Body:
     Name: Lord Bearers Armor Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_R_BEARERS_ARMOR_BOX
     Script: |
       getgroupitem(IG_R_BEARERS_ARMOR_BOX,true);
   - Id: 101805
@@ -75736,8 +74538,7 @@ Body:
     Name: Road Bearers Shoes Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_R_BEARERS_SHOES_BOX
     Script: |
       getgroupitem(IG_R_BEARERS_SHOES_BOX,true);
   - Id: 101806
@@ -75752,8 +74553,7 @@ Body:
     Name: Hasty Weapon Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HASTY_WEAPON_BOX
     Script: |
       getgroupitem(IG_HASTY_WEAPON_BOX,true);
   - Id: 101808
@@ -75761,8 +74561,7 @@ Body:
     Name: Hasty Shield Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_HASTY_SHIELD_BOX
     Script: |
       getgroupitem(IG_HASTY_SHIELD_BOX,true);
   - Id: 101809
@@ -75772,7 +74571,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_S_RELOAD_SHIELD_BOX
     Script: |
       getgroupitem(IG_S_RELOAD_SHIELD_BOX,true);
   - Id: 101816
@@ -75830,8 +74629,6 @@ Body:
     AegisName: RO_Arena_Box
     Name: Ragnarok Arena Pre-Order Reward Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75840,14 +74637,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_ARENA_BOX
     Script: |
       getgroupitem(IG_RO_ARENA_BOX,true);
   - Id: 101840
     AegisName: RO_Arena_Box2
     Name: Ragnarok Arena Level 7 Achievement Reward Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75856,6 +74652,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_ARENA_BOX2
     Script: |
       getgroupitem(IG_RO_ARENA_BOX2);
   - Id: 101856
@@ -75870,8 +74667,7 @@ Body:
     Name: Major Auto Spell Earring Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAUTOSPELL_EARRING_BOX
     Script: |
       getgroupitem(IG_MAUTOSPELL_EARRING_BOX,true);
   - Id: 101859
@@ -75879,8 +74675,7 @@ Body:
     Name: Major Auto Spell Pendant Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAUTOSPELL_PENDANT_BOX
     Script: |
       getgroupitem(IG_MAUTOSPELL_PENDANT_BOX,true);
   - Id: 101860
@@ -75888,8 +74683,7 @@ Body:
     Name: Major Auto Spell Armor Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAUTOSPELL_ARMOR_BOX
     Script: |
       getgroupitem(IG_MAUTOSPELL_ARMOR_BOX,true);
   - Id: 101861
@@ -75897,8 +74691,7 @@ Body:
     Name: Major Auto Spell Shoes Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_MAUTOSPELL_SHOES_BOX
     Script: |
       getgroupitem(IG_MAUTOSPELL_SHOES_BOX,true);
   - Id: 101862
@@ -75913,8 +74706,7 @@ Body:
     Name: Infinity Weapon Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_INFINITY_WEAPON_BOX
     Script: |
       getgroupitem(IG_INFINITY_WEAPON_BOX,true);
   - Id: 101864
@@ -75922,8 +74714,7 @@ Body:
     Name: Infinity Shield Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_INFINITY_SHIELD_BOX
     Script: |
       getgroupitem(IG_INFINITY_SHIELD_BOX,true);
   - Id: 101869
@@ -75933,7 +74724,7 @@ Body:
     Weight: 50
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_LUXURIOUS_BLUE_BOX
     Script: |
       getgroupitem(IG_LUXURIOUS_BLUE_BOX);
   - Id: 101876
@@ -75941,17 +74732,14 @@ Body:
     Name: Costume Enchant Stone Box 29
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX29
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box29);
+      getgroupitem(IG_ENCHANT_STONE_BOX29);
   - Id: 101889
     AegisName: Vr_Book_Event
     Name: Fantasy Collection Collection Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75960,14 +74748,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VR_BOOK_EVENT
     Script: |
       getgroupitem(IG_VR_BOOK_EVENT);
   - Id: 101912
     AegisName: Temple_Rune_Box5
     Name: Holy Rune Box 5    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75976,14 +74763,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TEMPLE_RUNE_BOX5
     Script: |
       getgroupitem(IG_TEMPLE_RUNE_BOX5);
   - Id: 101913
     AegisName: Venom_Rune_Box5
     Name: Poison Rune x5 Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -75992,14 +74778,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VENOM_RUNE_BOX5
     Script: |
       getgroupitem(IG_VENOM_RUNE_BOX5);
   - Id: 101914
     AegisName: Soul_Rune_Box5
     Name: Box of 5 Soul Runes    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76008,6 +74793,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SOUL_RUNE_BOX5
     Script: |
       getgroupitem(IG_SOUL_RUNE_BOX5);
   - Id: 101919
@@ -76022,8 +74808,7 @@ Body:
     Name: Experience Weapon Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EXP_WEAPON_BOX
     Script: |
       getgroupitem(IG_EXP_WEAPON_BOX,true);
   - Id: 101921
@@ -76031,8 +74816,7 @@ Body:
     Name: Experience Shield Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_EXP_SHIELD_BOX
     Script: |
       getgroupitem(IG_EXP_SHIELD_BOX,true);
   - Id: 101922
@@ -76047,8 +74831,7 @@ Body:
     Name: Mega Blitz Weapon Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_M_BLITZ_WEAPON_BOX
     Script: |
       getgroupitem(IG_M_BLITZ_WEAPON_BOX,true);
   - Id: 101924
@@ -76056,8 +74839,7 @@ Body:
     Name: Mega Blitz Shield Shadow Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_M_BLITZ_SHIELD_BOX
     Script: |
       getgroupitem(IG_M_BLITZ_SHIELD_BOX,true);
   - Id: 101925
@@ -76066,7 +74848,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_CVT_WING_BOX
     Script: |
       getgroupitem(IG_CVT_WING_BOX,true);
   - Id: 101930
@@ -76198,8 +74980,6 @@ Body:
     AegisName: A_Bubble_Gum_Box10
     Name: "[Achievement] 10 boxes of bubble gum"    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76208,6 +74988,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_BUBBLE_GUM_BOX10
     Script: |
       getgroupitem(IG_A_BUBBLE_GUM_BOX10);
   - Id: 101954
@@ -76215,10 +74996,9 @@ Body:
     Name: Intake Hair Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_INTAKE_HAIR_BOX
     Script: |
-      getgroupitem(IG_Intake_Hair_Box);
+      getgroupitem(IG_INTAKE_HAIR_BOX);
   - Id: 102015
     AegisName: Mocadas_Enchant_Box
     Name: Mocadas Equipment Enchantment    # !todo check english name
@@ -76230,8 +75010,7 @@ Body:
     Name: Metal Detector Box    # !todo check english name
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
+    ItemGroup: IG_F_EIN_1HDAGGER_BOX
     Script: |
       getgroupitem(IG_F_EIN_1HDAGGER_BOX);
   - Id: 102017
@@ -76531,8 +75310,6 @@ Body:
     AegisName: Pene_Set_Cube
     Name: Refined Penetration Shadow Cube    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76541,14 +75318,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PENE_SET_CUBE
     Script: |
       getgroupitem(IG_PENE_SET_CUBE,true);
   - Id: 102068
     AegisName: S_Bearers_Cube
     Name: Bearers Shadow Cube    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76557,14 +75333,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BEARERS_CUBE
     Script: |
       getgroupitem(IG_S_BEARERS_CUBE);
   - Id: 102069
     AegisName: Temp_Set_Cube
     Name: Refined Tempest Shadow Cube    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76573,6 +75348,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_TEMP_SET_CUBE
     Script: |
       getgroupitem(IG_TEMP_SET_CUBE,true);
   - Id: 102070
@@ -76581,7 +75357,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_JUSTICE_WEAPON_BOX
     Script: |
       getgroupitem(IG_JUSTICE_WEAPON_BOX,true);
   - Id: 102071
@@ -76590,7 +75366,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_INJUSTICE_WEAPON_BOX
     Script: |
       getgroupitem(IG_INJUSTICE_WEAPON_BOX,true);
   - Id: 102072
@@ -76618,7 +75394,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_GOODNEVIL_HELM_BOX
     Script: |
       getgroupitem(IG_GOODNEVIL_HELM_BOX,true);
   - Id: 102075
@@ -76650,7 +75426,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SHADOW_SELECT_BOX_SET
     Script: |
       getgroupitem(IG_SHADOW_SELECT_BOX_SET);
   - Id: 102124
@@ -76669,7 +75445,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_REFINE_HAMMER_BOX
     Script: |
       getgroupitem(IG_REFINE_HAMMER_BOX);
   - Id: 102126
@@ -76702,10 +75478,9 @@ Body:
     Name: Costume Enchant Stone Box 30
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX30
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box30);
+      getgroupitem(IG_ENCHANT_STONE_BOX30);
   - Id: 102202
     AegisName: Ep20_Fatty_Icegangu
     Name: Chubby Ice Steel Ball    # !todo check english name
@@ -76788,7 +75563,7 @@ Body:
     Weight: 10
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SLD_BOSS_CARD_ALBUM
     Script: |
       getgroupitem(IG_SLD_BOSS_CARD_ALBUM);
   - Id: 102227
@@ -76840,8 +75615,6 @@ Body:
     AegisName: VIP_Gift
     Name: VIP Gift
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76850,14 +75623,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIP_GIFT
     Script: |
       getgroupitem(IG_VIP_GIFT);
   - Id: 102248
     AegisName: VVIP_Gift
     Name: VVIP Gift
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76866,14 +75638,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VVIP_GIFT
     Script: |
       getgroupitem(IG_VVIP_GIFT);
   - Id: 102249
     AegisName: SVIP_Gift
     Name: SVIP Gift
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76882,6 +75653,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SVIP_GIFT
     Script: |
       getgroupitem(IG_SVIP_GIFT);
   - Id: 102277
@@ -76928,8 +75700,6 @@ Body:
     AegisName: 2023_Spring_Collection
     Name: 2023 Spring Reward Costume Collection Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -76938,6 +75708,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2023_SPRING_COLLECTION
     Script: |
       getgroupitem(IG_2023_SPRING_COLLECTION);
   - Id: 102308
@@ -76975,25 +75746,21 @@ Body:
     Name: Costume Enchant Stone Box 31
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX31
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box31);
+      getgroupitem(IG_ENCHANT_STONE_BOX31);
   - Id: 102333
     AegisName: Stone_Robe3_Box
     Name: 3rd Expansion Stone III (Drapping) Box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_STONE_ROBE3_BOX
     Script: |
       getgroupitem(IG_STONE_ROBE3_BOX);
   - Id: 102337
     AegisName: RO_Concert_Scroll
     Name: RO Concert Costume Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77002,6 +75769,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_CONCERT_SCROLL
     Script: |
       getgroupitem(IG_RO_CONCERT_SCROLL);
   - Id: 102338
@@ -77020,8 +75788,6 @@ Body:
     AegisName: RO_Concert_Scroll_Box
     Name: RO Concert Outfit Selection Box x2    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77030,6 +75796,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_RO_CONCERT_SCROLL_BOX
     Script: |
       getgroupitem(IG_RO_CONCERT_SCROLL_BOX);
   - Id: 102342
@@ -77061,8 +75828,7 @@ Body:
     AegisName: Fan_Upgrade_Kit_EX_10
     Name: Fan Modification Kit EX 10 sets    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_FAN_UPGRADE_KIT_EX_10
     Script: |
       getgroupitem(IG_FAN_UPGRADE_KIT_EX_10);
   - Id: 102353
@@ -77070,8 +75836,6 @@ Body:
     Name: Cat Hand Ticket 1 Day Box    # !todo check english name
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77080,6 +75844,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CATPAW_1DAY_BOX
     Script: |
       getgroupitem(IG_CATPAW_1DAY_BOX);
   - Id: 102373
@@ -77122,19 +75887,17 @@ Body:
     Name: Ancient Hero Box 2
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_ANCIENT_HERO_BOX_2
     Script: |
-      getgroupitem(IG_Ancient_Hero_Box_2);
+      getgroupitem(IG_ANCIENT_HERO_BOX_2);
   - Id: 102414
     AegisName: aegis_102414
     Name: Ancient Hero Box 3
     Type: Usable
     Weight: 200
-    Flags:
-      Container: true
+    ItemGroup: IG_ANCIENT_HERO_BOX_3
     Script: |
-      getgroupitem(IG_Ancient_Hero_Box_3);
+      getgroupitem(IG_ANCIENT_HERO_BOX_3);
   - Id: 102419
     AegisName: Melody_Card_191
     Name: Special Melody Card    # !todo check english name
@@ -77150,8 +75913,7 @@ Body:
     AegisName: Season_Evt_Reward_8
     Name: Night Market Blue Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_SEASON_EVT_REWARD_8
     Script: |
       getgroupitem(IG_SEASON_EVT_REWARD_8);
   - Id: 102433
@@ -77183,17 +75945,14 @@ Body:
     Name: Costume Enchant Stone Box 32
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX32
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box32);
+      getgroupitem(IG_ENCHANT_STONE_BOX32);
   - Id: 102450
     AegisName: 21th_Present_Box
     Name: 21st anniversary gift box    # !todo check english name
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77201,14 +75960,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_21TH_PRESENT_BOX
     Script: |
       getgroupitem(IG_21TH_PRESENT_BOX);
   - Id: 102451
     AegisName: Mileage_Coupon
     Name: Mileage Voucher Envelope    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77218,6 +75976,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MILEAGE_COUPON
     Script: |
       getgroupitem(IG_MILEAGE_COUPON);
   - Id: 102454
@@ -77262,8 +76021,6 @@ Body:
     AegisName: 21th_Costume_Collection
     Name: 21st Anniversary Costume Collection Box    # !todo check english name
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77272,6 +76029,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_21TH_COSTUME_COLLECTION
     Script: |
       getgroupitem(IG_21TH_COSTUME_COLLECTION,true);
   - Id: 102482
@@ -77287,8 +76045,6 @@ Body:
     AegisName: S_Enchant_Essence_Box_3
     Name: Shadow Essence 3 Boxes    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77297,6 +76053,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_ENCHANT_ESSENCE_BOX_3
     Script: |
       getgroupitem(IG_S_ENCHANT_ESSENCE_BOX_3);
   - Id: 102514
@@ -77320,7 +76077,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_M_ARMOR_BOX
     Script: |
       getgroupitem(IG_M_ARMOR_BOX);
   - Id: 102541
@@ -77329,7 +76086,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_M_SHOES_BOX
     Script: |
       getgroupitem(IG_M_SHOES_BOX);
   - Id: 102542
@@ -77338,7 +76095,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_M_PENDANT_BOX
     Script: |
       getgroupitem(IG_M_PENDANT_BOX);
   - Id: 102543
@@ -77347,7 +76104,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_M_EARRING_BOX
     Script: |
       getgroupitem(IG_M_EARRING_BOX);
   - Id: 102544
@@ -77356,7 +76113,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_EIN_ORE_BOX
     Script: |
       getgroupitem(IG_EIN_ORE_BOX);
   - Id: 102545
@@ -77365,7 +76122,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_FATE_FRAGMENT_BOX
     Script: |
       getgroupitem(IG_FATE_FRAGMENT_BOX);
   - Id: 102546
@@ -77374,7 +76131,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SIN_FRAGMENT_BOX
     Script: |
       getgroupitem(IG_SIN_FRAGMENT_BOX);
   - Id: 102547
@@ -77383,7 +76140,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_AMETHYST_FRAGMENT_BOX
     Script: |
       getgroupitem(IG_AMETHYST_FRAGMENT_BOX);
   - Id: 102548
@@ -77392,7 +76149,7 @@ Body:
     Type: Usable
     Flags:
       BuyingStore: true
-      Container: true
+    ItemGroup: IG_SNOW_F_ORE_BOX
     Script: |
       getgroupitem(IG_SNOW_F_ORE_BOX);
   - Id: 102550
@@ -77401,8 +76158,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_SCHMIDT_ANTIQUITY
     Script: |
       getgroupitem(IG_SCHMIDT_ANTIQUITY,true);
   - Id: 102551
@@ -77412,8 +76169,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_SCHMIDT_ANTIQUITY2
     Script: |
       getgroupitem(IG_SCHMIDT_ANTIQUITY2,true);
   - Id: 102552
@@ -77422,8 +76179,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_C_AMDARAIS_ANTIQUITY
     Script: |
       getgroupitem(IG_C_AMDARAIS_ANTIQUITY,true);
   - Id: 102553
@@ -77432,8 +76189,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_C_HIMEL_ANTIQUITY
     Script: |
       getgroupitem(IG_C_HIMEL_ANTIQUITY,true);
   - Id: 102554
@@ -77442,8 +76199,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AMDARAIS_ANTIQUITY
     Script: |
       getgroupitem(IG_AMDARAIS_ANTIQUITY,true);
   - Id: 102555
@@ -77452,8 +76209,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AMDARAIS_ANTIQUITY2
     Script: |
       getgroupitem(IG_AMDARAIS_ANTIQUITY2,true);
   - Id: 102556
@@ -77462,8 +76219,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_MIGUEL_ANTIQUITY
     Script: |
       getgroupitem(IG_MIGUEL_ANTIQUITY,true);
   - Id: 102557
@@ -77471,8 +76228,8 @@ Body:
     Name: Antiquity Cor (EL-A17T)
     Type: Usable
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_EL_A17T_ANTIQUITY
     Script: |
       getgroupitem(IG_EL_A17T_ANTIQUITY,true);
   - Id: 102558
@@ -77481,8 +76238,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_PITAYA_BOSS_ANTIQUITY
     Script: |
       getgroupitem(IG_PITAYA_BOSS_ANTIQUITY,true);
   - Id: 102559
@@ -77491,8 +76248,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_SWEETY_ANTIQUITY
     Script: |
       getgroupitem(IG_SWEETY_ANTIQUITY,true);
   - Id: 102560
@@ -77501,8 +76258,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_REDPEPPER_ANTIQUITY
     Script: |
       getgroupitem(IG_REDPEPPER_ANTIQUITY,true);
   - Id: 102561
@@ -77511,8 +76268,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_REDPEPPER_ANTIQUITY2
     Script: |
       getgroupitem(IG_REDPEPPER_ANTIQUITY2,true);
   - Id: 102562
@@ -77521,8 +76278,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_DEMI_FREYJA_ANTIQUITY
     Script: |
       getgroupitem(IG_DEMI_FREYJA_ANTIQUITY,true);
   - Id: 102563
@@ -77531,8 +76288,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_JUNCEA_ANTIQUITY
     Script: |
       getgroupitem(IG_JUNCEA_ANTIQUITY,true);
   - Id: 102564
@@ -77541,8 +76298,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AQUILA_ANTIQUITY
     Script: |
       getgroupitem(IG_AQUILA_ANTIQUITY,true);
   - Id: 102565
@@ -77551,8 +76308,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AQUILA_ANTIQUITY2
     Script: |
       getgroupitem(IG_AQUILA_ANTIQUITY2,true);
   - Id: 102566
@@ -77561,8 +76318,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_F_ICESLUG_ANTIQUIY
     Script: |
       getgroupitem(IG_F_ICESLUG_ANTIQUIY,true);
   - Id: 102567
@@ -77571,8 +76328,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_LASGAND_ANTIQUITY
     Script: |
       getgroupitem(IG_LASGAND_ANTIQUITY,true);
   - Id: 102568
@@ -77581,8 +76338,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_LASGAND_ANTIQUITY2
     Script: |
       getgroupitem(IG_LASGAND_ANTIQUITY2,true);
   - Id: 102569
@@ -77591,8 +76348,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_CELINE_KIMI_ANTIQUITY
     Script: |
       getgroupitem(IG_CELINE_KIMI_ANTIQUITY,true);
   - Id: 102570
@@ -77601,8 +76358,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_SAKRAY_ANTIQUITY
     Script: |
       getgroupitem(IG_SAKRAY_ANTIQUITY,true);
   - Id: 102571
@@ -77611,8 +76368,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_UNKNOWN_ANTIQUITY
     Script: |
       getgroupitem(IG_UNKNOWN_ANTIQUITY,true);
   - Id: 102572
@@ -77621,8 +76378,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_THANATOS_ANTIQUITY
     Script: |
       getgroupitem(IG_THANATOS_ANTIQUITY,true);
   - Id: 102573
@@ -77631,8 +76388,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AIRBOAT_ANTIQUITY
     Script: |
       getgroupitem(IG_AIRBOAT_ANTIQUITY,true);
   - Id: 102580
@@ -77640,10 +76397,9 @@ Body:
     Name: Ponytail Gift Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_PONYTAIL_HAIR_BOX
     Script: |
-      getgroupitem(IG_Ponytail_Hair_Box);
+      getgroupitem(IG_PONYTAIL_HAIR_BOX);
   - Id: 102593
     AegisName: Honey_Songpyun_E
     Name: "[Event] Honey Songpyeon"
@@ -77663,17 +76419,14 @@ Body:
     Name: Costume Enchant Stone Box 33
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX33
     Script: |
-      getgroupitem(IG_Enchant_Stone_Box33);
+      getgroupitem(IG_ENCHANT_STONE_BOX33);
   - Id: 102624
     AegisName: T_Garden_Ev_1
     Name: Energy Box of Spirit
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77682,6 +76435,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_T_GARDEN_EV_1
     Script: |
       getgroupitem(IG_T_GARDEN_EV_1);
   - Id: 102625
@@ -77689,8 +76443,6 @@ Body:
     Name: Energy Box of Season
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77699,6 +76451,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_T_GARDEN_EV_2
     Script: |
       getgroupitem(IG_T_GARDEN_EV_2);
   - Id: 102626
@@ -77706,8 +76459,6 @@ Body:
     Name: Box of Life
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77716,6 +76467,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_T_GARDEN_EV_3
     Script: |
       getgroupitem(IG_T_GARDEN_EV_3);
   - Id: 102631
@@ -77736,8 +76488,6 @@ Body:
     Name: Costume Stone Mix I Box
     Type: Usable
     Weight: 30
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77746,6 +76496,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COS_ENCHANTSTONE_BOX1
     Script: |
       getgroupitem(IG_COS_ENCHANTSTONE_BOX1);
   - Id: 102633
@@ -77753,8 +76504,6 @@ Body:
     Name: Costume Stone Mix II Box
     Type: Usable
     Weight: 30
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77763,6 +76512,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COS_ENCHANTSTONE_BOX2
     Script: |
       getgroupitem(IG_COS_ENCHANTSTONE_BOX2);
   - Id: 102634
@@ -77770,8 +76520,6 @@ Body:
     Name: Costume Stone Mix III Box
     Type: Usable
     Weight: 30
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77780,6 +76528,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COS_ENCHANTSTONE_BOX3
     Script: |
       getgroupitem(IG_COS_ENCHANTSTONE_BOX3);
   - Id: 102638
@@ -77787,8 +76536,6 @@ Body:
     Name: Sonic Badge Package
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77797,6 +76544,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BADGE_PACK
     Script: |
       getgroupitem(IG_S_BADGE_PACK);
   - Id: 102668
@@ -77833,8 +76581,6 @@ Body:
     Name: "[Reward] Kachua's Secret Key"
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77843,6 +76589,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MAIN_LUCKY_BOX_
     Script: |
       getgroupitem(IG_MAIN_LUCKY_BOX_,true);
   - Id: 102716
@@ -77850,8 +76597,6 @@ Body:
     Name: Deep Rune Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77860,6 +76605,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BL_DEPTH_EV_1
     Script: |
       getgroupitem(IG_BL_DEPTH_EV_1);
   - Id: 102717
@@ -77867,8 +76613,6 @@ Body:
     Name: Deep Abyss Rune Box
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77877,6 +76621,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BL_DEPTH_EV_2
     Script: |
       getgroupitem(IG_BL_DEPTH_EV_2);
   - Id: 102732
@@ -77907,8 +76652,6 @@ Body:
     AegisName: Brown_Dia_Box
     Name: Golden Diamond 15 ea Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77917,14 +76660,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROWN_DIA_BOX
     Script: |
       getgroupitem(IG_BROWN_DIA_BOX);
   - Id: 102740
     AegisName: PresentBox_EP17_2
     Name: Episode 17.2 Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77933,14 +76675,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRESENTBOX_EP17_2
     Script: |
       getgroupitem(IG_PRESENTBOX_EP17_2);
   - Id: 102741
     AegisName: PresentBox_EP18
     Name: Episode 18 Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77949,14 +76690,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRESENTBOX_EP18
     Script: |
       getgroupitem(IG_PRESENTBOX_EP18);
   - Id: 102742
     AegisName: Refine_Event_Box
     Name: Refine Event Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77965,14 +76705,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_REFINE_EVENT_BOX
     Script: |
       getgroupitem(IG_REFINE_EVENT_BOX);
   - Id: 102745
     AegisName: PresentBox_EP19
     Name: Episode 19 Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77981,14 +76720,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRESENTBOX_EP19
     Script: |
       getgroupitem(IG_PRESENTBOX_EP19);
   - Id: 102746
     AegisName: PresentBox_EP20
     Name: Episode 20 Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -77997,14 +76735,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRESENTBOX_EP20
     Script: |
       getgroupitem(IG_PRESENTBOX_EP20);
   - Id: 102747
     AegisName: PresentBox_GlastHeim
     Name: Glast Heim Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78013,6 +76750,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_PRESENTBOX_GLASTHEIM
     Script: |
       getgroupitem(IG_PRESENTBOX_GLASTHEIM);
   - Id: 102750
@@ -78020,8 +76758,6 @@ Body:
     Name: Black Diamond 3 ea Box
     Type: Cash
     Weight: 900
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78030,14 +76766,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BLACK_DIA_3_BOX
     Script: |
       getgroupitem(IG_BLACK_DIA_3_BOX);
   - Id: 102767
     AegisName: R_Ep17_Album
     Name: Episode 17-18 Card Album
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_R_EP17_ALBUM
     Script: |
       getgroupitem(IG_R_EP17_ALBUM);
   - Id: 102771
@@ -78096,8 +76832,6 @@ Body:
     Name: Sulki's Lunch Box
     Type: Usable
     Weight: 50
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78106,6 +76840,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2401_EV_LUNCH_BOX
     Script: |
       getgroupitem(IG_2401_EV_LUNCH_BOX);
   - Id: 102795
@@ -78141,8 +76876,6 @@ Body:
     Name: Super Sonic Package
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78151,6 +76884,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_SONIC_PACK
     Script: |
       getgroupitem(IG_SUPER_SONIC_PACK);
   - Id: 102798
@@ -78158,8 +76892,6 @@ Body:
     Name: Chaos Emerald Package
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78168,6 +76900,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHAOS_EMERALD_PACK
     Script: |
       getgroupitem(IG_CHAOS_EMERALD_PACK);
   - Id: 102800
@@ -78215,8 +76948,6 @@ Body:
     AegisName: Brown_Dia_Box_3_7
     Name: Golden Diamond Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78225,6 +76956,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_BROWN_DIA_BOX_3_7
     Script: |
       getgroupitem(IG_BROWN_DIA_BOX_3_7);
   - Id: 102812
@@ -78238,8 +76970,7 @@ Body:
     AegisName: R_Ep178_boss
     Name: Episode 17-18 Boss Card Album
     Type: Usable
-    Flags:
-      Container: true
+    ItemGroup: IG_R_EP178_BOSS
     Script: |
       getgroupitem(IG_R_EP178_BOSS);
   - Id: 102815
@@ -78253,16 +76984,13 @@ Body:
     Name: Costume Enchant Stone Box 34
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX34
     Script: |
       getgroupitem(IG_ENCHANT_STONE_BOX34);
   - Id: 102858
     AegisName: VIP_Birthday_Box
     Name: Birthday Gift Box
     Type: Usable
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78271,6 +76999,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_VIP_BIRTHDAY_BOX
     Script: |
       getgroupitem(IG_VIP_BIRTHDAY_BOX);
   - Id: 102869
@@ -78466,8 +77195,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AEGIS_102947
     Script: |
       getgroupitem(IG_AEGIS_102947);
   - Id: 102948
@@ -78476,8 +77205,8 @@ Body:
     Type: Usable
     Weight: 200
     Flags:
-      Container: true
       DropEffect: CLIENT
+    ItemGroup: IG_AEGIS_102948
     Script: |
       getgroupitem(IG_AEGIS_102948);
   - Id: 102949
@@ -78522,8 +77251,7 @@ Body:
     Name: Furious Lance Shield Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_AEGIS_103033
     Script: |
       getgroupitem(IG_AEGIS_103033);
   - Id: 103034
@@ -78531,8 +77259,7 @@ Body:
     Name: Furious Dual Dagger Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
+    ItemGroup: IG_AEGIS_103034
     Script: |
       getgroupitem(IG_AEGIS_103034);
   - Id: 103048
@@ -78540,8 +77267,6 @@ Body:
     Name: "[Not For Sale] Premium Booster Box"
     Type: Usable
     EquipLevelMax: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78550,6 +77275,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_P_BOOSTER_CALL_PACKAGE
     Script: |
       getgroupitem(IG_P_BOOSTER_CALL_PACKAGE);
   - Id: 103049
@@ -78557,8 +77283,6 @@ Body:
     Name: Probability Disclosure Conpensation Box
     Type: Usable
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78567,6 +77291,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_P_COMPENSATION_BOX
     Script: |
       getgroupitem(IG_P_COMPENSATION_BOX);
   - Id: 103050
@@ -78646,8 +77371,7 @@ Body:
     Name: Costume Enchant Stone Box 35
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
+    ItemGroup: IG_ENCHANT_STONE_BOX35
     Script: |
       getgroupitem(IG_ENCHANT_STONE_BOX35);
   - Id: 103095
@@ -78674,8 +77398,6 @@ Body:
     Name: Inventory Expansion Voucher Box (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78684,6 +77406,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_INVENTORY_EX_10BOX
     Script: |
       getgroupitem(IG_INVENTORY_EX_10BOX);
   - Id: 200002
@@ -78706,8 +77429,6 @@ Body:
     Name: (Limited) HD Oridecon Box (Blacksmith)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78716,6 +77437,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ORIDECON_BOX2
     Script: |
       getgroupitem(IG_LI_HD_ORIDECON_BOX2);
   - Id: 200004
@@ -78723,8 +77445,6 @@ Body:
     Name: (Limited) HD Elunium Box (Blacksmith)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78733,6 +77453,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ELUNIUM_BOX2
     Script: |
       getgroupitem(IG_LI_HD_ELUNIUM_BOX2);
   - Id: 200005
@@ -78740,8 +77461,6 @@ Body:
     Name: (Limited) HD Bradium Box (Blacksmith)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78750,6 +77469,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_BRADIUMBOX2
     Script: |
       getgroupitem(IG_LI_HD_BRADIUMBOX2);
   - Id: 200006
@@ -78757,8 +77477,6 @@ Body:
     Name: (Limited) HD Carnium Box (Blacksmith)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78767,6 +77485,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_CARNIUMBOX2
     Script: |
       getgroupitem(IG_LI_HD_CARNIUMBOX2);
   - Id: 200031
@@ -78774,8 +77493,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package I
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78784,6 +77501,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX100
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX100);
   - Id: 200032
@@ -78791,8 +77509,6 @@ Body:
     Name: (Limited) Three Master Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78801,14 +77517,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_3_POTION_PACK
     Script: |
       getgroupitem(IG_LI_A_3_POTION_PACK);
   - Id: 200049
     AegisName: Stone_Coin_PackageI
     Name: Stoin Coin Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78817,14 +77532,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STONE_COIN_PACKAGEI
     Script: |
       getgroupitem(IG_STONE_COIN_PACKAGEI);
   - Id: 200050
     AegisName: Stone_Coin_PackageII
     Name: Stoin Coin Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78833,14 +77547,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STONE_COIN_PACKAGEII
     Script: |
       getgroupitem(IG_STONE_COIN_PACKAGEII);
   - Id: 200051
     AegisName: Stone_Coin_PackageIII
     Name: Stoin Coin Package III
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78849,6 +77562,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_STONE_COIN_PACKAGEIII
     Script: |
       getgroupitem(IG_STONE_COIN_PACKAGEIII);
   - Id: 200055
@@ -78864,6 +77578,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ACID_B_50BOX
     Script: |
       getgroupitem(IG_C_ACID_B_50BOX);
   - Id: 200056
@@ -78879,6 +77594,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_C_ACID_B_500_BOX
     Script: |
       getgroupitem(IG_C_ACID_B_500_BOX);
   - Id: 200064
@@ -78894,6 +77610,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_GIANT_FLY_WING_2500
     Script: |
       getgroupitem(IG_GIANT_FLY_WING_2500);
   - Id: 200069
@@ -78901,8 +77618,6 @@ Body:
     Name: HD Elunium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78911,6 +77626,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_ELUNIUM_BOX
     Script: |
       getgroupitem(IG_A_HD_ELUNIUM_BOX);
   - Id: 200070
@@ -78918,8 +77634,6 @@ Body:
     Name: HD Oridecon Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78928,6 +77642,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_ORIDECON_BOX
     Script: |
       getgroupitem(IG_A_HD_ORIDECON_BOX);
   - Id: 200071
@@ -78935,8 +77650,6 @@ Body:
     Name: HD Carnium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78945,6 +77658,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_CARNIUM_BOX
     Script: |
       getgroupitem(IG_A_HD_CARNIUM_BOX);
   - Id: 200072
@@ -78952,8 +77666,6 @@ Body:
     Name: HD Bradium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78962,6 +77674,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_HD_BRADIUM_BOX
     Script: |
       getgroupitem(IG_A_HD_BRADIUM_BOX);
   - Id: 200074
@@ -78969,8 +77682,6 @@ Body:
     Name: (Limited) Battle Manual Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78979,6 +77690,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_L_BATTLE_MANUAL_PACK
     Script: |
       getgroupitem(IG_L_BATTLE_MANUAL_PACK);
   - Id: 200090
@@ -78986,8 +77698,6 @@ Body:
     Name: (Limited) Mana Potion Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -78996,6 +77706,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_MANA_POTION_BOX
     Script: |
       getgroupitem(IG_LI_MANA_POTION_BOX);
   - Id: 200091
@@ -79003,8 +77714,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79013,6 +77722,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX_II
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX_II);
   - Id: 200092
@@ -79020,8 +77730,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79030,6 +77738,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX_III
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX_III);
   - Id: 200093
@@ -79037,8 +77746,6 @@ Body:
     Name: (Limited) HD Oridecon Box (Hollgrehenn)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79047,6 +77754,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ORIDECON_BOX3
     Script: |
       getgroupitem(IG_LI_HD_ORIDECON_BOX3);
   - Id: 200094
@@ -79054,8 +77762,6 @@ Body:
     Name: (Limited) HD Elunium Box (Hollgrehenn)(30)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79064,6 +77770,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_HD_ELUNIUM_BOX3
     Script: |
       getgroupitem(IG_LI_HD_ELUNIUM_BOX3);
   - Id: 200108
@@ -79072,8 +77779,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79082,6 +77787,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_STONE_BOX
     Script: |
       getgroupitem(IG_LI_NYANGVINE_STONE_BOX);
   - Id: 200109
@@ -79089,8 +77795,6 @@ Body:
     Name: Limited Refinement Ore Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79099,6 +77803,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_REFINE_ORE_BOX
     Script: |
       getgroupitem(IG_LI_A_REFINE_ORE_BOX);
   - Id: 200110
@@ -79106,8 +77811,6 @@ Body:
     Name: Limited HD Elunium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79116,6 +77819,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_HD_ELUNIUM_BOX
     Script: |
       getgroupitem(IG_LI_A_HD_ELUNIUM_BOX);
   - Id: 200111
@@ -79123,8 +77827,6 @@ Body:
     Name: Limited HD Oridecon Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79133,6 +77835,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_HD_ORIDECON_BOX
     Script: |
       getgroupitem(IG_LI_A_HD_ORIDECON_BOX);
   - Id: 200112
@@ -79140,8 +77843,6 @@ Body:
     Name: Limited HD Carnium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79150,6 +77851,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_HD_CARNIUM_BOX
     Script: |
       getgroupitem(IG_LI_A_HD_CARNIUM_BOX);
   - Id: 200113
@@ -79157,8 +77859,6 @@ Body:
     Name: Limited HD Bradium Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79167,6 +77867,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_HD_BRADIUM_BOX
     Script: |
       getgroupitem(IG_LI_A_HD_BRADIUM_BOX);
   - Id: 200123
@@ -79174,8 +77875,6 @@ Body:
     Name: Thanos Upgrade Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79184,6 +77883,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_THANOS_UPGRADE_PACKAGE
     Script: |
       getgroupitem(IG_THANOS_UPGRADE_PACKAGE);
   - Id: 200124
@@ -79191,8 +77891,6 @@ Body:
     Name: Hero's Weapon Modification Package I
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79201,6 +77899,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_1
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_1);
   - Id: 200125
@@ -79208,8 +77907,6 @@ Body:
     Name: Hero's Weapon Modification Package II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79218,6 +77915,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_2
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_2);
   - Id: 200126
@@ -79225,8 +77923,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package I
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79235,6 +77931,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_1
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_1);
   - Id: 200127
@@ -79242,8 +77939,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package II
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79252,6 +77947,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_2
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_2);
   - Id: 200128
@@ -79259,8 +77955,6 @@ Body:
     Name: Hero's Weapon Modification Package III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79269,6 +77963,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_3
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_3);
   - Id: 200129
@@ -79276,8 +77971,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package III
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79286,14 +77979,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_3
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_3);
   - Id: 200136
     AegisName: EXP_Drop_Up_Box
     Name: Kafra Buff Box (7 Days)
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79302,6 +77994,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_EXP_DROP_UP_BOX
     Script: |
       getgroupitem(IG_EXP_DROP_UP_BOX);
   - Id: 200137
@@ -79309,8 +78002,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79319,6 +78010,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_4
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_4);
   - Id: 200138
@@ -79326,8 +78018,6 @@ Body:
     Name: Hero's Weapon Modification Package IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79336,6 +78026,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_4
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_4);
   - Id: 200140
@@ -79344,8 +78035,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79354,6 +78043,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_STONE_BOX2
     Script: |
       getgroupitem(IG_LI_NYANGVINE_STONE_BOX2);
   - Id: 200141
@@ -79361,8 +78051,6 @@ Body:
     Name: Hero's Weapon Modification Package V
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79371,14 +78059,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_5
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_5);
   - Id: 200144
     AegisName: CostumeMileage_Package1
     Name: Silvervine Costume Mileage Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79387,14 +78074,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE1
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE1);
   - Id: 200145
     AegisName: CostumeMileage_Package2
     Name: Silvervine Costume Mileage Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79403,14 +78089,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE2
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE2);
   - Id: 200146
     AegisName: CostumeMileage_Package3
     Name: Silvervine Costume Mileage Package III
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79419,6 +78104,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE3
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE3);
   - Id: 200155
@@ -79426,8 +78112,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package IV
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79436,6 +78120,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX100_2
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX100_2);
   - Id: 200163
@@ -79444,8 +78129,6 @@ Body:
     Name: (Limited) Silvervine Cat Fruit Package(Stone Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79454,14 +78137,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_STONE_BOX3
     Script: |
       getgroupitem(IG_LI_NYANGVINE_STONE_BOX3);
   - Id: 200168
     AegisName: 2021_Promo_Package_1
     Name: 2021 Promotional Commemorative Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79470,14 +78152,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2021_PROMO_PACKAGE_1
     Script: |
       getgroupitem(IG_2021_PROMO_PACKAGE_1);
   - Id: 200169
     AegisName: 2021_Promo_Package_2
     Name: 2021 Promotional Commemorative Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79486,14 +78167,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2021_PROMO_PACKAGE_2
     Script: |
       getgroupitem(IG_2021_PROMO_PACKAGE_2);
   - Id: 200170
     AegisName: CostumeMileage_Package4
     Name: Silvervine Costume Mileage Package IV
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79502,14 +78182,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE4
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE4);
   - Id: 200171
     AegisName: CostumeMileage_Package5
     Name: Silvervine Costume Mileage Package V
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79518,14 +78197,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE5
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE5);
   - Id: 200172
     AegisName: CostumeMileage_Package6
     Name: Silvervine Costume Mileage Package VI
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79534,6 +78212,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEAGE_PACKAGE6
     Script: |
       getgroupitem(IG_COSTUMEMILEAGE_PACKAGE6);
   - Id: 200174
@@ -79541,8 +78220,6 @@ Body:
     Name: Modified Hero's Weapon Refine Hammer Package VI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79551,6 +78228,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_HAMMER_PACKAGE_6
     Script: |
       getgroupitem(IG_HERO_HAMMER_PACKAGE_6);
   - Id: 200175
@@ -79558,8 +78236,6 @@ Body:
     Name: Hero's Weapon Modification Package VI
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79568,6 +78244,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_HERO_UP_PACKAGE_6
     Script: |
       getgroupitem(IG_HERO_UP_PACKAGE_6);
   - Id: 200185
@@ -79576,8 +78253,6 @@ Body:
     Name: (Limited) Actinidia Cat Fruit Box I
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79586,16 +78261,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_26
     Script: |
-      getgroupitem(IG_LI_Nyangvine_Box1_26);
+      getgroupitem(IG_LI_NYANGVINE_BOX1_26);
   - Id: 200186
     AegisName: LI_Nyangvine_Box2_26
 #   Name: (Limited) Actinidia Cat Fruit Box II (Stone Box 26)
     Name: (Limited) Actinidia Cat Fruit Box II
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79604,16 +78278,15 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_26
     Script: |
-      getgroupitem(IG_LI_Nyangvine_Box2_26);
+      getgroupitem(IG_LI_NYANGVINE_BOX2_26);
   - Id: 200187
     AegisName: LI_Nyangvine_Box3_26
 #   Name: (Limited) Actinidia Cat Fruit Box III (Stone Box 26)
     Name: (Limited) Actinidia Cat Fruit Box III
     Type: Usable
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79622,15 +78295,14 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_26
     Script: |
-      getgroupitem(IG_LI_Nyangvine_Box3_26);
+      getgroupitem(IG_LI_NYANGVINE_BOX3_26);
   - Id: 200191
     AegisName: CostumeMilePack_26_1
 #   Name: Actinidia Costume Mileage Package I (Stone Box 26)
     Name: Actinidia Costume Mileage Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79639,6 +78311,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUME_MILE_PACK_26_1
     Script: |
       getgroupitem(IG_COSTUME_MILE_PACK_26_1);
   - Id: 200193
@@ -79646,8 +78319,6 @@ Body:
 #   Name: Actinidia Costume Mileage Package II (Stone Box 26)
     Name: Actinidia Costume Mileage Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79656,6 +78327,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUME_MILE_PACK_26_2
     Script: |
       getgroupitem(IG_COSTUME_MILE_PACK_26_2);
   - Id: 200194
@@ -79663,8 +78335,6 @@ Body:
 #   Name: Actinidia Costume Mileage Package III (Stone Box 26)
     Name: Actinidia Costume Mileage Package III
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79673,14 +78343,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUME_MILE_PACK_26_3
     Script: |
       getgroupitem(IG_COSTUME_MILE_PACK_26_3);
   - Id: 200195
     AegisName: Monthly_Package_1
     Name: Monthly Supply Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79689,14 +78358,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONTHLY_PACKAGE_1
     Script: |
       getgroupitem(IG_MONTHLY_PACKAGE_1);
   - Id: 200196
     AegisName: Monthly_Package_2
     Name: Monthly Supply Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79705,14 +78373,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONTHLY_PACKAGE_2
     Script: |
       getgroupitem(IG_MONTHLY_PACKAGE_2);
   - Id: 200197
     AegisName: Monthly_Package_3
     Name: Monthly Supply Package III
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79721,14 +78388,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONTHLY_PACKAGE_3
     Script: |
       getgroupitem(IG_MONTHLY_PACKAGE_3);
   - Id: 200198
     AegisName: Monthly_Buff_Package
     Name: Monthly Premium Buff Package
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79737,14 +78403,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONTHLY_BUFF_PACKAGE
     Script: |
       getgroupitem(IG_MONTHLY_BUFF_PACKAGE);
   - Id: 200199
     AegisName: Monthly_Battle_Package
     Name: Monthly Combat Manual Package
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79753,6 +78418,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_MONTHLY_BATTLE_PACKAGE
     Script: |
       getgroupitem(IG_MONTHLY_BATTLE_PACKAGE);
   - Id: 200214
@@ -79760,8 +78426,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package I (Stone Box 27)
     Name: Nyangdarae Costume Mileage Package I (Stone Box 2    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79770,6 +78434,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_27_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_27_1);
   - Id: 200215
@@ -79777,8 +78442,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package II (Stone Box 27)
     Name: Nyangdarae Costume Mileage Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79787,6 +78450,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_27_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_27_2);
   - Id: 200216
@@ -79794,8 +78458,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package III (Stone Box 27)
     Name: Nyangdarae Costume Mileage Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79804,6 +78466,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_27_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_27_3);
   - Id: 200219
@@ -79811,8 +78474,6 @@ Body:
 #   Name: (Limited) Nutcracker Fruit Package I (Stone Box 28)
     Name: (Limited) Nutcracker Fruit Package I (Stone Box 2    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79821,6 +78482,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_28
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_28);
   - Id: 200220
@@ -79828,8 +78490,6 @@ Body:
 #   Name: (Limited) Nutcracker Fruit Package II (Stone Box 28)
     Name: (Limited) Nutcracker Fruit Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79838,6 +78498,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_28
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_28);
   - Id: 200221
@@ -79845,8 +78506,6 @@ Body:
 #   Name: (Limited) Nutcracker Fruit Package III (Stone Box 28)
     Name: (Limited) Nutcracker Fruit Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79855,6 +78514,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_28
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_28);
   - Id: 200236
@@ -79862,8 +78522,6 @@ Body:
 #   Name: (Limited) Nyangdarae Fruit Package I (29 Stone Boxes)
     Name: (Limited) Nyangdarae Fruit Package I (29 Stone Bo    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79872,6 +78530,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_29
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_29);
   - Id: 200237
@@ -79879,8 +78538,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package II (29 Stone Boxes)
     Name: (Limited) Nyandarae Fruit Package II (29 Stone Bo    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79889,6 +78546,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_29
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_29);
   - Id: 200238
@@ -79896,8 +78554,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package III (29 Stone Boxes)
     Name: (Limited) Nyandarae Fruit Package III (29 Stone B    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79906,14 +78562,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_29
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_29);
   - Id: 200247
     AegisName: Cash_Booster_Box
     Name: Growth Support Package    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79922,6 +78577,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CASH_BOOSTER_BOX
     Script: |
       getgroupitem(IG_CASH_BOOSTER_BOX);
   - Id: 200256
@@ -79929,8 +78585,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package I (Stone Box 29)
     Name: Nyangdarae Costume Mileage Package I (Stone Box 2    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79939,6 +78593,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_29_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_29_1);
   - Id: 200257
@@ -79946,8 +78601,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package II (Stone Box 29)
     Name: Nyangdarae Costume Mileage Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79956,6 +78609,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_29_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_29_2);
   - Id: 200258
@@ -79963,8 +78617,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package III (Stone Box 29)
     Name: Nyangdarae Costume Mileage Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79973,6 +78625,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_29_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_29_3);
   - Id: 200287
@@ -79980,8 +78633,6 @@ Body:
 #   Name: (Limited) Nyangdarae Fruit Package I (30 Stone Boxes)
     Name: (Limited) Nyangdarae Fruit Package I (30 Stone Bo    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -79990,6 +78641,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_30
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_30);
   - Id: 200288
@@ -79997,8 +78649,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package II (30 Stone Boxes)
     Name: (Limited) Nyandarae Fruit Package II (30 Stone Bo    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80007,6 +78657,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_30
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_30);
   - Id: 200289
@@ -80014,8 +78665,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package III (Stone Box 30)
     Name: (Limited) Nyandarae Fruit Package III (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80024,6 +78673,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_30
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_30);
   - Id: 200291
@@ -80031,8 +78681,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package I (30 Stone Box)
     Name: Nyangdarae Costume Mileage Package I (30 Stone Bo    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80041,6 +78689,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_30_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_30_1);
   - Id: 200292
@@ -80048,8 +78697,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package II (Stone Box 30)
     Name: Nyangdarae Costume Mileage Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80058,6 +78705,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_30_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_30_2);
   - Id: 200293
@@ -80065,8 +78713,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package III (Stone Box 30)
     Name: Nyangdarae Costume Mileage Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80075,6 +78721,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_30_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_30_3);
   - Id: 200305
@@ -80082,8 +78729,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package I (Stone Box 31)
     Name: (Limited) Nyandarae Fruit Package I (Stone Box 31    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80092,6 +78737,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_31
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_31);
   - Id: 200306
@@ -80099,8 +78745,6 @@ Body:
 #   Name: (Limited) Nyangdarae Fruit Package II (Stone Box 31)
     Name: (Limited) Nyangdarae Fruit Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80109,6 +78753,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_31
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_31);
   - Id: 200307
@@ -80116,8 +78761,6 @@ Body:
 #   Name: (Limited) Nyandarae Fruit Package III (Stone Box 31)
     Name: (Limited) Nyandarae Fruit Package III (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80126,6 +78769,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_31
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_31);
   - Id: 200312
@@ -80133,8 +78777,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package I (Stone Box 31)
     Name: Nyangdarae Costume Mileage Package I (Stone Box 3    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80143,6 +78785,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_31_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_31_1);
   - Id: 200313
@@ -80150,8 +78793,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package II (Stone Box 31)
     Name: Nyangdarae Costume Mileage Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80160,6 +78801,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_31_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_31_2);
   - Id: 200314
@@ -80167,8 +78809,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package III (Stone Box 31)
     Name: Nyangdarae Costume Mileage Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80177,14 +78817,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_31_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_31_3);
   - Id: 200321
     AegisName: LI_Nyangvine_Box1_32
     Name: "[Limited] Silvervine Package I (Stone Box 32)"
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80193,14 +78832,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_32
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_32);
   - Id: 200322
     AegisName: LI_Nyangvine_Box2_32
     Name: "[Limited] Silvervine Package II (Stone Box 32)"
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80209,14 +78847,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_32
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_32);
   - Id: 200323
     AegisName: LI_Nyangvine_Box3_32
     Name: "[Limited] Silvervine Package III (Stone Box 32)"
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80225,6 +78862,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_32
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_32);
   - Id: 200325
@@ -80232,8 +78870,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package I (Stone Box 32)
     Name: Nyangdarae Costume Mileage Package I (Stone Box 3    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80242,6 +78878,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_32_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_32_1);
   - Id: 200326
@@ -80249,8 +78886,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package II (Stone Box 32)
     Name: Nyangdarae Costume Mileage Package II (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80259,6 +78894,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_32_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_32_2);
   - Id: 200327
@@ -80266,8 +78902,6 @@ Body:
 #   Name: Nyangdarae Costume Mileage Package III (Stone Box 32)
     Name: Nyangdarae Costume Mileage Package III (Stone Box    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80276,6 +78910,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_32_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_32_3);
   - Id: 200330
@@ -80283,8 +78918,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package I (Stone Box 33)
     Name: (Limited) Nyangvine Fruit Package I (Stone Box 33
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80293,6 +78926,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_33
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_33);
   - Id: 200331
@@ -80300,8 +78934,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package II (Stone Box 33)
     Name: (Limited) Nyangvine Fruit Package II (Stone Box 3
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80310,6 +78942,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_33
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_33);
   - Id: 200332
@@ -80317,8 +78950,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package III (Stone Box 33)
     Name: (Limited) Nyangvine Fruit Package III (Stone Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80327,6 +78958,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_33
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_33);
   - Id: 200333
@@ -80334,8 +78966,6 @@ Body:
     Name: Cinnamoroll Collaboration Package I
     Type: Cash
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80344,6 +78974,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CINNAMON_PACK1
     Script: |
       getgroupitem(IG_CINNAMON_PACK1);
   - Id: 200334
@@ -80351,8 +78982,6 @@ Body:
     Name: Cinnamoroll Collaboration Package II
     Type: Cash
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80361,6 +78990,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CINNAMON_PACK2
     Script: |
       getgroupitem(IG_CINNAMON_PACK2);
   - Id: 200335
@@ -80368,8 +78998,6 @@ Body:
     Name: Cinnamoroll Collaboration Package III
     Type: Cash
     Weight: 200
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80378,6 +79006,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CINNAMON_PACK3
     Script: |
       getgroupitem(IG_CINNAMON_PACK3);
   - Id: 200336
@@ -80385,8 +79014,6 @@ Body:
     Name: RO x Cinnamoroll Box
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80395,6 +79022,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CINNAMON_PACK4
     Script: |
       getgroupitem(IG_CINNAMON_PACK4,true);
   - Id: 200340
@@ -80402,8 +79030,6 @@ Body:
 #   Name: (Limited) Cinnamoroll Nyangvine Fruit Package I (Stone Box 33)
     Name: (Limited) Cinnamoroll Nyangvine Fruit Package I (
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80412,6 +79038,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANG_CINNA_BOX1_33
     Script: |
       getgroupitem(IG_LI_NYANG_CINNA_BOX1_33);
   - Id: 200341
@@ -80419,8 +79046,6 @@ Body:
 #   Name: (Limited) Cinnamoroll Nyangvine Fruit Package II (Stone Box 33)
     Name: (Limited) Cinnamoroll Nyangvine Fruit Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80429,6 +79054,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANG_CINNA_BOX2_33
     Script: |
       getgroupitem(IG_LI_NYANG_CINNA_BOX2_33);
   - Id: 200342
@@ -80436,8 +79062,6 @@ Body:
 #   Name: (Limited) Cinnamoroll Nyatarae Fruit Package III (Stone Box 33)
     Name: (Limited) Cinnamoroll Nyatarae Fruit Package III     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80446,6 +79070,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANG_CINNA_BOX3_33
     Script: |
       getgroupitem(IG_LI_NYANG_CINNA_BOX3_33);
   - Id: 200349
@@ -80453,8 +79078,6 @@ Body:
     Name: Enriched Elunium Account-limited Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80463,6 +79086,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_ELUNIUM_BOX
     Script: |
       getgroupitem(IG_LI_A_ELUNIUM_BOX);
   - Id: 200350
@@ -80470,8 +79094,6 @@ Body:
     Name: Enriched Oridecon Account-limited Package
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80480,6 +79102,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_A_ORIDECON_BOX
     Script: |
       getgroupitem(IG_LI_A_ORIDECON_BOX);
   - Id: 200351
@@ -80487,8 +79110,6 @@ Body:
 #   Name: Nyangvine Costume Mileage Package I (Stone Box 33)
     Name: Nyangvine Costume Mileage Package I (Stone Box 33
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80497,6 +79118,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_33_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_33_1);
   - Id: 200352
@@ -80504,8 +79126,6 @@ Body:
 #   Name: Nyangvine Costume Mileage Package II (Stone Box 33)
     Name: Nyangvine Costume Mileage Package II (Stone Box 3
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80514,6 +79134,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_33_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_33_2);
   - Id: 200353
@@ -80521,8 +79142,6 @@ Body:
 #   Name: Nyangvine Costume Mileage Package III (Stone Box 33)
     Name: Nyangvine Costume Mileage Package III (Stone Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80531,14 +79150,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_33_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_33_3);
   - Id: 200354
     AegisName: 2023_Xmax_Pack_1
     Name: Christmas Account Limited Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80547,14 +79165,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2023_XMAX_PACK_1
     Script: |
       getgroupitem(IG_2023_XMAX_PACK_1);
   - Id: 200355
     AegisName: 2023_Xmax_Pack_2
     Name: Christmas Account Limited Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80563,6 +79180,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_2023_XMAX_PACK_2
     Script: |
       getgroupitem(IG_2023_XMAX_PACK_2);
   - Id: 200366
@@ -80570,8 +79188,6 @@ Body:
     Name: Force Booster Package (10)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80580,6 +79196,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_FORCE_BOOSTER_BOX
     Script: |
       getgroupitem(IG_A_FORCE_BOOSTER_BOX);
   - Id: 200367
@@ -80587,8 +79204,6 @@ Body:
     Name: Force Booster Package (100)
     Type: Cash
     Weight: 10
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80597,6 +79212,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_A_FORCE_BOOSTER_10_BOX
     Script: |
       getgroupitem(IG_A_FORCE_BOOSTER_10_BOX);
   - Id: 200368
@@ -80604,8 +79220,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package I (Stone Box 34)
     Name: (Limited) Nyangvine Fruit Package I (Stone Box 34
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80614,6 +79228,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX1_34
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX1_34);
   - Id: 200369
@@ -80621,8 +79236,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package II (Stone Box 34)
     Name: (Limited) Nyangvine Fruit Package II (Stone Box 3
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80631,6 +79244,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX2_34
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX2_34);
   - Id: 200370
@@ -80638,8 +79252,6 @@ Body:
 #   Name: (Limited) Nyangvine Fruit Package III (Stone Box 34)
     Name: (Limited) Nyangvine Fruit Package III (Stone Box
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80648,14 +79260,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_LI_NYANGVINE_BOX3_34
     Script: |
       getgroupitem(IG_LI_NYANGVINE_BOX3_34);
   - Id: 200375
     AegisName: Sonic_Premium_Pack1
     Name: Sonic Premium Package I
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80664,14 +79275,13 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SONIC_PREMIUM_PACK1
     Script: |
       getgroupitem(IG_SONIC_PREMIUM_PACK1);
   - Id: 200376
     AegisName: Sonic_Premium_Pack2
     Name: Sonic Premium Package II
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80680,6 +79290,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SONIC_PREMIUM_PACK2
     Script: |
       getgroupitem(IG_SONIC_PREMIUM_PACK2);
   - Id: 200377
@@ -80687,8 +79298,6 @@ Body:
     Name: Sonic Badge Package
     Type: Cash
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80697,6 +79306,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_S_BADGE_PACK_
     Script: |
       getgroupitem(IG_S_BADGE_PACK_);
   - Id: 200378
@@ -80704,8 +79314,6 @@ Body:
     Name: Super Sonic Package
     Type: Cash
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80714,6 +79322,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_SUPER_SONIC_PACK_
     Script: |
       getgroupitem(IG_SUPER_SONIC_PACK_);
   - Id: 200379
@@ -80721,8 +79330,6 @@ Body:
     Name: Chaos Emerald Package
     Type: Cash
     Weight: 100
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80731,6 +79338,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_CHAOS_EMERALD_PACK_
     Script: |
       getgroupitem(IG_CHAOS_EMERALD_PACK_);
   - Id: 200385
@@ -80738,8 +79346,6 @@ Body:
 #   Name: Nyandarae Costume Mileage Package I (Stone Box 34)
     Name: Nyandarae Costume Mileage Package I (Stone Box 34    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80748,6 +79354,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_34_1
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_34_1);
   - Id: 200386
@@ -80755,8 +79362,6 @@ Body:
 #   Name: Nyandarae Costume Mileage Package II (Stone Box 34)
     Name: Nyandarae Costume Mileage Package II (Stone Box 3    # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80765,6 +79370,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_34_2
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_34_2);
   - Id: 200387
@@ -80772,8 +79378,6 @@ Body:
 #   Name: Nyandarae Costume Mileage Package III (Stone Box 34)
     Name: Nyandarae Costume Mileage Package III (Stone Box     # !todo check english name
     Type: Cash
-    Flags:
-      Container: true
     Trade:
       NoDrop: true
       NoTrade: true
@@ -80782,6 +79386,7 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
+    ItemGroup: IG_COSTUMEMILEPACK_34_3
     Script: |
       getgroupitem(IG_COSTUMEMILEPACK_34_3);
   - Id: 200405
@@ -80817,7 +79422,7 @@ Body:
   - Id: 200407
     AegisName: LI_Nyangvine_Box3_35
 #   Name: (Limited) Nyangvine Fruit Package III (Stone Box 35)
-    Name: (Limited) Nyangvine Fruit Package III (Stone Box 
+    Name: (Limited) Nyangvine Fruit Package III (Stone Box
     Type: Cash
     Trade:
       NoDrop: true

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -62413,6 +62413,7 @@ Body:
     AegisName: Psychotropic
     Name: Psychotropic
     Type: DelayConsume
+    Weight: 10
     EquipLevelMin: 100
     Flags:
       BuyingStore: true

--- a/db/re/item_group_db.yml
+++ b/db/re/item_group_db.yml
@@ -113177,3 +113177,31 @@ Body:
           - Index: 65
             Item: Critical_Stone_Bottom
             Rate: 400
+  - Group: COSTAMA_EGG22
+    SubGroups:
+      - SubGroup: 1
+        List:
+          - Index: 0
+            Item: C_Rabbit_Earplug
+            Rate: 12
+          - Index: 1
+            Item: C_Rabbit_Magic_Hat
+            Rate: 12
+          - Index: 2
+            Item: C_Rabbit_Ear_Knit_Hat
+            Rate: 12
+          - Index: 3
+            Item: C_Love_Rabbit_Hood
+            Rate: 12
+          - Index: 4
+            Item: C_Rabbit_Ear_Hat
+            Rate: 12
+          - Index: 5
+            Item: C_Pretty_Rabbit_Hood
+            Rate: 12
+          - Index: 6
+            Item: C_Camouflage_RabbitHood
+            Rate: 12
+          - Index: 7
+            Item: C_Snow_Rabbit_Knit_Hat
+            Rate: 12

--- a/src/map/itemdb.hpp
+++ b/src/map/itemdb.hpp
@@ -2825,6 +2825,7 @@ enum e_random_item_group {
 	IG_P_BOOSTER_CALL_PACKAGE,
 	IG_P_COMPENSATION_BOX,
 	IG_ENCHANT_STONE_BOX35,
+	IG_COSTAMA_EGG22,
 
 	IG_MAX,
 };
@@ -3011,6 +3012,7 @@ struct s_item_group_db
 {
 	uint16 id; /// Item Group ID
 	std::unordered_map<uint16, std::shared_ptr<s_item_group_random>> random;	/// group ID, s_item_group_random
+	uint16 maxAmount;
 };
 
 /// Struct of Roulette db
@@ -3072,7 +3074,7 @@ struct item_data
 		unsigned autoequip: 1;
 		bool buyingstore;
 		bool dead_branch; // As dead branch item. Logged at `branchlog` table and cannot be used at 'nobranch' mapflag [Cydh]
-		bool group; // As item group container [Cydh]
+		bool container; // As item container [Cydh]
 		unsigned guid : 1; // This item always be attached with GUID and make it as bound item! [Cydh]
 		bool broadcast; ///< Will be broadcasted if someone obtain the item [Cydh]
 		bool bindOnEquip; ///< Set item as bound when equipped
@@ -3093,6 +3095,7 @@ struct item_data
 		uint32 duration;
 		sc_type sc; ///< Use delay group if any instead using player's item_delay data [Cydh]
 	} delay;
+	uint16 group_id; ///< Item Group ID
 
 	~item_data() {
 		if (this->script){
@@ -3174,6 +3177,7 @@ public:
 	t_itemid get_random_item_id(uint16 group_id, uint8 sub_group);
 	std::shared_ptr<s_item_group_entry> get_random_entry(uint16 group_id, uint8 sub_group);
 	uint8 pc_get_itemgroup( uint16 group_id, bool identify, map_session_data& sd );
+	uint16 get_max_amount( uint16 group_id );
 
 private:
 	void pc_get_itemgroup_sub( map_session_data& sd, bool identify, std::shared_ptr<s_item_group_entry> data );

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6262,8 +6262,8 @@ bool pc_isUseitem(map_session_data *sd,int n)
 	if( itemdb_group.item_exists(IG_MERCENARY, nameid) && sd->md != nullptr )
 		return false; // Mercenary Scrolls
 
-	// Safe check type cash disappear when overweight [Napster]
-	if( item->flag.group || item->type == IT_CASH ){
+	// Safe check for container items
+	if( item->flag.container ){
 #ifdef RENEWAL
 		// Check if the player is not overweighted
 		// In Renewal the limit is 70% weight and gives the same error message
@@ -6282,9 +6282,10 @@ bool pc_isUseitem(map_session_data *sd,int n)
 
 		// Check if the player has enough free spaces in the inventory
 		// Official servers use 10 as the minimum amount of slots required to get the items
+		// For item groups, the amount of slots required is the maximum amount of items it can give
+		// For other containers, the amount of slots required is always 10, as there's no official containers that give more than 10 items
 		// The <= is intentional, as in official servers you actually need an extra empty slot
-		// TODO: Count the items the player will get and check for the actual inventory space required std::max<size_t>( count, 10 )
-		if (pc_inventoryblank(sd) <= 10) {
+		if (pc_inventoryblank(sd) <= item->group_id ? std::max<size_t>(itemdb_group.get_max_amount(item->group_id), 10) : 10) {
 #ifdef RENEWAL
 			clif_msg_color(sd, MSI_PICKUP_FAILED_ITEMCREATE, color_table[COLOR_RED]);
 #else

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -7790,6 +7790,7 @@
 	export_constant(IG_P_BOOSTER_CALL_PACKAGE);
 	export_constant(IG_P_COMPENSATION_BOX);
 	export_constant(IG_ENCHANT_STONE_BOX35);
+	export_constant(IG_COSTAMA_EGG22);
 
 	/* unit stop walking */
 	export_constant(USW_NONE);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
-Added new item_db parameter ItemGroup for associating itemgroup containers to its corresponding group
-Cash items and items with ItemGroup parameter now are always considered containers
-Renamed flag.group to flag.container for consistency, and repurposed for the rest of item containers
-Removed the container flag from Cash and group items, as now are always containers by default
-Added missing container flag to other container items
-Added group->maxAmount and ItemGroupDatabase::get_max_amount to calculate the max amount of items an item group can produce
-Fixed the inventory space check for item groups
-Added missing group IG_COSTAMA_EGG22

TODO:
- [ ] Documentation
- [ ] Check if the group set in ItemGroup exists in item_group_db

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
