### PR TITLE
Corrected Spore Explosion and Earth Shaker skills

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7037,6 +7037,7 @@ Body:
     Icon: EFST_SPORE_EXPLOSION_DEBUFF
     DurationLookup: GN_SPORE_EXPLOSION
     Flags:
+      BlEffect: true
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7022,7 +7022,9 @@ Body:
     CalcFlags:
       Regen: true
   - Status: Earthshaker
+    Icon: EFST_EARTHSHAKER
     Flags:
+      BlEffect: true
       NoWarning: true
   - Status: Weaponblock_On
     Icon: EFST_WEAPONBLOCK_ON

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1956,7 +1956,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src,bl, SC_SILENCE, 5 * skill_lv + (status_get_dex(src) + status_get_lv(src)) / 10, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
 	case SR_EARTHSHAKER:
-		if( bl->type == BL_MOB )
+		if (dstmd != nullptr && dstmd->guardian_data == nullptr)    // Target is a mob and not a guardian type. [Atemo]
 			sc_start(src, bl, SC_EARTHSHAKER, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
 		sc_start(src,bl,SC_STUN, 25 + 5 * skill_lv,skill_lv,skill_get_time(skill_id,skill_lv));
 		status_change_end(bl, SC_SV_ROOTTWIST);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1956,8 +1956,11 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src,bl, SC_SILENCE, 5 * skill_lv + (status_get_dex(src) + status_get_lv(src)) / 10, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
 	case SR_EARTHSHAKER:
+		if( bl->type == BL_MOB ) {
+			sc_start(src, bl, SC_EARTHSHAKER, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
+			clif_specialeffect(bl, 1398, AREA);
+		}
 		sc_start(src,bl,SC_STUN, 25 + 5 * skill_lv,skill_lv,skill_get_time(skill_id,skill_lv));
-		sc_start(src, bl, SC_EARTHSHAKER, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
 		status_change_end(bl, SC_SV_ROOTTWIST);
 		break;
 	case SO_EARTHGRAVE:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1956,7 +1956,7 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src,bl, SC_SILENCE, 5 * skill_lv + (status_get_dex(src) + status_get_lv(src)) / 10, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
 	case SR_EARTHSHAKER:
-		if (dstmd != nullptr && dstmd->guardian_data == nullptr)    // Target is a mob and not a guardian type. [Atemo]
+		if (dstmd != nullptr && dstmd->guardian_data == nullptr)    // Target is a mob (boss included) and not a guardian type. [Atemo]
 			sc_start(src, bl, SC_EARTHSHAKER, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
 		sc_start(src,bl,SC_STUN, 25 + 5 * skill_lv,skill_lv,skill_get_time(skill_id,skill_lv));
 		status_change_end(bl, SC_SV_ROOTTWIST);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1956,10 +1956,8 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		sc_start(src,bl, SC_SILENCE, 5 * skill_lv + (status_get_dex(src) + status_get_lv(src)) / 10, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
 	case SR_EARTHSHAKER:
-		if( bl->type == BL_MOB ) {
+		if( bl->type == BL_MOB )
 			sc_start(src, bl, SC_EARTHSHAKER, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
-			clif_specialeffect(bl, 1398, AREA);
-		}
 		sc_start(src,bl,SC_STUN, 25 + 5 * skill_lv,skill_lv,skill_get_time(skill_id,skill_lv));
 		status_change_end(bl, SC_SV_ROOTTWIST);
 		break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13714,6 +13714,9 @@ int status_change_end(struct block_list* bl, enum sc_type type, int tid)
 		case SC_INTRAVISION:
 			calc_flag = status_db.getSCB_ALL(); // Required for overlapping
 			break;
+        case SC_EARTHSHAKER:
+            clif_specialeffect_remove(bl, 1398, AREA, bl);
+            break;
 
 		case SC_GRAVITYCONTROL:
 			status_fix_damage(bl, bl, sce->val2, clif_damage(*bl, *bl, gettick(), 0, 0, sce->val2, 0, DMG_NORMAL, 0, false), 0);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13714,9 +13714,6 @@ int status_change_end(struct block_list* bl, enum sc_type type, int tid)
 		case SC_INTRAVISION:
 			calc_flag = status_db.getSCB_ALL(); // Required for overlapping
 			break;
-		case SC_EARTHSHAKER:
-			clif_specialeffect_remove(bl, 1398, AREA, bl);
-			break;
 
 		case SC_GRAVITYCONTROL:
 			status_fix_damage(bl, bl, sce->val2, clif_damage(*bl, *bl, gettick(), 0, 0, sce->val2, 0, DMG_NORMAL, 0, false), 0);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13714,9 +13714,9 @@ int status_change_end(struct block_list* bl, enum sc_type type, int tid)
 		case SC_INTRAVISION:
 			calc_flag = status_db.getSCB_ALL(); // Required for overlapping
 			break;
-        case SC_EARTHSHAKER:
-            clif_specialeffect_remove(bl, 1398, AREA, bl);
-            break;
+		case SC_EARTHSHAKER:
+			clif_specialeffect_remove(bl, 1398, AREA, bl);
+			break;
 
 		case SC_GRAVITYCONTROL:
 			status_fix_damage(bl, bl, sce->val2, clif_damage(*bl, *bl, gettick(), 0, 0, sce->val2, 0, DMG_NORMAL, 0, false), 0);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Part of #8378 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: RE

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: I was watching iRO videos and found that Spore Explosion bonus is missing an effect
https://youtu.be/9ELfg4PtCg4?si=7vVXrwkQqY44tzWI&t=60
and about the Earth Shaker i tested it in kRO, it should give a Red Effect on target and the bonus only works with mobs, not players.
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/#comment-5519
![image](https://github.com/user-attachments/assets/080290b5-c566-4b44-b2f2-a0810cbe4705)


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
