### PR TITLE
Monster Losing Target Display

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -180,7 +180,7 @@ static inline void WBUFPOS(uint8* p, unsigned short pos, short x, short y, unsig
 
 
 // client-side: x0+=sx0*0.0625-0.5 and y0+=sy0*0.0625-0.5
-static inline void WBUFPOS2(uint8* p, unsigned short pos, short x0, short y0, short x1, short y1, unsigned char sx0, unsigned char sy0) {
+static inline void WBUFPOS2(uint8* p, unsigned short pos, short x0, short y0, short x1, short y1, uint8 sx0, uint8 sy0) {
 	p += pos;
 	p[0] = (uint8)(x0>>2);
 	p[1] = (uint8)((x0<<6) | ((y0>>4)&0x3f));

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1436,7 +1436,7 @@ static void clif_set_unit_walking( struct block_list& bl, map_session_data* tsd,
 	p.virtue = (sc) ? sc->opt3 : 0;
 	p.isPKModeON = (sd && sd->status.karma) ? 1 : 0;
 	p.sex = vd->sex;
-	WBUFPOS2( &p.MoveData[0], 0, bl.x, bl.y, ud.to_x, ud.to_y, 8, 8 );
+	WBUFPOS2(&p.MoveData[0], 0, bl.x, bl.y, ud.to_x, ud.to_y, ud.sx, ud.sy);
 	p.xSize = p.ySize = (sd) ? 5 : 0;
 	p.clevel = clif_setlevel( &bl );
 #if PACKETVER >= 20080102

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1566,7 +1566,7 @@ int mob_unlocktarget(struct mob_data *md, t_tick tick)
 		break;
 	default:
 		mob_stop_attack(md);
-		mob_stop_walking(md,1); //Stop chasing.
+		unit_stop_walking_soon(md->bl); //Stop chasing.
 		if (status_has_mode(&md->status,MD_ANGRY) && !md->state.aggressive)
 			md->state.aggressive = 1; //Restore angry state when switching to idle
 		md->state.skillstate = MSS_IDLE;
@@ -1908,6 +1908,8 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			md->state.skillstate = MSS_LOOT;
 			if (!unit_walktobl(&md->bl, tbl, 0, 0))
 				mob_unlocktarget(md, tick); //Can't loot...
+			else
+				md->ud.target = tbl->id; //Remember current loot target
 			return true;
 		}
 		//Within looting range.

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1909,7 +1909,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			if (!unit_walktobl(&md->bl, tbl, 0, 0))
 				mob_unlocktarget(md, tick); //Can't loot...
 			else
-				md->ud.target = tbl->id; //Remember current loot target
+				unit_set_target(&md->ud, tbl->id); //Remember current loot target
 			return true;
 		}
 		//Within looting range.

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1431,12 +1431,12 @@ void unit_stop_walking_soon(struct block_list& bl)
 		return;
 
 	// Get how much percent we traversed on the timer
-	double cell_percent = 1 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
+	double cell_percent = 1.0 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
 
 	short ox = bl.x, oy = bl.y; // Remember original x and y coordinates
 	short path_remain = 1; // Remaining path to walk
 
-	if (cell_percent > 0 && cell_percent < 1) {
+	if (cell_percent > 0.0 && cell_percent < 1.0) {
 		// Set subcell coordinates according to timer
 		// This gives a value between 8 and 39
 		ud->sx = static_cast<decltype(ud->sx)>(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
@@ -1454,7 +1454,7 @@ void unit_stop_walking_soon(struct block_list& bl)
 		ud->sx %= 16;
 		ud->sy %= 16;
 	}
-	else if (cell_percent >= 1) {
+	else if (cell_percent >= 1.0) {
 		// Assume exactly one cell moved
 		bl.x += dirx[ud->walkpath.path[ud->walkpath.path_pos]];
 		bl.y += diry[ud->walkpath.path[ud->walkpath.path_pos]];

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1424,59 +1424,59 @@ void unit_stop_walking_soon(struct block_list& bl)
 
 	if (ud->walkpath.path_pos + 1 >= ud->walkpath.path_len)
 		return;
-		const struct TimerData* td = get_timer(ud->walktimer);
 
-		if (td == nullptr)
-			return;
+	const struct TimerData* td = get_timer(ud->walktimer);
 
-		// Get how much percent we traversed on the timer
-		double cell_percent = 1 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
+	if (td == nullptr)
+		return;
 
-		short ox = bl.x, oy = bl.y; // Remember original x and y coordinates
-		short path_remain = 1; // Remaining path to walk
+	// Get how much percent we traversed on the timer
+	double cell_percent = 1 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
 
-		if (cell_percent > 0 && cell_percent < 1) {
-			// Set subcell coordinates according to timer
-			// This gives a value between 8 and 39
-			ud->sx = (unsigned char)(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
-			ud->sy = (unsigned char)(24.0 + diry[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
-			// 16-31 reflect sub position 0-15 on the current cell
-			// 8-15 reflect sub position 8-15 at -1 main coordinate
-			// 32-39 reflect sub position 0-7 at +1 main coordinate
-			if (ud->sx < 16 || ud->sy < 16 || ud->sx > 31 || ud->sy > 31) {
-				path_remain = 2;
-				if (ud->sx < 16) bl.x--;
-				if (ud->sy < 16) bl.y--;
-				if (ud->sx > 31) bl.x++;
-				if (ud->sy > 31) bl.y++;
-			}
-			ud->sx = ud->sx % 16;
-			ud->sy = ud->sy % 16;
-		}
-		else if (cell_percent >= 1) {
-			// Assume exactly one cell moved
-			bl.x = bl.x + dirx[ud->walkpath.path[ud->walkpath.path_pos]];
-			bl.y = bl.y + diry[ud->walkpath.path[ud->walkpath.path_pos]];
+	short ox = bl.x, oy = bl.y; // Remember original x and y coordinates
+	short path_remain = 1; // Remaining path to walk
+
+	if (cell_percent > 0 && cell_percent < 1) {
+		// Set subcell coordinates according to timer
+		// This gives a value between 8 and 39
+		ud->sx = (unsigned char)(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+		ud->sy = (unsigned char)(24.0 + diry[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+		// 16-31 reflect sub position 0-15 on the current cell
+		// 8-15 reflect sub position 8-15 at -1 main coordinate
+		// 32-39 reflect sub position 0-7 at +1 main coordinate
+		if (ud->sx < 16 || ud->sy < 16 || ud->sx > 31 || ud->sy > 31) {
 			path_remain = 2;
+			if (ud->sx < 16) bl.x--;
+			if (ud->sy < 16) bl.y--;
+			if (ud->sx > 31) bl.x++;
+			if (ud->sy > 31) bl.y++;
 		}
-		// Shorten walkpath
-		if (ud->walkpath.path_pos + path_remain < ud->walkpath.path_len) {
-			ud->walkpath.path_len = ud->walkpath.path_pos + path_remain;
-			ud->to_x = ox;
-			ud->to_y = oy;
-			for (int i = 0; i < path_remain; i++) {
-				ud->to_x = ud->to_x + dirx[ud->walkpath.path[ud->walkpath.path_pos+i]];
-				ud->to_y = ud->to_y + diry[ud->walkpath.path[ud->walkpath.path_pos+i]];
-			}
-			// Send movement packet with calculated coordinates and subcoordinates
-			clif_move(*ud);
-		}
-		// Reset coordinates
-		bl.x = ox;
-		bl.y = oy;
-		ud->sx = 8;
-		ud->sy = 8;
+		ud->sx = ud->sx % 16;
+		ud->sy = ud->sy % 16;
 	}
+	else if (cell_percent >= 1) {
+		// Assume exactly one cell moved
+		bl.x = bl.x + dirx[ud->walkpath.path[ud->walkpath.path_pos]];
+		bl.y = bl.y + diry[ud->walkpath.path[ud->walkpath.path_pos]];
+		path_remain = 2;
+	}
+	// Shorten walkpath
+	if (ud->walkpath.path_pos + path_remain < ud->walkpath.path_len) {
+		ud->walkpath.path_len = ud->walkpath.path_pos + path_remain;
+		ud->to_x = ox;
+		ud->to_y = oy;
+		for (int i = 0; i < path_remain; i++) {
+			ud->to_x = ud->to_x + dirx[ud->walkpath.path[ud->walkpath.path_pos + i]];
+			ud->to_y = ud->to_y + diry[ud->walkpath.path[ud->walkpath.path_pos + i]];
+		}
+		// Send movement packet with calculated coordinates and subcoordinates
+		clif_move(*ud);
+	}
+	// Reset coordinates
+	bl.x = ox;
+	bl.y = oy;
+	ud->sx = 8;
+	ud->sy = 8;
 }
 
 /**

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1451,13 +1451,13 @@ void unit_stop_walking_soon(struct block_list& bl)
 			if (ud->sx > 31) bl.x++;
 			if (ud->sy > 31) bl.y++;
 		}
-		ud->sx = ud->sx % 16;
-		ud->sy = ud->sy % 16;
+		ud->sx %= 16;
+		ud->sy %= 16;
 	}
 	else if (cell_percent >= 1) {
 		// Assume exactly one cell moved
-		bl.x = bl.x + dirx[ud->walkpath.path[ud->walkpath.path_pos]];
-		bl.y = bl.y + diry[ud->walkpath.path[ud->walkpath.path_pos]];
+		bl.x += dirx[ud->walkpath.path[ud->walkpath.path_pos]];
+		bl.y += diry[ud->walkpath.path[ud->walkpath.path_pos]];
 		path_remain = 2;
 	}
 	// Shorten walkpath
@@ -1466,8 +1466,8 @@ void unit_stop_walking_soon(struct block_list& bl)
 		ud->to_x = ox;
 		ud->to_y = oy;
 		for (int i = 0; i < path_remain; i++) {
-			ud->to_x = ud->to_x + dirx[ud->walkpath.path[ud->walkpath.path_pos + i]];
-			ud->to_y = ud->to_y + diry[ud->walkpath.path[ud->walkpath.path_pos + i]];
+			ud->to_x += dirx[ud->walkpath.path[ud->walkpath.path_pos + i]];
+			ud->to_y += diry[ud->walkpath.path[ud->walkpath.path_pos + i]];
 		}
 		// Send movement packet with calculated coordinates and subcoordinates
 		clif_move(*ud);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -397,6 +397,9 @@ static TIMER_FUNC(unit_walktoxy_timer)
 	}
 
 	ud->walktimer = INVALID_TIMER;
+	// As movement to next cell finished, set sub-cell position to center
+	ud->sx = 8;
+	ud->sy = 8;
 
 	if (bl->prev == nullptr)
 		return 0; // Stop moved because it is missing from the block_list
@@ -1405,6 +1408,72 @@ int unit_warp(struct block_list *bl,short m,short x,short y,clr_type type)
 }
 
 /**
+ * Updates the walkpath of a unit to end after 0.5-1.5 cells moved
+ * Sends required packet for proper display on the client using subcoordinates
+ * @param bl: Object to stop walking
+ */
+void unit_stop_walking_soon(struct block_list& bl)
+{
+	struct unit_data* ud = unit_bl2ud(&bl);
+
+	if (ud == nullptr) return;
+
+	if (ud->walktimer != INVALID_TIMER && ud->walkpath.path_pos + 1 < ud->walkpath.path_len) {
+		const struct TimerData* td = get_timer(ud->walktimer);
+
+		if (td == nullptr) return;
+
+		// Get how much percent we traversed on the timer
+		double cell_percent = 1 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
+
+		short ox = bl.x, oy = bl.y; // Remember original x and y coordinates
+		short path_remain = 1; // Remaining path to walk
+
+		if (cell_percent > 0 && cell_percent < 1) {
+			// Set subcell coordinates according to timer
+			// This gives a value between 8 and 39
+			ud->sx = (unsigned char)(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+			ud->sy = (unsigned char)(24.0 + diry[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+			// 16-31 reflect sub position 0-15 on the current cell
+			// 8-15 reflect sub position 8-15 at -1 main coordinate
+			// 32-39 reflect sub position 0-7 at +1 main coordinate
+			if (ud->sx < 16 || ud->sy < 16 || ud->sx > 31 || ud->sy > 31) {
+				path_remain = 2;
+				if (ud->sx < 16) bl.x--;
+				if (ud->sy < 16) bl.y--;
+				if (ud->sx > 31) bl.x++;
+				if (ud->sy > 31) bl.y++;
+			}
+			ud->sx = ud->sx % 16;
+			ud->sy = ud->sy % 16;
+		}
+		else if (cell_percent >= 1) {
+			// Assume exactly one cell moved
+			bl.x = bl.x + dirx[ud->walkpath.path[ud->walkpath.path_pos]];
+			bl.y = bl.y + diry[ud->walkpath.path[ud->walkpath.path_pos]];
+			path_remain = 2;
+		}
+		// Shorten walkpath
+		if (ud->walkpath.path_pos + path_remain < ud->walkpath.path_len) {
+			ud->walkpath.path_len = ud->walkpath.path_pos + path_remain;
+			ud->to_x = ox;
+			ud->to_y = oy;
+			for (int i = 0; i < path_remain; i++) {
+				ud->to_x = ud->to_x + dirx[ud->walkpath.path[ud->walkpath.path_pos+i]];
+				ud->to_y = ud->to_y + diry[ud->walkpath.path[ud->walkpath.path_pos+i]];
+			}
+			// Send movement packet with calculated coordinates and subcoordinates
+			clif_move(*ud);
+		}
+		// Reset coordinates
+		bl.x = ox;
+		bl.y = oy;
+		ud->sx = 8;
+		ud->sy = 8;
+	}
+}
+
+/**
  * Stops a unit from walking
  * @param bl: Object to stop walking
  * @param type: Options
@@ -1446,8 +1515,12 @@ int unit_stop_walking(struct block_list *bl,int type)
 		unit_walktoxy_timer(INVALID_TIMER, tick, bl->id, ud->walkpath.path_pos);
 	}
 
-	if(type&USW_FIXPOS)
-		clif_fixpos( *bl );
+	if (type&USW_FIXPOS) {
+		// Stop on cell center
+		ud->sx = 8;
+		ud->sy = 8;
+		clif_fixpos(*bl);
+	}
 
 	ud->walkpath.path_len = 0;
 	ud->walkpath.path_pos = 0;
@@ -3014,6 +3087,8 @@ void unit_dataset(struct block_list *bl)
 	ud->attackabletime =
 	ud->canact_tick    =
 	ud->canmove_tick   = gettick();
+	ud->sx = 8;
+	ud->sy = 8;
 }
 
 /**

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1439,8 +1439,8 @@ void unit_stop_walking_soon(struct block_list& bl)
 	if (cell_percent > 0 && cell_percent < 1) {
 		// Set subcell coordinates according to timer
 		// This gives a value between 8 and 39
-		ud->sx = (unsigned char)(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
-		ud->sy = (unsigned char)(24.0 + diry[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+		ud->sx = static_cast<decltype(ud->sx)>(24.0 + dirx[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
+		ud->sy = static_cast<decltype(ud->sy)>(24.0 + diry[ud->walkpath.path[ud->walkpath.path_pos]] * 16.0 * cell_percent);
 		// 16-31 reflect sub position 0-15 on the current cell
 		// 8-15 reflect sub position 8-15 at -1 main coordinate
 		// 32-39 reflect sub position 0-7 at +1 main coordinate

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1416,12 +1416,18 @@ void unit_stop_walking_soon(struct block_list& bl)
 {
 	struct unit_data* ud = unit_bl2ud(&bl);
 
-	if (ud == nullptr) return;
+	if (ud == nullptr)
+		return;
 
-	if (ud->walktimer != INVALID_TIMER && ud->walkpath.path_pos + 1 < ud->walkpath.path_len) {
+	if (ud->walktimer == INVALID_TIMER)
+		return;
+
+	if (ud->walkpath.path_pos + 1 >= ud->walkpath.path_len)
+		return;
 		const struct TimerData* td = get_timer(ud->walktimer);
 
-		if (td == nullptr) return;
+		if (td == nullptr)
+			return;
 
 		// Get how much percent we traversed on the timer
 		double cell_percent = 1 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -27,6 +27,7 @@ struct unit_data {
 	struct skill_unit_group_tickset skillunittick[MAX_SKILLUNITGROUPTICKSET];
 	short attacktarget_lv;
 	short to_x, to_y;
+	unsigned char sx, sy; // Subtile position (0-15, with 8 being center of cell)
 	short skillx, skilly;
 	uint16 skill_id, skill_lv;
 	int skilltarget;
@@ -114,6 +115,7 @@ int unit_calc_pos(struct block_list *bl, int tx, int ty, uint8 dir);
 TIMER_FUNC(unit_delay_walktoxy_timer);
 TIMER_FUNC(unit_delay_walktobl_timer);
 
+void unit_stop_walking_soon(struct block_list& bl);
 // Causes the target object to stop moving.
 int unit_stop_walking(struct block_list *bl,int type);
 bool unit_can_move(struct block_list *bl);

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -27,7 +27,7 @@ struct unit_data {
 	struct skill_unit_group_tickset skillunittick[MAX_SKILLUNITGROUPTICKSET];
 	short attacktarget_lv;
 	short to_x, to_y;
-	unsigned char sx, sy; // Subtile position (0-15, with 8 being center of cell)
+	uint8 sx, sy; // Subtile position (0-15, with 8 being center of cell)
 	short skillx, skilly;
 	uint16 skill_id, skill_lv;
 	int skilltarget;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8232

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When a monster loses its target, it will now properly display movement to the next cell rather than snapping back to the previous cell
- Looters will no longer spam movement packets to the client when they go for loot
- Added some base implementation for sub-cell coordinates
- Fixes #8232

**Hints for Reviewers**:

Currently the sub-cell coordinates will always be 8 except for this one specific use case of a monster stopping to chase its target (the function unit_stop_walking_soon will reset it to 8 at the end as well). Still I decided to already add the reset to 8 in other parts of the code even though it's not yet needed, so the sub-cell coordinates can be used in other use-cases in the future without breaking the rest of the functionality.

This is more or less a quick solution to the problem and it works perfectly fine for this use-case. I'm aware a better solution would be to keep the sub-tile coordinates updated at all times, but this will not only take a lot of extra resources, it would also require a major refactoring of the code. That's why I decided it to fix it like this for now.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
