### PR TITLE
Added Illusion Teddy Bear Map Drops

### DIFF
--- a/db/re/map_drops.yml
+++ b/db/re/map_drops.yml
@@ -44,101 +44,133 @@ Header:
   Version: 2
 
 Body:
-  - Map: tur_d03_i
+  - Map: ein_d02_i
     SpecificDrops:
-      - Monster: ILL_ASSULTER
+      - Monster: ILL_TEDDY_BEAR_B 
         Drops:
           - Index: 0
             Item: IllusionStone
             Rate: 10
           - Index: 1
-            Item: Huuma_Bird_Wing_IL
+            Item: Survival_Staff_IL
             Rate: 25
-            RandomOptionGroup: ILL_PHYSIC_NORMAL
+            RandomOptionGroup: ILL_MAGIC_NORMAL
           - Index: 2
-            Item: Turtle_Is_Box_IL
+            Item: Teddy_Bear_Box_IL
             Rate: 5
-      - Monster: ILL_PERMETER
+      - Monster: ILL_MINERAL
         Drops:
           - Index: 0
-            Item: Fancy_Flower_IL
-            Rate: 25
-          - Index: 1
             Item: IllusionStone
             Rate: 10
+          - Index: 1
+            Item: Survival_Staff_IL
+            Rate: 25
+            RandomOptionGroup: ILL_MAGIC_NORMAL
           - Index: 2
-            Item: Turtle_Is_Box_IL
+            Item: Teddy_Bear_Box_IL
             Rate: 5
-      - Monster: ILL_FREEZER
+      - Monster: ILL_PITMAN
         Drops:
           - Index: 0
-            Item: Immaterial_Sword_IL
+            Item: Gate_KeeperDD_IL
             Rate: 25
             RandomOptionGroup: ILL_PHYSIC_NORMAL
           - Index: 1
             Item: IllusionStone
             Rate: 10
           - Index: 2
-            Item: Turtle_Is_Box_IL
+            Item: Teddy_Bear_Box_IL
             Rate: 5
-      - Monster: ILL_SOLIDER
+      - Monster: ILL_TEDDY_BEAR_R
         Drops:
           - Index: 0
-            Item: Iron_Driver_IL
+            Item: Headband_Of_Power_IL
+            Rate: 25
+          - Index: 1
+            Item: IllusionStone
+            Rate: 10
+          - Index: 2
+            Item: Teddy_Bear_Box_IL
+            Rate: 5
+      - Monster: ILL_TEDDY_BEAR_Y
+        Drops:
+          - Index: 0
+            Item: Boots_IL
+            Rate: 25
+          - Index: 1
+            Item: IllusionStone
+            Rate: 10
+          - Index: 2
+            Item: Teddy_Bear_Box_IL
+            Rate: 5
+      - Monster: ILL_TEDDY_BEAR_W
+        Drops:
+          - Index: 0
+            Item: Counter_Dagger_IL
             Rate: 25
             RandomOptionGroup: ILL_PHYSIC_NORMAL
           - Index: 1
             Item: IllusionStone
             Rate: 10
           - Index: 2
-            Item: War_Axe_IL
+            Item: Teddy_Bear_Box_IL
+            Rate: 5
+      - Monster: ILL_OBSIDIAN
+        Drops:
+          - Index: 0
+            Item: Counter_Dagger_IL
             Rate: 25
             RandomOptionGroup: ILL_PHYSIC_NORMAL
+          - Index: 1
+            Item: IllusionStone
+            Rate: 10
+          - Index: 2
+            Item: Teddy_Bear_Box_IL
+            Rate: 5
+      - Monster: ILL_TEDDY_BEAR_G
+        Drops:
+          - Index: 0
+            Item: Gate_KeeperDD_IL
+            Rate: 25
+            RandomOptionGroup: ILL_PHYSIC_NORMAL
+          - Index: 1
+            Item: IllusionStone
+            Rate: 10
+          - Index: 2
+            Item: Teddy_Bear_Box_IL
+            Rate: 5
+      - Monster: ILL_TEDDY_BEAR_S
+        Drops:
+          - Index: 0
+            Item: Boots_IL
+            Rate: 5000
+          - Index: 1
+            Item: Counter_Dagger_IL
+            Rate: 5000
+            RandomOptionGroup: ILL_PHYSIC_BOSS
+          - Index: 2
+            Item: Gate_KeeperDD_IL
+            Rate: 5000
+            RandomOptionGroup: ILL_PHYSIC_BOSS
           - Index: 3
-            Item: Turtle_Is_Box_IL
-            Rate: 5
-      - Monster: ILL_HEATER
-        Drops:
-          - Index: 0
-            Item: Pole_Axe_IL
-            Rate: 25
-            RandomOptionGroup: ILL_PHYSIC_NORMAL
-          - Index: 1
-            Item: IllusionStone
-            Rate: 10
-          - Index: 2
-            Item: Turtle_Is_Box_IL
-            Rate: 5
-      - Monster: ILL_TURTLE_GENERAL
-        Drops:
-          - Index: 0
-            Item: Fancy_Flower_IL
+            Item: Headband_Of_Power_IL
             Rate: 5000
-          - Index: 1
-            Item: Immaterial_Sword_IL
-            Rate: 5000
-            RandomOptionGroup: ILL_PHYSIC_BOSS
-          - Index: 2
-            Item: Iron_Driver_IL
-            Rate: 5000
-            RandomOptionGroup: ILL_PHYSIC_BOSS
-          - Index: 3
-            Item: Pole_Axe_IL
-            Rate: 5000
-            RandomOptionGroup: ILL_PHYSIC_BOSS
           - Index: 4
             Item: IllusionStone
-            Rate: 15000
+            Rate: 5000
           - Index: 5
-            Item: War_Axe_IL
-            Rate: 5000
-            RandomOptionGroup: ILL_PHYSIC_BOSS
+            Item: IllusionStone
+            Rate: 10000
           - Index: 6
-            Item: Huuma_Bird_Wing_IL
-            Rate: 5000
-            RandomOptionGroup: ILL_PHYSIC_BOSS
+            Item: IllusionStone
+            Rate: 15000
           - Index: 7
-            Item: S_Turtle_Is_Box_IL
+            Item: Survival_Staff_IL
+            Rate: 25
+            RandomOptionGroup: ILL_MAGIC_NORMAL
+          - Index: 8
+            Item: S_Teddy_Bear_Box_IL
             Rate: 150
   - Map: tur_d04_i
     SpecificDrops:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9163

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Renewal
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Added the map drops according to https://www.divine-pride.net/

Map Mobs:
https://www.divine-pride.net/database/map/ein_d02_i/nasarian-empire

Normal Mobs:
https://www.divine-pride.net/database/monster/20259/blue-teddybear
https://www.divine-pride.net/database/monster/20262/piece-of-spirit
https://www.divine-pride.net/database/monster/20261/pitman-labor-type
https://www.divine-pride.net/database/monster/20255/red-teddybear
https://www.divine-pride.net/database/monster/20256/yellow-teddybear
https://www.divine-pride.net/database/monster/20258/white-teddybear
https://www.divine-pride.net/database/monster/20263/spirit-dwelling-obsidia
https://www.divine-pride.net/database/monster/20257/green-teddybear

MVP:
https://www.divine-pride.net/database/monster/20260/shining-teddy-bear

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
