### PR TITLE
Corrected damage type vs target with endure effect

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5125,6 +5125,12 @@ static enum e_damage_type clif_calc_delay(block_list& bl, e_damage_type type, in
 	if (delay != 0)
 		return type;
 
+	// General change of type based on div against target with endure effect
+	if (div > 1 && type == DMG_SINGLE)
+		type = DMG_MULTI_HIT;
+	else if (div < 2 && type == DMG_MULTI_HIT)
+		type = DMG_SINGLE;
+
 	switch( type ) {
 		case DMG_ENDURE:
 		case DMG_MULTI_HIT_ENDURE:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Currently type is not updated when damage div is changed. This PR now changes the type based on div for targets with endure effects. The type is changed elsewhere for targets without endure effects so this part remains untouched.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
