### PR TITLE
Fixed timer SCs killing units

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14793,6 +14793,17 @@ TIMER_FUNC(status_change_timer){
 		break;
 	}
 
+	bl = map_id2bl( id );
+
+	// Probably already dead and freed
+	if( bl == nullptr ){
+		if( dounlock ){
+			map_freeblock_unlock();
+		}
+
+		return 0;
+	}
+
 	// If status has an interval and there is at least 100ms remaining time, wait for next interval
 	if(interval > 0 && sc->getSCE(type) && sce->val4 >= 100) {
 		sc_timer_next(min(sce->val4,interval)+tick);


### PR DESCRIPTION
* **Addressed Issue(s)**: See description below.

* **Server Mode**: Both

* **Description of Pull Request**: 
The block list pointer bl, the status change pointer sc and the status change entry pointer sce may point to already freed memory, in cases where the status change has killed the unit.
