### PR TITLE
Cleanup CLI config parsing

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3205,7 +3205,7 @@ bool CharacterServer::initialize( int argc, char *argv[] ){
 	}
 #endif
 
-	inter_init_sql((argc > 2) ? argv[2] : SQL_CONF_NAME); // inter server configuration
+	inter_init_sql((argc > 2 && strstr(argv[2], "inter") != nullptr) ? argv[2] : SQL_CONF_NAME); // inter server configuration
 
 	char_mmo_sql_init();
 	char_read_fame_list(); //Read fame lists.

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3183,7 +3183,7 @@ bool CharacterServer::initialize( int argc, char *argv[] ){
 	// Init default value
 	CHAR_CONF_NAME =   "conf/char_athena.conf";
 	LAN_CONF_NAME =    "conf/subnet_athena.conf";
-	SQL_CONF_NAME =    "conf/inter_athena.conf";
+	INTER_CONF_NAME =  "conf/inter_athena.conf";
 	MSG_CONF_NAME_EN = "conf/msg_conf/char_msg.conf";
 	safestrncpy(console_log_filepath, "./log/char-msg_log.log", sizeof(console_log_filepath));
 
@@ -3194,7 +3194,7 @@ bool CharacterServer::initialize( int argc, char *argv[] ){
 	char_config_adjust();
 	char_lan_config_read(LAN_CONF_NAME);
 	char_set_default_sql();
-	char_sql_config_read(SQL_CONF_NAME);
+	char_sql_config_read(INTER_CONF_NAME);
 	msg_config_read(MSG_CONF_NAME_EN);
 
 #if !defined(BUILDBOT)
@@ -3205,7 +3205,7 @@ bool CharacterServer::initialize( int argc, char *argv[] ){
 	}
 #endif
 
-	inter_init_sql((argc > 2 && strstr(argv[2], "inter") != nullptr) ? argv[2] : SQL_CONF_NAME); // inter server configuration
+	inter_init_sql((argc > 2 && strstr(argv[2], "inter") != nullptr) ? argv[2] : INTER_CONF_NAME); // inter server configuration
 
 	char_mmo_sql_init();
 	char_read_fame_list(); //Read fame lists.

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -3181,10 +3181,6 @@ void CharacterServer::handle_shutdown(){
 
 bool CharacterServer::initialize( int argc, char *argv[] ){
 	// Init default value
-	CHAR_CONF_NAME =   "conf/char_athena.conf";
-	LAN_CONF_NAME =    "conf/subnet_athena.conf";
-	INTER_CONF_NAME =  "conf/inter_athena.conf";
-	MSG_CONF_NAME_EN = "conf/msg_conf/char_msg.conf";
 	safestrncpy(console_log_filepath, "./log/char-msg_log.log", sizeof(console_log_filepath));
 
 	cli_get_options(argc,argv);
@@ -3205,7 +3201,7 @@ bool CharacterServer::initialize( int argc, char *argv[] ){
 	}
 #endif
 
-	inter_init_sql((argc > 2 && strstr(argv[2], "inter") != nullptr) ? argv[2] : INTER_CONF_NAME); // inter server configuration
+	inter_init_sql(INTER_CONF_NAME); // inter server configuration
 
 	char_mmo_sql_init();
 	char_read_fame_list(); //Read fame lists.

--- a/src/common/cli.cpp
+++ b/src/common/cli.cpp
@@ -21,7 +21,7 @@
 using namespace rathena::server_core;
 
 //map confs
-const char* MAP_CONF_NAME = "conf/log_athena.conf";
+const char* MAP_CONF_NAME = "conf/map_athena.conf";
 const char* INTER_CONF_NAME = "conf/inter_athena.conf";
 const char* LOG_CONF_NAME = "conf/log_athena.conf";
 const char* BATTLE_CONF_FILENAME = "conf/battle_athena.conf";

--- a/src/common/cli.cpp
+++ b/src/common/cli.cpp
@@ -29,7 +29,6 @@ const char* SCRIPT_CONF_NAME;
 const char* GRF_PATH_FILENAME;
 //char confs
 const char* CHAR_CONF_NAME;
-const char* SQL_CONF_NAME;
 //login confs
 const char* LOGIN_CONF_NAME;
 //common conf (used by multiple serv)

--- a/src/common/cli.cpp
+++ b/src/common/cli.cpp
@@ -21,19 +21,20 @@
 using namespace rathena::server_core;
 
 //map confs
-const char* MAP_CONF_NAME;
-const char* INTER_CONF_NAME;
-const char* LOG_CONF_NAME;
-const char* BATTLE_CONF_FILENAME;
-const char* SCRIPT_CONF_NAME;
-const char* GRF_PATH_FILENAME;
+const char* MAP_CONF_NAME = "conf/log_athena.conf";
+const char* INTER_CONF_NAME = "conf/inter_athena.conf";
+const char* LOG_CONF_NAME = "conf/log_athena.conf";
+const char* BATTLE_CONF_FILENAME = "conf/battle_athena.conf";
+const char* SCRIPT_CONF_NAME = "conf/script_athena.conf";
+const char* GRF_PATH_FILENAME = "conf/grf-files.txt";
 //char confs
-const char* CHAR_CONF_NAME;
+const char* CHAR_CONF_NAME = "conf/char_athena.conf";
 //login confs
-const char* LOGIN_CONF_NAME;
+const char* LOGIN_CONF_NAME = "conf/login_athena.conf";
+const char *LOGIN_MSG_CONF_NAME = "conf/msg_conf/login_msg.conf";
 //common conf (used by multiple serv)
-const char* LAN_CONF_NAME; //char-login
-const char* MSG_CONF_NAME_EN; //all
+const char* LAN_CONF_NAME = "conf/subnet_athena.conf"; //char-login
+const char* MSG_CONF_NAME_EN = "conf/msg_conf/char_msg.conf"; //all
 
 /**
  * Function to check if the specified option has an argument following it.

--- a/src/common/cli.hpp
+++ b/src/common/cli.hpp
@@ -19,7 +19,6 @@
  extern const char* GRF_PATH_FILENAME;
 //char
  extern const char* CHAR_CONF_NAME;
- extern const char* SQL_CONF_NAME;
 //login
  extern const char* LOGIN_CONF_NAME;
 //common

--- a/src/common/cli.hpp
+++ b/src/common/cli.hpp
@@ -21,6 +21,7 @@
  extern const char* CHAR_CONF_NAME;
 //login
  extern const char* LOGIN_CONF_NAME;
+ extern const char *LOGIN_MSG_CONF_NAME;
 //common
  extern const char* LAN_CONF_NAME; //char-login
  extern const char* MSG_CONF_NAME_EN; //all

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -12,6 +12,7 @@
 #include <mysql.h>
 
 #include "cbasetypes.hpp"
+#include "cli.hpp"
 #include "malloc.hpp"
 #include "showmsg.hpp"
 #include "strlib.hpp"
@@ -23,8 +24,6 @@
 #if !defined(MARIADB_BASE_VERSION) && !defined(MARIADB_VERSION_ID) && MYSQL_VERSION_ID >= 80001 && MYSQL_VERSION_ID != 80002
 #define my_bool bool
 #endif
-
-#define SQL_CONF_NAME "conf/inter_athena.conf"
 
 void ra_mysql_error_handler(unsigned int ecode);
 
@@ -1103,7 +1102,7 @@ void Sql_inter_server_read(const char* cfgName, bool first) {
 }
 
 void Sql_Init(void) {
-	Sql_inter_server_read(SQL_CONF_NAME,true);
+	Sql_inter_server_read(INTER_CONF_NAME,true);
 }
 
 #ifdef my_bool

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -511,7 +511,7 @@ int lan_subnetcheck(uint32 ip) {
 
 
 /// Msg_conf tayloring
-int login_msg_config_read(char *cfgName){
+int login_msg_config_read(const char *cfgName){
 	return _msg_config_read(cfgName,LOGIN_MAX_MSG,msg_table);
 }
 const char* login_msg_txt(int msg_number){
@@ -787,11 +787,6 @@ void login_set_defaults() {
 #endif
 	login_config.use_web_auth_token = true;
 	login_config.disable_webtoken_delay = 10000;
-
-	//other default conf
-	safestrncpy(login_config.loginconf_name, "conf/login_athena.conf", sizeof(login_config.loginconf_name));
-	safestrncpy(login_config.lanconf_name, "conf/subnet_athena.conf", sizeof(login_config.lanconf_name));
-	safestrncpy(login_config.msgconf_name, "conf/msg_conf/login_msg.conf", sizeof(login_config.msgconf_name));
 }
 
 
@@ -861,11 +856,11 @@ bool LoginServer::initialize( int argc, char* argv[] ){
 
 	// read login-server configuration
 	login_set_defaults();
-	logcnslif_get_options(argc,argv);
+	cli_get_options(argc,argv);
 
-	login_config_read(login_config.loginconf_name, true);
-	msg_config_read(login_config.msgconf_name);
-	login_lan_config_read(login_config.lanconf_name);
+	login_config_read(LOGIN_CONF_NAME, true);
+	msg_config_read(LOGIN_MSG_CONF_NAME);
+	login_lan_config_read(LAN_CONF_NAME);
 	//end config
 
 	do_init_loginclif();

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -109,9 +109,6 @@ struct Login_Config {
 
 	int client_hash_check;							/// flags for checking client md5
 	struct client_hash_node *client_hash_nodes;		/// linked list containing md5 hash for each gm group
-	char loginconf_name[256];						/// name of main config file
-	char msgconf_name[256];							/// name of msg_conf config file
-	char lanconf_name[256];							/// name of lan config file
 
 	bool usercount_disable;							/// Disable colorization and description in general?
 	int usercount_low;								/// Amount of users that will display in green
@@ -136,7 +133,7 @@ extern struct Login_Config login_config;
 #define msg_config_read(cfgName) login_msg_config_read(cfgName)
 #define msg_txt(msg_number) login_msg_txt(msg_number)
 #define do_final_msg() login_do_final_msg()
-int login_msg_config_read(char *cfgName);
+int login_msg_config_read(const char *cfgName);
 const char* login_msg_txt(int msg_number);
 void login_do_final_msg(void);
 bool login_config_read(const char* cfgName, bool normal);

--- a/src/login/logincnslif.cpp
+++ b/src/login/logincnslif.cpp
@@ -35,56 +35,6 @@ void display_helpscreen(bool do_exit) {
 }
 
 /**
- * Read the option specified in command line
- *  and assign the confs used by the different server.
- * @param argc:
- * @param argv:
- * @return true or Exit on failure.
- */
-int logcnslif_get_options(int argc, char ** argv) {
-	int i = 0;
-	for (i = 1; i < argc; i++) {
-		const char* arg = argv[i];
-
-		if (arg[0] != '-' && (arg[0] != '/' || arg[1] == '-')) {// -, -- and /
-			ShowError("Unknown option '%s'.\n", argv[i]);
-			exit(EXIT_FAILURE);
-		} else if ((++arg)[0] == '-') {// long option
-			arg++;
-
-			if (strcmp(arg, "help") == 0) {
-				display_helpscreen(true);
-			} else if (strcmp(arg, "version") == 0) {
-				display_versionscreen(true);
-			} else if (strcmp(arg, "run-once") == 0){ // close the map-server as soon as its done.. for testing [Celest]
-				global_core->set_run_once( true );
-			} else if (strcmp(arg, "lan-config") == 0) {
-				if (opt_has_next_value(arg, i, argc)) safestrncpy(login_config.lanconf_name, argv[++i], sizeof(login_config.lanconf_name));
-			} else if (strcmp(arg, "login-config") == 0) {
-				if (opt_has_next_value(arg, i, argc)) safestrncpy(login_config.loginconf_name, argv[++i], sizeof(login_config.loginconf_name));
-			} else if (strcmp(arg, "msg-config") == 0) {
-				if (opt_has_next_value(arg, i, argc)) safestrncpy(login_config.msgconf_name, argv[++i], sizeof(login_config.msgconf_name));
-			} else {
-				ShowError("Unknown option '%s'.\n", argv[i]);
-				exit(EXIT_FAILURE);
-			}
-		} else switch (arg[0]) {// short option
-			case '?':
-			case 'h':
-				display_helpscreen(true);
-				break;
-			case 'v':
-				display_versionscreen(true);
-				break;
-			default:
-				ShowError("Unknown option '%s'.\n", argv[i]);
-				exit(EXIT_FAILURE);
-		}
-	}
-	return 1;
-}
-
-/**
  * Console Command Parser
  * Transmited from command cli.cpp
  * note common name for all serv do not rename (extern in cli)
@@ -115,8 +65,8 @@ int cnslif_parse(const char* buf){
 			else if( strcmpi("alive", command) == 0 || strcmpi("status", command) == 0 )
 				ShowInfo(CL_CYAN "Console: " CL_BOLD "I'm Alive." CL_RESET"\n");
 			else if( strcmpi("reloadconf", command) == 0 ) {
-				ShowInfo("Reloading config file \"%s\"\n", login_config.loginconf_name);
-				login_config_read(login_config.loginconf_name, false);
+				ShowInfo("Reloading config file \"%s\"\n", LOGIN_CONF_NAME);
+				login_config_read(LOGIN_CONF_NAME, false);
 			}
 		}
 		if( strcmpi("create",type) == 0 )
@@ -142,7 +92,7 @@ int cnslif_parse(const char* buf){
 		ShowInfo("Available commands:\n");
 		ShowInfo("\t server:shutdown => Stops the server.\n");
 		ShowInfo("\t server:alive => Checks if the server is running.\n");
-		ShowInfo("\t server:reloadconf => Reload config file: \"%s\"\n", login_config.loginconf_name);
+		ShowInfo("\t server:reloadconf => Reload config file: \"%s\"\n", LOGIN_CONF_NAME);
 		ShowInfo("\t create:<username> <password> <sex:M|F> => Creates a new account.\n");
 	}
 	return 1;

--- a/src/login/logincnslif.hpp
+++ b/src/login/logincnslif.hpp
@@ -15,15 +15,6 @@
 int cnslif_parse(const char* buf);
 
 /**
- * Read the option specified in command line
- *  and assign the confs used by the different server.
- * @param argc:
- * @param argv:
- * @return true or Exit on failure.
- */
-int logcnslif_get_options(int argc, char ** argv);
-
-/**
  * Initialize the module.
  * Launched at login-serv start, create db or other long scope variable here.
  */

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -5206,12 +5206,6 @@ bool MapServer::initialize( int argc, char *argv[] ){
 	GC_enable_incremental();
 #endif
 
-	INTER_CONF_NAME="conf/inter_athena.conf";
-	LOG_CONF_NAME="conf/log_athena.conf";
-	MAP_CONF_NAME = "conf/map_athena.conf";
-	BATTLE_CONF_FILENAME = "conf/battle_athena.conf";
-	SCRIPT_CONF_NAME = "conf/script_athena.conf";
-	GRF_PATH_FILENAME = "conf/grf-files.txt";
 	safestrncpy(console_log_filepath, "./log/map-msg_log.log", sizeof(console_log_filepath));
 
 	/* Multilanguage */


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #8618

* **Server Mode**: Pre-renewal and Renewal

* **Description of Pull Request**: 
  * When --char-config is provided, the argument value was being sent to the function that loads the inter-server config resulting in some configuration values not being properly parsed.
Thanks to @joaogardenberg!