### PR TITLE
Rebalance Spirit handler 2024.02.05

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -6341,12 +6341,12 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			RE_LVL_DMOD(100);
 			break;
 		case SH_CHUL_HO_SONIC_CLAW:
-			skillratio += -100 + 850 + 1650 * skill_lv;
+			skillratio += -100 + 1100 + 2200 * skill_lv;
 			skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 			skillratio += 5 * sstatus->pow;
 
 			if( pc_checkskill( sd, SH_COMMUNE_WITH_CHUL_HO ) > 0 || ( sc != nullptr && sc->getSCE( SC_TEMPORARY_COMMUNION ) != nullptr ) ){
-				skillratio += 100 + 400 * skill_lv;
+				skillratio += 400 * skill_lv;
 				skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 			}
 			RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8943,12 +8943,12 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SH_HYUN_ROK_CANNON:
-						skillratio += -100 + 1050 + 1550 * skill_lv;
+						skillratio += -100 + 1100 + 2050 * skill_lv;
 						skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 						skillratio += 5 * sstatus->spl;
 
 						if( pc_checkskill( sd, SH_COMMUNE_WITH_HYUN_ROK ) > 0 || ( sc != nullptr && sc->getSCE( SC_TEMPORARY_COMMUNION ) != nullptr ) ){
-							skillratio += 300 * skill_lv;
+							skillratio += 400 * skill_lv;
 							skillratio += 25 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 						}
 						RE_LVL_DMOD(100);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/8130

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Spirit handler
-----------------------------------------------

1. [Chulho Sonic Claw](https://www.divine-pride.net/database/skill/5435)
	- Increases base damage from **12400+(Mystical Creature level x 50)%/15200+(Mystical Creature level x 100)%(Commune With Chulho)Atk** to **16500+(Mystical Creature level x 50)%/19300+(Mystical Creature level x 100)%(Commune With Chulho)Atk** based on level 7. 

2. [Hyunrok Cannon](https://www.divine-pride.net/database/skill/5446)
	- Increases base damage from **11900+(Mystical Creature level x 50)%/14000+(Mystical Creature level x 75)%(Commune With Hyunrok)Matk** to **15450+(Mystical Creature level x 50)%/18250+(Mystical Creature level x 75)%(Commune With Hyunrok)Matk** based on level 7. 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
