### PR TITLE
Fixed NPC_SELFDESTRUCTION not giving items and exp

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8817,7 +8817,8 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 			map_freeblock_unlock();
 			return 1;
 		}
-		status_kill(src);
+		// Won't display the damage, but drop items and give exp
+		status_zap(src, sstatus->max_hp, 0, 0);
 		break;
 	case AL_ANGELUS:
 #ifdef RENEWAL

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8818,7 +8818,7 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 			return 1;
 		}
 		// Won't display the damage, but drop items and give exp
-		status_zap(src, sstatus->max_hp, 0, 0);
+		status_zap(src, sstatus->hp, 0, 0);
 		break;
 	case AL_ANGELUS:
 #ifdef RENEWAL


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes NPC_SELFDESTRUCTION not giving items or exp when the monster dies.
It should not show display the damage, but should give exp and items, so I used **status_zap** instead.
Follow up to dc64916ec4975b446188fc93aa4c10171c1b6bf2

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
