### PR TITLE
Fixed Error Messages when using Splash Skills on Skill Units

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6116,8 +6116,8 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 			//special case: Venom Splasher uses a different range for searching than for splashing
 			if (flag&SD_LEVEL || skill_get_nk(skill_id, NK_SPLASHSPLIT)) {
 				skill_area_temp[0] = map_foreachinallrange(skill_area_sub, bl, (skill_id == AS_SPLASHER)?1:splash_size, BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
-				// If no chars are in the area, then it always counts as if there was one target
-				// This happens when targetting skills such as icewall
+				// If there are no characters in the area, then it always counts as if there was one target
+				// This happens when targetting skill units such as icewall
 				skill_area_temp[0] = std::max(1, skill_area_temp[0]);
 			}
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6114,8 +6114,12 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 			// if skill damage should be split among targets, count them
 			//SD_LEVEL -> Forced splash damage for Auto Blitz-Beat -> count targets
 			//special case: Venom Splasher uses a different range for searching than for splashing
-			if( flag&SD_LEVEL || skill_get_nk(skill_id, NK_SPLASHSPLIT) )
+			if (flag&SD_LEVEL || skill_get_nk(skill_id, NK_SPLASHSPLIT)) {
 				skill_area_temp[0] = map_foreachinallrange(skill_area_sub, bl, (skill_id == AS_SPLASHER)?1:splash_size, BL_CHAR, src, skill_id, skill_lv, tick, BCT_ENEMY, skill_area_sub_count);
+				// If no chars are in the area, then it always counts as if there was one target
+				// This happens when targetting skills such as icewall
+				skill_area_temp[0] = std::max(1, skill_area_temp[0]);
+			}
 
 			// recursive invocation of skill_castend_damage_id() with flag|1
 			map_foreachinrange(skill_area_sub, bl, splash_size, starget, src, skill_id, skill_lv, tick, flag|BCT_ENEMY|SD_SPLASH|1, skill_castend_damage_id);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #5410 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Prevent sending 0 as number of targets when splash skills split damage among targets
  * This happened when using splash skills on skill units such as Icewall
  * Map server console will no longer be spammed with division by 0 error messages
- Fixes #5410

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
