### PR TITLE
Implemented statuses SC_BATH_FOAM_A, SC_BATH_FOAM_B, SC_BATH_FOAM_C

### DIFF
--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -67439,7 +67439,7 @@ Body:
       NoAuction: true
       NoGuildStorage: true
     Script: |
-      bonus_script "{ bonus2 bAddRace2,RC2_EP172BATH,5; }",900,1,0,EFST_BATH_FOAM_A;
+      sc_start SC_BATH_FOAM_A,900000,5;
   - Id: 100148
     AegisName: Bath_Foam_B
     Name: Bath Foam B
@@ -67454,7 +67454,7 @@ Body:
       NoAuction: true
       NoGuildStorage: true
     Script: |
-      bonus_script "{ bonus2 bAddRace2,RC2_EP172BATH,10; }",900,1,0,EFST_BATH_FOAM_B;
+      sc_start SC_BATH_FOAM_B,900000,10;
   - Id: 100149
     AegisName: Bath_Foam_C
     Name: Bath Foam C
@@ -67469,7 +67469,7 @@ Body:
       NoAuction: true
       NoGuildStorage: true
     Script: |
-      bonus_script "{ bonus2 bAddRace2,RC2_EP172BATH,15; }",900,1,0,EFST_BATH_FOAM_C;
+      sc_start SC_BATH_FOAM_C,900000,15;
   - Id: 100150
     AegisName: Aroma_Oil
     Name: Aromatherapy Oil

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -8969,3 +8969,30 @@ Body:
       Bleeding: true
       Confusion: true
       Freeze: true
+  - Status: Bath_foam_a
+    Icon: EFST_BATH_FOAM_A
+    CalcFlags:
+      All: true
+    Flags:
+      NoBanishingBuster: true
+      NoClearance: true
+      NoClearbuff: true
+      NoDispell: true
+  - Status: Bath_foam_b
+    Icon: EFST_BATH_FOAM_B
+    CalcFlags:
+      All: true
+    Flags:
+      NoBanishingBuster: true
+      NoClearance: true
+      NoClearbuff: true
+      NoDispell: true
+  - Status: Bath_foam_c
+    Icon: EFST_BATH_FOAM_C
+    CalcFlags:
+      All: true
+    Flags:
+      NoBanishingBuster: true
+      NoClearance: true
+      NoClearbuff: true
+      NoDispell: true

--- a/doc/status_change.txt
+++ b/doc/status_change.txt
@@ -2848,3 +2848,15 @@ SC_AGIUP
 	desc: Increase Speed and Flee.
 	val1: +% Walkspeed
 	val2: +% Flee
+
+SC_BATH_FOAM_A	()
+	desc: Increases physical and magical damage against Meditathio Dungeon Monsters by 5%.
+	val1: +% damage
+
+SC_BATH_FOAM_B	()
+	desc: Increases physical and magical damage against Meditathio Dungeon Monsters by 10%.
+	val1: +% damage
+
+SC_BATH_FOAM_C	()
+	desc: Increases physical and magical damage against Meditathio Dungeon Monsters by 15%.
+	val1: +% damage

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -1916,6 +1916,9 @@
 	export_constant(SC_POWERUP);
 	export_constant(SC_AGIUP);
 	export_constant(SC_PROTECTION);
+	export_constant(SC_BATH_FOAM_A);
+	export_constant(SC_BATH_FOAM_B);
+	export_constant(SC_BATH_FOAM_C);
 
 	/* status icons */
 	export_deprecated_constant2("SI_BLANK",-1);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -4900,6 +4900,27 @@ int status_calc_pc_sub(map_session_data* sd, uint8 opt)
 		}
 		if (sc->getSCE(SC_PORK_RIB_STEW))
 			sd->dsprate -= 2;
+		if (sc->getSCE(SC_BATH_FOAM_A)) {
+			sd->right_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_A)->val1;
+			sd->indexed_bonus.magic_addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_A)->val1;
+			if( !battle_config.left_cardfix_to_right ){
+				sd->left_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_A)->val1;
+			}
+		}
+		if (sc->getSCE(SC_BATH_FOAM_B)) {
+			sd->right_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_B)->val1;
+			sd->indexed_bonus.magic_addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_B)->val1;
+			if( !battle_config.left_cardfix_to_right ){
+				sd->left_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_B)->val1;
+			}
+		}
+		if (sc->getSCE(SC_BATH_FOAM_C)) {
+			sd->right_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_C)->val1;
+			sd->indexed_bonus.magic_addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_C)->val1;
+			if( !battle_config.left_cardfix_to_right ){
+				sd->left_weapon.addrace2[RC2_EP172BATH] += sc->getSCE(SC_BATH_FOAM_C)->val1;
+			}
+		}
 	}
 	status_cpy(&sd->battle_status, base_status);
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -1311,6 +1311,9 @@ enum sc_type : int16 {
 	SC_POWERUP = 951,
 	SC_AGIUP,
 	SC_PROTECTION,
+	SC_BATH_FOAM_A,
+	SC_BATH_FOAM_B,
+	SC_BATH_FOAM_C,
 
 	SC_MAX, //Automatically updated max, used in for's to check we are within bounds.
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

These statuses replace `bonus_script` (which was missing `bMagicAddRace2`) in item script IDs 100147~100149. On official server, these statuses are not removed after logout, cannot be dispelled, and are removed upon death.


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
