### PR TITLE
Fixed incorrect ChaseRange value for MD_E_13EN0

### DIFF
--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -101395,7 +101395,7 @@ Body:
     Luk: 61
     AttackRange: 2
     SkillRange: 10
-    ChaseRange: 12432
+    ChaseRange: 12
     Size: Medium
     Race: Fish
     Element: Water


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

Reverts accidental change of `ChaseRange` for mob `MD_E_13EN0` that happened in e803ba5.
