### PR TITLE
Updated accessible maps and coordinates

### DIFF
--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -34,7 +34,7 @@ std::vector<struct s_point_str> accessible_maps{
 	s_point_str{ MAP_GEFFEN, 120, 100 },
 	s_point_str{ MAP_MORROC, 160, 94 },
 	s_point_str{ MAP_ALBERTA, 116, 57 },
-	s_point_str{ MAP_PAYON, 87, 117 },
+	s_point_str{ MAP_PAYON, 120, 60 },
 	s_point_str{ MAP_IZLUDE, 94, 103 }
 };
 

--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -39,7 +39,9 @@ std::vector<struct s_point_str> accessible_maps{
 	s_point_str{ MAP_VEINS, 204, 103 },
 	s_point_str{ MAP_AYOTHAYA, 218, 187 },
 	s_point_str{ MAP_LIGHTHALZEN, 159, 95 },
+#ifdef RENEWAL
 	s_point_str{ MAP_MORA, 57, 143 }
+#endif
 };
 
 #if PACKETVER_SUPPORTS_PINCODE

--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -30,12 +30,16 @@
 using namespace rathena;
 
 std::vector<struct s_point_str> accessible_maps{
-	s_point_str{ MAP_PRONTERA, 273, 354 },
-	s_point_str{ MAP_GEFFEN, 120, 100 },
-	s_point_str{ MAP_MORROC, 160, 94 },
-	s_point_str{ MAP_ALBERTA, 116, 57 },
-	s_point_str{ MAP_PAYON, 120, 60 },
-	s_point_str{ MAP_IZLUDE, 94, 103 }
+	s_point_str{ MAP_PRONTERA, 116, 73 },
+	s_point_str{ MAP_PAYON, 162, 58 },
+	s_point_str{ MAP_GEFFEN, 121, 37 },
+	s_point_str{ MAP_ALDEBARAN, 167, 112 },
+	s_point_str{ MAP_MORROC, 157, 45 },
+	s_point_str{ MAP_COMODO, 179, 152 },
+	s_point_str{ MAP_VEINS, 204, 103 },
+	s_point_str{ MAP_AYOTHAYA, 218, 187 },
+	s_point_str{ MAP_LIGHTHALZEN, 159, 95 },
+	s_point_str{ MAP_MORA, 57, 143 }
 };
 
 #if PACKETVER_SUPPORTS_PINCODE


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

payon default coordinates (87,117) are invalid (not walkable). As a result, for example, the player could be warped and stuck on an invalid cell.
The coordinates now are on valid cell (walkable).
![Capture d’écran (2073)](https://github.com/user-attachments/assets/89cd0fbf-e00f-49d8-8906-08a01846ae85)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
