### PR TITLE
Attack Delays on Cast Begin

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -24,6 +24,16 @@ delay_dependon_agi: no
 // Note: Setting this to anything above 0 can stop speedhacks.
 min_skill_delay_limit: 100
 
+// Should attack motion be applied as minimum skill delay at castbegin? (Note 1)
+// The client usually doesn't send skill commands faster than attack motion.
+// However, there are a few tricks to make the client send commands faster.
+// For some unit types like mercenaries and homunculus, there is no adequate
+// server-sided delay in some situations, so it's possible to use skills faster
+// than attack motion using these tricks.
+// Set this to "yes" if you want to prevent these tricks and ensure that the
+// delay between using skills at castbegin is at least attack motion.
+amotion_min_skill_delay: no
+
 // This delay is the min 'can't walk delay' of all skills.
 // NOTE: Do not set this too low, if a character starts moving too soon after 
 // doing a skill, the client will not update this, and the player will appear

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11783,6 +11783,7 @@ static const struct _battle_data {
 	{ "exp_bonus_attacker",                 &battle_config.exp_bonus_attacker,              25,     0,      INT_MAX,        },
 	{ "exp_bonus_max_attacker",             &battle_config.exp_bonus_max_attacker,          12,     2,      INT_MAX,        },
 	{ "min_skill_delay_limit",              &battle_config.min_skill_delay_limit,           100,    10,     INT_MAX,        },
+	{ "amotion_min_skill_delay",            &battle_config.amotion_min_skill_delay,         0,      0,      1,              },
 	{ "default_walk_delay",                 &battle_config.default_walk_delay,              300,    0,      INT_MAX,        },
 	{ "no_skill_delay",                     &battle_config.no_skill_delay,                  BL_MOB, BL_NUL, BL_ALL,         },
 	{ "attack_walk_delay",                  &battle_config.attack_walk_delay,               BL_ALL, BL_NUL, BL_ALL,         },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -433,6 +433,7 @@ struct Battle_Config
 	int32 exp_bonus_attacker;
 	int32 exp_bonus_max_attacker;
 	int32 min_skill_delay_limit;
+	int32 amotion_min_skill_delay;
 	int32 default_walk_delay;
 	int32 no_skill_delay;
 	int32 attack_walk_delay;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9155 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Players can no longer immediately do a normal attack after using a skill
  * Same goes for mercenaries after using a ground skill
- Homunculus and mercenaries now have a fixed server-sided delay of 200ms between skill casts
  * Client-sided it's still slower as it uses attack motion
  * Added a config to go back to the previous, more-secure behavior that uses attack motion server-sided as well
- Code optimization
- Fixes #9155

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
