### PR TITLE
fix strncpy warning at ZC_CHANGE_CHATROOM packet

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -4494,7 +4494,7 @@ void clif_changechatstatus(chat_data& cd) {
 	p->users = cd.users;
 
 	// not zero-terminated
-	strncpy(p->title, cd.title, strlen(cd.title));
+	memcpy(p->title, cd.title, strlen(cd.title));
 
 	if(cd.owner->type == BL_NPC){
 		// NPC itself counts as additional chat user


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixed Warning caused by strncpy usage at ZC_CHANGE_CHATROOM packet
![image](https://github.com/user-attachments/assets/9e2a1d3d-64b1-441a-bc0a-8a92827cf58f)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
