### PR TITLE
Fixed Vanilmirth skills + NPC_SELFDESTRUCTION

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -31026,19 +31026,7 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
-    Range: 15
-    Hit: Single
-    HitCount:
-      - Level: 1
-        Count: 1
-      - Level: 2
-        Count: 2
-      - Level: 3
-        Count: 3
-      - Level: 4
-        Count: 4
-      - Level: 5
-        Count: 5
+    Range: 9
     Requires:
       SpCost:
         - Level: 1
@@ -31055,10 +31043,10 @@ Body:
     Name: HVAN_CHAOTIC
     Description: Benediction of Chaos
     MaxLevel: 5
+    Type: Magic
     TargetType: Self
     DamageFlags:
       NoDamage: true
-    Hit: Single
     AfterCastWalkDelay: 1500
     Requires:
       SpCost: 40
@@ -31066,8 +31054,6 @@ Body:
     Name: HVAN_INSTRUCT
     Description: Instruct
     MaxLevel: 5
-    DamageFlags:
-      NoDamage: true
   - Id: 8016
     Name: HVAN_EXPLOSION
     Description: Bio Explosion
@@ -31079,10 +31065,13 @@ Body:
       IgnoreElement: true
       IgnoreFlee: true
       IgnoreDefCard: true
+    Flags:
+      TargetTrap: true
     Hit: Single
     HitCount: 1
-    Element: Weapon
-    SplashArea: 4
+    Element: Neutral
+    SplashArea: 5
+    Duration1: 1500
     Requires:
       SpCost: 1
   - Id: 8018

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -43312,19 +43312,7 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
-    Range: 15
-    Hit: Single
-    HitCount:
-      - Level: 1
-        Count: 1
-      - Level: 2
-        Count: 2
-      - Level: 3
-        Count: 3
-      - Level: 4
-        Count: 4
-      - Level: 5
-        Count: 5
+    Range: 9
     Cooldown:
       - Level: 1
         Time: 2000
@@ -43352,10 +43340,10 @@ Body:
     Name: HVAN_CHAOTIC
     Description: Benediction of Chaos
     MaxLevel: 5
+    Type: Magic
     TargetType: Self
     DamageFlags:
       NoDamage: true
-    Hit: Single
     AfterCastWalkDelay: 1500
     Cooldown: 3000
     Requires:
@@ -43364,8 +43352,6 @@ Body:
     Name: HVAN_INSTRUCT
     Description: Instruct
     MaxLevel: 5
-    DamageFlags:
-      NoDamage: true
   - Id: 8016
     Name: HVAN_EXPLOSION
     Description: Bio Explosion
@@ -43377,11 +43363,13 @@ Body:
       IgnoreElement: true
       IgnoreFlee: true
       IgnoreDefCard: true
+    Flags:
+      TargetTrap: true
     Hit: Single
     HitCount: 1
-    Element: Weapon
-    SplashArea: 4
-    AfterCastActDelay: 5000
+    Element: Neutral
+    SplashArea: 5
+    Duration1: 1500
     CoolDown: 1000
     Requires:
       SpCost: 1

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -15457,7 +15457,7 @@ void clif_parse_HomMoveTo(int fd, map_session_data *sd){
 	else
 		return;
 
-	if (x < 0 || y < 0 || x == bl->x || y == bl->y)
+	if (x < 0 || y < 0 || (x == bl->x && y == bl->y))
 		return;
 
 	unit_walktoxy(bl, x, y, 4);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -15459,19 +15459,19 @@ void clif_parse_HomMoveToMaster(int fd, map_session_data *sd){
 }
 
 
-/// Request to move homunculus/mercenary (CZ_REQUEST_MOVENPC).
-/// 0232 <id>.L <position data>.3B
+/// Request to move homunculus/mercenary.
+/// 0232 <id>.L <position data>.3B (CZ_REQUEST_MOVENPC)
 void clif_parse_HomMoveTo(int fd, map_session_data *sd){
-	struct s_packet_db* info = &packet_db[RFIFOW(fd,0)];
-	int id = RFIFOL(fd,info->pos[0]); // Mercenary or Homunculus
+#if PACKETVER >= 20050425
+	const PACKET_CZ_REQUEST_MOVENPC* p = reinterpret_cast<const PACKET_CZ_REQUEST_MOVENPC*>( RFIFOP( fd, 0 ) );
 	struct block_list *bl = nullptr;
 	short x, y;
 
-	RFIFOPOS(fd, info->pos[1], &x, &y, nullptr);
+	RBUFPOS( p->PosDir, 0, &x, &y, nullptr );
 
-	if( sd->md && sd->md->bl.id == id )
+	if( sd->md && sd->md->bl.id == p->GID )
 		bl = &sd->md->bl; // Moving Mercenary
-	else if( hom_is_active(sd->hd) && sd->hd->bl.id == id )
+	else if( hom_is_active(sd->hd) && sd->hd->bl.id == p->GID )
 		bl = &sd->hd->bl; // Moving Homunculus
 	else
 		return;
@@ -15480,6 +15480,7 @@ void clif_parse_HomMoveTo(int fd, map_session_data *sd){
 		return;
 
 	unit_walktoxy(bl, x, y, 4);
+#endif
 }
 
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -15457,6 +15457,9 @@ void clif_parse_HomMoveTo(int fd, map_session_data *sd){
 	else
 		return;
 
+	if (x < 0 || y < 0 || x == bl->x || y == bl->y)
+		return;
+
 	unit_walktoxy(bl, x, y, 4);
 }
 
@@ -15479,7 +15482,6 @@ void clif_parse_HomAttack(int fd,map_session_data *sd)
 		bl = &sd->md->bl;
 	else return;
 
-	unit_stop_attack(bl);
 	unit_attack(bl, target_id, action_type != 0);
 }
 

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -563,7 +563,7 @@
 // 2005-04-25aSakexe
 #if PACKETVER >= 20050425
 	parseable_packet(0x022d,5,clif_parse_HomMenu,2,4);
-	parseable_packet(0x0232,9,clif_parse_HomMoveTo,2,6);
+	parseable_packet( HEADER_CZ_REQUEST_MOVENPC, sizeof( PACKET_CZ_REQUEST_MOVENPC ), clif_parse_HomMoveTo, 0 );
 	parseable_packet(0x0233,11,clif_parse_HomAttack,2,6,10);
 	parseable_packet(0x0234,6,clif_parse_HomMoveToMaster,2);
 #endif

--- a/src/map/packets.hpp
+++ b/src/map/packets.hpp
@@ -1362,6 +1362,13 @@ struct PACKET_ZC_NOTIFY_ACT{
 DEFINE_PACKET_HEADER(ZC_NOTIFY_ACT, 0x8a);
 #endif
 
+struct PACKET_CZ_REQUEST_MOVENPC{
+	int16 packetType;
+	uint32 GID;
+	uint8 PosDir[3];
+} __attribute__((packed));
+DEFINE_PACKET_HEADER(CZ_REQUEST_MOVENPC, 0x232);
+
 // NetBSD 5 and Solaris don't like pragma pack but accept the packed attribute
 #if !defined( sun ) && ( !defined( __NETBSD__ ) || __NetBSD_Version__ >= 600000000 )
 	#pragma pack( pop )

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10700,18 +10700,16 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 			status_heal(bl, heal, 0, 0);
 		} break;
 	case HVAN_EXPLOSION:
-	{
-		clif_skill_nodamage(src, *src, skill_id, skill_lv, 1);
-		map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR | BL_SKILL, src, skill_id, skill_lv, tick, flag | BCT_ENEMY, skill_castend_damage_id);
+		if( hd != nullptr ){
+			clif_skill_nodamage(src, *src, skill_id, skill_lv, 1);
+			map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR | BL_SKILL, src, skill_id, skill_lv, tick, flag | BCT_ENEMY, skill_castend_damage_id);
 
-		homun_data& hd = reinterpret_cast<homun_data&>(*src);
-		hd.homunculus.intimacy = hom_intimacy_grade2intimacy(HOMGRADE_HATE_WITH_PASSION);
-		clif_send_homdata(hd, SP_INTIMATE);
+			hd->homunculus.intimacy = hom_intimacy_grade2intimacy(HOMGRADE_HATE_WITH_PASSION);
+			clif_send_homdata(*hd, SP_INTIMATE);
 
-		// There's a delay between the explosion and the homunculus death
-		skill_addtimerskill(src, tick + skill_get_time(skill_id, skill_lv), src->id, 0, 0, skill_id, skill_lv, 0, flag);
-		break;
-	}
+			// There's a delay between the explosion and the homunculus death
+			skill_addtimerskill(src, tick + skill_get_time(skill_id, skill_lv), src->id, 0, 0, skill_id, skill_lv, 0, flag);
+		} break;
 	// Homun single-target support skills [orn]
 	case HLIF_CHANGE:
 #ifndef RENEWAL

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6196,10 +6196,10 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 		sc_start(src,src,SC_MAGICALATTACK,100,skill_lv,skill_get_time(skill_id,skill_lv));
 		break;
 
-	case HVAN_CAPRICE: //[blackhole89]
+	case HVAN_CAPRICE:
 		{
-			static std::vector<e_skill> subskills = { MG_COLDBOLT, MG_FIREBOLT, MG_LIGHTNINGBOLT, WZ_EARTHSPIKE };
-			e_skill subskill_id = util::vector_random( subskills );
+			static const std::array<e_skill, 4> subskills = { MG_COLDBOLT, MG_FIREBOLT, MG_LIGHTNINGBOLT, WZ_EARTHSPIKE };
+			e_skill subskill_id = subskills.at(rnd() % subskills.size());
 			skill_attack(skill_get_type(subskill_id), src, src, bl, subskill_id, skill_lv, tick, flag);
 		}
 		break;
@@ -10693,14 +10693,14 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case HVAN_CHAOTIC:
 		{
 			// Chance per skill level
-			static const uint8 chance_homunculus[5] = {
+			static const std::array<uint8, 5> chance_homunculus = {
 				20,
 				50,
 				25,
 				50,
 				34
 			};
-			static const uint8 chance_master[5] = {
+			static const std::array<uint8, 5> chance_master = {
 				static_cast<uint8>(chance_homunculus[0] + 30),
 				static_cast<uint8>(chance_homunculus[1] + 10),
 				static_cast<uint8>(chance_homunculus[2] + 50),

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10700,7 +10700,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		break;
 	case HVAN_EXPLOSION:
 	{
-		clif_skill_nodamage(src, src, skill_id, skill_lv, 1);
+		clif_skill_nodamage(src, *src, skill_id, skill_lv, 1);
 		map_foreachinshootrange(skill_area_sub, bl, skill_get_splash(skill_id, skill_lv), BL_CHAR | BL_SKILL, src, skill_id, skill_lv, tick, flag | BCT_ENEMY, skill_castend_damage_id);
 
 		homun_data& hd = reinterpret_cast<homun_data&>(*src);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10692,6 +10692,38 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		break;
 	case HVAN_CHAOTIC:
 		{
+			// Chance per skill level
+			static const uint8 chance_homunculus[5] = {
+				20,
+				50,
+				25,
+				50,
+				34
+			};
+			static const uint8 chance_master[5] = {
+				static_cast<uint8>(chance_homunculus[0] + 30),
+				static_cast<uint8>(chance_homunculus[1] + 10),
+				static_cast<uint8>(chance_homunculus[2] + 50),
+				static_cast<uint8>(chance_homunculus[3] + 4),
+				static_cast<uint8>(chance_homunculus[4] + 33)
+			};
+
+			uint8 chance = rnd_value(1, 100);
+
+			// Homunculus
+			if (chance <= chance_homunculus[skill_lv - 1])
+				bl = src;
+			// Master
+			else if (chance <= chance_master[skill_lv - 1])
+				bl = battle_get_master(src);
+			// Enemy (A random enemy targeting the master)
+			else
+				bl = battle_gettargeted(battle_get_master(src));
+
+			// If there's no enemy the chance reverts to the homunculus
+			if (bl == nullptr)
+				bl = src;
+
 			int32 heal = skill_calc_heal(src, bl, skill_id, rnd_value<uint16>(1, skill_lv), true);
 
 			// Official servers send the Heal skill packet with the healed amount, and then the skill packet with 1 as healed amount

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10698,7 +10698,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		hd.homunculus.intimacy = hom_intimacy_grade2intimacy(HOMGRADE_HATE_WITH_PASSION);
 		clif_send_homdata(hd, SP_INTIMATE);
 
-		// There's a delay between splash damage and the homunculus death
+		// There's a delay between the explosion and the homunculus death
 		skill_addtimerskill(src, tick + skill_get_time(skill_id, skill_lv), src->id, 0, 0, skill_id, skill_lv, 0, flag);
 		break;
 	}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10690,14 +10690,15 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		else if (sd != nullptr)
 			clif_skill_fail( *sd, skill_id );
 		break;
-	case HVAN_CHAOTIC:	//[orn]
-		i = skill_calc_heal(src, bl, skill_id, rnd_value<uint16>(1, skill_lv), true);
+	case HVAN_CHAOTIC:
+		{
+			int32 heal = skill_calc_heal(src, bl, skill_id, rnd_value<uint16>(1, skill_lv), true);
 
-		// Official servers send the Heal skill packet with the healed amount, and then the skill packet with 1 as healed amount
-		clif_skill_nodamage(src, *bl, AL_HEAL, i);
-		clif_skill_nodamage(src, *bl, skill_id, 1);
-		status_heal(bl, i, 0, 0);
-		break;
+			// Official servers send the Heal skill packet with the healed amount, and then the skill packet with 1 as healed amount
+			clif_skill_nodamage(src, *bl, AL_HEAL, heal);
+			clif_skill_nodamage(src, *bl, skill_id, 1);
+			status_heal(bl, heal, 0, 0);
+		} break;
 	case HVAN_EXPLOSION:
 	{
 		clif_skill_nodamage(src, *src, skill_id, skill_lv, 1);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6198,8 +6198,8 @@ int skill_castend_damage_id (struct block_list* src, struct block_list *bl, uint
 
 	case HVAN_CAPRICE: //[blackhole89]
 		{
-			static const e_skill subskills[] = { MG_COLDBOLT, MG_FIREBOLT, MG_LIGHTNINGBOLT, WZ_EARTHSPIKE };
-			e_skill subskill_id = subskills[rnd()%ARRAYLENGTH(subskills)];
+			static std::vector<e_skill> subskills = { MG_COLDBOLT, MG_FIREBOLT, MG_LIGHTNINGBOLT, WZ_EARTHSPIKE };
+			e_skill subskill_id = util::vector_random( subskills );
 			skill_attack(skill_get_type(subskill_id), src, src, bl, subskill_id, skill_lv, tick, flag);
 		}
 		break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5046,8 +5046,10 @@ int status_calc_homunculus_(struct homun_data *hd, uint8 opt)
 		status->def += skill_lv * 4;
 
 	if((skill_lv = hom_checkskill(hd, HVAN_INSTRUCT)) > 0) {
-		status->int_ += 1 + skill_lv / 2 + skill_lv / 4 + skill_lv / 5;
-		status->str += 1 + skill_lv / 3 + skill_lv / 3 + skill_lv / 4;
+		static const uint8 bonus_int[] = { 1, 2, 2, 4, 5 };
+		static const uint8 bonus_str[] = { 1, 1, 3, 4, 4 };
+		status->int_ += bonus_int[skill_lv - 1];
+		status->str += bonus_str[skill_lv - 1];
 	}
 
 	if((skill_lv = hom_checkskill(hd, HAMI_SKIN)) > 0)

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1831,6 +1831,33 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 
 				target_id = target->id;
 				break;
+			case HVAN_CHAOTIC:
+			{
+				// Chance per skill level
+				static const uint8 chance_table[2][5] = {
+					{ 20, 50, 25, 50, 34 }, // Homunculus
+					{ 30, 10, 50,  4, 33 }  // Master
+				};
+
+				uint8 chance = rnd_value(1, 100);
+
+				// Homunculus
+				if (chance <= chance_table[0][skill_lv - 1])
+					target = src;
+				// Master
+				else if (chance <= (chance_table[0][skill_lv - 1] + chance_table[1][skill_lv - 1]))
+					target = battle_get_master(src);
+				// Enemy
+				else
+					target = map_id2bl(battle_gettarget(src));
+
+				// If there's no enemy the chance reverts to the homunculus
+				if (target == nullptr)
+					target = src;
+
+				target_id = target->id;
+				break;
+			}
 			case MH_SONIC_CRAW:
 			case MH_TINDER_BREAKER: {
 				int skill_id2 = ((skill_id==MH_SONIC_CRAW)?MH_MIDNIGHT_FRENZY:MH_EQC);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1831,42 +1831,6 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 
 				target_id = target->id;
 				break;
-			case HVAN_CHAOTIC:
-				{
-					// Chance per skill level
-					static const uint8 chance_homunculus[5] = {
-						20,
-						50,
-						25,
-						50,
-						34
-					};
-					static const uint8 chance_master[5] = {
-						static_cast<uint8>( chance_homunculus[0] + 30 ),
-						static_cast<uint8>( chance_homunculus[1] + 10 ),
-						static_cast<uint8>( chance_homunculus[2] + 50 ),
-						static_cast<uint8>( chance_homunculus[3] + 4 ),
-						static_cast<uint8>( chance_homunculus[4] + 33 )
-					};
-
-					uint8 chance = rnd_value(1, 100);
-
-					// Homunculus
-					if (chance <= chance_homunculus[skill_lv - 1])
-						target = src;
-					// Master
-					else if (chance <= chance_master[skill_lv - 1])
-						target = battle_get_master(src);
-					// Enemy
-					else
-						target = map_id2bl(battle_gettarget(src));
-
-					// If there's no enemy the chance reverts to the homunculus
-					if (target == nullptr)
-						target = src;
-
-					target_id = target->id;
-				} break;
 			case MH_SONIC_CRAW:
 			case MH_TINDER_BREAKER: {
 				int skill_id2 = ((skill_id==MH_SONIC_CRAW)?MH_MIDNIGHT_FRENZY:MH_EQC);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1832,32 +1832,41 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 				target_id = target->id;
 				break;
 			case HVAN_CHAOTIC:
-			{
-				// Chance per skill level
-				static const uint8 chance_table[2][5] = {
-					{ 20, 50, 25, 50, 34 }, // Homunculus
-					{ 30, 10, 50,  4, 33 }  // Master
-				};
+				{
+					// Chance per skill level
+					static const uint8 chance_homunculus[5] = {
+						20,
+						50,
+						25,
+						50,
+						34
+					};
+					static const uint8 chance_master[5] = {
+						chance_homunculus[0] + 30,
+						chance_homunculus[1] + 10,
+						chance_homunculus[2] + 50,
+						chance_homunculus[3] + 4,
+						chance_homunculus[4] + 33
+					};
 
-				uint8 chance = rnd_value(1, 100);
+					uint8 chance = rnd_value(1, 100);
 
-				// Homunculus
-				if (chance <= chance_table[0][skill_lv - 1])
-					target = src;
-				// Master
-				else if (chance <= (chance_table[0][skill_lv - 1] + chance_table[1][skill_lv - 1]))
-					target = battle_get_master(src);
-				// Enemy
-				else
-					target = map_id2bl(battle_gettarget(src));
+					// Homunculus
+					if (chance <= chance_homunculus[skill_lv - 1])
+						target = src;
+					// Master
+					else if (chance <= chance_master[skill_lv - 1])
+						target = battle_get_master(src);
+					// Enemy
+					else
+						target = map_id2bl(battle_gettarget(src));
 
-				// If there's no enemy the chance reverts to the homunculus
-				if (target == nullptr)
-					target = src;
+					// If there's no enemy the chance reverts to the homunculus
+					if (target == nullptr)
+						target = src;
 
-				target_id = target->id;
-				break;
-			}
+					target_id = target->id;
+				} break;
 			case MH_SONIC_CRAW:
 			case MH_TINDER_BREAKER: {
 				int skill_id2 = ((skill_id==MH_SONIC_CRAW)?MH_MIDNIGHT_FRENZY:MH_EQC);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1842,11 +1842,11 @@ int unit_skilluse_id2(struct block_list *src, int target_id, uint16 skill_id, ui
 						34
 					};
 					static const uint8 chance_master[5] = {
-						chance_homunculus[0] + 30,
-						chance_homunculus[1] + 10,
-						chance_homunculus[2] + 50,
-						chance_homunculus[3] + 4,
-						chance_homunculus[4] + 33
+						static_cast<uint8>( chance_homunculus[0] + 30 ),
+						static_cast<uint8>( chance_homunculus[1] + 10 ),
+						static_cast<uint8>( chance_homunculus[2] + 50 ),
+						static_cast<uint8>( chance_homunculus[3] + 4 ),
+						static_cast<uint8>( chance_homunculus[4] + 33 )
 					};
 
 					uint8 chance = rnd_value(1, 100);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  Fixes Vanilmirth skills behavior:

    * HVAN_CAPRICE (Caprice):
      * Fixed range (9 cells)
      * Fixed displaying 'Caprice' instead of the randomly selected skill, being the later the correct one

    * HVAN_CHAOTIC (Chaotic Blessings):
      * Fixed skill type
      * Fixed target calculation math (previously homunculus and master chances overlapped, since master chance didn't add homun chance)
      * Moved target calculation to unit_skilluse_id2 since battle_gettarget can't work on skill_castend_nodamage_id as the homunculus already lost the target
      * Sanitized clif_parse_HomMoveTo, since some AIs caused the homunculus to lose the target
      * Fixed clif_parse_HomAttack making the homunculus to stop attacking and hence losing the target
      * Small fix on the skill packets and added some clarification

    * HVAN_INSTRUCT (Instruction Change):
      * Fixed INT and STR bonuses and cleaned the code a bit

    * HVAN_EXPLOSION (Self-Destruction):
      * Fixed not damaging traps
      * Fixed damage element to neutral
      * Fixed splash area to 5 (11x11)
      * Removed knockback
      * Moved the main code away from NPC_SELFDESTRUCTION as it's way different
      * Fixed skill name not showing over the homunculus
      * Added official 1.5s delay between the explosion and the death of the homunculus



    * NPC_SELFDESTRUCTION
      * Removed clif_skill_nodamage call as on official servers never shows the skill name over the monster
      * Changed status_damage to status_kill as on official server never shows the damage, it just dies

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
