### PR TITLE
Star Gladiator Heat Official Behavior

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -11618,7 +11618,6 @@ Body:
     SplashArea: 1
     Knockback: 2
     CastCancel: true
-    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 10000
@@ -11631,7 +11630,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 429
@@ -11652,7 +11651,6 @@ Body:
     SplashArea: 1
     Knockback: 2
     CastCancel: true
-    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 10000
@@ -11665,7 +11663,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 430
@@ -11686,7 +11684,6 @@ Body:
     SplashArea: 1
     Knockback: 2
     CastCancel: true
-    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 10000
@@ -11699,7 +11696,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 431

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -11904,7 +11904,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 429
@@ -11937,7 +11937,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 430
@@ -11970,7 +11970,7 @@ Body:
     Unit:
       Id: Dummyskill
       Range: 1
-      Interval: 100
+      Interval: 20
       Target: Enemy
     Status: Warm
   - Id: 431

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7230,6 +7230,12 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 			case TK_TURNKICK:
 				wd.blewcount = 0;
 				break;
+			case SG_SUN_WARM:
+			case SG_MOON_WARM:
+			case SG_STAR_WARM:
+				// Knockback is random
+				wd.blewcount += rnd_value(0, 3);
+				break;
 #ifdef RENEWAL
 			case KN_BOWLINGBASH:
 				if (sd && sd->status.weapon == W_2HSWORD) {

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7233,7 +7233,7 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 			case SG_SUN_WARM:
 			case SG_MOON_WARM:
 			case SG_STAR_WARM:
-				// Knockback is random
+				// A random 0~3 knockback bonus is added to the base knockback
 				wd.blewcount += rnd_value(0, 3);
 				break;
 #ifdef RENEWAL

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16112,12 +16112,14 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 							// Bosses have a 80% chance to not trigger the effect
 							if (status_get_class_(bl) == CLASS_BOSS && rnd_chance(4, 5))
 								continue;
-							if (status_charge(ss, 0, 2)) // costs 2 SP per hit
-								skill_attack(BF_WEAPON, ss, &unit->bl, bl, sg->skill_id, sg->skill_lv, tick + (t_tick)count * sg->interval, 0);
-							else { //should end when out of sp.
+							// costs 2 SP per hit
+							if (!status_charge(ss, 0, 2)) {
+								//should end when out of sp.
 								sg->limit = DIFF_TICK(tick, sg->tick);
 								break;
 							}
+	
+							skill_attack(BF_WEAPON, ss, &unit->bl, bl, sg->skill_id, sg->skill_lv, tick + (t_tick)count * sg->interval, 0);
 						}
 					} while(sg->interval > 0 && x == bl->x && y == bl->y &&
 						++count < SKILLUNITTIMER_INTERVAL/sg->interval && !status_isdead(*bl) );
@@ -18555,8 +18557,8 @@ bool skill_check_condition_castend( map_session_data& sd, uint16 skill_id, uint1
 				if (sc->getSCE(SC_MIRACLE))
 					break;
 			}
-			i = skill_id - SG_SUN_WARM;
-			if (sd.bl.m == sd.feel_map[i].m)
+
+			if (sd.bl.m == sd.feel_map[skill_id - SG_SUN_WARM].m)
 				break;
 			clif_skill_nodamage(&sd.bl, sd.bl, skill_id, skill_lv, 0);
 			return false;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16109,7 +16109,7 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 						if( bl->type == BL_PC )
 							status_zap(bl, 0, 10); // sp damage to players
 						else { // mobs
-							// Bosses have a 80% chance to not trigger the effect
+							// Bosses trigger the effect only 1 out of 5 times
 							if (status_get_class_(bl) == CLASS_BOSS && rnd_chance(4, 5))
 								continue;
 							// costs 2 SP per hit
@@ -16118,7 +16118,6 @@ int skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t_t
 								sg->limit = DIFF_TICK(tick, sg->tick);
 								break;
 							}
-	
 							skill_attack(BF_WEAPON, ss, &unit->bl, bl, sg->skill_id, sg->skill_lv, tick + (t_tick)count * sg->interval, 0);
 						}
 					} while(sg->interval > 0 && x == bl->x && y == bl->y &&
@@ -18557,7 +18556,6 @@ bool skill_check_condition_castend( map_session_data& sd, uint16 skill_id, uint1
 				if (sc->getSCE(SC_MIRACLE))
 					break;
 			}
-
 			if (sd.bl.m == sd.feel_map[skill_id - SG_SUN_WARM].m)
 				break;
 			clif_skill_nodamage(&sd.bl, sd.bl, skill_id, skill_lv, 0);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8799 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Heat now has an interval of 20ms instead of 100ms
- Heat no longer has an aftercast delay
- Knockback of Heat is now a random value between 2 and 5 cells
- Heat now drains 10 SP on players per interval (500 SP per second)
- Heat now has an 80% chance to not activate on bosses per interval
- Heat no longer has an SP penalty when it misses
- Heat now fails when it's already active
- If Heat fails, you will now do the "T-Pose" animation without the effect activating instead of getting a skill failed message
- Fixed order of packets sent to the client (prevents position lag)
- Fixes #8799

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
