### PR TITLE
Third Job Stats Level 61-70

### DIFF
--- a/db/re/job_stats.yml
+++ b/db/re/job_stats.yml
@@ -6754,6 +6754,34 @@ Body:
         Dex: 1
       - Level: 49
         Luk: 1
+      - Level: 51
+        Str: 1
+      - Level: 52
+        Agi: 1
+      - Level: 54
+        Vit: 1
+      - Level: 56
+        Int: 1
+      - Level: 57
+        Dex: 1
+      - Level: 59
+        Luk: 1
+      - Level: 61
+        Str: 1
+      - Level: 62
+        Agi: 1
+      - Level: 63
+        Int: 1
+      - Level: 64
+        Dex: 1
+      - Level: 66
+        Str: 1
+      - Level: 67
+        Agi: 1
+      - Level: 68
+        Int: 1
+      - Level: 70
+        Dex: 1
   - Jobs:
       Super_Baby_E: true
     BonusStats:
@@ -6817,6 +6845,34 @@ Body:
         Dex: 1
       - Level: 49
         Luk: 1
+      - Level: 51
+        Str: 1
+      - Level: 52
+        Agi: 1
+      - Level: 54
+        Vit: 1
+      - Level: 56
+        Int: 1
+      - Level: 57
+        Dex: 1
+      - Level: 59
+        Luk: 1
+      - Level: 61
+        Str: 1
+      - Level: 62
+        Agi: 1
+      - Level: 63
+        Int: 1
+      - Level: 64
+        Dex: 1
+      - Level: 66
+        Str: 1
+      - Level: 67
+        Agi: 1
+      - Level: 68
+        Int: 1
+      - Level: 70
+        Dex: 1
   - Jobs:
       Kagerou: true
     MaxWeight: 26000
@@ -6893,6 +6949,22 @@ Body:
         Str: 1
       - Level: 50
         Dex: 1
+      - Level: 55
+        Agi: 1
+      - Level: 60
+        Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
       Oboro: true
     MaxWeight: 26000
@@ -6969,6 +7041,22 @@ Body:
         Str: 1
       - Level: 50
         Dex: 1
+      - Level: 55
+        Agi: 1
+      - Level: 60
+        Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Rebellion: true
     MaxWeight: 28000
@@ -7048,6 +7136,20 @@ Body:
         Dex: 1
       - Level: 57
         Agi: 1
+      - Level: 60
+        Dex: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Dex: 1
+      - Level: 69
+        Agi: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Summoner: true
     HpFactor: 70
@@ -7120,6 +7222,14 @@ Body:
       - Level: 48
         Agi: 1
       - Level: 50
+        Dex: 1
+      - Level: 53
+        Int: 1
+      - Level: 55
+        Dex: 1
+      - Level: 58
+        Int: 1
+      - Level: 60
         Dex: 1
   - Jobs:
       Baby_Summoner: true
@@ -7194,6 +7304,14 @@ Body:
       - Level: 48
         Agi: 1
       - Level: 50
+        Dex: 1
+      - Level: 53
+        Int: 1
+      - Level: 55
+        Dex: 1
+      - Level: 58
+        Int: 1
+      - Level: 60
         Dex: 1
   - Jobs:
       Baby_Ninja: true
@@ -7327,6 +7445,22 @@ Body:
         Str: 1
       - Level: 50
         Dex: 1
+      - Level: 55
+        Agi: 1
+      - Level: 60
+        Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
       Baby_Oboro: true
     MaxWeight: 26000
@@ -7403,6 +7537,22 @@ Body:
         Str: 1
       - Level: 50
         Dex: 1
+      - Level: 55
+        Agi: 1
+      - Level: 60
+        Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Baby_Taekwon: true
     MaxWeight: 28000
@@ -7713,6 +7863,20 @@ Body:
         Dex: 1
       - Level: 57
         Agi: 1
+      - Level: 60
+        Dex: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Dex: 1
+      - Level: 69
+        Agi: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Star_Emperor: true
       Star_Emperor2: true
@@ -7795,6 +7959,18 @@ Body:
         Str: 1
       - Level: 59
         Agi: 1
+      - Level: 61
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Vit: 1
+      - Level: 69
+        Str: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
       Soul_Reaper: true
     MaxWeight: 24000
@@ -7875,6 +8051,18 @@ Body:
         Int: 1
       - Level: 59
         Int: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Baby_Star_Emperor: true
       Baby_Star_Emperor2: true
@@ -7957,6 +8145,18 @@ Body:
         Str: 1
       - Level: 59
         Agi: 1
+      - Level: 61
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Vit: 1
+      - Level: 69
+        Str: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
       Baby_Soul_Reaper: true
     MaxWeight: 24000
@@ -8037,6 +8237,18 @@ Body:
         Int: 1
       - Level: 59
         Int: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Dragon_Knight: true
       Dragon_Knight2: true

--- a/db/re/job_stats.yml
+++ b/db/re/job_stats.yml
@@ -4267,487 +4267,6 @@ Body:
   - Jobs:
       Rune_Knight: true
       Rune_Knight2: true
-    MaxWeight: 35000
-    HpFactor: 150
-    SpIncrease: 300
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Dex: 1
-      - Level: 4
-        Vit: 1
-      - Level: 5
-        Int: 1
-      - Level: 10
-        Str: 1
-      - Level: 11
-        Str: 1
-      - Level: 12
-        Int: 1
-      - Level: 13
-        Int: 1
-      - Level: 14
-        Vit: 1
-      - Level: 15
-        Dex: 1
-      - Level: 19
-        Dex: 1
-      - Level: 20
-        Agi: 1
-      - Level: 21
-        Agi: 1
-      - Level: 22
-        Int: 1
-      - Level: 23
-        Vit: 1
-      - Level: 24
-        Dex: 1
-      - Level: 30
-        Int: 1
-      - Level: 31
-        Dex: 1
-      - Level: 32
-        Vit: 1
-      - Level: 33
-        Str: 1
-      - Level: 39
-        Int: 1
-      - Level: 40
-        Dex: 1
-      - Level: 41
-        Agi: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Vit: 1
-      - Level: 46
-        Int: 1
-      - Level: 47
-        Luk: 1
-      - Level: 48
-        Luk: 1
-      - Level: 49
-        Luk: 1
-      - Level: 50
-        Int: 1
-      - Level: 51
-        Str: 1
-      - Level: 53
-        Agi: 1
-      - Level: 55
-        Dex: 1
-      - Level: 57
-        Luk: 1
-      - Level: 59
-        Vit: 1
-      - Level: 60
-        Str: 1
-  - Jobs:
-      Warlock: true
-    MaxWeight: 30000
-    HpFactor: 55
-    SpIncrease: 900
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Dex: 1
-      - Level: 6
-        Dex: 1
-      - Level: 7
-        Int: 1
-      - Level: 8
-        Agi: 1
-      - Level: 12
-        Int: 1
-      - Level: 13
-        Dex: 1
-      - Level: 15
-        Vit: 1
-      - Level: 18
-        Vit: 1
-      - Level: 19
-        Dex: 1
-      - Level: 20
-        Agi: 1
-      - Level: 23
-        Int: 1
-      - Level: 24
-        Vit: 1
-      - Level: 25
-        Vit: 1
-      - Level: 28
-        Dex: 1
-      - Level: 29
-        Agi: 1
-      - Level: 31
-        Luk: 1
-      - Level: 34
-        Str: 1
-      - Level: 35
-        Int: 1
-      - Level: 36
-        Int: 1
-      - Level: 39
-        Dex: 1
-      - Level: 40
-        Agi: 1
-      - Level: 41
-        Int: 1
-      - Level: 44
-        Int: 1
-      - Level: 45
-        Int: 1
-      - Level: 47
-        Agi: 1
-      - Level: 50
-        Int: 1
-      - Level: 51
-        Dex: 1
-      - Level: 52
-        Vit: 1
-      - Level: 53
-        Luk: 1
-      - Level: 54
-        Agi: 1
-      - Level: 55
-        Int: 1
-      - Level: 57
-        Vit: 1
-      - Level: 58
-        Agi: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Int: 1
-  - Jobs:
-      Ranger: true
-      Ranger2: true
-    MaxWeight: 32000
-    HpFactor: 85
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Dex: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Int: 1
-      - Level: 4
-        Agi: 1
-      - Level: 7
-        Agi: 1
-      - Level: 8
-        Dex: 1
-      - Level: 9
-        Int: 1
-      - Level: 12
-        Vit: 1
-      - Level: 13
-        Vit: 1
-      - Level: 14
-        Vit: 1
-      - Level: 17
-        Dex: 1
-      - Level: 18
-        Agi: 1
-      - Level: 21
-        Int: 1
-      - Level: 22
-        Vit: 1
-      - Level: 23
-        Dex: 1
-      - Level: 26
-        Str: 1
-      - Level: 27
-        Str: 1
-      - Level: 30
-        Dex: 1
-      - Level: 31
-        Agi: 1
-      - Level: 32
-        Vit: 1
-      - Level: 36
-        Int: 1
-      - Level: 37
-        Int: 1
-      - Level: 38
-        Int: 1
-      - Level: 39
-        Agi: 1
-      - Level: 43
-        Agi: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Agi: 1
-      - Level: 49
-        Int: 1
-      - Level: 50
-        Agi: 1
-      - Level: 51
-        Luk: 1
-      - Level: 52
-        Dex: 1
-      - Level: 54
-        Int: 1
-      - Level: 55
-        Agi: 1
-      - Level: 57
-        Vit: 1
-      - Level: 58
-        Luk: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Agi: 1
-  - Jobs:
-      Arch_Bishop: true
-    MaxWeight: 30000
-    HpFactor: 75
-    SpIncrease: 800
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 3
-        Vit: 1
-      - Level: 5
-        Dex: 1
-      - Level: 7
-        Int: 1
-      - Level: 8
-        Int: 1
-      - Level: 10
-        Vit: 1
-      - Level: 11
-        Vit: 1
-      - Level: 14
-        Dex: 1
-      - Level: 15
-        Dex: 1
-      - Level: 18
-        Str: 1
-      - Level: 19
-        Str: 1
-      - Level: 22
-        Int: 1
-      - Level: 24
-        Str: 1
-      - Level: 26
-        Agi: 1
-      - Level: 27
-        Agi: 1
-      - Level: 28
-        Str: 1
-      - Level: 32
-        Int: 1
-      - Level: 34
-        Vit: 1
-      - Level: 36
-        Dex: 1
-      - Level: 38
-        Agi: 1
-      - Level: 39
-        Agi: 1
-      - Level: 40
-        Int: 1
-      - Level: 41
-        Int: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Vit: 1
-      - Level: 46
-        Str: 1
-      - Level: 49
-        Int: 1
-      - Level: 50
-        Dex: 1
-      - Level: 51
-        Luk: 1
-      - Level: 52
-        Agi: 1
-      - Level: 53
-        Vit: 1
-      - Level: 54
-        Str: 1
-      - Level: 55
-        Int: 1
-      - Level: 57
-        Vit: 1
-      - Level: 58
-        Luk: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Int: 1
-  - Jobs:
-      Mechanic: true
-      Mechanic2: true
-    MaxWeight: 38000
-    HpFactor: 90
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Luk: 1
-      - Level: 2
-        Str: 1
-      - Level: 5
-        Str: 1
-      - Level: 7
-        Luk: 1
-      - Level: 8
-        Agi: 1
-      - Level: 9
-        Dex: 1
-      - Level: 10
-        Int: 1
-      - Level: 13
-        Int: 1
-      - Level: 14
-        Luk: 1
-      - Level: 17
-        Agi: 1
-      - Level: 19
-        Vit: 1
-      - Level: 20
-        Vit: 1
-      - Level: 21
-        Int: 1
-      - Level: 22
-        Dex: 1
-      - Level: 25
-        Vit: 1
-      - Level: 26
-        Luk: 1
-      - Level: 29
-        Vit: 1
-      - Level: 31
-        Str: 1
-      - Level: 32
-        Str: 1
-      - Level: 33
-        Vit: 1
-      - Level: 34
-        Luk: 1
-      - Level: 37
-        Int: 1
-      - Level: 38
-        Int: 1
-      - Level: 42
-        Vit: 1
-      - Level: 43
-        Vit: 1
-      - Level: 44
-        Str: 1
-      - Level: 45
-        Str: 1
-      - Level: 48
-        Dex: 1
-      - Level: 49
-        Agi: 1
-      - Level: 51
-        Luk: 1
-      - Level: 52
-        Str: 1
-      - Level: 53
-        Dex: 1
-      - Level: 55
-        Int: 1
-      - Level: 56
-        Vit: 1
-      - Level: 57
-        Agi: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Str: 1
-  - Jobs:
-      Guillotine_Cross: true
-    MaxWeight: 32000
-    HpFactor: 110
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Agi: 1
-      - Level: 2
-        Dex: 1
-      - Level: 4
-        Str: 1
-      - Level: 5
-        Str: 1
-      - Level: 9
-        Str: 1
-      - Level: 10
-        Agi: 1
-      - Level: 11
-        Dex: 1
-      - Level: 14
-        Vit: 1
-      - Level: 15
-        Vit: 1
-      - Level: 16
-        Str: 1
-      - Level: 19
-        Vit: 1
-      - Level: 20
-        Str: 1
-      - Level: 23
-        Agi: 1
-      - Level: 24
-        Agi: 1
-      - Level: 25
-        Dex: 1
-      - Level: 28
-        Int: 1
-      - Level: 29
-        Int: 1
-      - Level: 30
-        Str: 1
-      - Level: 31
-        Vit: 1
-      - Level: 35
-        Agi: 1
-      - Level: 36
-        Dex: 1
-      - Level: 37
-        Dex: 1
-      - Level: 41
-        Int: 1
-      - Level: 42
-        Vit: 1
-      - Level: 43
-        Agi: 1
-      - Level: 44
-        Agi: 1
-      - Level: 48
-        Int: 1
-      - Level: 49
-        Dex: 1
-      - Level: 50
-        Dex: 1
-      - Level: 51
-        Luk: 1
-      - Level: 52
-        Str: 1
-      - Level: 53
-        Agi: 1
-      - Level: 54
-        Vit: 1
-      - Level: 56
-        Int: 1
-      - Level: 58
-        Str: 1
-      - Level: 59
-        Luk: 1
-      - Level: 60
-        Agi: 1
-  - Jobs:
       Rune_Knight_T: true
       Rune_Knight_T2: true
     MaxWeight: 35000
@@ -4828,7 +4347,20 @@ Body:
         Vit: 1
       - Level: 60
         Str: 1
+      - Level: 61
+        Vit: 1
+      - Level: 63
+        Agi: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
+        Str: 1
   - Jobs:
+      Warlock: true
       Warlock_T: true
     MaxWeight: 30000
     HpFactor: 55
@@ -4908,7 +4440,21 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 62
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Vit: 1
+      - Level: 67
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
+      Ranger: true
+      Ranger2: true
       Ranger_T: true
       Ranger_T2: true
     MaxWeight: 32000
@@ -4989,7 +4535,20 @@ Body:
         Dex: 1
       - Level: 60
         Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
+      Arch_Bishop: true
       Arch_Bishop_T: true
     MaxWeight: 30000
     HpFactor: 75
@@ -5069,7 +4628,21 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
+      Mechanic: true
+      Mechanic2: true
       Mechanic_T: true
       Mechanic_T2: true
     MaxWeight: 38000
@@ -5150,7 +4723,20 @@ Body:
         Dex: 1
       - Level: 60
         Str: 1
+      - Level: 61
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Str: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
+      Guillotine_Cross: true
       Guillotine_Cross_T: true
     MaxWeight: 32000
     HpFactor: 110
@@ -5229,6 +4815,18 @@ Body:
       - Level: 59
         Luk: 1
       - Level: 60
+        Agi: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Luk: 1
+      - Level: 70
         Agi: 1
   - Jobs:
       Royal_Guard: true
@@ -6445,6 +6043,18 @@ Body:
         Vit: 1
       - Level: 60
         Str: 1
+      - Level: 61
+        Vit: 1
+      - Level: 63
+        Agi: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
+        Str: 1
   - Jobs:
       Baby_Warlock: true
     MaxWeight: 24000
@@ -6525,6 +6135,18 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 62
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Vit: 1
+      - Level: 67
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
       Baby_Ranger: true
       Baby_Ranger2: true
@@ -6606,6 +6228,18 @@ Body:
         Dex: 1
       - Level: 60
         Agi: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Vit: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Vit: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Baby_Arch_Bishop: true
     MaxWeight: 26000
@@ -6686,6 +6320,18 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
       Baby_Mechanic: true
       Baby_Mechanic2: true
@@ -6767,6 +6413,18 @@ Body:
         Dex: 1
       - Level: 60
         Str: 1
+      - Level: 61
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Str: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
       Baby_Guillotine_Cross: true
     MaxWeight: 24000
@@ -6846,6 +6504,18 @@ Body:
       - Level: 59
         Luk: 1
       - Level: 60
+        Agi: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Agi: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Luk: 1
+      - Level: 70
         Agi: 1
   - Jobs:
       Baby_Royal_Guard: true

--- a/db/re/job_stats.yml
+++ b/db/re/job_stats.yml
@@ -4831,571 +4831,6 @@ Body:
   - Jobs:
       Royal_Guard: true
       Royal_Guard2: true
-    MaxWeight: 35000
-    HpFactor: 110
-    HpIncrease: 700
-    SpIncrease: 400
-    BonusStats:
-      - Level: 2
-        Vit: 1
-      - Level: 3
-        Int: 1
-      - Level: 4
-        Str: 1
-      - Level: 5
-        Int: 1
-      - Level: 6
-        Dex: 1
-      - Level: 9
-        Vit: 1
-      - Level: 11
-        Int: 1
-      - Level: 13
-        Str: 1
-      - Level: 14
-        Dex: 1
-      - Level: 16
-        Luk: 1
-      - Level: 19
-        Int: 1
-      - Level: 20
-        Dex: 1
-      - Level: 23
-        Agi: 1
-      - Level: 24
-        Int: 1
-      - Level: 26
-        Int: 1
-      - Level: 27
-        Vit: 1
-      - Level: 30
-        Str: 1
-      - Level: 31
-        Dex: 1
-      - Level: 33
-        Luk: 1
-      - Level: 34
-        Agi: 1
-      - Level: 37
-        Int: 1
-      - Level: 38
-        Int: 1
-      - Level: 40
-        Str: 1
-      - Level: 41
-        Vit: 1
-      - Level: 42
-        Vit: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Str: 1
-      - Level: 46
-        Int: 1
-      - Level: 48
-        Str: 1
-      - Level: 49
-        Dex: 1
-      - Level: 51
-        Agi: 1
-      - Level: 53
-        Vit: 1
-      - Level: 54
-        Luk: 1
-      - Level: 56
-        Dex: 1
-      - Level: 58
-        Str: 1
-      - Level: 59
-        Vit: 1
-      - Level: 60
-        Int: 1
-  - Jobs:
-      Sorcerer: true
-    MaxWeight: 30000
-    HpFactor: 75
-    SpIncrease: 900
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Dex: 1
-      - Level: 4
-        Vit: 1
-      - Level: 5
-        Int: 1
-      - Level: 10
-        Str: 1
-      - Level: 11
-        Str: 1
-      - Level: 12
-        Int: 1
-      - Level: 13
-        Int: 1
-      - Level: 14
-        Vit: 1
-      - Level: 15
-        Dex: 1
-      - Level: 19
-        Dex: 1
-      - Level: 20
-        Agi: 1
-      - Level: 21
-        Agi: 1
-      - Level: 22
-        Int: 1
-      - Level: 23
-        Vit: 1
-      - Level: 24
-        Dex: 1
-      - Level: 30
-        Int: 1
-      - Level: 31
-        Dex: 1
-      - Level: 32
-        Vit: 1
-      - Level: 33
-        Str: 1
-      - Level: 39
-        Int: 1
-      - Level: 40
-        Dex: 1
-      - Level: 41
-        Agi: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Vit: 1
-      - Level: 46
-        Int: 1
-      - Level: 47
-        Luk: 1
-      - Level: 48
-        Luk: 1
-      - Level: 49
-        Luk: 1
-      - Level: 50
-        Int: 1
-      - Level: 51
-        Dex: 1
-      - Level: 53
-        Str: 1
-      - Level: 55
-        Agi: 1
-      - Level: 57
-        Vit: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Int: 1
-  - Jobs:
-      Minstrel: true
-    MaxWeight: 32000
-    HpFactor: 75
-    HpIncrease: 300
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 3
-        Vit: 1
-      - Level: 5
-        Dex: 1
-      - Level: 7
-        Int: 1
-      - Level: 8
-        Int: 1
-      - Level: 10
-        Vit: 1
-      - Level: 11
-        Vit: 1
-      - Level: 14
-        Dex: 1
-      - Level: 15
-        Dex: 1
-      - Level: 18
-        Str: 1
-      - Level: 19
-        Str: 1
-      - Level: 22
-        Int: 1
-      - Level: 24
-        Str: 1
-      - Level: 26
-        Agi: 1
-      - Level: 27
-        Agi: 1
-      - Level: 28
-        Str: 1
-      - Level: 32
-        Int: 1
-      - Level: 34
-        Vit: 1
-      - Level: 36
-        Dex: 1
-      - Level: 38
-        Agi: 1
-      - Level: 39
-        Agi: 1
-      - Level: 40
-        Int: 1
-      - Level: 41
-        Int: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Vit: 1
-      - Level: 46
-        Str: 1
-      - Level: 49
-        Int: 1
-      - Level: 50
-        Dex: 1
-      - Level: 51
-        Agi: 1
-      - Level: 52
-        Vit: 1
-      - Level: 53
-        Str: 1
-      - Level: 54
-        Luk: 1
-      - Level: 56
-        Dex: 1
-      - Level: 57
-        Vit: 1
-      - Level: 58
-        Str: 1
-      - Level: 59
-        Int: 1
-      - Level: 60
-        Dex: 1
-  - Jobs:
-      Wanderer: true
-    MaxWeight: 32000
-    HpFactor: 75
-    HpIncrease: 300
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Dex: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Int: 1
-      - Level: 4
-        Agi: 1
-      - Level: 7
-        Agi: 1
-      - Level: 8
-        Dex: 1
-      - Level: 9
-        Int: 1
-      - Level: 12
-        Vit: 1
-      - Level: 13
-        Vit: 1
-      - Level: 14
-        Vit: 1
-      - Level: 17
-        Dex: 1
-      - Level: 18
-        Agi: 1
-      - Level: 21
-        Int: 1
-      - Level: 22
-        Vit: 1
-      - Level: 23
-        Dex: 1
-      - Level: 26
-        Str: 1
-      - Level: 27
-        Str: 1
-      - Level: 30
-        Dex: 1
-      - Level: 31
-        Agi: 1
-      - Level: 32
-        Vit: 1
-      - Level: 36
-        Int: 1
-      - Level: 37
-        Int: 1
-      - Level: 38
-        Int: 1
-      - Level: 39
-        Agi: 1
-      - Level: 43
-        Agi: 1
-      - Level: 44
-        Dex: 1
-      - Level: 45
-        Agi: 1
-      - Level: 49
-        Int: 1
-      - Level: 50
-        Agi: 1
-      - Level: 51
-        Str: 1
-      - Level: 52
-        Vit: 1
-      - Level: 53
-        Dex: 1
-      - Level: 55
-        Luk: 1
-      - Level: 56
-        Int: 1
-      - Level: 58
-        Vit: 1
-      - Level: 59
-        Agi: 1
-      - Level: 60
-        Dex: 1
-  - Jobs:
-      Sura: true
-    MaxWeight: 30000
-    HpFactor: 90
-    HpIncrease: 650
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Agi: 1
-      - Level: 2
-        Dex: 1
-      - Level: 4
-        Str: 1
-      - Level: 5
-        Str: 1
-      - Level: 9
-        Str: 1
-      - Level: 10
-        Agi: 1
-      - Level: 11
-        Dex: 1
-      - Level: 14
-        Vit: 1
-      - Level: 15
-        Vit: 1
-      - Level: 16
-        Str: 1
-      - Level: 19
-        Vit: 1
-      - Level: 20
-        Str: 1
-      - Level: 23
-        Agi: 1
-      - Level: 24
-        Agi: 1
-      - Level: 25
-        Dex: 1
-      - Level: 28
-        Int: 1
-      - Level: 29
-        Int: 1
-      - Level: 30
-        Str: 1
-      - Level: 31
-        Vit: 1
-      - Level: 35
-        Agi: 1
-      - Level: 36
-        Dex: 1
-      - Level: 37
-        Dex: 1
-      - Level: 41
-        Int: 1
-      - Level: 42
-        Vit: 1
-      - Level: 43
-        Agi: 1
-      - Level: 44
-        Agi: 1
-      - Level: 48
-        Int: 1
-      - Level: 49
-        Dex: 1
-      - Level: 50
-        Dex: 1
-      - Level: 51
-        Str: 1
-      - Level: 53
-        Agi: 1
-      - Level: 54
-        Int: 1
-      - Level: 55
-        Luk: 1
-      - Level: 56
-        Vit: 1
-      - Level: 58
-        Dex: 1
-      - Level: 59
-        Str: 1
-      - Level: 60
-        Int: 1
-      - Level: 61
-        Str: 1
-  - Jobs:
-      Genetic: true
-    MaxWeight: 32000
-    HpFactor: 90
-    SpIncrease: 900
-    BonusStats:
-      - Level: 1
-        Int: 1
-      - Level: 2
-        Int: 1
-      - Level: 3
-        Dex: 1
-      - Level: 6
-        Dex: 1
-      - Level: 7
-        Int: 1
-      - Level: 8
-        Agi: 1
-      - Level: 12
-        Int: 1
-      - Level: 13
-        Dex: 1
-      - Level: 15
-        Vit: 1
-      - Level: 18
-        Vit: 1
-      - Level: 19
-        Dex: 1
-      - Level: 20
-        Agi: 1
-      - Level: 23
-        Int: 1
-      - Level: 24
-        Vit: 1
-      - Level: 25
-        Vit: 1
-      - Level: 28
-        Dex: 1
-      - Level: 29
-        Agi: 1
-      - Level: 31
-        Luk: 1
-      - Level: 34
-        Str: 1
-      - Level: 35
-        Int: 1
-      - Level: 36
-        Int: 1
-      - Level: 39
-        Dex: 1
-      - Level: 40
-        Agi: 1
-      - Level: 41
-        Int: 1
-      - Level: 44
-        Int: 1
-      - Level: 45
-        Int: 1
-      - Level: 47
-        Agi: 1
-      - Level: 50
-        Int: 1
-      - Level: 51
-        Str: 1
-      - Level: 52
-        Vit: 1
-      - Level: 53
-        Dex: 1
-      - Level: 55
-        Agi: 1
-      - Level: 56
-        Str: 1
-      - Level: 57
-        Vit: 1
-      - Level: 58
-        Luk: 1
-      - Level: 59
-        Dex: 1
-      - Level: 60
-        Int: 1
-  - Jobs:
-      Shadow_Chaser: true
-    MaxWeight: 28000
-    HpFactor: 85
-    SpIncrease: 400
-    BonusStats:
-      - Level: 1
-        Luk: 1
-      - Level: 2
-        Str: 1
-      - Level: 5
-        Str: 1
-      - Level: 7
-        Luk: 1
-      - Level: 8
-        Agi: 1
-      - Level: 9
-        Dex: 1
-      - Level: 10
-        Int: 1
-      - Level: 13
-        Int: 1
-      - Level: 14
-        Luk: 1
-      - Level: 17
-        Agi: 1
-      - Level: 19
-        Vit: 1
-      - Level: 20
-        Vit: 1
-      - Level: 21
-        Int: 1
-      - Level: 22
-        Dex: 1
-      - Level: 25
-        Vit: 1
-      - Level: 26
-        Luk: 1
-      - Level: 29
-        Vit: 1
-      - Level: 31
-        Str: 1
-      - Level: 32
-        Str: 1
-      - Level: 33
-        Vit: 1
-      - Level: 34
-        Luk: 1
-      - Level: 37
-        Int: 1
-      - Level: 38
-        Int: 1
-      - Level: 42
-        Vit: 1
-      - Level: 43
-        Vit: 1
-      - Level: 44
-        Str: 1
-      - Level: 45
-        Str: 1
-      - Level: 48
-        Dex: 1
-      - Level: 49
-        Agi: 1
-      - Level: 51
-        Int: 1
-      - Level: 52
-        Vit: 1
-      - Level: 53
-        Str: 1
-      - Level: 54
-        Agi: 1
-      - Level: 56
-        Luk: 1
-      - Level: 57
-        Dex: 1
-      - Level: 59
-        Str: 1
-      - Level: 60
-        Agi: 1
-  - Jobs:
       Royal_Guard_T: true
       Royal_Guard_T2: true
     MaxWeight: 35000
@@ -5477,7 +4912,20 @@ Body:
         Vit: 1
       - Level: 60
         Int: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Str: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Str: 1
   - Jobs:
+      Sorcerer: true
       Sorcerer_T: true
     MaxWeight: 30000
     HpFactor: 75
@@ -5557,7 +5005,20 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Vit: 1
+      - Level: 66
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
+      Minstrel: true
       Minstrel_T: true
     MaxWeight: 32000
     HpFactor: 75
@@ -5638,7 +5099,20 @@ Body:
         Int: 1
       - Level: 60
         Dex: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Dex: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Dex: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
+      Wanderer: true
       Wanderer_T: true
     MaxWeight: 32000
     HpFactor: 75
@@ -5719,7 +5193,20 @@ Body:
         Agi: 1
       - Level: 60
         Dex: 1
+      - Level: 62
+        Str: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Str: 1
+      - Level: 67
+        Str: 1
+      - Level: 69
+        Luk: 1
+      - Level: 70
+        Str: 1
   - Jobs:
+      Sura: true
       Sura_T: true
     MaxWeight: 30000
     HpFactor: 90
@@ -5802,7 +5289,18 @@ Body:
         Int: 1
       - Level: 61
         Str: 1
+      - Level: 63
+        Int: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Str: 1
+      - Level: 68
+        Int: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
+      Genetic: true
       Genetic_T: true
     MaxWeight: 32000
     HpFactor: 90
@@ -5882,7 +5380,20 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Luk: 1
+      - Level: 62
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 66
+        Luk: 1
+      - Level: 67
+        Str: 1
+      - Level: 69
+        Vit: 1
   - Jobs:
+      Shadow_Chaser: true
       Shadow_Chaser_T: true
     MaxWeight: 28000
     HpFactor: 85
@@ -5961,6 +5472,18 @@ Body:
       - Level: 59
         Str: 1
       - Level: 60
+        Agi: 1
+      - Level: 62
+        Dex: 1
+      - Level: 63
+        Agi: 1
+      - Level: 65
+        Agi: 1
+      - Level: 67
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
         Agi: 1
   - Jobs:
       Baby_Rune_Knight: true
@@ -6599,6 +6122,18 @@ Body:
         Vit: 1
       - Level: 60
         Int: 1
+      - Level: 62
+        Dex: 1
+      - Level: 64
+        Vit: 1
+      - Level: 65
+        Str: 1
+      - Level: 67
+        Dex: 1
+      - Level: 69
+        Vit: 1
+      - Level: 70
+        Str: 1
   - Jobs:
       Baby_Sorcerer: true
     MaxWeight: 24000
@@ -6679,6 +6214,18 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Int: 1
+      - Level: 63
+        Luk: 1
+      - Level: 65
+        Vit: 1
+      - Level: 66
+        Int: 1
+      - Level: 68
+        Luk: 1
+      - Level: 70
+        Vit: 1
   - Jobs:
       Baby_Minstrel: true
     MaxWeight: 27000
@@ -6760,6 +6307,18 @@ Body:
         Int: 1
       - Level: 60
         Dex: 1
+      - Level: 61
+        Agi: 1
+      - Level: 63
+        Dex: 1
+      - Level: 65
+        Luk: 1
+      - Level: 66
+        Agi: 1
+      - Level: 68
+        Dex: 1
+      - Level: 70
+        Luk: 1
   - Jobs:
       Baby_Wanderer: true
     MaxWeight: 27000
@@ -6841,6 +6400,18 @@ Body:
         Agi: 1
       - Level: 60
         Dex: 1
+      - Level: 62
+        Str: 1
+      - Level: 64
+        Luk: 1
+      - Level: 65
+        Str: 1
+      - Level: 67
+        Str: 1
+      - Level: 69
+        Luk: 1
+      - Level: 70
+        Str: 1
   - Jobs:
       Baby_Sura: true
     MaxWeight: 26000
@@ -6924,6 +6495,16 @@ Body:
         Int: 1
       - Level: 61
         Str: 1
+      - Level: 63
+        Int: 1
+      - Level: 65
+        Agi: 1
+      - Level: 66
+        Str: 1
+      - Level: 68
+        Int: 1
+      - Level: 70
+        Agi: 1
   - Jobs:
       Baby_Genetic: true
     MaxWeight: 30000
@@ -7004,6 +6585,18 @@ Body:
         Dex: 1
       - Level: 60
         Int: 1
+      - Level: 61
+        Luk: 1
+      - Level: 62
+        Str: 1
+      - Level: 64
+        Vit: 1
+      - Level: 66
+        Luk: 1
+      - Level: 67
+        Str: 1
+      - Level: 69
+        Vit: 1
   - Jobs:
       Baby_Shadow_Chaser: true
     MaxWeight: 24000
@@ -7083,6 +6676,18 @@ Body:
       - Level: 59
         Str: 1
       - Level: 60
+        Agi: 1
+      - Level: 62
+        Dex: 1
+      - Level: 63
+        Agi: 1
+      - Level: 65
+        Agi: 1
+      - Level: 67
+        Dex: 1
+      - Level: 68
+        Agi: 1
+      - Level: 70
         Agi: 1
   - Jobs:
       Super_Novice_E: true


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: (new feature)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Combined trans and non-trans 3rd jobs in job_stats.yml as they have the exact same values
- Added job bonus stats for level 61-70 for 3rd jobs
- Added job bonus stats for level 51-70 for various extended classes

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
