### PR TITLE
Fixed map server crash in BUILDIN_FUNC(sscanf) script.cpp

### DIFF
--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -17621,7 +17621,7 @@ BUILDIN_FUNC(sscanf){
 			if(ref_str==nullptr){
 				CREATE(ref_str, char, strlen(str)+1);
 			}
-			if( sscanf( str, buf, &ref_str ) != 1 ){
+			if( sscanf( str, buf, ref_str ) != 1 ){
 				ShowError( "buildin_sscanf: sscanf failed to scan value for string variable \"%s\".\n", buf_p );
 				script_pushint( st, -1 );
 				if( buf != nullptr ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: (https://github.com/rathena/rathena/issues/9130)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
The error occurred due to incorrect &ref_str value being passed, which occurred in 1782bd1.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
