### PR TITLE
Crash Fix When Using Skill Through Script

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3971,6 +3971,14 @@ bool mob_chat_display_message(mob_data &md, uint16 msg_id) {
  */
 void mobskill_end(mob_data& md, t_tick tick)
 {
+	// After a skill a monster cannot attack for its attack delay
+	// We make sure to not reduce it in case it was set by a skill for another purpose
+	md.ud.attackabletime = i64max(tick + md.status.adelay, md.ud.attackabletime);
+
+	// If skill was used by a script, do not apply any skill delay
+	if (md.skill_idx < 0)
+		return;
+
 	std::vector<std::shared_ptr<s_mob_skill>>& ms = md.db->skill;
 
 	if (ms.empty())
@@ -3998,10 +4006,6 @@ void mobskill_end(mob_data& md, t_tick tick)
 	}
 	else
 		md.skilldelay[md.skill_idx] = tick + ms[md.skill_idx]->delay;
-
-	// After a skill a monster cannot attack for its attack delay
-	// We make sure to not reduce it in case it was set by a skill for another purpose
-	md.ud.attackabletime = i64max(tick + md.status.adelay, md.ud.attackabletime);
 }
 
 /*==========================================


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9111 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Map server will no longer crash when making a monster use a skill via a script
  * No skill delay will be applied in this case, but the attack delay will still be set
- Fixes #9111

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
