### PR TITLE
Fixed stockall counter

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -6043,7 +6043,8 @@ ACMD_FUNC(stockall)
 				return -1;
 		}
 	}
-	uint16 count = 0, count2 = 0;
+
+	int32 count = 0, count2 = 0;
 	for ( uint16 i = 0; i < MAX_CART; i++ ) {
 		if ( sd->cart.u.items_cart[i].amount > 0 ) {
 			std::shared_ptr<item_data> id = item_db.find(sd->cart.u.items_cart[i].nameid);
@@ -6052,10 +6053,13 @@ ACMD_FUNC(stockall)
 				continue;
 			}
 			if ( type == -1 || static_cast<item_types>(type) == id->type ) {
-				if (pc_getitemfromcart(sd, i, sd->cart.u.items_cart[i].amount))
-					count += sd->cart.u.items_cart[i].amount;
-				else
-					count2 += sd->cart.u.items_cart[i].amount;
+				int32 amount = sd->cart.u.items_cart[i].amount;
+
+				if( pc_getitemfromcart( sd, i, amount ) ){
+					count += amount;
+				}else{
+					count2 += amount;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**: #8858

* **Server Mode**: Both

* **Description of Pull Request**: 
`@stockall` deletes the items from the cart and after deletion it tries to access the item amount from the same cart index again, which of course will always return 0. Fixed this behavior by saving the amount before deleting the item.
Similar to what was done in #4331 for `@dropall`

Thanks to @gidzdlcrz