### PR TITLE
Chase Skill Fixes and Code Optimization

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2072,18 +2072,6 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		return true;
 	}
 
-	// Monsters can use chase skills before starting to walk
-	// So we need to change the state and check for a skill here already
-	// But only use skill if able to walk on next tick and not attempted a skill the last second
-	// Skills during movement are handled in the walktobl routine
-	if (md->ud.walktimer == INVALID_TIMER
-		&& DIFF_TICK(md->ud.canmove_tick, tick) <= MIN_MOBTHINKTIME
-		&& DIFF_TICK(tick, md->last_skillcheck) >= MOB_SKILL_INTERVAL) {
-		md->state.skillstate = md->state.aggressive ? MSS_FOLLOW : MSS_RUSH;
-		if (mobskill_use(md, tick, -1))
-			return true;
-	}
-
 	if(!unit_walktobl(&md->bl, tbl, md->status.rhw.range, 2))
 		mob_unlocktarget(md, tick);
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -171,17 +171,17 @@ bool unit_walktoxy_nextcell(block_list& bl, bool sendMove, t_tick tick) {
 
 	// Monsters first check for a chase skill and if they didn't use one if their target is in range each cell after checking for a chase skill
 	if (bl.type == BL_MOB) {
-		mob_data* md = reinterpret_cast<mob_data*>(&bl);
+		mob_data& md = reinterpret_cast<mob_data&>(bl);
 		// Walk skills are triggered regardless of target due to the idle-walk mob state.
 		// But avoid triggering when already reached the end of the walkpath.
 		// Monsters use walk/chase skills every second, but we only get here every "speed" ms
 		// To make sure we check one skill per second on average, we substract half the speed as ms
 		if (!ud->state.force_walk &&
-			DIFF_TICK(tick, md->last_skillcheck) > MOB_SKILL_INTERVAL - md->status.speed / 2 &&
-			mobskill_use(md, tick, -1)) {
-			if ((ud->skill_id != NPC_SPEEDUP || md->trickcasting == 0) //Stop only when trickcasting expired
+			DIFF_TICK(tick, md.last_skillcheck) > MOB_SKILL_INTERVAL - md.status.speed / 2 &&
+			mobskill_use(&md, tick, -1)) {
+			if ((ud->skill_id != NPC_SPEEDUP || md.trickcasting == 0) //Stop only when trickcasting expired
 				&& ud->skill_id != NPC_EMOTION && ud->skill_id != NPC_EMOTION_ON //NPC_EMOTION doesn't make the monster stop
-				&& md->state.skillstate != MSS_WALK) //Walk skills are supposed to be used while walking
+				&& md.state.skillstate != MSS_WALK) //Walk skills are supposed to be used while walking
 			{
 				// Skill used, abort walking
 				// Fix position as walk has been cancelled.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8989 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Unified the code for using chase skills and put it at the ideal location
  * Removed the check before starting a chase
  * Removed the check at the end of having moved a cell (but not the last cell)
  * Instead we now check it at the beginning of the movement to the next cell (unit_walktoxy_nextcell)
  * This fixes an issue that monsters did not start moving when using NPC_EMOTION at the start of a chase
- Unified the location where a monsters switches to chase state
  * This needs to happen before we check for chase skills
- Fixed an issue that caused position lag when a monster recalculated its chase while having walk delay
- Monsters will now also use walk skills when nobody is on the map if they have been spotted
  * For example relevant for Aliza who casts Heal in walk state
- Fixes #8989

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
