### PR TITLE
Fixed Monsters Not Getting Skill Delays if Target Invalid on Castend

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13957,7 +13957,7 @@ TIMER_FUNC(skill_castend_id){
 			break;
 
 		// These actions happen even if the skill fails except when the caster is already dead
-		if (md) {
+		if (md != nullptr) {
 			// When a monster uses a skill, its AI will be inactive for its attack motion
 			// This is also the reason why it doesn't move during this time
 			md->next_thinktime = tick + status_get_amotion(src);
@@ -14335,7 +14335,7 @@ TIMER_FUNC(skill_castend_pos){
 			break;
 
 		// These actions happen even if the skill fails except when the caster is already dead
-		if (md) {
+		if (md != nullptr) {
 			// When a monster uses a skill, its AI will be inactive for its attack motion
 			// This is also the reason why it doesn't move during this time
 			md->next_thinktime = tick + status_get_amotion(src);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13953,10 +13953,26 @@ TIMER_FUNC(skill_castend_id){
 		bool fail = false;
 		int8 res = USESKILL_FAIL_LEVEL;
 
+		if (status_isdead(*src))
+			break;
+
+		// These actions happen even if the skill fails except when the caster is already dead
+		if (md) {
+			// When a monster uses a skill, its AI will be inactive for its attack motion
+			// This is also the reason why it doesn't move during this time
+			md->next_thinktime = tick + status_get_amotion(src);
+
+			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
+				clif_emotion(*src, static_cast<emotion_type>(md->db->skill[md->skill_idx]->emotion));
+
+			// Sets cooldowns and attack delay
+			mobskill_end(*md, tick);
+		}
+
 		if (!target || target->prev == nullptr)
 			break;
 
-		if (src->m != target->m || status_isdead(*src))
+		if (src->m != target->m)
 			break;
 
 		//These should become skill_castend_pos
@@ -14028,14 +14044,6 @@ TIMER_FUNC(skill_castend_id){
 		//Avoid doing double checks for instant-cast skills.
 		if (tid != INVALID_TIMER && !status_check_skilluse(src, target, ud->skill_id, 1))
 			break;
-
-		if(md) {
-			// When a monster uses a skill, its AI will be inactive for its attack motion
-			// This is also the reason why it doesn't move during this time
-			md->next_thinktime = tick + status_get_amotion(src);
-			if(md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
-				clif_emotion( *src, static_cast<emotion_type>( md->db->skill[md->skill_idx]->emotion ) );
-		}
 
 		if (src != target && battle_config.skill_add_range &&
 			!check_distance_bl(src, target, skill_get_range2(src, ud->skill_id, ud->skill_lv, true) + battle_config.skill_add_range))
@@ -14132,10 +14140,6 @@ TIMER_FUNC(skill_castend_id){
 				if (cooldown > 0)
 					skill_blockpc_start(*sd, ud->skill_id, cooldown);
 			}
-			break;
-			case BL_MOB:
-				// Sets cooldowns and attack delay
-				mobskill_end(*md, tick);
 			break;
 			case BL_HOM:
 			{
@@ -14330,6 +14334,19 @@ TIMER_FUNC(skill_castend_pos){
 		if( status_isdead(*src) )
 			break;
 
+		// These actions happen even if the skill fails except when the caster is already dead
+		if (md) {
+			// When a monster uses a skill, its AI will be inactive for its attack motion
+			// This is also the reason why it doesn't move during this time
+			md->next_thinktime = tick + status_get_amotion(src);
+
+			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
+				clif_emotion(*src, static_cast<emotion_type>(md->db->skill[md->skill_idx]->emotion));
+
+			// Sets cooldowns and attack delay
+			mobskill_end(*md, tick);
+		}
+
 		if (!skill_pos_maxcount_check(src, ud->skillx, ud->skilly, ud->skill_id, ud->skill_lv, src->type, true))
 			break;
 
@@ -14373,14 +14390,6 @@ TIMER_FUNC(skill_castend_pos){
 		if( (src->type == BL_MER || src->type == BL_HOM) && !skill_check_condition_mercenary(src, ud->skill_id, ud->skill_lv, 1) )
 			break;
 
-		if(md) {
-			// When a monster uses a skill, its AI will be inactive for its attack motion
-			// This is also the reason why it doesn't move during this time
-			md->next_thinktime = tick + status_get_amotion(src);
-			if(md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
-				clif_emotion( *src, static_cast<emotion_type>( md->db->skill[md->skill_idx]->emotion ) );
-		}
-
 		if(battle_config.skill_log && battle_config.skill_log&src->type)
 			ShowInfo("Type %d, ID %d skill castend pos [id =%d, lv=%d, (%d,%d)]\n",
 				src->type, src->id, ud->skill_id, ud->skill_lv, ud->skillx, ud->skilly);
@@ -14393,10 +14402,6 @@ TIMER_FUNC(skill_castend_pos){
 		if (sd) { //Cooldown application
 			int32 cooldown = pc_get_skillcooldown(sd,ud->skill_id, ud->skill_lv);
 			if(cooldown) skill_blockpc_start(*sd, ud->skill_id, cooldown);
-		}
-		else if (md != nullptr) {
-			// Sets cooldowns and attack delay
-			mobskill_end(*md, tick);
 		}
 		if( battle_config.display_status_timers && sd )
 			clif_status_change(src, EFST_POSTDELAY, 1, skill_delayfix(src, ud->skill_id, ud->skill_lv), 0, 0, 0);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13962,7 +13962,7 @@ TIMER_FUNC(skill_castend_id){
 			// This is also the reason why it doesn't move during this time
 			md->next_thinktime = tick + status_get_amotion(src);
 
-			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
+			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= ET_SURPRISE && md->db->skill[md->skill_idx]->emotion < ET_MAX)
 				clif_emotion(*src, static_cast<emotion_type>(md->db->skill[md->skill_idx]->emotion));
 
 			// Sets cooldowns and attack delay
@@ -14340,7 +14340,7 @@ TIMER_FUNC(skill_castend_pos){
 			// This is also the reason why it doesn't move during this time
 			md->next_thinktime = tick + status_get_amotion(src);
 
-			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= 0)
+			if (md->skill_idx >= 0 && md->db->skill[md->skill_idx]->emotion >= ET_SURPRISE && md->db->skill[md->skill_idx]->emotion < ET_MAX)
 				clif_emotion(*src, static_cast<emotion_type>(md->db->skill[md->skill_idx]->emotion));
 
 			// Sets cooldowns and attack delay


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9142

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed monsters not getting skill delays if the target is invalid on castend
- Fixes #9142

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
