### PR TITLE
Fixed Pneuma against monsters

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2868,12 +2868,12 @@ static bool is_skill_using_arrow(struct block_list *src, int32 skill_id)
 	if (sd == nullptr && skill_id != 0) {
 		if (skill_get_ammotype(skill_id) != 0)
 			return true;
-
-		status_data* sstatus = status_get_status_data(*src);
-
-		if (sstatus->rhw.range > 3)
-			return true;
 	}
+
+	status_data* sstatus = status_get_status_data(*src);
+
+	if (sstatus->rhw.range > 3)
+		return true;
 
 	switch( skill_id ) {
 		case HT_PHANTASMIC:


### PR DESCRIPTION
Pneuma against monsters has stopped working after 435b2b6

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9109

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Fixes an issue with Pneuma when used against range monsters.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
