### PR TITLE
Fixed Elemental SP recalc and packet conversion

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -18791,14 +18791,13 @@ void clif_parse_ItemListWindowSelected(int fd, map_session_data* sd) {
 /// Notifies client of a change in an elemental's status parameter.
 /// 0x81e <type>.W <value>.L (ZC_EL_PAR_CHANGE)
 void clif_elemental_updatestatus(map_session_data& sd, _sp type) {
-#if PACKETVER >= 20091222
+#if PACKETVER >= 20100309
+	if (sd.ed == nullptr)
+		return;
+
 	PACKET_ZC_EL_PAR_CHANGE p = {};
 
 	p.packetType = HEADER_ZC_EL_PAR_CHANGE;
-
-	if( sd.ed == nullptr )
-		return;
-
 	p.type = static_cast<decltype(p.type)>(type);
 	status_data* status = &sd.ed->battle_status;
 	switch( type ) {

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10823,9 +10823,9 @@ void clif_parse_LoadEndAck(int fd,map_session_data *sd)
 			return;
 		clif_spawn(&sd->ed->bl);
 		clif_elemental_info(sd);
-		clif_elemental_updatestatus(sd,SP_HP);
+		clif_elemental_updatestatus(*sd, SP_HP);
 		clif_hpmeter_single( *sd, sd->ed->bl.id, sd->ed->battle_status.hp, sd->ed->battle_status.max_hp );
-		clif_elemental_updatestatus(sd,SP_SP);
+		clif_elemental_updatestatus(*sd, SP_SP);
 		status_calc_bl(&sd->ed->bl, { SCB_SPEED }); //Elemental mimic their master's speed on each map change
 	}
 
@@ -18787,34 +18787,37 @@ void clif_parse_ItemListWindowSelected(int fd, map_session_data* sd) {
 /*==========================================
  * Elemental System
  *==========================================*/
-void clif_elemental_updatestatus(map_session_data *sd, int type) {
-	s_elemental_data *ed;
-	struct status_data *status;
-	int fd;
 
-	if( !clif_session_isValid(sd) || (ed = sd->ed) == nullptr )
+/// Notifies client of a change in an elemental's status parameter.
+/// 0x81e <type>.W <value>.L (ZC_EL_PAR_CHANGE)
+void clif_elemental_updatestatus(map_session_data& sd, _sp type) {
+#if PACKETVER >= 20091222
+	PACKET_ZC_EL_PAR_CHANGE p = {};
+
+	p.packetType = HEADER_ZC_EL_PAR_CHANGE;
+
+	if( sd.ed == nullptr )
 		return;
 
-	fd = sd->fd;
-	status = &ed->battle_status;
-	WFIFOHEAD(fd,8);
-	WFIFOW(fd,0) = 0x81e;
-	WFIFOW(fd,2) = type;
+	p.type = static_cast<decltype(p.type)>(type);
+	status_data* status = &sd.ed->battle_status;
 	switch( type ) {
 		case SP_HP:
-			WFIFOL(fd,4) = status->hp;
+			p.value = static_cast<decltype(p.value)>(status->hp);
 			break;
 		case SP_MAXHP:
-			WFIFOL(fd,4) = status->max_hp;
+			p.value = static_cast<decltype(p.value)>(status->max_hp);
 			break;
 		case SP_SP:
-			WFIFOL(fd,4) = status->sp;
+			p.value = static_cast<decltype(p.value)>(status->sp);
 			break;
 		case SP_MAXSP:
-			WFIFOL(fd,4) = status->max_sp;
+			p.value = static_cast<decltype(p.value)>(status->max_sp);
 			break;
 	}
-	WFIFOSET(fd,8);
+
+	clif_send( &p, sizeof( p ), &sd.bl, SELF );
+#endif
 }
 
 void clif_elemental_info(map_session_data *sd) {

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -1299,7 +1299,7 @@ void clif_autoshadowspell_list( map_session_data& sd );
 
 int clif_skill_itemlistwindow( map_session_data *sd, uint16 skill_id, uint16 skill_lv );
 void clif_elemental_info(map_session_data *sd);
-void clif_elemental_updatestatus(map_session_data *sd, int type);
+void clif_elemental_updatestatus(map_session_data& sd, _sp type);
 
 void clif_spiritcharm( map_session_data& sd );
 

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -1544,7 +1544,6 @@
 	//packet(0x081B,4);
 	//packet(0x081C,6);
 	packet(0x081d,22);
-	packet(0x081e,8);
 #endif
 
 // 2010-03-23aRagexeRE

--- a/src/map/elemental.cpp
+++ b/src/map/elemental.cpp
@@ -282,9 +282,9 @@ int elemental_data_received(s_elemental *ele, bool flag) {
 			return 0;
 		clif_spawn(&ed->bl);
 		clif_elemental_info(sd);
-		clif_elemental_updatestatus(sd,SP_HP);
+		clif_elemental_updatestatus(*sd, SP_HP);
 		clif_hpmeter_single( *sd, ed->bl.id, ed->battle_status.hp, ed->battle_status.max_hp );
-		clif_elemental_updatestatus(sd,SP_SP);
+		clif_elemental_updatestatus(*sd, SP_SP);
 	}
 
 	return 1;
@@ -441,9 +441,9 @@ void elemental_heal(s_elemental_data *ed, int hp, int sp) {
 	if (ed->master == nullptr)
 		return;
 	if( hp )
-		clif_elemental_updatestatus(ed->master, SP_HP);
+		clif_elemental_updatestatus(*ed->master, SP_HP);
 	if( sp )
-		clif_elemental_updatestatus(ed->master, SP_SP);
+		clif_elemental_updatestatus(*ed->master, SP_SP);
 }
 
 int elemental_dead(s_elemental_data *ed) {
@@ -595,8 +595,8 @@ static int elemental_ai_sub_timer(s_elemental_data *ed, map_session_data *sd, t_
 	if( master_dist > AREA_SIZE ) {	// Master out of vision range.
 		elemental_unlocktarget(ed);
 		unit_warp(&ed->bl,sd->bl.m,sd->bl.x,sd->bl.y,CLR_TELEPORT);
-		clif_elemental_updatestatus(sd,SP_HP);
-		clif_elemental_updatestatus(sd,SP_SP);
+		clif_elemental_updatestatus(*sd, SP_HP);
+		clif_elemental_updatestatus(*sd, SP_SP);
 		return 0;
 	} else if( master_dist > MAX_ELEDISTANCE ) {	// Master too far, chase.
 		short x = sd->bl.x, y = sd->bl.y;

--- a/src/map/packets.hpp
+++ b/src/map/packets.hpp
@@ -1154,6 +1154,13 @@ struct PACKET_CZ_PARTY_JOIN_REQ_ACK{
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(CZ_PARTY_JOIN_REQ_ACK, 0x2c7);
 
+struct PACKET_ZC_EL_PAR_CHANGE {
+	int16 packetType;
+	uint16 type;
+	uint32 value;
+} __attribute__((packed));
+DEFINE_PACKET_HEADER(ZC_EL_PAR_CHANGE, 0x81e);
+
 // NetBSD 5 and Solaris don't like pragma pack but accept the packed attribute
 #if !defined( sun ) && ( !defined( __NETBSD__ ) || __NetBSD_Version__ >= 600000000 )
 	#pragma pack( pop )

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -6445,13 +6445,13 @@ void status_calc_bl_(struct block_list* bl, std::bitset<SCB_MAX> flag, uint8 opt
 			return;
 
 		if( b_status.max_hp != status->max_hp )
-			clif_elemental_updatestatus(ed->master, SP_MAXHP);
+			clif_elemental_updatestatus(*ed->master, SP_MAXHP);
 		if( b_status.max_sp != status->max_sp )
-			clif_elemental_updatestatus(ed->master, SP_MAXSP);
+			clif_elemental_updatestatus(*ed->master, SP_MAXSP);
 		if( b_status.hp != status->hp )
-			clif_elemental_updatestatus(ed->master, SP_HP);
+			clif_elemental_updatestatus(*ed->master, SP_HP);
 		if( b_status.sp != status->sp )
-			clif_mercenary_updatestatus(ed->master, SP_SP);
+			clif_elemental_updatestatus(*ed->master, SP_SP);
 	}
 }
 


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes Elemental SP recalculation calling `clif_mercenary_updatestatus` instead of `clif_elemental_updatestatus` and packet ZC_EL_PAR_CHANGE conversion and cleanup

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
