### PR TITLE
Prevent Skill Usage after Normal Attacks for Players

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1532,7 +1532,7 @@ bool battle_status_block_damage(struct block_list *src, struct block_list *targe
 
 	if ((sce = sc->getSCE(SC_PARRYING)) && flag&BF_WEAPON && skill_id != WS_CARTTERMINATION && rnd() % 100 < sce->val2) {
 		clif_skill_nodamage(target, *target, LK_PARRYING, sce->val1);
-		unit_set_attackdelay(*target, gettick());
+		unit_set_attackdelay(*target, gettick(), DELAY_EVENT_PARRY);
 		return false;
 	}
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1815,10 +1815,6 @@ TIMER_FUNC(unit_resume_running){
 
 /**
  * Sets the delays that prevent attacks and skill usage considering the bl type
- * Officially for players it just remembers the last attack time here and applies the delays during the comparison
- * But we pre-calculate the delays instead and store them in attackabletime and canact_tick
- * For ground skills this also applies to mercenaries
- * For non-PCs this function also handles setting of attack delay (which we also store in attackabletime)
  * TODO: Currently this function is only called for normal attacks and parry events and is a work-in-progress
  * @param bl Object to apply attack delay to
  * @param tick Current tick
@@ -1835,9 +1831,10 @@ void unit_set_attackdelay(block_list& bl, t_tick tick, e_delay_event event)
 		case BL_PC:
 			switch (event) {
 				case DELAY_EVENT_ATTACK:
-				//case DELAY_EVENT_CASTBEGIN_ID:
-				//case DELAY_EVENT_CASTBEGIN_POS:
 				case DELAY_EVENT_PARRY:
+					// TODO: This should also happen on cast begin
+					// Officially for players it just remembers the last attack time here and applies the delays during the comparison
+					// But we pre-calculate the delays instead and store them in attackabletime and canact_tick
 					ud->attackabletime = tick + status_get_adelay(&bl);
 					// A fixed delay is added here which is equal to the minimum attack motion you can get
 					// This ensures that at max ASPD attackabletime and canact_tick are equal
@@ -1845,20 +1842,10 @@ void unit_set_attackdelay(block_list& bl, t_tick tick, e_delay_event event)
 					break;
 			}
 			break;
-		case BL_MER:
-			switch (event) {
-				case DELAY_EVENT_ATTACK:
-					ud->attackabletime = tick + status_get_adelay(&bl);
-					break;
-				//case DELAY_EVENT_CASTBEGIN_POS:
-				//	ud->attackabletime = tick + status_get_adelay(&bl);
-				//	ud->canact_tick = tick + status_get_amotion(&bl) + MAX_ASPD_NOPC;
-				//	break;
-			}
-			break;
 		default:
 			switch (event) {
 				case DELAY_EVENT_ATTACK:
+					// This represents setting of attack delay (recharge time) that happens for non-PCs
 					ud->attackabletime = tick + status_get_adelay(&bl);
 					break;
 			}

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -105,6 +105,17 @@ enum e_unit_stop_walking {
 	USW_ALL = 0x1f,
 };
 
+/// Enum for delay events
+enum e_delay_event {
+	DELAY_EVENT_ATTACK = 1, /// Executed a normal attack
+	DELAY_EVENT_CASTBEGIN_ID, /// Started casting a target skill
+	DELAY_EVENT_CASTBEGIN_POS, /// Started casting a ground skill
+	DELAY_EVENT_CASTEND, /// Finished casting a skill
+	DELAY_EVENT_CASTCANCEL, /// Skill cast was cancelled
+	DELAY_EVENT_DAMAGED, /// Got damaged
+	DELAY_EVENT_PARRY, /// Parry activated
+};
+
 // PC, MOB, PET
 
 // Does walk action for unit
@@ -126,7 +137,7 @@ bool unit_can_move(struct block_list *bl);
 int32 unit_is_walking(struct block_list *bl);
 
 // Delay functions
-void unit_set_attackdelay(block_list& bl, t_tick tick);
+void unit_set_attackdelay(block_list& bl, t_tick tick, e_delay_event event);
 int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type);
 
 t_tick unit_get_walkpath_time(struct block_list& bl);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9154 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Normal attacks now prevent players from using skills for AttackMotion+[200-MaxASPD]*10
  * This is the same delay that is already applied when parrying
- Improved structure of unit_set_attackdelay
  * Now uses an event enum so we know from where it was called
  * Added commented code for the skill use delays that still need to be integrated in the future
- Fixes #9154

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
