### PR TITLE
Eternal Chaos rebalance missing change

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -86,7 +86,7 @@ Body:
     Opt1: StoneWait
     Flags:
       SendOption: true
-      BossResist: true      
+      BossResist: true
       StopAttacking: true
     Fail:
       Whiteimprison: true
@@ -1822,6 +1822,7 @@ Body:
     Icon: EFST_ETERNALCHAOS
     DurationLookup: BD_ETERNALCHAOS
     CalcFlags:
+      Def: true
       Def2: true
     Flags:
       NoDispell: true

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7683,6 +7683,10 @@ static defType status_calc_def(struct block_list *bl, status_change *sc, int def
 
 	if(sc->getSCE(SC_BERSERK))
 		return 0;
+#ifdef RENEWAL
+	if(sc->getSCE(SC_ETERNALCHAOS))
+		return 0;
+#endif
 	if(sc->getSCE(SC_BARRIER))
 		return 100;
 	if(sc->getSCE(SC_KEEPING))


### PR DESCRIPTION
* **Addressed Issue(s)**: -

* **Server Mode**: Renewal

* **Description of Pull Request**: After 2nd class rebalance, Eternal Chaos now sets both hard DEF and soft DEF to 0.