### PR TITLE
Finger Offensive Renewal Damage

### DIFF
--- a/db/re/job_stats.yml
+++ b/db/re/job_stats.yml
@@ -5635,6 +5635,8 @@ Body:
         Str: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Str: 1
   - Jobs:
       Genetic: true
     MaxWeight: 32000
@@ -6200,6 +6202,8 @@ Body:
         Str: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Str: 1
   - Jobs:
       Genetic_T: true
     MaxWeight: 32000
@@ -7248,6 +7252,8 @@ Body:
         Str: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Str: 1
   - Jobs:
       Baby_Genetic: true
     MaxWeight: 30000

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -7535,7 +7535,7 @@ Body:
       TargetTrap: true
     Range: 9
     Hit: Multi_Hit
-    HitCount: 5
+    HitCount: -5
     Element: Weapon
     CopyFlags:
       Skill:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -3693,6 +3693,12 @@ static int battle_get_spiritball_damage(struct Damage& wd, struct block_list& sr
 			// These skills used as many spheres as they do hits
 			damage = (wd.div_ + sd->spiritball) * 3;
 			break;
+#ifdef RENEWAL
+		case MO_FINGEROFFENSIVE:
+			// These skills store the spheres used in spiritball_old
+			damage = (sd->spiritball_old + sd->spiritball) * 3;
+			break;
+#endif
 		case MO_EXTREMITYFIST:
 			// These skills store the number of spheres the player had before cast
 			damage = sd->spiritball_old * 3;
@@ -6803,9 +6809,9 @@ static void battle_calc_attack_plant(struct Damage* wd, struct block_list *src,s
 		return;
 	}
 
-	// Triple Attack has a special property that it does not split damage on plant mode
+	// Triple Attack and Finger Offensive have a special property, they do not split damage on plant mode
 	// In pre-renewal, it requires the monster to have exactly 100 def
-	if (skill_id == MO_TRIPLEATTACK && wd->div_ < 0
+	if ((skill_id == MO_TRIPLEATTACK || skill_id == MO_FINGEROFFENSIVE) && wd->div_ < 0
 #ifndef RENEWAL
 		&& tstatus->def == 100
 #endif


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8667 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed damage of Finger Offensive being 5 times too high
- Added job stat bonus for Sura job level 61
- Fixes #8667

**Hint for reviewers**:

The job bonus is incorrect for 3rd job level 61-70 on rAthena in general. I only know the correct value for Sura Job 61 due to the tests done in the linked incidents. I fixed it so that the stats and damage match the result on kRO so that we know that the formula is correct. The rest it out-of-scope for this PR.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
