### PR TITLE
Earth Spike and Heaven's Drive

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -3661,16 +3661,26 @@ Body:
     CastCancel: true
     CastTime:
       - Level: 1
+        Time: 700
+      - Level: 2
+        Time: 1400
+      - Level: 3
+        Time: 2100
+      - Level: 4
+        Time: 2800
+      - Level: 5
+        Time: 3500
+    AfterCastActDelay:
+      - Level: 1
         Time: 1000
       - Level: 2
-        Time: 2000
+        Time: 1200
       - Level: 3
-        Time: 3000
+        Time: 1400
       - Level: 4
-        Time: 4000
+        Time: 1600
       - Level: 5
-        Time: 5000
-    AfterCastActDelay: 700
+        Time: 1800
     Requires:
       SpCost:
         - Level: 1
@@ -3722,7 +3732,7 @@ Body:
         Time: 4000
       - Level: 5
         Time: 5000
-    AfterCastActDelay: 700
+    AfterCastActDelay: 1000
     Duration1: 100
     Requires:
       SpCost:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8533 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Earth Spike now has the same cast time and aftercast delay as bolt spells (pre-re)
- Heaven's Drive now has an aftercast delay of 1000ms (pre-re)
- Fixes #8533

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
