### PR TITLE
Fix Alberta Ship Warp Coordinates 

### DIFF
--- a/npc/cities/amatsu.txt
+++ b/npc/cities/amatsu.txt
@@ -138,7 +138,7 @@ amatsu,194,79,5	script	Sea Captain#ama2	709,{
 		mes "right? All aboard now.";
 		close2;
 		if (checkre(0))
-			warp "alberta",244,72;
+			warp "alberta",244,86;
 		else
 			warp "alberta",243,91;
 		end;

--- a/npc/cities/amatsu.txt
+++ b/npc/cities/amatsu.txt
@@ -138,7 +138,7 @@ amatsu,194,79,5	script	Sea Captain#ama2	709,{
 		mes "right? All aboard now.";
 		close2;
 		if (checkre(0))
-			warp "alberta",244,86;
+			warp "alberta",245,87;
 		else
 			warp "alberta",243,91;
 		end;

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -86,7 +86,10 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "[Aibakthing]";
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
-		warp "alberta",235,45;
+		if (checkre(0))
+			warp "alberta",235,45;
+		else
+			warp "alberta",238,32;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -87,9 +87,9 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
 		if (checkre(0))
-			warp "alberta",235,45;
+			warp "alberta",235,32;
 		else
-			warp "alberta",238,32;
+			warp "alberta",238,45;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -87,9 +87,9 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
 		if (checkre(0))
-			warp "alberta",238,32;
+			warp "alberta",245,87;
 		else
-			warp "alberta",235,45;
+			warp "alberta",238,45;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -86,10 +86,7 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "[Aibakthing]";
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
-		if (checkre(0))
-			warp "alberta",235,45;
-		else
-			warp "alberta",238,22;
+		warp "alberta",235,45;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -89,7 +89,7 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		if (checkre(0))
 			warp "alberta",245,87;
 		else
-			warp "alberta",238,45;
+			warp "alberta",235,45;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/ayothaya.txt
+++ b/npc/cities/ayothaya.txt
@@ -87,9 +87,9 @@ ayothaya,152,68,1	script	Aibakthing#ayo2	843,{
 		mes "You will be welcome to come back whenever you please. I hope that we will see each other again sometime soon. Thank you~";
 		close2;
 		if (checkre(0))
-			warp "alberta",235,32;
+			warp "alberta",238,32;
 		else
-			warp "alberta",238,45;
+			warp "alberta",235,45;
 		end;
 	}
 	mes "[Aibakthing]";

--- a/npc/cities/brasilis.txt
+++ b/npc/cities/brasilis.txt
@@ -60,7 +60,7 @@ brasilis,316,57,3	script	Crewman#bra1	100,{
 		mes "I sure do miss home.";
 		close2;
 		if (checkre(0))
-			warp "alberta",243,82;
+			warp "alberta",245,87;
 		else
 			warp "alberta",244,115;
 		end;

--- a/npc/cities/gonryun.txt
+++ b/npc/cities/gonryun.txt
@@ -145,7 +145,7 @@ gon_fild01,255,79,7	script	Kunlun Envoy#gon2	776,{
 		mes "back to Alberta.";
 		close2;
 		if (checkre(0))
-			warp "alberta",244,60;
+			warp "alberta",245,87;
 		else
 			warp "alberta",243,67;
 		end;

--- a/npc/cities/louyang.txt
+++ b/npc/cities/louyang.txt
@@ -110,7 +110,7 @@ lou_fild01,190,100,7	script	Girl#1lou	815,{
 		mes "Bye bye!";
 		close2;
 		if (checkre(0))
-			warp "alberta",236,40;
+			warp "alberta",245,87;
 		else
 			warp "alberta",235,45;
 		end;

--- a/npc/cities/moscovia.txt
+++ b/npc/cities/moscovia.txt
@@ -110,7 +110,7 @@ moscovia,166,53,4	script	Moscovia P.R. Officer#2	960,{
 	mes "Ok then, Let's get going.";
 	close2;
 	if (checkre(0))
-		warp "alberta",244,52;
+		warp "alberta",244,86;
 	else
 		warp "alberta",243,67;
 	end;

--- a/npc/re/cities/dewata.txt
+++ b/npc/re/cities/dewata.txt
@@ -66,7 +66,7 @@ dewata,229,49,6	script	Alberta Sailor#dewata	536,{
 		mes "your trip to ^8B4513Dewata^000000 Island.";
 		mes "Please come again!";
 		close2;
-		warp "alberta",210,198;
+		warp "alberta",192,215;
 		end;
 	case 2:
 		mes "[Alberta Sailor]";

--- a/npc/re/cities/malaya.txt
+++ b/npc/re/cities/malaya.txt
@@ -81,7 +81,7 @@ malaya,276,55,4	script	Optamara Crew#malaya	100,{
 		mes "[Optamara Crew]";
 		mes "Great! Let's leave now for Alberta!!";
 		close2;
-		warp "alberta",239,68;
+		warp "alberta",192,217;
 		end;
 	case 2:
 		mes "[Optamara Crew]";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2172aa23-0a4e-492c-851f-4997a74ef6d6)



The current warp for pre-renewal teleports the character to a non-walkable cell.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

Remove IF statement to use the same warp coordinate for PRE-RE and RE.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The current warp for pre-renewal teleports the character to a non-walkable cell. The incorrect coordinate will be removed, ensuring the same coordinate is used for both renewal and pre-renewal.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
