### PR TITLE
Corrected Matk status calculation

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1429,8 +1429,7 @@ Body:
     Icon: EFST_MINDBREAKER
     DurationLookup: PF_MINDBREAKER
     CalcFlags:
-      Matk: true
-      MDef2: true
+      All: true
     Flags:
       NoSave: true
       Debuff: true
@@ -2118,7 +2117,7 @@ Body:
       NoClearance: true
   - Status: Incmatkrate
     CalcFlags:
-      Matk: true
+      All: true
     Flags:
       NoRemoveOnDead: true
       NoClearbuff: true
@@ -6178,10 +6177,7 @@ Body:
     Icon: EFST_CATNIPPOWDER
     DurationLookup: SU_CN_POWDERING
     CalcFlags:
-      Watk: true
-      Matk: true
-      Speed: true
-      Regen: true
+      All: true
     Flags:
       BossResist: true
   - Status: Sv_Roottwist

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1456,8 +1456,7 @@ Body:
     Icon: EFST_MINDBREAKER
     DurationLookup: PF_MINDBREAKER
     CalcFlags:
-      Matk: true
-      MDef2: true
+      All: true
     Flags:
       NoSave: true
       Debuff: true
@@ -2243,7 +2242,7 @@ Body:
       NoClearance: true
   - Status: Incmatkrate
     CalcFlags:
-      Matk: true
+      All: true
     Flags:
       NoRemoveOnDead: true
       NoClearbuff: true
@@ -6479,10 +6478,7 @@ Body:
     Icon: EFST_CATNIPPOWDER
     DurationLookup: SU_CN_POWDERING
     CalcFlags:
-      Watk: true
-      Matk: true
-      Speed: true
-      Regen: true
+      All: true
     Flags:
       BossResist: true
   - Status: Sv_Roottwist

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1237,7 +1237,14 @@ enum e_mado_type : uint16 {
 	#define pc_leftside_mdef(sd) ((sd)->battle_status.mdef2)
 	#define pc_rightside_mdef(sd) ((sd)->battle_status.mdef)
 	#define pc_leftside_matk(sd) (status_base_matk_min(&(sd)->bl, status_get_status_data((sd)->bl), (sd)->status.base_level))
-	#define pc_rightside_matk(sd) ((sd)->battle_status.rhw.matk+(sd)->battle_status.lhw.matk+(sd)->bonus.ematk)
+#define pc_rightside_matk(sd) \
+	(\
+	(sd)->battle_status.rhw.matk + \
+	(sd)->battle_status.lhw.matk + \
+	(sd)->bonus.ematk + \
+	status_calc_consumablematk(&(sd)->sc, 0) + \
+	status_calc_pseudobuff_matk((sd), &(sd)->sc, 0) \
+	)
 #else
 	#define pc_leftside_atk(sd) ((sd)->battle_status.batk + (sd)->battle_status.rhw.atk + (sd)->battle_status.lhw.atk)
 	#define pc_rightside_atk(sd) ((sd)->battle_status.rhw.atk2 + (sd)->battle_status.lhw.atk2)

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22827,7 +22827,7 @@ void skill_select_menu( map_session_data& sd, uint16 skill_id ){
 	lv = (aslvl + 5) / 2; // The level the skill will be autocasted
 	lv = min(lv,sd.status.skill[sk_idx].lv);
 	prob = (aslvl >= 10) ? 15 : (30 - 2 * aslvl); // Probability at level 10 was increased to 15.
-	sc_start4(&sd.bl,&sd.bl,SC__AUTOSHADOWSPELL,100,id,lv,prob,aslvl,skill_get_time(SC_AUTOSHADOWSPELL,aslvl));
+	sc_start4(&sd.bl,&sd.bl,SC__AUTOSHADOWSPELL,100,id,lv,prob,(aslvl*5),skill_get_time(SC_AUTOSHADOWSPELL,aslvl));
 }
 
 int skill_elementalanalysis( map_session_data& sd, int n, uint16 skill_lv, unsigned short* item_list ){

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -6218,17 +6218,16 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 
 		// ExtraMATK = EquipMATK + ConsumableMATK + PseudoBuffMATK
 		// Bonuses from ExtraMATK are separated in order to order them (order has no impact)
-		if (sd != nullptr) {
-			// EquipMATK (flat MATK from equipments)
-			if (sd->bonus.ematk > 0) {
-				matk_min += sd->bonus.ematk;
-				matk_max += sd->bonus.ematk;
-			}
 
-			// PseudoBuffMATK (flat MATK from skills)
-			matk_min = status_calc_pseudobuff_matk( sd, sc, matk_min );
-			matk_max = status_calc_pseudobuff_matk( sd, sc, matk_max );
+		// EquipMATK (flat MATK from equipments)
+		if (sd != nullptr && sd->bonus.ematk > 0) {
+			matk_min += sd->bonus.ematk;
+			matk_max += sd->bonus.ematk;
 		}
+
+		// PseudoBuffMATK (flat MATK from skills)
+		matk_min = status_calc_pseudobuff_matk( sd, sc, matk_min );
+		matk_max = status_calc_pseudobuff_matk( sd, sc, matk_max );
 
 		// ConsumableMATK (flat MATK from consumables)
 		matk_min = status_calc_consumablematk( sc, matk_min );

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3571,6 +3571,8 @@ unsigned short status_base_atk_max(struct block_list *bl, const struct status_da
 unsigned short status_base_matk_min(struct block_list *bl, const struct status_data* status, int level);
 unsigned short status_base_matk_max(struct block_list *bl, const struct status_data* status, int level);
 #endif
+uint16 status_calc_consumablematk( status_change *sc, int32 matk );
+uint16 status_calc_pseudobuff_matk( map_session_data *sd, status_change *sc, int32 matk );
 
 unsigned short status_base_atk(const struct block_list *bl, const struct status_data *status, int level);
 


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 


Calculation of MATK corrected for SC_INCMATKRATE, SC_MINDBREAKER, SC_CATNIPPOWDER, SC_NIBELUNGEN
Clean-up MATK calculation
Corrected pc_rightside_matk to show MATK flats from buffs in player status window (part of https://github.com/rathena/rathena/pull/2126)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
