### PR TITLE
Added HT_FREEZINGTRAP to is_skill_using_arrow

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2876,6 +2876,7 @@ static bool is_skill_using_arrow(struct block_list *src, int32 skill_id)
 	}
 
 	switch( skill_id ) {
+		case HT_FREEZINGTRAP:
 		case HT_PHANTASMIC:
 		case GS_GROUNDDRIFT:
 		case SS_KUNAIKUSSETSU:


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
The skill was accidentally removed in 435b2b6.

Thanks to @Playtester.
