### PR TITLE
Fixing variable "chan_banentry" is not a type name error

### DIFF
--- a/src/map/channel.hpp
+++ b/src/map/channel.hpp
@@ -59,7 +59,7 @@ struct chan_banentry {
 	uint32 char_id;
 	char char_name[NAME_LENGTH];
 };
-extern chan_banentry chan_banentry;
+extern struct chan_banentry chan_banentry;
 
 struct Channel_Config {
 	unsigned long *colors;		///< List of available colors


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->


<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Fixes the external declaration of chan_banentry by adding the missing 'struct' keyword, as chan_banentry is a structure and not a type.

Changes made:
- **From**: extern chan_banentry chan_banentry;
- **To**: extern struct chan_banentry chan_banentry;

This fixes the compiler error "variable 'chan_banentry' is not a type name", which occurred because the compiler couldn't interpret chan_banentry as a type without the struct keyword.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
