### PR TITLE
Gravitational Field on Emperium

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9651,6 +9651,12 @@ struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *
 		case HW_GRAVITATION:
 			md.damage = 200 + 200 * skill_lv;
 			md.dmotion = 0; //No flinch animation
+			if (target->type == BL_MOB) {
+				mob_data* mob = reinterpret_cast<mob_data*>(target);
+				// Deals 400 damage to Emperium on all levels
+				if (mob != nullptr && mob->mob_id == MOBID_EMPERIUM)
+					md.damage = 400;
+			}
 			break;
 		case PA_PRESSURE:
 			md.damage = 500 + 300 * skill_lv;

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -9652,9 +9652,9 @@ struct Damage battle_calc_misc_attack(struct block_list *src,struct block_list *
 			md.damage = 200 + 200 * skill_lv;
 			md.dmotion = 0; //No flinch animation
 			if (target->type == BL_MOB) {
-				mob_data* mob = reinterpret_cast<mob_data*>(target);
+				mob_data& mob = *reinterpret_cast<mob_data*>(target);
 				// Deals 400 damage to Emperium on all levels
-				if (mob != nullptr && mob->mob_id == MOBID_EMPERIUM)
+				if (mob.mob_id == MOBID_EMPERIUM)
 					md.damage = 400;
 			}
 			break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9149

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Gravitational Field will now always deal 400 damage on Emperium on all levels in pre-re
- Renewal is unaffected
- Fixes #9149

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
