### PR TITLE
Improved Monster Search and Summon

### DIFF
--- a/src/common/utilities.cpp
+++ b/src/common/utilities.cpp
@@ -132,11 +132,11 @@ int32 rathena::util::strtoint32def(const char* str, int32 def) {
 	int32 result = std::strtol(str, &str_end, 10);
 
 	if (str_end != nullptr && *str_end != '\0') {
-		result = def;
+		return def;
 	}
 
 	if (errno == ERANGE) {
-		result = def;
+		return def;
 	}
 
 	return result;

--- a/src/common/utilities.cpp
+++ b/src/common/utilities.cpp
@@ -127,6 +127,21 @@ std::string rathena::util::string_left_pad(const std::string& original, char pad
 	return std::string( num - std::min( num, original.length() ), padding ) + original;
 }
 
+int32 rathena::util::strtoint32def(const char* str, int32 def) {
+	char* str_end{};
+	int32 result = std::strtol(str, &str_end, 10);
+
+	if (str_end != nullptr && *str_end != '\0') {
+		result = def;
+	}
+
+	if (errno == ERANGE) {
+		result = def;
+	}
+
+	return result;
+}
+
 constexpr char base62_dictionary[] = {
 	'0', '1', '2', '3', '4', '5', '6', '7',
 	'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',

--- a/src/common/utilities.hpp
+++ b/src/common/utilities.hpp
@@ -321,6 +321,16 @@ namespace rathena {
 		std::string string_left_pad(const std::string& original, char padding, size_t num);
 
 		/**
+		* Converts a string (char pointer) to an int32 value
+		* Returns the given default value when conversion fails or string is not a number
+		* @param str: String to convert
+		* @param def: Default value that should be returned on failure
+		*
+		* @return Converted int32 value
+		*/
+		int32 strtoint32def(const char* str, int32 def = 0);
+
+		/**
 		* Encode base10 number to base62. Originally by lututui
 		* @param val: Base10 Number
 		* @return Base62 string

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2280,8 +2280,8 @@ ACMD_FUNC(monster)
 	else {
 		// Otherwise, search for monster with that ID or name
 		// Check for ID first as this is faster; if search string is not a number it will return 0
-		mob_id = mobdb_checkid(util::strtoint32def(monster));
-		if (mob_id == 0)
+		mob_id = util::strtoint32def(monster);
+		if (mob_id == 0 || mobdb_checkid(mob_id) == 0)
 			mob_id = mobdb_searchname(monster);
 	}
 

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2280,7 +2280,7 @@ ACMD_FUNC(monster)
 	else {
 		// Otherwise, search for monster with that ID or name
 		// Check for ID first as this is faster; if search string is not a number it will return 0
-		mob_id = mobdb_checkid(strtol(monster, nullptr, 10));
+		mob_id = mobdb_checkid(util::strtoint32def(monster));
 		if (mob_id == 0)
 			mob_id = mobdb_searchname(monster);
 	}

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -7823,7 +7823,8 @@ ACMD_FUNC(mobinfo)
 	}
 
 	// If monster identifier/name argument is a name
-	if ((i = mobdb_checkid(strtoul(message, nullptr, 10))))
+	i = util::strtoint32def(message);
+	if (i != 0 && (i = mobdb_checkid(i)))
 	{
 		mob_ids[0] = i;
 		count = 1;

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2273,7 +2273,11 @@ ACMD_FUNC(monster)
 		return -1;
 	}
 
-	if ((mob_id = mobdb_searchname(monster)) == 0) // check name first (to avoid possible name begining by a number)
+	// If AegisName matches exactly, summon that monster
+	std::shared_ptr<s_mob_db> mob = mobdb_search_aegisname(monster);
+	if (mob != nullptr)
+		mob_id = mob->id;
+	else if ((mob_id = mobdb_searchname(monster)) == 0) // check name first (to avoid possible name begining by a number)
 		mob_id = mobdb_checkid(atoi(monster));
 
 	if (mob_id == 0) {

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -2277,8 +2277,13 @@ ACMD_FUNC(monster)
 	std::shared_ptr<s_mob_db> mob = mobdb_search_aegisname(monster);
 	if (mob != nullptr)
 		mob_id = mob->id;
-	else if ((mob_id = mobdb_searchname(monster)) == 0) // check name first (to avoid possible name begining by a number)
-		mob_id = mobdb_checkid(atoi(monster));
+	else {
+		// Otherwise, search for monster with that ID or name
+		// Check for ID first as this is faster; if search string is not a number it will return 0
+		mob_id = mobdb_checkid(strtol(monster, nullptr, 10));
+		if (mob_id == 0)
+			mob_id = mobdb_searchname(monster);
+	}
 
 	if (mob_id == 0) {
 		clif_displaymessage(fd, msg_txt(sd,40)); // Invalid monster ID or name.

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14787,7 +14787,6 @@ void clif_parse_GMRecall2(int32 fd, map_session_data* sd)
 void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 {
 	struct s_packet_db* info = &packet_db[RFIFOW(fd,0)];
-	int32 mob_id = 0;
 	StringBuf command;
 	char *str;
 //#if PACKETVER >= 20131218
@@ -14831,10 +14830,15 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 	}
 
 	// Monster
-	if ((mob_id = mobdb_searchname(str)) == 0)
-		mob_id = mobdb_checkid(atoi(str));
-
-	std::shared_ptr<s_mob_db> mob = mob_db.find(mob_id);
+	// If AegisName matches exactly, summon that monster (official behavior)
+	std::shared_ptr<s_mob_db> mob = mobdb_search_aegisname(str);
+	// Otherwise, search for monster with that name or ID (rAthena added behavior)
+	if (mob == nullptr) {
+		int32 mob_id = 0;
+		if ((mob_id = mobdb_searchname(str)) == 0)
+			mob_id = mobdb_checkid(atoi(str));
+		mob = mob_db.find(mob_id);
+	}
 
 	if( mob != nullptr ) {
 		StringBuf_Init(&command);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14837,12 +14837,13 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 		if (mob == nullptr) {
 			// Check for ID first as this is faster; if search string is not a number it will return 0
 			int32 mob_id = util::strtoint32def(str);
-			if (mob_id == 0 || mobdb_checkid(mob_id) == 0){
+			if (mob_id == 0 || mobdb_checkid(mob_id) == 0) {
 				mob_id = mobdb_searchname(str);
 
-				if (mob_id != 0){
+				if (mob_id != 0) {
 					mob = mob_db.find(mob_id);
 				}
+			}
 			else
 				mob = mob_db.find(mob_id);
 		}

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14836,7 +14836,7 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 		// Otherwise, search for monster with that ID or name (rAthena added behavior)
 		if (mob == nullptr) {
 			// Check for ID first as this is faster; if search string is not a number it will return 0
-			int32 mob_id = mobdb_checkid(strtol(str, nullptr, 10));
+			int32 mob_id = mobdb_checkid(util::strtoint32def(str));
 			if (mob_id == 0)
 				mob_id = mobdb_searchname(str);
 			mob = mob_db.find(mob_id);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14836,17 +14836,21 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 		// Otherwise, search for monster with that ID or name (rAthena added behavior)
 		if (mob == nullptr) {
 			// Check for ID first as this is faster; if search string is not a number it will return 0
-			int32 mob_id = mobdb_checkid(util::strtoint32def(str));
-			if (mob_id == 0)
+			int32 mob_id = util::strtoint32def(str);
+			if (mob_id == 0 || mobdb_checkid(mob_id) == 0){
 				mob_id = mobdb_searchname(str);
-			mob = mob_db.find(mob_id);
+
+				if (mob_id != 0){
+					mob = mob_db.find(mob_id);
+				}
+			else
+				mob = mob_db.find(mob_id);
 		}
 		// Call corresponding atcommand when a valid monster was found
 		if (mob != nullptr) {
-			StringBuf_Init(&command);
-			StringBuf_Printf(&command, "%cmonster %s", atcommand_symbol, mob->sprite.c_str());
-			is_atcommand(fd, sd, StringBuf_Value(&command), 1);
-			StringBuf_Destroy(&command);
+			char command[CHAT_SIZE_MAX];
+			safesnprintf(command, sizeof(command), "%cmonster %s", atcommand_symbol, mob->sprite.c_str());
+			is_atcommand(fd, sd, command, 1);
 			return;
 		}
 	}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -325,10 +325,10 @@ uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
 	const auto &mob_list = mob_db.getCache();
 
 	// Full compare first
-	for( const auto &mob : mob_list ) {
+	for (const auto& mob : mob_list) {
 		if (mob == nullptr)
 			continue;
-		if( mobdb_searchname_sub(mob->id, str, true) ) {
+		if (mobdb_searchname_sub(mob->id, str, true)) {
 			out[count] = mob->id;
 			if (++count >= size)
 				return count;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -269,13 +269,14 @@ static bool mobdb_searchname_sub(uint16 mob_id, const char * const str, bool ful
 	
 	if( mobdb_checkid(mob_id) <= 0 )
 		return false; // invalid mob_id (includes clone check)
+	if (strcmpi(mob->sprite.c_str(), str) == 0)
+		return true; // If AegisName matches exactly, always return true
 	if(!mob->base_exp && !mob->job_exp && !mob_has_spawn(mob_id))
 		return false; // Monsters with no base/job exp and no spawn point are, by this criteria, considered "slave mobs" and excluded from search results
 	if( full_cmp ) {
 		// str must equal the db value
 		if( strcmpi(mob->name.c_str(), str) == 0 || 
-			strcmpi(mob->jname.c_str(), str) == 0 || 
-			strcmpi(mob->sprite.c_str(), str) == 0 )
+			strcmpi(mob->jname.c_str(), str) == 0)
 			return true;
 	} else {
 		// str must be in the db value
@@ -316,29 +317,39 @@ std::shared_ptr<s_mob_db> mobdb_search_aegisname( const char* str ){
 }
 
 /*==========================================
- * Searches up to N matches. Returns number of matches [Skotlex]
+ * Searches up to N matches. Prioritizing full matches first. Returns number of matches [Skotlex]
  *------------------------------------------*/
-uint16 mobdb_searchname_array_(const char *str, uint16 * out, uint16 size, bool full_cmp)
+uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
 {
 	uint16 count = 0;
 	const auto &mob_list = mob_db.getCache();
 
+	// Full compare first
 	for( const auto &mob : mob_list ) {
 		if (mob == nullptr)
 			continue;
-		if( mobdb_searchname_sub(mob->id, str, full_cmp) ) {
+		if( mobdb_searchname_sub(mob->id, str, true) ) {
 			if( count < size )
 				out[count] = mob->id;
-			count++;
+			if (++count >= size)
+				break;
+		}
+	}
+	// If there are still free places, check if search string is contained in a name but not equal
+	if (count < size) {
+		for (const auto& mob : mob_list) {
+			if (mob == nullptr)
+				continue;
+			if (mobdb_searchname_sub(mob->id, str, false) && !mobdb_searchname_sub(mob->id, str, true)) {
+				if (count < size)
+					out[count] = mob->id;
+				if (++count >= size)
+					break;
+			}
 		}
 	}
 
 	return count;
-}
-
-uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
-{
-	return mobdb_searchname_array_(str, out, size, false);
 }
 
 /*==========================================

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -317,7 +317,7 @@ std::shared_ptr<s_mob_db> mobdb_search_aegisname( const char* str ){
 }
 
 /*==========================================
- * Searches up to N matches. Prioritizing full matches first. Returns number of matches [Skotlex]
+ * Searches up to N matches. Prioritizing full matches first. Returns the number of matches
  *------------------------------------------*/
 uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
 {
@@ -329,10 +329,9 @@ uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
 		if (mob == nullptr)
 			continue;
 		if( mobdb_searchname_sub(mob->id, str, true) ) {
-			if( count < size )
-				out[count] = mob->id;
+			out[count] = mob->id;
 			if (++count >= size)
-				break;
+				return count;
 		}
 	}
 	// If there are still free places, check if search string is contained in a name but not equal
@@ -341,10 +340,9 @@ uint16 mobdb_searchname_array(const char *str, uint16 * out, uint16 size)
 			if (mob == nullptr)
 				continue;
 			if (mobdb_searchname_sub(mob->id, str, false) && !mobdb_searchname_sub(mob->id, str, true)) {
-				if (count < size)
-					out[count] = mob->id;
+				out[count] = mob->id;
 				if (++count >= size)
-					break;
+					return count;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Feature Improvement

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 
 
- When searching for a monster with the exact AegisName, it will now return this monster, even if it doesn't give Exp
- When searching for an array of monsters, it will now prioritize fully matching names first
- When summoning a monster using the exact AegisName, it will now summon exactly that monster instead of any with that name
- Small performance optimization when searching for a monster to summon
- Added helper function "strtoint32def" that converts a char pointer to an int32 and returns a default value on failure
  * This ensures that a parameter such as "1001Poring" does not result in monster 1001 (Scorpion) being summoned / returned
  * Using the solution via default value allows easy usage in a single line

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
