### PR TITLE
Endless Loop Emergency Quick Fix

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -113,7 +113,7 @@ bool unit_update_chase(block_list& bl, t_tick tick, bool fullcheck) {
 		tbl = map_id2bl(ud->target_to);
 
 	// Reached destination, start attacking
-	if (tbl != nullptr && tbl->m == bl.m && check_distance_bl(&bl, tbl, ud->chaserange) && status_check_visibility(&bl, tbl, false)) {
+	if (tbl != nullptr && tbl->m == bl.m && ud->walkpath.path_pos > 0 && check_distance_bl(&bl, tbl, ud->chaserange) && status_check_visibility(&bl, tbl, false)) {
 		ud->to_x = bl.x;
 		ud->to_y = bl.y;
 		ud->target_to = 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9097

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Units will now move at least one cell before trying to attack through a movement event
  * Other triggers of an attack such as the AI are unaffected
- This serves as a quick fix for an endless loop that is caused by movement that starts when target is already in range
  * Proper fix of the "Official Walkpath" will come later
- Fixes #9097
- Follow-up to 322bd2c

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
