### PR TITLE
Corrected SP_CURSEEXPLOSION and Soulcurse status

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7330,6 +7330,8 @@ Body:
   - Status: Soulcurse
     Icon: EFST_SOULCURSE
     DurationLookup: SP_SOULCURSE
+    Flags:
+      BlEffect: true
   - Status: Hells_Plant
     Icon: EFST_HELLS_PLANT_ARMOR
     DurationLookup: GN_HELLS_PLANT

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8383,9 +8383,10 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case SP_CURSEEXPLOSION:
 						if (tsc && tsc->getSCE(SC_SOULCURSE))
-							skillratio += 1400 + 200 * skill_lv;
+							skillratio += -100 + 1200 + 300 * skill_lv;
 						else
-							skillratio += 300 + 100 * skill_lv;
+							skillratio += -100 + 400 + 100 * skill_lv;
+						RE_LVL_DMOD(100);
 						break;
 					case SP_SPA:
 						skillratio += 400 + 250 * skill_lv;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2150,9 +2150,6 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 	case SJ_STAREMPEROR:
 		sc_start(src, bl, SC_SILENCE, 50 + 10 * skill_lv, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;
-	case SP_CURSEEXPLOSION:
-		status_change_end(bl, SC_SOULCURSE);
-		break;
 	case SP_SHA:
 		sc_start(src, bl, SC_SP_SHA, 100, skill_lv, skill_get_time(skill_id, skill_lv));
 		break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/a

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Latest **SP_CURSEEXPLOSION** formula 
----------------------------------
https://www.divine-pride.net/database/skill/2600

[Level 1]: magical damage 500%/1500% (cursed target)
[Level 2]: magical damage 600%/1800% (cursed target)
[Level 3]: magical damage 700%/2100% (cursed target)
[Level 4]: magical damage 800%/2400% (cursed target)
[Level 5]: magical damage 900%/2700% (cursed target)
[Level 6]: magical damage 1000%/3000% (cursed target)
[Level 7]: magical damage 1100%/3300% (cursed target)
[Level 8]: magical damage 1200%/3600% (cursed target)
[Level 9]: magical damage 1300%/3900% (cursed target)
[Level 10]: magical damage 1400%/4200% (cursed target)

Damage increases additionally based on the caster's base level according to the skill description.
SP_CURSEEXPLOSION does not remove SC_SOULCURSE according to test on kRO (and not mentioned in the skill description).
The effect of SC_Soulcurse should also be displayed on monster.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
