### PR TITLE
Improved Alchemist Summon Setting

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -125,12 +125,15 @@ gvg_traps_target_all: 1
 // Default on official servers: 0 for Pre-renewal, 2 for Renewal
 //traps_setting: 0
 
-// Restrictions applied to the Alchemist's Summon Flora skill (add as necessary)
+// Restrictions applied to the Alchemist's Summon skills (add as necessary)
 // 1: Enable players to damage the floras outside of versus grounds.
-// 2: Disable having different types out at the same time
+// 2: Enable players to damage marine spheres outside of versus grounds.
+// 4: Disable having different types out at the same time
 //    (eg: forbid summoning anything except hydras when there's already 
 //     one hydra out)
-summon_flora_setting: 3
+// 8: Enable Marine Spheres to damage own Homunculus and summons outside PVP
+// Default on official servers: 15 for Pre-renewal, 12 for Renewal
+//alchemist_summon_setting: 15
 
 // Whether placed down skills will check walls (Note 1)
 // (ex. Storm Gust cast against a wall will not hit the other side.) 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10993,8 +10993,8 @@ int32 battle_check_target( struct block_list *src, struct block_list *target,int
 
 			if (ud && ud->immune_attack)
 				return 0;
-			if(((md->special_state.ai == AI_SPHERE || //Marine Spheres
-				(md->special_state.ai == AI_FLORA && battle_config.summon_flora&1)) && s_bl->type == BL_PC && src->type != BL_MOB) || //Floras
+			if((((md->special_state.ai == AI_SPHERE && battle_config.alchemist_summon_setting&2) || //Marine Spheres
+				 (md->special_state.ai == AI_FLORA && battle_config.alchemist_summon_setting&1)) && s_bl->type == BL_PC && src->type != BL_MOB) || //Floras
 				(md->special_state.ai == AI_ZANZOU && t_bl->id != s_bl->id) || //Zanzou
 				(md->special_state.ai == AI_FAW && (t_bl->id != s_bl->id || (s_bl->type == BL_PC && src->type != BL_MOB)))
 			){	//Targettable by players
@@ -11345,7 +11345,6 @@ static const struct _battle_data {
 #else
 	{ "traps_setting",                      &battle_config.traps_setting,                   0,      0,      2,              },
 #endif
-	{ "summon_flora_setting",               &battle_config.summon_flora,                    1|2,    0,      1|2,            },
 	{ "clear_skills_on_death",              &battle_config.clear_unit_ondeath,              BL_NUL, BL_NUL, BL_ALL,         },
 	{ "clear_skills_on_warp",               &battle_config.clear_unit_onwarp,               BL_ALL, BL_NUL, BL_ALL,         },
 	{ "random_monster_checklv",             &battle_config.random_monster_checklv,          0,      0,      1,              },
@@ -11953,9 +11952,11 @@ static const struct _battle_data {
 #ifdef RENEWAL
 	{ "hom_delay_reset_vaporize",           &battle_config.hom_delay_reset_vaporize,        0,      0,      1,              },
 	{ "hom_delay_reset_warp",               &battle_config.hom_delay_reset_warp,            0,      0,      1,              },
+	{ "alchemist_summon_setting",           &battle_config.alchemist_summon_setting,        12,     0,      15,             },
 #else
 	{ "hom_delay_reset_vaporize",           &battle_config.hom_delay_reset_vaporize,        1,      0,      1,              },
 	{ "hom_delay_reset_warp",               &battle_config.hom_delay_reset_warp,            1,      0,      1,              },
+	{ "alchemist_summon_setting",           &battle_config.alchemist_summon_setting,        15,     0,      15,             },
 #endif
 	{ "loot_range",                         &battle_config.loot_range,                      12,     1,      MAX_WALKPATH,   },
 	{ "assist_range",                       &battle_config.assist_range,                    11,     1,      MAX_WALKPATH,   },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -181,7 +181,6 @@ struct Battle_Config
 	int32 defnotenemy;
 	int32 vs_traps_bctall;
 	int32 traps_setting;
-	int32 summon_flora; //[Skotlex]
 	int32 clear_unit_ondeath; //[Skotlex]
 	int32 clear_unit_onwarp; //[Skotlex]
 	int32 random_monster_checklv;
@@ -768,6 +767,7 @@ struct Battle_Config
 	int32 item_stacking;
 	int32 hom_delay_reset_vaporize;
 	int32 hom_delay_reset_warp;
+	int32 alchemist_summon_setting;
 	int32 loot_range;
 	int32 assist_range;
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9038,8 +9038,14 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 	case NPC_SELFDESTRUCTION:
 		//Self Destruction hits everyone in range (allies+enemies)
 		//Except for Summoned Marine spheres on non-versus maps, where it's just enemies and your own slaves.
-		i = ((!md || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m))?
-			BCT_ENEMY|BCT_SLAVE:BCT_ALL;
+		if ((!md || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m)) {
+			if (battle_config.alchemist_summon_setting&8)
+				i = BCT_ENEMY|BCT_SLAVE;
+			else
+				i = BCT_ENEMY;
+		} else {
+			i = BCT_ALL;
+		}
 		clif_skill_nodamage(src, *src, skill_id, skill_lv);
 		map_delblock(src); //Required to prevent chain-self-destructions hitting back.
 		map_foreachinshootrange(skill_area_sub, bl,
@@ -19199,7 +19205,7 @@ bool skill_check_condition_castend( map_session_data& sd, uint16 skill_id, uint1
 			if(battle_config.land_skill_limit && maxcount>0 && (battle_config.land_skill_limit&BL_PC)) {
 				i = map_foreachinmap(skill_check_condition_mob_master_sub, sd.bl.m, BL_MOB, sd.bl.id, mob_class, skill_id, &c);
 				if(c >= maxcount ||
-					(skill_id==AM_CANNIBALIZE && c != i && battle_config.summon_flora&2))
+					(skill_id==AM_CANNIBALIZE && c != i && battle_config.alchemist_summon_setting&4))
 				{	//Fails when: exceed max limit. There are other plant types already out.
 					clif_skill_fail( sd, skill_id );
 					return false;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9039,6 +9039,7 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 		//Self Destruction hits everyone in range (allies+enemies)
 		//Except for Summoned Marine spheres on non-versus maps, where it's just enemies and your own slaves.
 		if ((md == nullptr || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m)) {
+			// Enable Marine Spheres to damage own Homunculus and summons outside PVP
 			if (battle_config.alchemist_summon_setting&8)
 				i = BCT_ENEMY|BCT_SLAVE;
 			else

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9038,7 +9038,7 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 	case NPC_SELFDESTRUCTION:
 		//Self Destruction hits everyone in range (allies+enemies)
 		//Except for Summoned Marine spheres on non-versus maps, where it's just enemies and your own slaves.
-		if ((!md || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m)) {
+		if ((md == nullptr || md->special_state.ai == AI_SPHERE) && !map_flag_vs(src->m)) {
 			if (battle_config.alchemist_summon_setting&8)
 				i = BCT_ENEMY|BCT_SLAVE;
 			else


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: (Feature)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (though the default setting does not impact pre-renewal)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Replaced "summon_flora_setting" with "alchemist_summon_setting"
- Allows you to now also set if Marine Spheres can be attacked or not
- Allows you now to set whether Marine Spheres can hit your other summons outside PVP
- As behavior is different between pre-re and re, the config is commented out by default now
  * As long as it's commented, it automatically uses the official behavior
  * In pre-re all options are enabled by default
  * In renewal it's no longer possible to attack summons yourself at all by default

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
