### PR TITLE
Monster Damage Log Improvements

### DIFF
--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -58,7 +58,9 @@ void map_msg_reload(void);
 
 #define MAX_NPC_PER_MAP 512
 #define AREA_SIZE battle_config.area_size
-#define DAMAGELOG_SIZE 20
+#ifndef DAMAGELOG_SIZE 
+	#define DAMAGELOG_SIZE 20
+#endif
 #define LOOTITEM_SIZE 10
 #define MAX_MOBSKILL 50		//Max 128, see mob skill_idx type if need this higher
 #define MAX_MOB_LIST_PER_MAP 128

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -58,7 +58,7 @@ void map_msg_reload(void);
 
 #define MAX_NPC_PER_MAP 512
 #define AREA_SIZE battle_config.area_size
-#define DAMAGELOG_SIZE 30
+#define DAMAGELOG_SIZE 20
 #define LOOTITEM_SIZE 10
 #define MAX_MOBSKILL 50		//Max 128, see mob skill_idx type if need this higher
 #define MAX_MOB_LIST_PER_MAP 128

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2400,7 +2400,7 @@ TIMER_FUNC(mob_respawn){
 	return 1;
 }
 
-void mob_log_damage(struct mob_data *md, struct block_list *src, int32 damage, int32 attdamage)
+void mob_log_damage(mob_data* md, block_list* src, int32 damage, int32 attdamage)
 {
 	uint32 char_id = 0;
 	int32 flag = MDLF_NORMAL;
@@ -2490,7 +2490,7 @@ void mob_log_damage(struct mob_data *md, struct block_list *src, int32 damage, i
 
 	if( char_id )
 	{ //Log damage...
-		int32 i;
+		size_t i;
 		for (i = 0; i < DAMAGELOG_SIZE; i++) {
 			// Character is already in damage log
 			if(md->dmglog[i].id==char_id &&

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -350,7 +350,7 @@ struct mob_data {
 	struct s_dmglog {
 		int32 id; //char id
 		uint32 dmg;
-		uint32 attdmg;
+		uint32 dmg_tanked; //Damage tanked from normal attacks of the monster, MVP is the player with highest dmg+dmg_tanked
 		uint32 flag : 2; //0: Normal. 1: Homunc exp. 2: Pet exp. 3: Self.
 	} dmglog[DAMAGELOG_SIZE];
 	uint32 spotted_log[DAMAGELOG_SIZE];
@@ -516,7 +516,7 @@ int32 mob_spawn(struct mob_data *md);
 TIMER_FUNC(mob_delayspawn);
 int32 mob_setdelayspawn(struct mob_data *md);
 int32 mob_parse_dataset(struct spawn_data *data);
-void mob_log_damage(mob_data* md, block_list* src, int32 damage, int32 attdamage = 0);
+void mob_log_damage(mob_data* md, block_list* src, int32 damage, int32 damage_tanked = 0);
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage);
 int32 mob_dead(struct mob_data *md, struct block_list *src, int32 type);
 void mob_revive(struct mob_data *md, uint32 hp);

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -350,6 +350,7 @@ struct mob_data {
 	struct s_dmglog {
 		int32 id; //char id
 		uint32 dmg;
+		uint32 attdmg;
 		uint32 flag : 2; //0: Normal. 1: Homunc exp. 2: Pet exp
 	} dmglog[DAMAGELOG_SIZE];
 	uint32 spotted_log[DAMAGELOG_SIZE];
@@ -515,7 +516,7 @@ int32 mob_spawn(struct mob_data *md);
 TIMER_FUNC(mob_delayspawn);
 int32 mob_setdelayspawn(struct mob_data *md);
 int32 mob_parse_dataset(struct spawn_data *data);
-void mob_log_damage(struct mob_data *md, struct block_list *src, int32 damage);
+void mob_log_damage(struct mob_data *md, struct block_list *src, int32 damage, int32 attdamage = 0);
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage);
 int32 mob_dead(struct mob_data *md, struct block_list *src, int32 type);
 void mob_revive(struct mob_data *md, uint32 hp);

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -351,7 +351,7 @@ struct mob_data {
 		int32 id; //char id
 		uint32 dmg;
 		uint32 attdmg;
-		uint32 flag : 2; //0: Normal. 1: Homunc exp. 2: Pet exp
+		uint32 flag : 2; //0: Normal. 1: Homunc exp. 2: Pet exp. 3: Self.
 	} dmglog[DAMAGELOG_SIZE];
 	uint32 spotted_log[DAMAGELOG_SIZE];
 	struct spawn_data *spawn; //Spawn data.
@@ -516,7 +516,7 @@ int32 mob_spawn(struct mob_data *md);
 TIMER_FUNC(mob_delayspawn);
 int32 mob_setdelayspawn(struct mob_data *md);
 int32 mob_parse_dataset(struct spawn_data *data);
-void mob_log_damage(struct mob_data *md, struct block_list *src, int32 damage, int32 attdamage = 0);
+void mob_log_damage(mob_data* md, block_list* src, int32 damage, int32 attdamage = 0);
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage);
 int32 mob_dead(struct mob_data *md, struct block_list *src, int32 type);
 void mob_revive(struct mob_data *md, uint32 hp);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -14497,7 +14497,7 @@ static void pc_clear_log_damage_sub(uint32 char_id, struct mob_data *md)
 	if (i < DAMAGELOG_SIZE) {
 		md->dmglog[i].id = 0;
 		md->dmglog[i].dmg = 0;
-		md->dmglog[i].attdmg = 0;
+		md->dmglog[i].dmg_tanked = 0;
 		md->dmglog[i].flag = 0;
 	}
 }

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -14497,6 +14497,7 @@ static void pc_clear_log_damage_sub(uint32 char_id, struct mob_data *md)
 	if (i < DAMAGELOG_SIZE) {
 		md->dmglog[i].id = 0;
 		md->dmglog[i].dmg = 0;
+		md->dmglog[i].attdmg = 0;
 		md->dmglog[i].flag = 0;
 	}
 }

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1585,7 +1585,8 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	dhp = cap_value(dhp, INT_MIN, INT_MAX);
 	switch (target->type) {
 	case BL_PC:
-		pc_damage(reinterpret_cast<map_session_data*>(target), src, hp, sp, ap); break;
+		pc_damage(reinterpret_cast<map_session_data*>(target), src, hp, sp, ap);
+		break;
 	case BL_MOB:
 		mob_damage(reinterpret_cast<mob_data*>(target), src, (int32)dhp);
 		break;
@@ -1599,6 +1600,11 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 		elemental_heal(reinterpret_cast<s_elemental_data*>(target), hp, sp);
 		break;
 	}
+
+	// Normal attack damage is logged in the monster's dmglog as attack damage
+	// This counts as exp tap and is used for determining the MVP
+	if (src && src->type == BL_MOB && skill_id == 0)
+		mob_log_damage(reinterpret_cast<mob_data*>(src), target, 0, (int32)dhp);
 
 	if( src && target->type == BL_PC && ((TBL_PC*)target)->disguise ) { // Stop walking when attacked in disguise to prevent walk-delay bug
 		unit_stop_walking( target, 1 );

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1604,7 +1604,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	// Normal attack damage is logged in the monster's dmglog as attack damage
 	// This counts as exp tap and is used for determining the MVP
 	if (src && src->type == BL_MOB && skill_id == 0)
-		mob_log_damage(reinterpret_cast<mob_data*>(src), target, 0, (int32)dhp);
+		mob_log_damage(reinterpret_cast<mob_data*>(src), target, 0, static_cast<int32>(dhp));
 
 	if( src && target->type == BL_PC && ((TBL_PC*)target)->disguise ) { // Stop walking when attacked in disguise to prevent walk-delay bug
 		unit_stop_walking( target, 1 );

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1588,7 +1588,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 		pc_damage(reinterpret_cast<map_session_data*>(target), src, hp, sp, ap);
 		break;
 	case BL_MOB:
-		mob_damage(reinterpret_cast<mob_data*>(target), src, (int32)dhp);
+		mob_damage(reinterpret_cast<mob_data*>(target), src, static_cast<int32>(dhp));
 		break;
 	case BL_HOM:
 		hom_heal(reinterpret_cast<homun_data&>(*target), hp != 0, sp != 0);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8847 (this is just a preparation PR for the actual fix)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- If a monster does a normal attack we now log the damage it dealt (will later be used for MVP reward)
- Official DAMAGELOG_SIZE of 20
- When there are more than 20 entries in the damage log, the oldest entry will be removed (this also updates the "first player")
- Related to #8847

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
