### PR TITLE
Fixed Castling not getting the correct target

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10682,7 +10682,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 	case HAMI_CASTLE:	//[orn]
 		if (src != bl && rnd_chance(20 * skill_lv, 100)) {
 			// Get one of the monsters targeting the player and set the homunculus as its new target
-			if (block_list* tbl = battle_getenemy(bl, BL_MOB, AREA_SIZE); tbl != nullptr) {
+			if (block_list* tbl = battle_gettargeted(bl); tbl != nullptr && tbl->type == BL_MOB) {
 				if (unit_data* ud = unit_bl2ud(tbl); ud != nullptr)
 					unit_changetarget_sub(*ud, *src);
 			}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Follow-up to ffead570b20060da5885f6babd28d5cc5b14eef0
Fixes HAMI_CASTLE (Castling) getting a random nearby monster as target instead of the ones targeting the player.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
