### PR TITLE
Status Recovery Fixes (Priest Skill) / No Recover

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -5974,6 +5974,8 @@ Body:
       MaxSp: true
   - Status: Norecover_State
     Icon: EFST_HANDICAPSTATE_NORECOVER
+    CalcFlags:
+      Regen: true
   - Status: Suhide
     Icon: EFST_SUHIDE
     DurationLookup: SU_HIDE

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -6499,8 +6499,8 @@ Body:
       MaxSp: true
   - Status: Norecover_State
     Icon: EFST_HANDICAPSTATE_NORECOVER
-    Fail:
-      Norecover_State: true
+    CalcFlags:
+      Regen: true
   - Status: Suhide
     Icon: EFST_SUHIDE
     DurationLookup: SU_HIDE

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9266,21 +9266,30 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 			clif_skill_nodamage(src,*bl,skill_id,skill_lv,false);
 			break;
 		}
-		if (tsc) {
-			status_change_end(bl, SC_FREEZE);
-			status_change_end(bl, SC_STONEWAIT);
-			status_change_end(bl, SC_STONE);
-			status_change_end(bl, SC_SLEEP);
-			status_change_end(bl, SC_STUN);
-			status_change_end(bl, SC_WHITEIMPRISON);
-			status_change_end(bl, SC_STASIS);
-			status_change_end(bl, SC_NETHERWORLD);
+		if (battle_check_undead(tstatus->race, tstatus->def_ele))
+			skill_addtimerskill(src, tick + 1000, bl->id, 0, 0, skill_id, skill_lv, 100, flag);
+		else {
+			// Bodystate is reset to "normal" for non-undead
+			if (tsc) {
+				// The following are bodystate status changes
+				status_change_end(bl, SC_STONE);
+				status_change_end(bl, SC_FREEZE);
+				status_change_end(bl, SC_STUN);
+				status_change_end(bl, SC_SLEEP);
+				status_change_end(bl, SC_STONEWAIT);
+				status_change_end(bl, SC_BURNING);
+				status_change_end(bl, SC_WHITEIMPRISON);
+			}
+			// Resetting bodystate to normal always also resets the monster AI to idle
+			if (dstmd)
+				mob_unlocktarget(dstmd, tick);
 		}
-		if(battle_check_undead(tstatus->race,tstatus->def_ele))
-			skill_addtimerskill(src, tick+1000, bl->id, 0, 0, skill_id, skill_lv, 100, flag);
+		if (tsc) {
+			// Ends SC_NETHERWORLD and SC_NORECOVER_STATE (even on undead)
+			status_change_end(bl, SC_NETHERWORLD);
+			status_change_end(bl, SC_NORECOVER_STATE);
+		}
 		clif_skill_nodamage(src,*bl,skill_id,skill_lv);
-		if(dstmd)
-			mob_unlocktarget(dstmd,tick);
 		break;
 
 	// Mercenary Supportive Skills

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5279,7 +5279,8 @@ void status_calc_regen_rate(struct block_list *bl, struct regen_data *regen, sta
 		|| sc->getSCE(SC_BLEEDING)
 		|| (sc->getSCE(SC_MAGICMUSHROOM) && sc->getSCE(SC_MAGICMUSHROOM)->val3 == 1)
 		|| sc->getSCE(SC_SATURDAYNIGHTFEVER)
-		|| sc->getSCE(SC_REBOUND))
+		|| sc->getSCE(SC_REBOUND)
+		|| sc->getSCE(SC_NORECOVER_STATE))
 		regen->flag = RGN_NONE;
 
 	// No natural SP regen


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8922

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Status Recovery now cures Stone, Freeze, Stun, Sleep and White Imprison only on non-undead
- Status Recovery now additional cures Burning on non-undead
- Status Recovery no longer resets the monster AI on undead
- Status Recovery now cures No Recover (from Bellum Flail) on both non-undead and undead
- No Recover now can have its duration refreshed (when hit again)
- No Recover now also prevents natural regen
- Fixes #8922

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
