### PR TITLE
Item Script for forgotten area 1 and 2 Crystal

### DIFF
--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -78223,8 +78223,11 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      if(strcharinfo(3) == "for_dun01"){
-        warp strcharinfo(3),0,0;
+      if (strcharinfo(3) == "for_dun01")
+         warp "for_dun01",0,0;
+      else {
+         specialeffect2 EF_FREEZING;
+         showscript "It doesn't seem to have any effect here.", playerattached(), SELF;
       }
   - Id: 102796
     AegisName: Forgotten_Crystal_2
@@ -78239,8 +78242,11 @@ Body:
       NoMail: true
       NoAuction: true
     Script: |
-      if(strcharinfo(3) == "for_dun02"){
-        warp strcharinfo(3),0,0;
+      if (strcharinfo(3) == "for_dun02")
+         warp "for_dun02",0,0;
+      else {
+         specialeffect2 EF_FREEZING;
+         showscript "It doesn't seem to have any effect here.", playerattached(), SELF;
       }
   - Id: 102797
     AegisName: Super_Sonic_pack

--- a/db/re/item_db_usable.yml
+++ b/db/re/item_db_usable.yml
@@ -78222,8 +78222,10 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-#   Script: |
-#     /* TODO */
+    Script: |
+      if(strcharinfo(3) == "for_dun01"){
+        warp strcharinfo(3),0,0;
+      }
   - Id: 102796
     AegisName: Forgotten_Crystal_2
     Name: Crystal of Forgotten Time (Area 2)
@@ -78236,8 +78238,10 @@ Body:
       NoGuildStorage: true
       NoMail: true
       NoAuction: true
-#   Script: |
-#     /* TODO */
+    Script: |
+      if(strcharinfo(3) == "for_dun02"){
+        warp strcharinfo(3),0,0;
+      }
   - Id: 102797
     AegisName: Super_Sonic_pack
     Name: Super Sonic Package

--- a/npc/re/mapflag/noteleport.txt
+++ b/npc/re/mapflag/noteleport.txt
@@ -462,10 +462,8 @@ itemmall	mapflag	monster_noteleport
 // Forgotten Area 1
 //============================================================
 for_dun01	mapflag	noteleport
-for_dun01	mapflag	monster_noteleport
 
 //============================================================
 // Forgotten Area 2
 //============================================================
 for_dun02	mapflag	noteleport
-for_dun02	mapflag	monster_noteleport

--- a/npc/re/mapflag/noteleport.txt
+++ b/npc/re/mapflag/noteleport.txt
@@ -457,3 +457,15 @@ que_thr	mapflag	noteleport
 //============================================================
 itemmall	mapflag	noteleport
 itemmall	mapflag	monster_noteleport
+
+//============================================================
+// Forgotten Area 1
+//============================================================
+for_dun01	mapflag	noteleport
+for_dun01	mapflag	monster_noteleport
+
+//============================================================
+// Forgotten Area 2
+//============================================================
+for_dun02	mapflag	noteleport
+for_dun02	mapflag	monster_noteleport


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  No item script for items 102795 and 102796, no map flag noteleport on both forgotten areas 1 and 2.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  Item script for item 102795 - Crystal of Forgotten Time (Area 1) and 102796 - Crystal of Forgotten Time (Area 2), include map for_dun01 and for_dun02 in mapflag/noteleport.txt

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
