### PR TITLE
Avoid [Error] division by zero detected

### DIFF
--- a/npc/airports/airships.txt
+++ b/npc/airports/airships.txt
@@ -1152,7 +1152,7 @@ airplane_01,32,61,4	script	Nils#ein	49,1,1,{
 		input .@save2$;
 		set .@end_time, gettimetick(1);
 		set .@total_time, .@total_time + (.@start_time - .@end_time);
-		set .@tasoo, (.@letters[.@wordtest] / .@total_time) * 6;
+		if (.@total_time > 0) set .@tasoo, (.@letters[.@wordtest] / .@total_time) * 6;
 		if ((.@save1$ == .@word1$[.@wordtest]) && (.@save2$ == .@word2$[.@wordtest])) {
 			mes "[Nils]";
 			mes "Your record is ^ff0000" + .@total_time + " seconds^000000 and";


### PR DESCRIPTION
If the user enters input too quickly, the following error will occur:

[Error]: script:op_2num: division by zero detected op=C_DIV i1=1300 i2=0

To prevent the player from getting stuck and having to force close the client, add an if statement.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
