### PR TITLE
Fixed pre-re items using bAtkRate bonus

### DIFF
--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -22792,7 +22792,7 @@ Body:
       Both_Accessory: true
     ArmorLevel: 1
     Script: |
-      bonus bAtkRate,5;
+      bonus2 bAddClass,Class_All,5;
       bonus bMatkRate,5;
   - Id: 2710
     AegisName: Bloody_Iron_Ball_C
@@ -23677,7 +23677,7 @@ Body:
       NoAuction: true
     Script: |
       bonus2 bAddClass,Class_All,5;
-      bonus bMatkrate,5;
+      bonus bMatkRate,5;
   - Id: 2753
     AegisName: Beholder_Ring
     Name: Beholder Ring
@@ -23883,8 +23883,8 @@ Body:
     ArmorLevel: 1
     EquipLevelMin: 95
     Script: |
-      bonus bAtkRate,5;
-      bonus bMatkrate,5;
+      bonus2 bAddClass,Class_All,5;
+      bonus bMatkRate,5;
       bonus bMaxHPrate,5;
       bonus2 bSkillHeal,"AL_HEAL",5;
       skill "MG_SIGHT",1;
@@ -40799,7 +40799,7 @@ Body:
     EquipLevelMin: 1
     View: 562
     Script: |
-      bonus bAtkRate,5;
+      bonus2 bAddClass,Class_All,5;
       bonus bMatkRate,5;
       bonus bMaxHPRate,10;
       bonus bMaxSPRate,10;
@@ -40939,18 +40939,12 @@ Body:
     Refineable: true
     View: 761
     Script: |
-      bonus bAtkRate,5;
-      if (getrefine() > 5 && getrefine() <= 12) {
+      bonus2 bAddClass,Class_All,5;
+      if (getrefine() > 5) {
          bonus2 bAddRace,RC_DemiHuman,(getrefine() - 5);
          bonus2 bSubRace,RC_DemiHuman,(getrefine() - 5);
          bonus2 bAddRace,RC_Player_Human,(getrefine() - 5);
          bonus2 bSubRace,RC_Player_Human,(getrefine() - 5);
-      }
-      if (getrefine() > 12) {
-         bonus2 bAddRace,RC_DemiHuman,7;
-         bonus2 bAddRace,RC_Player_Human,7;
-         bonus2 bSubRace,RC_DemiHuman,7;
-         bonus2 bSubRace,RC_Player_Human,7;
       }
   - Id: 18612
     AegisName: White_Musang_Hat


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Now all pre-re items consistently use bAddClass,Class_All instead of bAtkRate (which doesn't work in pre-re)
- Other minor corrections

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
