### PR TITLE
Lullaby, Throw Stone, Sprinkle Sand, Frost Nova Fixes

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -8167,10 +8167,11 @@ Body:
     Unit:
       Id: Lullaby
       Layout: 4
-      Interval: 4000
+      Interval: 6000
       Target: Enemy
       Flag:
         Ensemble: true
+    Status: Sleep
   - Id: 307
     Name: BD_RICHMANKIM
     Description: Mental Sensing

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -8516,7 +8516,6 @@ Body:
     SplashArea: 4
     CastTime: 1000
     Duration1: 60000
-    Duration2: 18000
     Cooldown: 20000
     Requires:
       SpCost: 40
@@ -8524,6 +8523,7 @@ Body:
         Musical: true
         Whip: true
     CastCancel: false
+    Status: Sleep
   - Id: 307
     Name: BD_RICHMANKIM
     Description: Mental Sensing

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1606,7 +1606,7 @@ int32 skill_additional_effect( struct block_list* src, struct block_list *bl, ui
 
 	case BD_LULLABY:
 #ifndef RENEWAL
-		if (sc && sc->getSCE(SC_DANCING)) {
+		if (sc != nullptr && sc->getSCE(SC_DANCING) != nullptr) {
 			block_list* partner = map_id2bl(sc->getSCE(SC_DANCING)->val4);
 			if (partner == nullptr)
 				break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1446,7 +1446,7 @@ int32 skill_additional_effect( struct block_list* src, struct block_list *bl, ui
 		break;
 
 	case WZ_FROSTNOVA:
-		sc_start(src,bl,SC_FREEZE,skill_lv*5+33,skill_lv,skill_get_time2(skill_id,skill_lv));
+		sc_start(src,bl,SC_FREEZE,(sd!=nullptr)?skill_lv*5+33:skill_lv*3+35,skill_lv,skill_get_time2(skill_id,skill_lv));
 		break;
 
 	case WZ_STORMGUST:
@@ -1514,12 +1514,19 @@ int32 skill_additional_effect( struct block_list* src, struct block_list *bl, ui
 		break;
 
 	case TF_SPRINKLESAND:
-		sc_start(src,bl,SC_BLIND,20,skill_lv,skill_get_time2(skill_id,skill_lv));
+		sc_start(src,bl,SC_BLIND,(sd!=nullptr)?20:15,skill_lv,skill_get_time2(skill_id,skill_lv));
 		break;
 
 	case TF_THROWSTONE:
-		if (!sc_start(src,bl,SC_STUN,3,skill_lv,skill_get_time(skill_id,skill_lv))) //only blind if success
-			sc_start(src,bl,SC_BLIND,3,skill_lv,skill_get_time2(skill_id,skill_lv));
+		if (sd != nullptr) {
+			// Only blind if used by player and stun failed
+			if (!sc_start(src, bl, SC_STUN, 3, skill_lv, skill_get_time(skill_id, skill_lv)))
+				sc_start(src, bl, SC_BLIND, 3, skill_lv, skill_get_time2(skill_id, skill_lv));
+		}
+		else {
+			// 5% stun chance and no blind chance when used by monsters
+			sc_start(src, bl, SC_STUN, 5, skill_lv, skill_get_time(skill_id, skill_lv));
+		}
 		break;
 
 	case NPC_DARKCROSS:
@@ -1598,7 +1605,20 @@ int32 skill_additional_effect( struct block_list* src, struct block_list *bl, ui
 		break;
 
 	case BD_LULLABY:
-		status_change_start(src, bl, SC_SLEEP, (sstatus->int_ * 2 + rnd_value(100, 300)) * 10, skill_lv, 0, 0, 0, skill_get_time2(skill_id, skill_lv), SCSTART_NONE);
+#ifndef RENEWAL
+		if (sc && sc->getSCE(SC_DANCING)) {
+			block_list* partner = map_id2bl(sc->getSCE(SC_DANCING)->val4);
+			if (partner == nullptr)
+				break;
+			status_data* pstatus = status_get_status_data(*partner);
+			if (pstatus == nullptr)
+				break;
+			status_change_start(src, bl, skill_get_sc(skill_id), (sstatus->int_ + pstatus->int_ + rnd_value(100, 300)) * 10, skill_lv, 0, 0, 0, skill_get_time2(skill_id, skill_lv), SCSTART_NONE);
+		}
+#else
+		// In renewal the chance is simply 100% and uses the original song duration as sleep duration
+		sc_start(src, bl, skill_get_sc(skill_id), 100, skill_lv, skill_get_time(skill_id, skill_lv));
+#endif
 		break;
 
 #ifdef RENEWAL
@@ -17485,6 +17505,9 @@ int32 skill_unit_onleft(uint16 skill_id, struct block_list *bl, t_tick tick)
 				//your own. Let's pray that scenario is pretty unlikely and noone will complain too much about it.
 				status_change_end(bl, SC_DANCING);
 			}
+			// Sleep effect of Lullaby doesn't end even if song ends
+			if (skill_id == BD_LULLABY)
+				break;
 			[[fallthrough]];
 		case MH_STEINWAND:
 		case MG_SAFETYWALL:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9043 #6916 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Sleep chance of Lullaby in pre-re is now increased by a combination of the user's and partner's INT
- Sleep chance of Lullaby in renewal is now 100% (reduced by AGI) and unaffected by INT
- Interval of Lullaby in pre-re is now every 6 seconds
- Even when Lullaby ends in pre-re, the sleep status will now persist
- Lullaby's sleep effect in renewal now has a base duration of 60+2 seconds
- When used by a non-player, Throw Stone now has a stun chance of 5% and no blind chance
- When used by a non-player, Sprinkle Sand now has a blind chance of 15%
- When used by a non-player, Frost Nova now has a freeze chance of 35%+3%*level
- Fixes #9043
- See also #6916

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
