### PR TITLE
Endless Loop without Official Walkpath Fix

### DIFF
--- a/src/config/core.hpp
+++ b/src/config/core.hpp
@@ -18,9 +18,11 @@
 #define MAX_SUGGESTIONS 10
 
 /// Comment to disable the official walk path
-/// The official walkpath disables users from taking non-clear walk paths,
-/// e.g. if they want to get around an obstacle they have to walk around it,
-/// while with OFFICIAL_WALKPATH disabled if they click to walk around a obstacle the server will do it automatically
+/// The official walkpath disables ranged units from taking non-clear walk paths to attack a target,
+/// e.g. if they need to get around an obstacle to attack, players will have to click to walk around it
+/// before attacking and monsters will just drop target once they get in attack range and can't attack.
+/// If disabled, the server automatically makes sure units find a position to attack from by moving closer.
+/// Disabling this also stops skills from failing when the target has walked behind an obstacle during cast.
 #define OFFICIAL_WALKPATH
 
 /// Uncomment to enable the Cell Stack Limit mod.

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2970,9 +2970,8 @@ static int32 unit_attack_timer_sub(struct block_list* src, int32 tid, t_tick tic
 		if (ud->state.attack_continue && ud->chaserange > 1) {
 			ud->chaserange = std::max(1, ud->chaserange - 2);
 
-			// Walk around the obstacle and start attacking once you are in range
-			unit_walktobl(src,target,ud->chaserange,ud->state.walk_easy|2);
-			return 1;
+			// Walk closer / around the obstacle and start attacking once you are in range
+			return unit_walktobl(src,target,ud->chaserange,ud->state.walk_easy|2);
 		}
 		// Can't attack even though next to the target? Giving up here.
 		return 0;

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2969,6 +2969,8 @@ static int32 unit_attack_timer_sub(struct block_list* src, int32 tid, t_tick tic
 		// This code can usually only be reached if OFFICIAL_WALKPATH is disabled
 		if (ud->state.attack_continue && ud->chaserange > 1) {
 			ud->chaserange = std::max(1, ud->chaserange - 2);
+
+			// Walk around the obstacle and start attacking once you are in range
 			unit_walktobl(src,target,ud->chaserange,ud->state.walk_easy|2);
 			return 1;
 		}

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2965,15 +2965,15 @@ static int32 unit_attack_timer_sub(struct block_list* src, int32 tid, t_tick tic
 	}
 
 	if( !battle_check_range(src,target,range) ) {
-	  	// Within range, but no direct line of attack
-		if( ud->state.attack_continue ) {
-			if(ud->chaserange > 2)
-				ud->chaserange-=2;
-
+		// Within range, but no direct line of attack
+		// This code can usually only be reached if OFFICIAL_WALKPATH is disabled
+		if (ud->state.attack_continue && ud->chaserange > 1) {
+			ud->chaserange = std::max(1, ud->chaserange - 2);
 			unit_walktobl(src,target,ud->chaserange,ud->state.walk_easy|2);
+			return 1;
 		}
-
-		return 1;
+		// Can't attack even though next to the target? Giving up here.
+		return 0;
 	}
 
 	// Sync packet only for players.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9092 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed an issue that could cause an endless loop when OFFICIAL_WALKPATH is disabled (fixes #9092)
- Improved comments so it's easier to understand what disabling OFFICIAL_WALKPATH actually means

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
