### PR TITLE
Disable RG_CLOSECONFINE against Boss monsters

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1751,6 +1751,7 @@ Body:
       NoSave: true
       NoRemoveOnDead: true
       RemoveOnChangeMap: true
+      BossResist: true
   - Status: Closeconfine2
     Icon: EFST_RG_CCONFINE_S
     DurationLookup: RG_CLOSECONFINE
@@ -1764,6 +1765,7 @@ Body:
       NoSave: true
       NoRemoveOnDead: true
       RemoveOnChangeMap: true
+      BossResist: true
     Fail:
       Closeconfine2: true
   - Status: Dancing

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1758,6 +1758,7 @@ Body:
       NoSave: true
       NoRemoveOnDead: true
       RemoveOnChangeMap: true
+      BossResist: true
   - Status: Closeconfine2
     Icon: EFST_RG_CCONFINE_S
     DurationLookup: RG_CLOSECONFINE
@@ -1771,6 +1772,7 @@ Body:
       NoSave: true
       NoRemoveOnDead: true
       RemoveOnChangeMap: true
+      BossResist: true
     Fail:
       Closeconfine2: true
   - Status: Dancing


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #8555

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * Close Confine will no longer apply the status when used against Boss monsters.
Thanks to @jamesandrewww!