### PR TITLE
Remove spawn info when unloading npc files

### DIFF
--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -469,6 +469,7 @@ struct spawn_data {
 		unsigned int boss : 1; //0: Non-boss monster | 1: Boss monster
 	} state;
 	char name[NAME_LENGTH], eventname[EVENT_NAME_LENGTH]; //Name/event
+	char filepath[200];
 };
 
 struct flooritem_data {

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -469,7 +469,7 @@ struct spawn_data {
 		unsigned int boss : 1; //0: Non-boss monster | 1: Boss monster
 	} state;
 	char name[NAME_LENGTH], eventname[EVENT_NAME_LENGTH]; //Name/event
-	char filepath[200];
+	char filepath[256];
 };
 
 struct flooritem_data {

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3428,10 +3428,10 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn)
 }
 
 void mob_remove_spawns(const char* path) {
-
 	//cache spawn infos of each freed unit
 	std::map<int,std::vector<spawn_info>> removed_mob_spawn_data{};
-	s_mapiterator* iter = mapit_geteachiddb();
+	s_mapiterator* iter = mapit_geteachmob();
+
 	for (block_list* bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter)) {
 		if (bl->type == BL_MOB) {
 			auto* md = reinterpret_cast<mob_data*>(bl);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3432,19 +3432,19 @@ void mob_remove_spawns(const char* path) {
 	std::map<int,std::vector<spawn_info>> removed_mob_spawn_data{};
 	s_mapiterator* iter = mapit_geteachmob();
 
-	for (block_list* bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter)) {
-		if (bl->type == BL_MOB) {
-			auto* md = reinterpret_cast<mob_data*>(bl);
-			if (md->spawn && !strcmp(md->spawn->filepath, path)) {
-				auto& removedspawns = removed_mob_spawn_data[md->db->id];
-				auto itSameMap = std::find_if(removedspawns.begin(), removedspawns.end(),
-					[&md](const spawn_info& s) { return (s.mapindex == map_id2index(md->bl.m)); });
-				if (itSameMap != removedspawns.end())
-					itSameMap->qty++; //add the found monster being deleted
-				else
-					removedspawns.push_back(spawn_info{map_id2index(md->bl.m),1}); //else create a new spawn_info
-				unit_free(bl, CLR_OUTSIGHT);
-			}
+	for (block_list* bl = (block_list*)mapit_first(iter); mapit_exists(iter); bl = (block_list*)mapit_next(iter)) {
+		auto* md = reinterpret_cast<mob_data*>(bl);
+
+		if (md != nullptr && md->spawn && !strcmp(md->spawn->filepath, path)) {
+			auto& removedspawns = removed_mob_spawn_data[md->db->id];
+			auto itSameMap = std::find_if(removedspawns.begin(), removedspawns.end(),
+				[&md](const spawn_info& s) { return (s.mapindex == map_id2index(md->bl.m)); });
+
+			if (itSameMap != removedspawns.end())
+				itSameMap->qty++; //add the found monster being deleted
+			else
+				removedspawns.push_back(spawn_info{map_id2index(md->bl.m),1}); //else create a new spawn_info
+			unit_free(bl, CLR_OUTSIGHT);
 		}
 	}
 	mapit_free(iter);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3476,6 +3476,7 @@ void mob_remove_spawns(const char* path) {
 
 			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
 				spawn_data* mob = mapdata->moblist[j];
+
 				if (mob != nullptr && !strcmp(mob->filepath, path)) {
 					aFree(mapdata->moblist[j]);
 					mapdata->moblist[j] = nullptr;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3427,67 +3427,6 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn)
 */
 }
 
-bool mob_remove_spawns(const char* path) {
-	bool found = false;
-	auto remove_spawn_info = []( spawn_data& spawn, uint16 qty ){
-		auto it = mob_spawn_data.find( spawn.id );
-
-		if( it != mob_spawn_data.end() ){
-			uint16 mapindex = map_id2index( spawn.m );
-
-			it->second.erase( std::remove_if( it->second.begin(), it->second.end(), [&]( spawn_info& spawninfo ){
-				if( spawninfo.mapindex == mapindex ){
-					spawninfo.qty -= qty;
-					return spawninfo.qty == 0;
-				}
-
-				return false;
-			} ), it->second.end() );
-		}
-	};
-
-	// Remove spawned mobs
-	s_mapiterator* iter = mapit_geteachmob();
-
-	for( block_list* bl = mapit_first( iter ); mapit_exists( iter ); bl = mapit_next( iter ) ){
-		mob_data* md = reinterpret_cast<mob_data*>( bl );
-
-		if( md->spawn != nullptr && !strcmp( md->spawn->filepath, path ) ){
-			remove_spawn_info( *md->spawn, 1 );
-			unit_free(bl, CLR_OUTSIGHT);
-			found = true;
-		}
-	}
-
-	mapit_free(iter);
-
-	//dynamic mobs cleaning
-	if (battle_config.dynamic_mobs) {
-		for (int i = 0; i < map_num; i++) {
-			map_data* mapdata = map_getmapdata(i);
-
-			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
-				spawn_data* mob = mapdata->moblist[j];
-
-				if (mob != nullptr && !strcmp(mob->filepath, path)) {
-					remove_spawn_info( *mob, mob->num );
-					aFree(mapdata->moblist[j]);
-					mapdata->moblist[j] = nullptr;
-					found = true;
-				}
-			}
-		}
-	}
-
-	// Sort spawns by spawn quantity
-	for( auto& pair : mob_spawn_data ){
-		std::sort( pair.second.begin(), pair.second.end(), []( const spawn_info& a, const spawn_info& b ) -> bool{
-			return a.qty > b.qty;
-		} );
-	}
-
-	return found;
-}
 /*==========================================
  * Change mob base class
  *------------------------------------------*/

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3452,6 +3452,7 @@ void mob_remove_spawns(const char* path) {
 	//remove wanted spawn from mob_spawn_data
 	auto remove_spawn_info = [](int mobid, const auto& rs) {
 		auto& spawns = mob_spawn_data[mobid];
+
 		spawns.erase(std::remove_if(spawns.begin(), spawns.end(), [&](spawn_info& spawninfo) {
 			if (spawninfo.mapindex == rs.mapindex) {
 				spawninfo.qty -= rs.qty;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3427,6 +3427,52 @@ void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn)
 */
 }
 
+void mob_remove_spawns(const char* path) {
+	std::map<int,std::vector<spawn_info>> spawnstodelete{};
+	s_mapiterator* iter = mapit_geteachiddb();
+	for (block_list* bl = (struct block_list*)mapit_first(iter); mapit_exists(iter); bl = (struct block_list*)mapit_next(iter)) {
+		if (bl->type == BL_MOB) {
+			auto* md = reinterpret_cast<mob_data*>(bl);
+			if (md->spawn && !strcmp(md->spawn->filepath, path)) {
+				auto& spawns = spawnstodelete[md->db->id];
+				auto itSameMap = std::find_if(spawns.begin(), spawns.end(),
+					[&md](const spawn_info& s) { return (s.mapindex == map_id2index(md->bl.m)); });
+				if (itSameMap != spawns.end())
+					itSameMap->qty++; //add the found monster being deleted
+				else
+					spawns.push_back(spawn_info{map_id2index(md->bl.m),1}); //else create a new spawn_info
+				unit_free(bl, CLR_OUTSIGHT);
+			}
+		}
+	}
+	mapit_free(iter);
+
+	for (auto& [mobid, savespawns] : spawnstodelete) {
+		for (auto& removespawn : savespawns) {
+			auto& spawns = mob_spawn_data[mobid];
+			spawns.erase(std::remove_if(spawns.begin(), spawns.end(), [&](spawn_info& s) {
+				if (s.mapindex == removespawn.mapindex) {
+					s.qty -= removespawn.qty;
+					return s.qty == 0;
+				}
+				return false;
+				}), spawns.end());
+		}
+	}
+
+	if (battle_config.dynamic_mobs) {
+		for (int i = 0; i < map_num; i++) {
+			map_data* mapdata = map_getmapdata(i);
+			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
+				spawn_data* mob = mapdata->moblist[j];
+				if (mob != nullptr && !strcmp(mob->filepath, path)) {
+					aFree(mapdata->moblist[j]);
+					mapdata->moblist[j] = nullptr;
+				}
+			}
+		}
+	}
+}
 /*==========================================
  * Change mob base class
  *------------------------------------------*/

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3473,6 +3473,7 @@ void mob_remove_spawns(const char* path) {
 	if (battle_config.dynamic_mobs) {
 		for (int i = 0; i < map_num; i++) {
 			map_data* mapdata = map_getmapdata(i);
+
 			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
 				spawn_data* mob = mapdata->moblist[j];
 				if (mob != nullptr && !strcmp(mob->filepath, path)) {

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -316,6 +316,7 @@ private:
 };
 
 extern MapDropDatabase map_drop_db;
+extern std::unordered_map<uint16, std::vector<spawn_info>> mob_spawn_data;
 
 struct mob_data {
 	struct block_list bl;
@@ -552,7 +553,7 @@ int mob_clone_delete(struct mob_data *md);
 void mob_reload_itemmob_data(void);
 void mob_reload(void);
 void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
-bool mob_remove_spawns(const char* path);
+
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -290,6 +290,7 @@ public:
 };
 
 extern MobDatabase mob_db;
+extern std::unordered_map<uint16, std::vector<spawn_info>> mob_spawn_data;
 
 struct s_map_mob_drop{
 	uint16 mob_id;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -290,7 +290,6 @@ public:
 };
 
 extern MobDatabase mob_db;
-extern std::unordered_map<uint16, std::vector<spawn_info>> mob_spawn_data;
 
 struct s_map_mob_drop{
 	uint16 mob_id;
@@ -553,6 +552,7 @@ int mob_clone_delete(struct mob_data *md);
 void mob_reload_itemmob_data(void);
 void mob_reload(void);
 void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
+void mob_remove_spawns(const char* path);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -553,7 +553,6 @@ int mob_clone_delete(struct mob_data *md);
 void mob_reload_itemmob_data(void);
 void mob_reload(void);
 void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
-
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -552,7 +552,7 @@ int mob_clone_delete(struct mob_data *md);
 void mob_reload_itemmob_data(void);
 void mob_reload(void);
 void mob_add_spawn(uint16 mob_id, const struct spawn_info& new_spawn);
-void mob_remove_spawns(const char* path);
+bool mob_remove_spawns(const char* path);
 const std::vector<spawn_info> mob_get_spawns(uint16 mob_id);
 bool mob_has_spawn(uint16 mob_id);
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6200,7 +6200,6 @@ bool npc_remove_mob_spawns(const char* path) {
 				}
 			}
 		}
-
 	}
 
 	// Sort spawns by spawn quantity

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6140,9 +6140,8 @@ bool npc_unloadfile( const char* path ) {
 }
 
 bool npc_remove_mob_spawns(const char* path) {
-
-	int spawn_count{};
-	int unit_count{};
+	int32 spawn_count = {};
+	int32 unit_count = {};
 
 	auto remove_spawn_info = [&]( spawn_data& spawn, uint16 qty ){
 		auto it = mob_spawn_data.find( spawn.id );
@@ -6180,7 +6179,7 @@ bool npc_remove_mob_spawns(const char* path) {
 
 	//dynamic mobs cleaning
 	if (battle_config.dynamic_mobs) {
-		for (int i = 0; i < map_num; i++) {
+		for (int32 i = 0; i < map_num; i++) {
 			map_data* mapdata = map_getmapdata(i);
 
 			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
@@ -6209,11 +6208,11 @@ bool npc_remove_mob_spawns(const char* path) {
 		} );
 	}
 
-	if(spawn_count || unit_count)
+	if(spawn_count > 0 || unit_count > 0)
 		ShowInfo("%d mobs and %d spawns were removed.\n",unit_count,spawn_count);
+
 	return spawn_count > 0 || unit_count > 0;
 }
-
 
 void do_clear_npc(void) {
 	db_clear(npcname_db);

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6140,8 +6140,10 @@ bool npc_unloadfile( const char* path ) {
 }
 
 bool npc_remove_mob_spawns(const char* path) {
+
 	int spawn_count{};
 	int unit_count{};
+
 	auto remove_spawn_info = [&]( spawn_data& spawn, uint16 qty ){
 		auto it = mob_spawn_data.find( spawn.id );
 
@@ -6167,8 +6169,9 @@ bool npc_remove_mob_spawns(const char* path) {
 		mob_data* md = reinterpret_cast<mob_data*>( bl );
 
 		if( md->spawn != nullptr && !strcmp( md->spawn->filepath, path ) ){
-			remove_spawn_info( *md->spawn, 1 );
-			unit_free(bl, CLR_OUTSIGHT);
+			if( !battle_config.dynamic_mobs )
+				remove_spawn_info( *md->spawn, 1 );
+			unit_free( bl, CLR_OUTSIGHT );
 			unit_count++;
 		}
 	}
@@ -6208,7 +6211,7 @@ bool npc_remove_mob_spawns(const char* path) {
 	}
 
 	if(spawn_count || unit_count)
-		ShowInfo("%d mobs and %d spawns removed.\n",unit_count,spawn_count);
+		ShowInfo("%d mobs and %d spawns were removed.\n",unit_count,spawn_count);
 	return spawn_count > 0 || unit_count > 0;
 }
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6139,22 +6139,20 @@ bool npc_unloadfile( const char* path ) {
 		}
 	}
 	mapit_free(iter2);
-	if( battle_config.dynamic_mobs ){
-
-		for (int i = 0; i < map_num; i++) {
-			map_data* mapdata = map_getmapdata(i);
-			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
-				spawn_data* mob = mapdata->moblist[j];
-				if (mob != nullptr && !strcmp(mob->filepath, path)) {
-					auto& spawn_list = mob_spawn_data[mob->id];
-					spawn_list.erase(std::remove_if(spawn_list.begin(), spawn_list.end(), [&](spawn_info& s) {
-						if (map_mapindex2mapid(s.mapindex) == mob->m) {
-							s.qty -= mob->num;
-							return s.qty == 0;
-						}
-						return false;
-						}), spawn_list.end());
-
+	for (int i = 0; i < map_num; i++) {
+		map_data* mapdata = map_getmapdata(i);
+		for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
+			spawn_data* mob = mapdata->moblist[j];
+			if (mob != nullptr && !strcmp(mob->filepath, path)) {
+				auto& spawn_list = mob_spawn_data[mob->id];
+				spawn_list.erase(std::remove_if(spawn_list.begin(), spawn_list.end(), [&](spawn_info& s) {
+					if (map_mapindex2mapid(s.mapindex) == mob->m) {
+						s.qty -= mob->num;
+						return s.qty == 0;
+					}
+					return false;
+					}), spawn_list.end());
+				if (battle_config.dynamic_mobs) {
 					aFree(mapdata->moblist[j]);
 					mapdata->moblist[j] = nullptr;
 				}

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6129,36 +6129,8 @@ bool npc_unloadfile( const char* path ) {
 
 	npc_delsrcfile(path);
 
+	mob_remove_spawns(path);
 
-	s_mapiterator* iter2 = mapit_geteachiddb();
-	for (block_list* bl = (struct block_list*)mapit_first(iter2); mapit_exists(iter2); bl = (struct block_list*)mapit_next(iter2)) {
-		if (bl->type == BL_MOB) {
-			auto* md = reinterpret_cast<mob_data*>(bl);
-			if(md->spawn && !strcmp(md->spawn->filepath,path))
-				unit_free(bl, CLR_OUTSIGHT);
-		}
-	}
-	mapit_free(iter2);
-	for (int i = 0; i < map_num; i++) {
-		map_data* mapdata = map_getmapdata(i);
-		for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
-			spawn_data* mob = mapdata->moblist[j];
-			if (mob != nullptr && !strcmp(mob->filepath, path)) {
-				auto& spawn_list = mob_spawn_data[mob->id];
-				spawn_list.erase(std::remove_if(spawn_list.begin(), spawn_list.end(), [&](spawn_info& s) {
-					if (map_mapindex2mapid(s.mapindex) == mob->m) {
-						s.qty -= mob->num;
-						return s.qty == 0;
-					}
-					return false;
-					}), spawn_list.end());
-				if (battle_config.dynamic_mobs) {
-					aFree(mapdata->moblist[j]);
-					mapdata->moblist[j] = nullptr;
-				}
-			}
-		}
-	}
 	return found;
 }
 

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5197,6 +5197,7 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	int ai = AI_NONE; // mob_ai
 
 	memset(&mob, 0, sizeof(struct spawn_data));
+
 	mob.state.boss = !strcmpi(w2,"boss_monster");
 
 	// w1=<map name>{,<x>,<y>{,<xs>,<ys>}}

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6186,11 +6186,18 @@ bool npc_remove_mob_spawns(const char* path) {
 				if (mob != nullptr && !strcmp(mob->filepath, path)) {
 					npc_cache_mob -= mob->num;
 					remove_spawn_info( *mob, mob->num );
+
 					aFree(mapdata->moblist[j]);
 					mapdata->moblist[j] = nullptr;
+
+					if (mapdata->mob_delete_timer != INVALID_TIMER) {
+						delete_timer(mapdata->mob_delete_timer, map_removemobs_timer);
+						mapdata->mob_delete_timer = INVALID_TIMER;
+					}
 				}
 			}
 		}
+
 	}
 
 	// Sort spawns by spawn quantity
@@ -6199,6 +6206,7 @@ bool npc_remove_mob_spawns(const char* path) {
 			return a.qty > b.qty;
 		} );
 	}
+
 	if(spawn_count || unit_count)
 		ShowInfo("%d mobs and %d spawns removed.\n",unit_count,spawn_count);
 	return spawn_count > 0 || unit_count > 0;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5197,7 +5197,6 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 	int ai = AI_NONE; // mob_ai
 
 	memset(&mob, 0, sizeof(struct spawn_data));
-	strcpy(mob.filepath,filepath);
 	mob.state.boss = !strcmpi(w2,"boss_monster");
 
 	// w1=<map name>{,<x>,<y>{,<xs>,<ys>}}
@@ -5349,6 +5348,9 @@ static const char* npc_parse_mob(char* w1, char* w2, char* w3, char* w4, const c
 		ShowError("npc_parse_mob: Invalid dataset for monster ID %d (file '%s', line '%d').\n", mob_id, filepath, strline(buffer,start-buffer));
 		return strchr(start,'\n');// skip and continue
 	}
+
+	// Store filepath for possible unloading
+	strcpy( mob.filepath, filepath );
 
 	//Update mob spawn lookup database
 	struct spawn_info spawn = { mapdata->index, mob.num };
@@ -6124,12 +6126,14 @@ bool npc_unloadfile( const char* path ) {
 
 	dbi_destroy(iter);
 
+	if( mob_remove_spawns( path ) ){
+		found = true;
+	}
+
 	if( found ) /* refresh event cache */
 		npc_read_event_script();
 
 	npc_delsrcfile(path);
-
-	mob_remove_spawns(path);
 
 	return found;
 }

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -6127,7 +6127,7 @@ bool npc_unloadfile( const char* path ) {
 
 	dbi_destroy(iter);
 
-	if( mob_remove_spawns( path ) ){
+	if(npc_remove_mob_spawns( path )){
 		found = true;
 	}
 
@@ -6138,6 +6138,72 @@ bool npc_unloadfile( const char* path ) {
 
 	return found;
 }
+
+bool npc_remove_mob_spawns(const char* path) {
+	int spawn_count{};
+	int unit_count{};
+	auto remove_spawn_info = [&]( spawn_data& spawn, uint16 qty ){
+		auto it = mob_spawn_data.find( spawn.id );
+
+		if( it != mob_spawn_data.end() ){
+			uint16 mapindex = map_id2index( spawn.m );
+
+			it->second.erase( std::remove_if( it->second.begin(), it->second.end(), [&]( spawn_info& spawninfo ){
+				if( spawninfo.mapindex == mapindex ){
+					spawninfo.qty -= qty;
+					spawn_count += qty;
+					return spawninfo.qty == 0;
+				}
+
+				return false;
+			} ), it->second.end() );
+		}
+	};
+
+	// Remove spawned mobs
+	s_mapiterator* iter = mapit_geteachmob();
+
+	for( block_list* bl = mapit_first( iter ); mapit_exists( iter ); bl = mapit_next( iter ) ){
+		mob_data* md = reinterpret_cast<mob_data*>( bl );
+
+		if( md->spawn != nullptr && !strcmp( md->spawn->filepath, path ) ){
+			remove_spawn_info( *md->spawn, 1 );
+			unit_free(bl, CLR_OUTSIGHT);
+			unit_count++;
+		}
+	}
+
+	mapit_free(iter);
+
+	//dynamic mobs cleaning
+	if (battle_config.dynamic_mobs) {
+		for (int i = 0; i < map_num; i++) {
+			map_data* mapdata = map_getmapdata(i);
+
+			for (int16 j = 0; j < MAX_MOB_LIST_PER_MAP; j++) {
+				spawn_data* mob = mapdata->moblist[j];
+
+				if (mob != nullptr && !strcmp(mob->filepath, path)) {
+					npc_cache_mob -= mob->num;
+					remove_spawn_info( *mob, mob->num );
+					aFree(mapdata->moblist[j]);
+					mapdata->moblist[j] = nullptr;
+				}
+			}
+		}
+	}
+
+	// Sort spawns by spawn quantity
+	for( auto& pair : mob_spawn_data ){
+		std::sort( pair.second.begin(), pair.second.end(), []( const spawn_info& a, const spawn_info& b ) -> bool{
+			return a.qty > b.qty;
+		} );
+	}
+	if(spawn_count || unit_count)
+		ShowInfo("%d mobs and %d spawns removed.\n",unit_count,spawn_count);
+	return spawn_count > 0 || unit_count > 0;
+}
+
 
 void do_clear_npc(void) {
 	db_clear(npcname_db);

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -1664,5 +1664,6 @@ void npc_market_delfromsql_(const char *exname, t_itemid nameid, bool clear);
 int npc_do_atcmd_event(map_session_data* sd, const char* command, const char* message, const char* eventname);
 
 bool npc_unloadfile( const char* path );
+bool npc_remove_mob_spawns(const char* path);
 
 #endif /* NPC_HPP */


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#8685 
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This keeps track of the source of permanent spawn generations by adding the filenames to `spawn_data` struct.
It allows removing units spawned by these files and their associated spawn data.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
