### PR TITLE
Configs for account and character names and passwords minimum length

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -144,6 +144,10 @@ unknown_char_name: Unknown
 // To log the character server?
 log_char: yes
 
+// Enable or disable the 4-letter character name minimum length limit
+// Must be set to 'yes' unless your client uses the 'Remove 4 letter Character Name limit' diff patch.
+char_name_length_limit: yes
+
 // Allow or not identical name for characters but with a different case (upper/lower):
 // example: Test-test-TEST-TesT; Value: 0 not allowed (default), 1 allowed
 name_ignoring_case: no

--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -144,9 +144,9 @@ unknown_char_name: Unknown
 // To log the character server?
 log_char: yes
 
-// Enable or disable the 4-letter character name minimum length limit
-// Must be set to 'yes' unless your client uses the 'Remove 4 letter Character Name limit' diff patch.
-char_name_length_limit: yes
+// Minimum length for a character name.
+// Must be set to '4' unless your client uses the 'Remove 4/6 letter Character Name limit' diff patch.
+char_name_min_length: 4
 
 // Allow or not identical name for characters but with a different case (upper/lower):
 // example: Test-test-TEST-TesT; Value: 0 not allowed (default), 1 allowed

--- a/conf/login_athena.conf
+++ b/conf/login_athena.conf
@@ -55,9 +55,15 @@ console: off
 // Note: This only works if client side password encryption is not enabled.
 new_account: no
 
-//If new_account is enabled, minimum length to userid and passwords should be 4?
-//Must be 'Yes' unless your client uses both 'Disable 4 LetterUserID/Password' Diffs
-new_acc_length_limit: yes
+// If new_account is enabled, changes the minimum length for the account name.
+// By default is set to '4' or '6' (depending on the new login UI).
+// Don't change it unless your client uses the 'Remove 4/6 letter User Name limit' diff patch.
+//acc_name_min_length: 6
+
+// If new_account is enabled, changes the minimum length for the password.
+// By default is set to '4' or '6' (depending on the new login UI).
+// Don't change it unless your client uses the 'Remove 4/6 letter Password limit' diff patch.
+//password_min_length: 6
 
 // Account registration flood protection system
 // allowed_regs is the number of registrations allowed in time_allowed (in seconds)

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3030,7 +3030,7 @@ bool char_config_read(const char* cfgName, bool normal){
 		} else if (strcmpi(w1, "char_name_letters") == 0) {
 			safestrncpy(charserv_config.char_config.char_name_letters, w2, sizeof(charserv_config.char_config.char_name_letters));
 		} else if (strcmpi(w1, "char_name_min_length") == 0) {
-			charserv_config.char_config.char_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH);
+			charserv_config.char_config.char_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH - 1);
 		} else if (strcmpi(w1, "char_del_level") == 0) { //disable/enable char deletion by its level condition [Lupus]
 			charserv_config.char_config.char_del_level = atoi(w2);
 		} else if (strcmpi(w1, "char_del_delay") == 0) {

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1360,7 +1360,7 @@ int char_check_char_name(char * name, char * esc_name)
 	 * The client does not allow you to create names with less than 4 characters, however,
 	 * the use of WPE can bypass this, and this fixes the exploit.
 	 **/
-	if( strlen( name ) < 4 )
+	if(charserv_config.char_config.char_name_length_limit && strlen( name ) < 4 )
 		return -2;
 	// check content of character name
 	if( remove_control_chars(name) )
@@ -2762,6 +2762,7 @@ void char_set_defaults(){
 	charserv_config.char_config.char_name_option = 0; // Option to know which letters/symbols are authorised in the name of a character (0: all, 1: only those in char_name_letters, 2: all EXCEPT those in char_name_letters) by [Yor]
 	safestrncpy(charserv_config.char_config.unknown_char_name,"Unknown",sizeof(charserv_config.char_config.unknown_char_name)); // Name to use when the requested name cannot be determined
 	safestrncpy(charserv_config.char_config.char_name_letters,"",sizeof(charserv_config.char_config.char_name_letters)); // list of letters/symbols allowed (or not) in a character name. by [Yor]
+	charserv_config.char_config.char_name_length_limit = true; // Enable or disable the 4-letter character name minimum length limit
 
 	charserv_config.save_log = 1; // show loading/saving messages
 	charserv_config.log_char = 1;	// loggin char or not [devil]
@@ -3025,6 +3026,8 @@ bool char_config_read(const char* cfgName, bool normal){
 			charserv_config.char_config.char_name_option = atoi(w2);
 		} else if (strcmpi(w1, "char_name_letters") == 0) {
 			safestrncpy(charserv_config.char_config.char_name_letters, w2, sizeof(charserv_config.char_config.char_name_letters));
+		} else if (strcmpi(w1, "char_name_length_limit") == 0) {
+			charserv_config.char_config.char_name_length_limit = static_cast<bool>(config_switch(w2));
 		} else if (strcmpi(w1, "char_del_level") == 0) { //disable/enable char deletion by its level condition [Lupus]
 			charserv_config.char_config.char_del_level = atoi(w2);
 		} else if (strcmpi(w1, "char_del_delay") == 0) {

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -25,6 +25,7 @@
 #include <common/strlib.hpp>
 #include <common/timer.hpp>
 #include <common/utilities.hpp>
+#include <common/utils.hpp>
 
 #include "char_clif.hpp"
 #include "char_cnslif.hpp"
@@ -1357,10 +1358,12 @@ int char_check_char_name(char * name, char * esc_name)
 	if( name[0] == '\0' )
 		return -2; // empty character name
 	/**
-	 * The client does not allow you to create names with less than 4 characters, however,
-	 * the use of WPE can bypass this, and this fixes the exploit.
+	 * By default the client does not allow you to create names with less than 4 characters,
+	 * however the use of WPE can bypass this, and this fixes the exploit.
+	 * It can also be changed in the configuration file in conjunction with the
+	 * 'Remove 4/6 letter Character Name Limit' client diff patch.
 	 **/
-	if( charserv_config.char_config.char_name_length_limit && strlen( name ) < 4 )
+	if( strlen( name ) < charserv_config.char_config.char_name_min_length )
 		return -2;
 	// check content of character name
 	if( remove_control_chars(name) )
@@ -2762,7 +2765,7 @@ void char_set_defaults(){
 	charserv_config.char_config.char_name_option = 0; // Option to know which letters/symbols are authorised in the name of a character (0: all, 1: only those in char_name_letters, 2: all EXCEPT those in char_name_letters) by [Yor]
 	safestrncpy(charserv_config.char_config.unknown_char_name,"Unknown",sizeof(charserv_config.char_config.unknown_char_name)); // Name to use when the requested name cannot be determined
 	safestrncpy(charserv_config.char_config.char_name_letters,"",sizeof(charserv_config.char_config.char_name_letters)); // list of letters/symbols allowed (or not) in a character name. by [Yor]
-	charserv_config.char_config.char_name_length_limit = true; // Enable or disable the 4-letter character name minimum length limit
+	charserv_config.char_config.char_name_min_length = 4; // Minimum character name length
 
 	charserv_config.save_log = 1; // show loading/saving messages
 	charserv_config.log_char = 1;	// loggin char or not [devil]
@@ -3026,8 +3029,8 @@ bool char_config_read(const char* cfgName, bool normal){
 			charserv_config.char_config.char_name_option = atoi(w2);
 		} else if (strcmpi(w1, "char_name_letters") == 0) {
 			safestrncpy(charserv_config.char_config.char_name_letters, w2, sizeof(charserv_config.char_config.char_name_letters));
-		} else if (strcmpi(w1, "char_name_length_limit") == 0) {
-			charserv_config.char_config.char_name_length_limit = static_cast<bool>(config_switch(w2));
+		} else if (strcmpi(w1, "char_name_min_length") == 0) {
+			charserv_config.char_config.char_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH);
 		} else if (strcmpi(w1, "char_del_level") == 0) { //disable/enable char deletion by its level condition [Lupus]
 			charserv_config.char_config.char_del_level = atoi(w2);
 		} else if (strcmpi(w1, "char_del_delay") == 0) {

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1360,7 +1360,7 @@ int char_check_char_name(char * name, char * esc_name)
 	 * The client does not allow you to create names with less than 4 characters, however,
 	 * the use of WPE can bypass this, and this fixes the exploit.
 	 **/
-	if(charserv_config.char_config.char_name_length_limit && strlen( name ) < 4 )
+	if( charserv_config.char_config.char_name_length_limit && strlen( name ) < 4 )
 		return -2;
 	// check content of character name
 	if( remove_control_chars(name) )

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -151,7 +151,7 @@ struct Char_Config {
 	char unknown_char_name[NAME_LENGTH]; // Name to use when the requested name cannot be determined
 	char char_name_letters[1024]; // list of letters/symbols allowed (or not) in a character name. by [Yor]
 	int char_name_option; // Option to know which letters/symbols are authorised in the name of a character (0: all, 1: only those in char_name_letters, 2: all EXCEPT those in char_name_letters) by [Yor]
-	bool char_name_length_limit; // Enable or disable the 4-letter character name minimum length limit
+	uint8 char_name_min_length; // Minimum character name length (default: 4)
 	int char_del_option;	// Character deletion type, email = 1, birthdate = 2 (default)
 	int char_del_restriction;	// Character deletion restriction (0: none, 1: if the character is in a party, 2: if the character is in a guild, 3: if the character is in a party or a guild)
 	bool char_rename_party;	// Character renaming in a party

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -151,6 +151,7 @@ struct Char_Config {
 	char unknown_char_name[NAME_LENGTH]; // Name to use when the requested name cannot be determined
 	char char_name_letters[1024]; // list of letters/symbols allowed (or not) in a character name. by [Yor]
 	int char_name_option; // Option to know which letters/symbols are authorised in the name of a character (0: all, 1: only those in char_name_letters, 2: all EXCEPT those in char_name_letters) by [Yor]
+	bool char_name_length_limit; // Enable or disable the 4-letter character name minimum length limit
 	int char_del_option;	// Character deletion type, email = 1, birthdate = 2 (default)
 	int char_del_restriction;	// Character deletion restriction (0: none, 1: if the character is in a party, 2: if the character is in a guild, 3: if the character is in a party or a guild)
 	bool char_rename_party;	// Character renaming in a party

--- a/src/common/mmo.hpp
+++ b/src/common/mmo.hpp
@@ -152,7 +152,7 @@ const t_itemid WEDDING_RING_F = 2635;
 //For character names, title names, guilds, maps, etc.
 //Includes null-terminator as it is the length of the array.
 #define NAME_LENGTH (23 + 1)
-#define PASSWD_LENGTH (32+1)
+#define PASSWD_LENGTH (32 + 1)
 //NPC names can be longer than it's displayed on client (NAME_LENGTH).
 #define NPC_NAME_LENGTH 50
 // <NPC_NAME_LENGTH> for npc name + 2 for a "::" + <NAME_LENGTH> for label + 1 for EOS

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -232,7 +232,7 @@ int login_mmo_auth_new(const char* userid, const char* pass, const char sex, con
 		return 3;
 	}
 
-	if( login_config.new_acc_length_limit && ( strlen(userid) < 4 || strlen(pass) < 4 ) )
+	if( strlen(userid) < login_config.acc_name_min_length || strlen(pass) < login_config.password_min_length)
 		return 1;
 
 	// check for invalid inputs
@@ -633,8 +633,10 @@ bool login_config_read(const char* cfgName, bool normal) {
 			login_config.log_login = (bool)config_switch(w2);
 		else if(!strcmpi(w1, "new_account"))
 			login_config.new_account_flag = (bool)config_switch(w2);
-		else if(!strcmpi(w1, "new_acc_length_limit"))
-			login_config.new_acc_length_limit = (bool)config_switch(w2);
+		else if(!strcmpi(w1, "acc_name_min_length"))
+			login_config.acc_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH);
+		else if(!strcmpi(w1, "password_min_length"))
+			login_config.password_min_length = cap_value(atoi(w2), 0, PASSWD_LENGTH);
 		else if(!strcmpi(w1, "start_limited_time"))
 			login_config.start_limited_time = atoi(w2);
 		else if(!strcmpi(w1, "use_MD5_passwords"))
@@ -751,7 +753,13 @@ void login_set_defaults() {
 	safestrncpy(login_config.date_format, "%Y-%m-%d %H:%M:%S", sizeof(login_config.date_format));
 	login_config.console = false;
 	login_config.new_account_flag = true;
-	login_config.new_acc_length_limit = true;
+#if PACKETVER >= 20181114
+	login_config.acc_name_min_length = 6;
+	login_config.password_min_length = 6;
+#else
+	login_config.acc_name_min_length = 4;
+	login_config.password_min_length = 4;
+#endif
 	login_config.use_md5_passwds = false;
 	login_config.group_id_to_connect = -1;
 	login_config.min_group_id_to_connect = -1;

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -634,9 +634,9 @@ bool login_config_read(const char* cfgName, bool normal) {
 		else if(!strcmpi(w1, "new_account"))
 			login_config.new_account_flag = (bool)config_switch(w2);
 		else if(!strcmpi(w1, "acc_name_min_length"))
-			login_config.acc_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH);
+			login_config.acc_name_min_length = cap_value(atoi(w2), 0, NAME_LENGTH - 1);
 		else if(!strcmpi(w1, "password_min_length"))
-			login_config.password_min_length = cap_value(atoi(w2), 0, PASSWD_LENGTH);
+			login_config.password_min_length = cap_value(atoi(w2), 0, PASSWD_LENGTH - 1);
 		else if(!strcmpi(w1, "start_limited_time"))
 			login_config.start_limited_time = atoi(w2);
 		else if(!strcmpi(w1, "use_MD5_passwords"))

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -88,7 +88,9 @@ struct Login_Config {
 	bool log_login;                                 /// whether to log login server actions or not
 	char date_format[32];                           /// date format used in messages
 	bool console;                                   /// console input system enabled?
-	bool new_account_flag,new_acc_length_limit;     /// autoregistration via _M/_F ? / if yes minimum length is 4?
+	bool new_account_flag;                          /// autoregistration via _M/_F ?
+	uint8 acc_name_min_length;                      /// minimum account name length
+	uint8 password_min_length;                      /// minimum password length
 	int start_limited_time;                         /// new account expiration time (-1: unlimited)
 	bool use_md5_passwds;                           /// work with password hashes instead of plaintext passwords?
 	int group_id_to_connect;                        /// required group id to connect


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Adds a setting in char_athena.conf to allow you to easily change the 4-letter character name minimum length limit when using the 'Remove 4/6 letter Character Name limit' diff patch.
Also modifies and splits the current setting for account names and passwords minimum lenght, to be more configurable.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
