### PR TITLE
Corrected the order of items displayed in player inventory/storage

### DIFF
--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -113,8 +113,8 @@ display_status_timers: yes
 // packets for the desired number. (Note 1)
 client_reshuffle_dice: yes
 
-// Sorts the character and guild storage before it is sent to the client.
-// Official servers do not sort storage. (Note 1)
+// Sorts the cart, guild storage, inventory and storage before it is sent to the client. (Note 1)
+// Official servers do not sort them.
 // NOTE: Enabling this option degrades performance.
 client_sort_storage: no
 

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -811,7 +811,7 @@ bool char_memitemdata_from_sql(struct s_storage* p, int32 max, int32 id, enum st
 		StringBuf_Printf(&buf, ", `option_val%d`", j);
 		StringBuf_Printf(&buf, ", `option_parm%d`", j);
 	}
-	StringBuf_Printf(&buf, " FROM `%s` WHERE `%s`=? ORDER BY `nameid`", tablename, selectoption );
+	StringBuf_Printf(&buf, " FROM `%s` WHERE `%s`=? ORDER BY `id`", tablename, selectoption );
 
 	if( SQL_ERROR == SqlStmt_PrepareStr(stmt, StringBuf_Value(&buf))
 		||	SQL_ERROR == SqlStmt_BindParam(stmt, 0, SQLDT_INT, &id, 0)

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -3060,6 +3060,8 @@ void clif_inventorylist( map_session_data *sd ){
 	int32 equip = 0;
 	int32 normal = 0;
 
+	storage_sortitem( sd->storage.u.items_inventory, ARRAYLENGTH( sd->storage.u.items_inventory ) );
+
 	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
 		if( sd->inventory.u.items_inventory[i].nameid == 0 || sd->inventory_data[i] == nullptr ){
 			continue;
@@ -3238,6 +3240,8 @@ void clif_cartlist( map_session_data *sd ){
 	static struct packet_itemlist_equip itemlist_equip;
 	int32 normal = 0;
 	int32 equip = 0;
+
+	storage_sortitem( sd->storage.u.items_cart, ARRAYLENGTH( sd->storage.u.items_cart ) );
 
 	for( int32 i = 0; i < MAX_CART; i++ ){
 		if( sd->cart.u.items_cart[i].nameid == 0 ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

On official server, items in the player inventory/storage are displayed in the order the player placed them. (at least on renewal)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
