### PR TITLE
Correct Death Valley behavior

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,7 +11708,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
-			tstatus->hp += tstatus->sp;
+			tstatus->hp += max(tstatus->sp, 1);
 			tstatus->sp = tstatus->sp * 10 * skill_lv / 100;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			pc_revive((TBL_PC*)bl,true,true);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,10 +11708,10 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
-			tstatus->hp += max(tstatus->sp, 1);
+			tstatus->hp = max(tstatus->sp, 1);
 			tstatus->sp = tstatus->sp * 10 * skill_lv / 100;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
-			pc_revive((TBL_PC*)bl,true,true);
+			pc_revive(reinterpret_cast<map_session_data*>(bl),true,true);
 			clif_resurrection( *bl );
 		}
 		break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11709,7 +11709,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				break;
 
 			tstatus->hp = max(tstatus->sp, 1);
-			tstatus->sp = tstatus->sp * 10 * skill_lv / 100;
+			tstatus->sp -= tstatus->sp * ( 60 - 10 * skill_lv ) / 100;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			pc_revive(reinterpret_cast<map_session_data*>(bl),true,true);
 			clif_resurrection( *bl );

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,13 +11708,11 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
-			unsigned int heal = tstatus->sp;
-
-			status_zap(bl, 0, tstatus->sp * 10 * skill_lv / 100);
+			tstatus->hp += tstatus->sp;
+			tstatus->sp = tstatus->sp * 10 * skill_lv / 100;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
-			pc_revive((TBL_PC*)bl,heal,0);
+			pc_revive((TBL_PC*)bl,true,true);
 			clif_resurrection( *bl );
-			status_heal(bl, max(heal, 1), 0, 0);
 		}
 		break;
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -11708,16 +11708,13 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			if( !status_isdead(bl) )
 				break;
 
+			unsigned int heal = tstatus->sp;
+
 			status_zap(bl, 0, tstatus->sp * 10 * skill_lv / 100);
-
-			int heal = tstatus->sp;
-
-			if( heal <= 0 )
-				heal = 1;
-			tstatus->hp = heal;
 			clif_skill_nodamage(src,bl,skill_id,skill_lv,1);
 			pc_revive((TBL_PC*)bl,heal,0);
 			clif_resurrection( *bl );
+			status_heal(bl, max(heal, 1), 0, 0);
 		}
 		break;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: N/A

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Follow up to 4b32621.
  * The target player should be healed from the remaining SP before the SP reduction is applied.
  * Adjust the variable type when storing the target's SP.