### PR TITLE
Corrected SU_CN_METEOR formula to match the skill description

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8393,8 +8393,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						skillratio += -100 + 200 + 100 * skill_lv;
 						if (status_get_lv(src) > 99) {
 							skillratio += sstatus->int_ * 5;
-							RE_LVL_DMOD(100);
 						}
+						RE_LVL_DMOD(100);
 						break;
 					case NPC_VENOMFOG:
 						skillratio += 600 + 100 * skill_lv;


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Corrected SU_CN_METEOR formula to match the skill description : "If the caster's base level is 100 or higher, damage is additionally increased according to the caster's base level and INT."
Tests on official server confirm that INT ratio is 5.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
