### PR TITLE
Super Novice Spirit and Two-Handed Axes

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1802,6 +1802,7 @@ uint8 pc_isequip(map_session_data *sd,int32 n)
 				case W_DAGGER: //All level 4 - Daggers
 				case W_1HSWORD: //All level 4 - 1H Swords
 				case W_1HAXE: //All level 4 - 1H Axes
+				case W_2HAXE: // All level 4 - 2H Axes (works, but low ASPD)
 				case W_MACE: //All level 4 - 1H Maces
 				case W_STAFF: //All level 4 - 1H Staves
 				case W_2HSTAFF: //All level 4 - 2H Staves


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9047 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Super Novices can now equip level 4 Two-Handed Axes when soul-linked
- However, since there is no entry in the SN ASPD table, the ASPD will be very low when doing so

Note: Yes this is how it officially works. Kinda like when Priests equip a Claw.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->