### PR TITLE
Prevent circle definitions in atcommands.yml

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -163,6 +163,13 @@ uint64 AtcommandAliasDatabase::parseBodyNode( const ryml::NodeRef& node ){
 			std::string alias;
 			subNode >> alias;
 
+			AtCommandInfo* parent_cmd = get_atcommandinfo_byname( alias.c_str() );
+
+			if( parent_cmd != nullptr ){
+				this->invalidWarning( subNode, "\"%s\" cannot be used as alias for \"%s\", since a command with this name exists.\n", alias.c_str(), command.c_str() );
+				return 0;
+			}
+
 			info->aliases.insert( alias );
 			this->aliases[alias] = command;
 		}


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
The map-server will now produce an error, if you try to define a circle definition and not silently override internal command definitions.
This may have happened to a certain developer, while testing ban/unban and this is how he noticed.
