### PR TITLE
Endure Effect Quick Fix

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5114,16 +5114,14 @@ void clif_getareachar_unit( map_session_data* sd,struct block_list *bl ){
 
 //Modifies the type of damage according to target status changes [Skotlex]
 //Aegis data specifies that: 4 endure against single hit sources, 9 against multi-hit.
-static enum e_damage_type clif_calc_delay( block_list& bl, e_damage_type type, int32 div, int64 damage ) {
+static enum e_damage_type clif_calc_delay(block_list& bl, e_damage_type type, int32 div, int64 damage, int32 delay) {
 	if (damage < 1)
 		return type;
 
-	status_change* sc = status_get_sc( &bl );
-
-	if (sc == nullptr || sc->empty())
-		return type;
-	
-	if (sc->getSCE(SC_ENDURE) == nullptr)	// !TODO: should berserk status also change the type?
+	// Currently we set dmotion to 0 to mark situations that should use the endure effect
+	// However, this also impacts units that natually have 0 dmotion
+	// TODO: Collect all possible situations that create the endure effect and implement function
+	if (delay != 0)
 		return type;
 
 	switch( type ) {
@@ -5235,7 +5233,7 @@ int32 clif_damage(block_list& src, block_list& dst, t_tick tick, int32 sdelay, i
 	int32 damage = (int32)cap_value(sdamage,INT_MIN,INT_MAX);
 	int32 damage2 = (int32)cap_value(sdamage2,INT_MIN,INT_MAX);
 
-	type = clif_calc_delay( dst, type, div, damage+damage2 );
+	type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
 
 	damage = static_cast<decltype(damage)>(clif_hallucination_damage(dst, damage));
 	damage2 = static_cast<decltype(damage2)>(clif_hallucination_damage(dst, damage2));
@@ -6023,7 +6021,7 @@ void clif_skill_cooldown( map_session_data &sd, uint16 skill_id, t_tick tick ){
 /// 0114 <skill id>.W <src id>.L <dst id>.L <tick>.L <src delay>.L <dst delay>.L <damage>.W <level>.W <div>.W <type>.B (ZC_NOTIFY_SKILL)
 /// 01de <skill id>.W <src id>.L <dst id>.L <tick>.L <src delay>.L <dst delay>.L <damage>.L <level>.W <div>.W <type>.B (ZC_NOTIFY_SKILL2)
 int32 clif_skill_damage( block_list& src, block_list& dst, t_tick tick, int32 sdelay, int32 ddelay, int64 sdamage, int32 div, uint16 skill_id, uint16 skill_lv, e_damage_type type ){
-	type = clif_calc_delay( dst, type, div, sdamage );
+	type = clif_calc_delay( dst, type, div, sdamage, ddelay );
 	sdamage = clif_hallucination_damage( dst, sdamage );
 
 	PACKET_ZC_NOTIFY_SKILL packet{};

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5233,7 +5233,8 @@ int32 clif_damage(block_list& src, block_list& dst, t_tick tick, int32 sdelay, i
 	int32 damage = (int32)cap_value(sdamage,INT_MIN,INT_MAX);
 	int32 damage2 = (int32)cap_value(sdamage2,INT_MIN,INT_MAX);
 
-	type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
+	if (type != DMG_MULTI_HIT_CRITICAL)
+		type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
 
 	damage = static_cast<decltype(damage)>(clif_hallucination_damage(dst, damage));
 	damage2 = static_cast<decltype(damage2)>(clif_hallucination_damage(dst, damage2));
@@ -5304,6 +5305,8 @@ int32 clif_damage(block_list& src, block_list& dst, t_tick tick, int32 sdelay, i
 	if(&src == &dst) 
 		unit_setdir(&src, unit_getdir(&src));
 
+	// In case this assignment is bypassed by DMG_MULTI_HIT_CRITICAL
+	type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
 	//Return adjusted can't walk delay for further processing.
 	return clif_calc_walkdelay(dst, ddelay, type, damage+damage2, div);
 }

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5119,7 +5119,7 @@ static enum e_damage_type clif_calc_delay(block_list& bl, e_damage_type type, in
 		return type;
 
 	// Currently we set dmotion to 0 to mark situations that should use the endure effect
-	// However, this also impacts units that natually have 0 dmotion
+	// However, this also impacts units that naturally have 0 dmotion
 	// TODO: Collect all possible situations that create the endure effect and implement function
 	if (delay != 0)
 		return type;

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5306,7 +5306,10 @@ int32 clif_damage(block_list& src, block_list& dst, t_tick tick, int32 sdelay, i
 		unit_setdir(&src, unit_getdir(&src));
 
 	// In case this assignment is bypassed by DMG_MULTI_HIT_CRITICAL
-	type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
+	if( type == DMG_MULTI_HIT_CRITICAL ){
+		type = clif_calc_delay( dst, type, div, damage+damage2, ddelay );
+	}
+
 	//Return adjusted can't walk delay for further processing.
 	return clif_calc_walkdelay(dst, ddelay, type, damage+damage2, div);
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9064

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Partially reverted 82b1764
- Any effect that grants "no damage motion" that is not SC_ENDURE is working again
- SC_ENDURE is correctly disabled on GVG2 and Battlegrounds again
- Fixes #9064

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
