### PR TITLE
Removed Gunslinger Mine Damage Delay

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3580,7 +3580,7 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 	dmg = battle_calc_attack(attack_type,src,bl,skill_id,skill_lv,flag&0xFFF);
 
 	//If the damage source is a unit, the damage is not delayed
-	if (src != dsrc && skill_id != GS_GROUNDDRIFT)
+	if (src != dsrc)
 		dmg.amotion = 0;
 
 	//! CHECKME: This check maybe breaks the battle_calc_attack, and maybe need better calculation.


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8516 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 
 
- Gunslinger Mine no longer has damage delay
- Freeze from Cryo Sphere / Ice Bullet will no longer be immediately broken by its own damage
- Fixes #8516

**Hints for Reviewers**

Note: This exception used to simulate a bug I found on official servers in 2016, but it is no longer present in current renewal and also was not present in pre-renewal, so the exception can be removed again.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
