### PR TITLE
Updated Whip size fix

### DIFF
--- a/db/pre-re/size_fix.yml
+++ b/db/pre-re/size_fix.yml
@@ -36,3 +36,5 @@ Body:
   - Weapon: Knuckle
     Medium: 75
     Large: 50
+  - Weapon: Whip
+    Large: 50

--- a/db/re/size_fix.yml
+++ b/db/re/size_fix.yml
@@ -35,3 +35,5 @@ Header:
 Body:
   - Weapon: Knuckle
     Large: 75
+  - Weapon: Whip
+    Large: 75

--- a/db/size_fix.yml
+++ b/db/size_fix.yml
@@ -66,7 +66,6 @@ Body:
     Large: 75
   - Weapon: Whip
     Small: 75
-    Large: 50
   - Weapon: Book
     Large: 50
   - Weapon: Katar


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

The December 18th maintenance changed the size penalty for whip weapons : the size penalty for large monsters is increased from 50% to 75%

Source : https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8003&curpage=1

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
