### PR TITLE
Refactored clif_refreshlook

### DIFF
--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -911,7 +911,6 @@ void clif_standing(block_list& bl);
 void clif_sprite_change(struct block_list *bl, int32 id, int32 type, int32 val, int32 val2, enum send_target target);
 void clif_changelook(struct block_list *bl,int32 type,int32 val);	// area
 void clif_changetraplook(struct block_list *bl,int32 val); // area
-void clif_refreshlook(struct block_list *bl,int32 id,int32 type,int32 val,enum send_target target); //area specified in 'target'
 void clif_arrowequip( map_session_data& sd );
 void clif_arrow_fail( map_session_data& sd, e_action_failure type );
 void clif_arrow_create_list( map_session_data& sd );


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 

This function was introduced by Skotlex back in 2006 in e9c44b5 to address a client-side bug. Sadly there is no documentation or issue report from back then anymore. The current assumption is that this bug is related to ZC_NOTIFY_STANDENTRY, which was disabled with PACKETVER 20091103.

While developing newer features some developers thought that if it was necessary to update the clothes color, that we also need to update the body style and robe. Since this data is already contained in the newer versions of ZC_NOTIFY_STANDENTRY, this would have never been necessary and can safely be removed.

Refactored the logic into a new function, which is only used in the required PACKETVER. Removed all calls to that function for body style and robe.
