### PR TITLE
Add missing knockback values for SR_KNUCKLEARROW

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -25678,12 +25678,22 @@ Body:
       - Level: 1
         Amount: 2
       - Level: 2
-        Amount: 3
+        Amount: 2
       - Level: 3
-        Amount: 4
+        Amount: 3
       - Level: 4
-        Amount: 5
+        Amount: 3
       - Level: 5
+        Amount: 4
+      - Level: 6
+        Amount: 4
+      - Level: 7
+        Amount: 5
+      - Level: 8
+        Amount: 5
+      - Level: 9
+        Amount: 6
+      - Level: 10
         Amount: 6
     CopyFlags:
       Skill:


### PR DESCRIPTION
* **Addressed Issue(s)**: Related to #8378

* **Server Mode**: Renewal

* **Description of Pull Request**: 
  * Knuckle Arrow is missing the new knockback values after the skill max level was increased from 5 to 10.
Thanks to @Haydrich!