### PR TITLE
Monster Ranges, Looters and Blind

### DIFF
--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -64,12 +64,12 @@ monster_ai: 0
 // 0: Every 100ms (MIN_MOBTHINKTIME)
 // 1: Every cell moved
 // x: Every x cells moved or at end of the chase path
-// 30 (max): Only at end of the chase path (official)
+// 32 (max): Only at end of the chase path (official)
 // Regardless of this setting, a monster will always check for targets in attack
 // range. Decrease this value if you want to make monsters to be more reactive while
 // chasing. This also defines the maximum amount of cells monsters will move after
 // they lost their target (hide, no line of sight, etc.).
-monster_chase_refresh: 30
+monster_chase_refresh: 32
 
 // Should mobs be able to be warped (add as needed)?
 // 0: Disable.
@@ -97,6 +97,9 @@ chase_range_rate: 100
 // only have a range of 9. If you put a number higher than 0, their range will
 // be increased by that number.
 monster_eye_range_bonus: 0
+
+// Range in which looters search for loot (eAthena - 10, official - 12, max - 32)
+loot_range: 12
 
 // Allow monsters to be aggresive and attack first? (Note 1)
 monster_active_enable: yes

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -19,9 +19,9 @@ monster_hp_rate: 100
 monster_max_aspd: 199
 
 // Defines various mob AI related settings. (Note 3)
-// 0x0001: When enabled mobs will update their target cell every few iterations
-//         (normally they never update their target cell until they reach it while
-//         chasing)
+// 0x0001: When enabled, mobs will update their target cell every x cells moved.
+//         (normally they never update their target cell until they are one cell
+//         before the end of their walkpath. x = monster_chase_refresh, see below)
 // 0x0002: Makes mob use their "rude attack" skill (usually warping away) if they
 //         are attacked and they can't attack back regardless of how they were
 //         attacked (eg: GrimTooth), otherwise, their "rude attack" is only activated
@@ -63,12 +63,13 @@ monster_ai: 0
 // How often should a monster rethink its chase?
 // 0: Every 100ms (MIN_MOBTHINKTIME)
 // 1: Every cell moved
-// x: Every x cells moved or at end of the chase path
-// 32 (max): Only at end of the chase path (official)
-// Regardless of this setting, a monster will always check for targets in attack
-// range. Decrease this value if you want to make monsters to be more reactive while
-// chasing. This also defines the maximum amount of cells monsters will move after
-// they lost their target (hide, no line of sight, etc.).
+// x: Every x cells moved or one cell before the end of the chase path
+// 32 (max): One cell before the end of the chase path (official)
+// Regardless of this setting, a monster will always check for targets in attack range.
+// Decrease this value if you want to make monsters be more reactive while chasing.
+// If you want monsters to update their target cell while chasing you also need to enable
+// monster_ai 0x0001, see above. Otherwise this only defines the maximum amount of cells
+// monsters will move after they lost their target (hide, no line of sight, etc.).
 monster_chase_refresh: 32
 
 // Should mobs be able to be warped (add as needed)?

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11681,7 +11681,7 @@ static const struct _battle_data {
 	{ "arrow_shower_knockback",             &battle_config.arrow_shower_knockback,          1,      0,      1,              },
 	{ "devotion_rdamage_skill_only",        &battle_config.devotion_rdamage_skill_only,     1,      0,      1,              },
 	{ "max_extended_aspd",                  &battle_config.max_extended_aspd,               193,    100,    199,            },
-	{ "monster_chase_refresh",              &battle_config.mob_chase_refresh,               30,     0,      MAX_MINCHASE,   },
+	{ "monster_chase_refresh",              &battle_config.mob_chase_refresh,               32,     0,      MAX_WALKPATH,   },
 	{ "mob_icewall_walk_block",             &battle_config.mob_icewall_walk_block,          75,     0,      255,            },
 	{ "boss_icewall_walk_block",            &battle_config.boss_icewall_walk_block,         0,      0,      255,            },
 	{ "snap_dodge",                         &battle_config.snap_dodge,                      0,      0,      1,              },
@@ -11831,6 +11831,7 @@ static const struct _battle_data {
 	{ "hom_delay_reset_vaporize",           &battle_config.hom_delay_reset_vaporize,        1,      0,      1,              },
 	{ "hom_delay_reset_warp",               &battle_config.hom_delay_reset_warp,            1,      0,      1,              },
 #endif
+	{ "loot_range",                         &battle_config.loot_range,                      12,     1,      MAX_WALKPATH,   },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -764,6 +764,7 @@ struct Battle_Config
 	int32 item_stacking;
 	int32 hom_delay_reset_vaporize;
 	int32 hom_delay_reset_warp;
+	int32 loot_range;
 
 #include <custom/battle_config_struct.inc>
 };

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1719,8 +1719,8 @@ int32 mob_warpchase(struct mob_data *md, struct block_list *target)
 static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 {
 	struct block_list *tbl = nullptr, *abl = nullptr;
-	int32 mode;
-	int32 view_range, can_move;
+	bool can_move;
+	int32 view_range, mode;
 
 	if(md->bl.prev == nullptr || md->status.hp == 0)
 		return false;

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -29,8 +29,6 @@ struct guardian_data;
 #define MAX_MOB_DROP_TOTAL (MAX_MOB_DROP+MAX_MOB_DROP_ADD)
 #define MAX_MVP_DROP_TOTAL (MAX_MVP_DROP+MAX_MVP_DROP_ADD)
 
-#define MAX_MINCHASE 30	//Max minimum chase value to use for mobs.
-
 //Min time between AI executions
 const t_tick MIN_MOBTHINKTIME = 100;
 //Min time before mobs do a check to call nearby friends for help (or for slaves to support their master)
@@ -368,7 +366,6 @@ struct mob_data {
 	t_tick next_walktime,last_thinktime,last_linktime,last_pcneartime,dmgtick,last_canmove,last_skillcheck;
 	short move_fail_count;
 	short lootitem_count;
-	short min_chase;
 	unsigned char walktoxy_fail_count; //Pathfinding succeeds but the actual walking failed (e.g. Icewall lock)
 
 	int32 deletetimer;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1699,8 +1699,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 		unit_remove_map(target,CLR_DEAD);
 	else { // Some death states that would normally be handled by unit_remove_map
 		unit_stop_attack(target);
-		unit_stop_walking(target,1);
-		unit_stop_chase(*target);
+		unit_stop_walking(target,USW_FIXPOS|USW_RELEASE_TARGET);
 		unit_skillcastcancel(target,0);
 		clif_clearunit_area( *target, CLR_DEAD );
 		skill_unit_move(target,gettick(),4);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2243,7 +2243,7 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
  * @return src can see (1) or target is invisible (0)
  * @author [Skotlex]
  */
-int32 status_check_visibility(struct block_list *src, struct block_list *target, bool checkblind)
+int32 status_check_visibility(block_list* src, block_list* target, bool checkblind)
 {
 	int32 view_range;
 	status_change* tsc = status_get_sc(target);
@@ -2260,7 +2260,7 @@ int32 status_check_visibility(struct block_list *src, struct block_list *target,
 
 	if (checkblind) {
 		status_change* sc = status_get_sc(src);
-		if (sc && sc->getSCE(SC_BLIND))
+		if (sc != nullptr && sc->getSCE(SC_BLIND) != nullptr)
 			view_range = 1;
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2240,10 +2240,10 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
  * @param src:	Object using skill on target [PC|MOB|PET|HOM|MER|ELEM]
  * @param target: Object being targeted by src [PC|MOB|HOM|MER|ELEM]
  * @param checkblind: Whether blind condition should be considered (sets view range to 1)
- * @return src can see (1) or target is invisible (0)
+ * @return src can see (true) or target is invisible (false)
  * @author [Skotlex]
  */
-int32 status_check_visibility(block_list* src, block_list* target, bool checkblind)
+bool status_check_visibility(block_list* src, block_list* target, bool checkblind)
 {
 	int32 view_range;
 	status_change* tsc = status_get_sc(target);
@@ -2265,10 +2265,10 @@ int32 status_check_visibility(block_list* src, block_list* target, bool checkbli
 	}
 
 	if (src->m != target->m || !check_distance_bl(src, target, view_range))
-		return 0;
+		return false;
 
 	if ( src->type == BL_NPC) // NPCs don't care for the rest
-		return 1;
+		return true;
 
 	if (tsc) {
 		bool is_boss = (status_get_class_(src) == CLASS_BOSS);
@@ -2279,24 +2279,24 @@ int32 status_check_visibility(block_list* src, block_list* target, bool checkbli
 					map_session_data *tsd = (TBL_PC*)target;
 
 					if (((tsc->option&(OPTION_HIDE|OPTION_CLOAK|OPTION_CHASEWALK)) || tsc->getSCE(SC_CAMOUFLAGE) || tsc->getSCE(SC_STEALTHFIELD) || tsc->getSCE(SC_SUHIDE)) && !is_boss && (tsd->special_state.perfect_hiding || !is_detector))
-						return 0;
+						return false;
 					if ((tsc->getSCE(SC_CLOAKINGEXCEED) || tsc->getSCE(SC_NEWMOON)) && !is_boss && ((tsd && tsd->special_state.perfect_hiding) || is_detector))
-						return 0;
+						return false;
 					if (tsc->getSCE(SC__FEINTBOMB) && !is_boss && !is_detector)
-						return 0;
+						return false;
 				}
 				break;
 			case BL_ELEM:
 				if (tsc->getSCE(SC_ELEMENTAL_VEIL) && !is_boss && !is_detector)
-					return 0;
+					return false;
 				break;
 			default:
 				if (((tsc->option&(OPTION_HIDE|OPTION_CLOAK|OPTION_CHASEWALK)) || tsc->getSCE(SC_CAMOUFLAGE) || tsc->getSCE(SC_STEALTHFIELD) || tsc->getSCE(SC_SUHIDE)) && !is_boss && !is_detector)
-					return 0;
+					return false;
 		}
 	}
 
-	return 1;
+	return true;
 }
 
 /**

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1700,6 +1700,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	else { // Some death states that would normally be handled by unit_remove_map
 		unit_stop_attack(target);
 		unit_stop_walking(target,1);
+		unit_stop_chase(*target);
 		unit_skillcastcancel(target,0);
 		clif_clearunit_area( *target, CLR_DEAD );
 		skill_unit_move(target,gettick(),4);
@@ -2248,7 +2249,10 @@ int32 status_check_visibility(struct block_list *src, struct block_list *target)
 	status_change* tsc = status_get_sc(target);
 	switch (src->type) {
 		case BL_MOB:
-			view_range = ((TBL_MOB*)src)->min_chase;
+			if (((TBL_MOB*)src)->sc.getSCE(SC_BLIND))
+				view_range = 1;
+			else
+				view_range = ((TBL_MOB*)src)->db->range3;
 			break;
 		case BL_PET:
 			view_range = ((TBL_PET*)src)->db->range2;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2240,25 +2240,29 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
  * Checks whether the src can see the target
  * @param src:	Object using skill on target [PC|MOB|PET|HOM|MER|ELEM]
  * @param target: Object being targeted by src [PC|MOB|HOM|MER|ELEM]
+ * @param checkblind: Whether blind condition should be considered (sets view range to 1)
  * @return src can see (1) or target is invisible (0)
  * @author [Skotlex]
  */
-int32 status_check_visibility(struct block_list *src, struct block_list *target)
+int32 status_check_visibility(struct block_list *src, struct block_list *target, bool checkblind)
 {
 	int32 view_range;
 	status_change* tsc = status_get_sc(target);
 	switch (src->type) {
 		case BL_MOB:
-			if (((TBL_MOB*)src)->sc.getSCE(SC_BLIND))
-				view_range = 1;
-			else
-				view_range = ((TBL_MOB*)src)->db->range3;
+			view_range = ((TBL_MOB*)src)->db->range3;
 			break;
 		case BL_PET:
 			view_range = ((TBL_PET*)src)->db->range2;
 			break;
 		default:
 			view_range = AREA_SIZE;
+	}
+
+	if (checkblind) {
+		status_change* sc = status_get_sc(src);
+		if (sc && sc->getSCE(SC_BLIND))
+			view_range = 1;
 	}
 
 	if (src->m != target->m || !check_distance_bl(src, target, view_range))

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3622,7 +3622,7 @@ void status_calc_state(struct block_list *bl, status_change *sc, std::bitset<SCS
 void status_calc_slave_mode(mob_data& md);
 
 bool status_check_skilluse(struct block_list *src, struct block_list *target, uint16 skill_id, int32 flag);
-int32 status_check_visibility(block_list* src, block_list* target, bool checkblind);
+bool status_check_visibility(block_list* src, block_list* target, bool checkblind);
 
 int32 status_change_spread(block_list *src, block_list *bl);
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3622,7 +3622,7 @@ void status_calc_state(struct block_list *bl, status_change *sc, std::bitset<SCS
 void status_calc_slave_mode(mob_data& md);
 
 bool status_check_skilluse(struct block_list *src, struct block_list *target, uint16 skill_id, int32 flag);
-int32 status_check_visibility(struct block_list *src, struct block_list *target, bool checkblind);
+int32 status_check_visibility(block_list* src, block_list* target, bool checkblind);
 
 int32 status_change_spread(block_list *src, block_list *bl);
 

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3622,7 +3622,7 @@ void status_calc_state(struct block_list *bl, status_change *sc, std::bitset<SCS
 void status_calc_slave_mode(mob_data& md);
 
 bool status_check_skilluse(struct block_list *src, struct block_list *target, uint16 skill_id, int32 flag);
-int32 status_check_visibility(struct block_list *src, struct block_list *target);
+int32 status_check_visibility(struct block_list *src, struct block_list *target, bool checkblind);
 
 int32 status_change_spread(block_list *src, block_list *bl);
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -161,9 +161,9 @@ bool unit_walktoxy_nextcell(block_list& bl, bool sendMove, t_tick tick) {
 		speed = status_get_speed(&bl);
 
 	// Monsters check if their target is in range each cell
-	if (bl.type == BL_MOB && ud->target_to) {
-		short tx = ud->to_x;
-		short ty = ud->to_y;
+	if (bl.type == BL_MOB && ud->target_to != 0) {
+		int16 tx = ud->to_x;
+		int16 ty = ud->to_y;
 		// Monsters update their chase path one cell before reaching their final destination
 		if (unit_update_chase(bl, tick, (ud->walkpath.path_pos == ud->walkpath.path_len - 1)))
 			return true;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -36,7 +36,6 @@ struct unit_data {
 	int32 target_to;
 	int32 attacktimer;
 	int32 walktimer;
-	int32 walkdelaytimer;
 	int32 chaserange;
 	bool stepaction; //Action should be executed on step [Playtester]
 	int32 steptimer; //Timer that triggers the action [Playtester]
@@ -102,7 +101,8 @@ enum e_unit_stop_walking {
 	USW_MOVE_ONCE = 0x2, /// Force the unit to move one cell if it hasn't yet
 	USW_MOVE_FULL_CELL = 0x4, /// Enable moving to the next cell when unit was already half-way there (may cause on-touch/place side-effects, such as a scripted map change)
 	USW_FORCE_STOP = 0x8, /// Force stop moving, even if walktimer is currently INVALID_TIMER
-	USW_ALL = 0xf,
+	USW_RELEASE_TARGET = 0x10, /// Release chase target
+	USW_ALL = 0x1f,
 };
 
 // PC, MOB, PET
@@ -119,7 +119,6 @@ TIMER_FUNC(unit_delay_walktobl_timer);
 void unit_stop_walking_soon(struct block_list& bl);
 // Causes the target object to stop moving.
 int32 unit_stop_walking(struct block_list *bl,int32 type);
-void unit_stop_chase(block_list& bl);
 bool unit_can_move(struct block_list *bl);
 int32 unit_is_walking(struct block_list *bl);
 int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type);

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -36,6 +36,7 @@ struct unit_data {
 	int32 target_to;
 	int32 attacktimer;
 	int32 walktimer;
+	int32 walkdelaytimer;
 	int32 chaserange;
 	bool stepaction; //Action should be executed on step [Playtester]
 	int32 steptimer; //Timer that triggers the action [Playtester]
@@ -118,6 +119,7 @@ TIMER_FUNC(unit_delay_walktobl_timer);
 void unit_stop_walking_soon(struct block_list& bl);
 // Causes the target object to stop moving.
 int32 unit_stop_walking(struct block_list *bl,int32 type);
+void unit_stop_chase(block_list& bl);
 bool unit_can_move(struct block_list *bl);
 int32 unit_is_walking(struct block_list *bl);
 int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8914

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Looters now have a loot range of 12 (configurable) that is no longer reduced by Blind
- Chase range is no longer increased when hitting a monster from outside its chase range 
  * Removed the "min_chase" custom solution
- Blind now reduces both aggro range and chase range to 1
- Chase range at the beginning of a chase is now only checked in Angry state (blind doesn't matter)
- Chase range (including blind) is now checked whenever the attack timer ends
  * The attack timer can no longer be stopped by pre-planning a chase
  * This will make monsters stop attacking when outside chase range at the end of the timer
- Monsters will now think about updating their chase already one cell before they reach the end of their path
  * This is not only official but also makes their movement and behavior smoother
  * If at this time no enemy is in chase range, the monster will drop its target but still finish moving
- A monster's chase path will now always go all the way next to the target, even if the monster has ranged attacks
  * Monsters will now check for each cell moved if target is in attack range and then immediately attack
  * If they still have attack delay they will stop and attack when ready (if in chase range at this point)
- Fixed a timer to delay movement during hit lock
  * Previously the timer didn't work at all and the whole mob AI had to be processed again
  * Now the monster will start moving immediately once the hit lock is gone
- Fixed an endless loop that occurred when we call mob_randomwalk while the mob still has a target
  * This happens because we pre-plan chases with timers but the state remains Idle until the chase starts
- Monsters now become active once a player is within 18 cells (AREA_SIZE+4)
- Slaves now teleport back to their master if they are more than 15 cells away (AREA_SIZE+1) 
  * This only applies to AI_ABR and AI_BIONIC unless "slave_stick_with_master" is enabled
- Improved code structure in unit.cpp: Bundling repeating code segments into new functions
- Fixes #8914

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
