### PR TITLE
Fix duplicate msg key in spanish translation

### DIFF
--- a/conf/msg_conf/map_msg_spn.conf
+++ b/conf/msg_conf/map_msg_spn.conf
@@ -1561,7 +1561,7 @@
 1343: casco,
 1344: boca/casco,
 1345: boca,
-1345: ojos/orejas,
+1346: ojos/orejas,
 1347: boca/ojos/orejas/casco,
 1348:  -> (huevo de mascota, ID de la mascota: %u, nombre cambiado)
 1349:  -> (huevo de mascota, ID de la mascota: %u, sin nombre cambiado)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8223

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Incorrect msg key in spanish translation file

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
