### PR TITLE
Fixed NW_GRENADES_DROPPING and NW_MISSION_BOMBARD

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -16611,6 +16611,8 @@ int32 skill_unit_onplace_timer(struct skill_unit *unit, struct block_list *bl, t
 		case UNT_SWIFTTRAP:
 		case UNT_FLAMETRAP:
 		case UNT_STAR_BURST:
+		case UNT_GRENADES_DROPPING:
+		case UNT_MISSION_BOMBARD:
 			skill_attack(skill_get_type(sg->skill_id),ss,&unit->bl,bl,sg->skill_id,sg->skill_lv,tick,0);
 			break;
 #ifdef RENEWAL


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Renewal

* **Description of Pull Request**: 
Added missing cases in skill unit attack switch.
