### PR TITLE
Resolve Death Valley HP/SP adjustment

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,12 +11708,13 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
+			status_zap(bl, 0, tstatus->sp * (60 - 10 * skill_lv) / 100);
+
 			int heal = tstatus->sp;
 
 			if( heal <= 0 )
 				heal = 1;
 			tstatus->hp = heal;
-			tstatus->sp -= tstatus->sp * ( 60 - 10 * skill_lv ) / 100;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			pc_revive((TBL_PC*)bl,heal,0);
 			clif_resurrection( *bl );

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,7 +11708,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
-			status_zap(bl, 0, tstatus->sp * (60 - 10 * skill_lv) / 100);
+			status_zap(bl, 0, tstatus->sp * 10 * skill_lv / 100);
 
 			int heal = tstatus->sp;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #8428

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * The skill will now properly take the SP first before healing HP of the target player.
Thanks to @jamesandrewww!