### PR TITLE
Fixed Giant Fly Wing

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5892,8 +5892,8 @@ BUILDIN_FUNC(warpparty)
 			[[fallthrough]];
 		case WARPPARTY_RANDOMALLAREA:
 			if(!mapdata->getMapFlag(MF_NORETURN) && !mapdata->getMapFlag(MF_NOWARP) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pc_get_group_level(pl_sd))){
-				int nx = x;
-				int ny = y;
+				int32 nx = x;
+				int32 ny = y;
 				if (rx || ry) {
 					uint8 attempts = 10;
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5892,24 +5892,23 @@ BUILDIN_FUNC(warpparty)
 			[[fallthrough]];
 		case WARPPARTY_RANDOMALLAREA:
 			if(!mapdata->getMapFlag(MF_NORETURN) && !mapdata->getMapFlag(MF_NOWARP) && pc_job_can_entermap((enum e_job)pl_sd->status.class_, m, pc_get_group_level(pl_sd))){
+				int nx = x;
+				int ny = y;
 				if (rx || ry) {
-					int32 x1 = x + rx, y1 = y + ry,
-						x0 = x - rx, y0 = y - ry,
-						nx, ny;
 					uint8 attempts = 10;
 
 					do {
-						nx = x0 + rnd_value(x0, x1);
-						ny = y0 + rnd_value(y0, y1);
+						nx = x + rnd_value(-rx, rx);
+						ny = y + rnd_value(-rx, rx);
 					} while ((--attempts) > 0 && !map_getcell(m, nx, ny, CELL_CHKPASS));
 
-					if (attempts != 0) { //Keep the original coordinates if fails to find a valid cell within the range
-						x = nx;
-						y = ny;
+					if (attempts == 0) { //Keep the original coordinates if fails to find a valid cell within the range
+						nx = x;
+						ny = y;
 					}
 				}
 
-				ret = pc_setpos(pl_sd, mapindex, x, y, CLR_TELEPORT);
+				ret = pc_setpos(pl_sd, mapindex, nx, ny, CLR_TELEPORT);
 			}
 			break;
 		}

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -5899,7 +5899,7 @@ BUILDIN_FUNC(warpparty)
 
 					do {
 						nx = x + rnd_value(-rx, rx);
-						ny = y + rnd_value(-rx, rx);
+						ny = y + rnd_value(-ry, ry);
 					} while ((--attempts) > 0 && !map_getcell(m, nx, ny, CELL_CHKPASS));
 
 					if (attempts == 0) { //Keep the original coordinates if fails to find a valid cell within the range


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#8839
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
For case WARPPARTY_RANDOMALLAREA inside warpparty command, that is used by Giant Fly Wings, the coordinates searching logic is broken, almost always leading to failed attempts, thus warping party members onto the leader. However, when it does find valid coordinates, it can separate the player from the team.
This restores the wanted coordinate searching logic, warping party members in random cells around the leader.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
