### PR TITLE
Alternative Solution for Exact Position

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1978,7 +1978,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 		int32 loot_range = 0;
 		if (md->ud.walktimer != INVALID_TIMER) {
 			// Ready to loot
-			if (unit_getx(md->bl, tick) == tbl->x && unit_gety(md->bl, tick) == tbl->y)
+			if (md->ud.getx(tick) == tbl->x && md->ud.gety(tick) == tbl->y)
 				loot_range = 1;
 			// Already moving to target item
 			else if (md->ud.target == tbl->id)

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1502,20 +1502,20 @@ int32 unit_warp(struct block_list *bl,int16 m,int16 x,int16 y,clr_type type)
 void unit_data::update_pos(t_tick tick)
 {
 	// Check if coordinates are still up-to-date
-	if (DIFF_TICK(tick, pos.tick) < MIN_POS_INTERVAL)
+	if (DIFF_TICK(tick, this->pos.tick) < MIN_POS_INTERVAL)
 		return;
 
 	if (this->bl == nullptr)
 		return;
 
 	// Set initial coordinates
-	pos.x = this->bl->x;
-	pos.y = this->bl->y;
-	pos.sx = 8;
-	pos.sy = 8;
+	this->pos.x = this->bl->x;
+	this->pos.y = this->bl->y;
+	this->pos.sx = 8;
+	this->pos.sy = 8;
 
 	// Remember time at which we did the last calculation
-	pos.tick = tick;
+	this->pos.tick = tick;
 
 	if (this->walkpath.path_pos >= this->walkpath.path_len)
 		return;
@@ -1534,24 +1534,24 @@ void unit_data::update_pos(t_tick tick)
 	if (cell_percent > 0.0 && cell_percent < 1.0) {
 		// Set subcell coordinates according to timer
 		// This gives a value between 8 and 39
-		pos.sx = static_cast<uint8>(24.0 + dirx[this->walkpath.path[this->walkpath.path_pos]] * 16.0 * cell_percent);
-		pos.sy = static_cast<uint8>(24.0 + diry[this->walkpath.path[this->walkpath.path_pos]] * 16.0 * cell_percent);
+		this->pos.sx = static_cast<uint8>(24.0 + dirx[this->walkpath.path[this->walkpath.path_pos]] * 16.0 * cell_percent);
+		this->pos.sy = static_cast<uint8>(24.0 + diry[this->walkpath.path[this->walkpath.path_pos]] * 16.0 * cell_percent);
 		// 16-31 reflect sub position 0-15 on the current cell
 		// 8-15 reflect sub position 8-15 at -1 main coordinate
 		// 32-39 reflect sub position 0-7 at +1 main coordinate
-		if (pos.sx < 16 || pos.sy < 16 || pos.sx > 31 || pos.sy > 31) {
-			if (pos.sx < 16) pos.x--;
-			if (pos.sy < 16) pos.y--;
-			if (pos.sx > 31) pos.x++;
-			if (pos.sy > 31) pos.y++;
+		if (this->pos.sx < 16 || this->pos.sy < 16 || this->pos.sx > 31 || this->pos.sy > 31) {
+			if (this->pos.sx < 16) this->pos.x--;
+			if (this->pos.sy < 16) this->pos.y--;
+			if (this->pos.sx > 31) this->pos.x++;
+			if (this->pos.sy > 31) this->pos.y++;
 		}
-		pos.sx %= 16;
-		pos.sy %= 16;
+		this->pos.sx %= 16;
+		this->pos.sy %= 16;
 	}
 	else if (cell_percent >= 1.0) {
 		// Assume exactly one cell moved
-		pos.x += dirx[this->walkpath.path[this->walkpath.path_pos]];
-		pos.y += diry[this->walkpath.path[this->walkpath.path_pos]];
+		this->pos.x += dirx[this->walkpath.path[this->walkpath.path_pos]];
+		this->pos.y += diry[this->walkpath.path[this->walkpath.path_pos]];
 	}
 }
 
@@ -1563,8 +1563,8 @@ void unit_data::update_pos(t_tick tick)
  */
 int16 unit_data::getx(t_tick tick) {
 	// Make sure exact coordinates are up-to-date
-	update_pos(tick);
-	return pos.x;
+	this->update_pos(tick);
+	return this->pos.x;
 }
 
 /**
@@ -1575,8 +1575,8 @@ int16 unit_data::getx(t_tick tick) {
  */
 int16 unit_data::gety(t_tick tick) {
 	// Make sure exact coordinates are up-to-date
-	update_pos(tick);
-	return pos.y;
+	this->update_pos(tick);
+	return this->pos.y;
 }
 
 /**
@@ -1591,11 +1591,11 @@ int16 unit_data::gety(t_tick tick) {
  */
 void unit_data::getpos(int16 &x, int16 &y, uint8 &sx, uint8 &sy, t_tick tick) {
 	// Make sure exact coordinates are up-to-date
-	update_pos(tick);
-	x = pos.x;
-	y = pos.y;
-	sx = pos.sx;
-	sy = pos.sy;
+	this->update_pos(tick);
+	x = this->pos.x;
+	y = this->pos.y;
+	sx = this->pos.sx;
+	sy = this->pos.sy;
 }
 
 /**

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1529,7 +1529,7 @@ void unit_data::update_pos(t_tick tick)
 		return;
 
 	// Get how much percent we traversed on the timer
-	double cell_percent = 1.0 - ((double)DIFF_TICK(td->tick, gettick()) / (double)td->data);
+	double cell_percent = 1.0 - ((double)DIFF_TICK(td->tick, tick) / (double)td->data);
 
 	if (cell_percent > 0.0 && cell_percent < 1.0) {
 		// Set subcell coordinates according to timer

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -71,7 +71,7 @@ struct unit_data {
 	void getpos(int16 &x, int16 &y, uint8 &sx, uint8 &sy, t_tick tick = gettick());
 private:
 	void update_pos(t_tick tick);
-	struct s_udPos {
+	struct {
 		int16 x;
 		int16 y;
 		uint8 sx;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -66,9 +66,9 @@ struct unit_data {
 	std::vector<int32> shadow_scar_timer;
 
 	// Functions and struct to calculate and store exact position at a certain tick
-	int16 getx(t_tick tick = gettick());
-	int16 gety(t_tick tick = gettick());
-	void getpos(int16 &x, int16 &y, uint8 &sx, uint8 &sy, t_tick tick = gettick());
+	int16 getx(t_tick tick);
+	int16 gety(t_tick tick);
+	void getpos(int16 &x, int16 &y, uint8 &sx, uint8 &sy, t_tick tick);
 private:
 	void update_pos(t_tick tick);
 	struct {

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -64,6 +64,20 @@ struct unit_data {
 	int32 group_id;
 
 	std::vector<int32> shadow_scar_timer;
+
+	// Functions and struct to calculate and store exact position at a certain tick
+	int16 getx(t_tick tick = gettick());
+	int16 gety(t_tick tick = gettick());
+	void getpos(int16 &x, int16 &y, uint8 &sx, uint8 &sy, t_tick tick = gettick());
+private:
+	void update_pos(t_tick tick);
+	struct s_udPos {
+		int16 x;
+		int16 y;
+		uint8 sx;
+		uint8 sy;
+		t_tick tick;
+	} pos;
 };
 
 struct view_data {
@@ -115,9 +129,6 @@ bool unit_run(struct block_list *bl, map_session_data *sd, enum sc_type type);
 int32 unit_calc_pos(struct block_list *bl, int32 tx, int32 ty, uint8 dir);
 TIMER_FUNC(unit_delay_walktoxy_timer);
 TIMER_FUNC(unit_delay_walktobl_timer);
-
-int16 unit_getx(block_list& bl, t_tick tick = gettick());
-int16 unit_gety(block_list& bl, t_tick tick = gettick());
 
 void unit_stop_walking_soon(struct block_list& bl, t_tick tick = gettick());
 // Causes the target object to stop moving.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Feature

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- This is an alternative solution to fetch the exact position of a unit (see 3cb7c9f)
- This makes use of a private struct inside unit_data that remembers the last calculated exact coordinates
- Recalculation only happens when 20 or more milliseconds (1 frame) have passed since the last calculation
- Access to the coordinates is only possible through helper functions that make sure the data is up-to-date

Please let me know if you like this solution more, otherwise we can also just cancel this PR.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
