### PR TITLE
Fixed Looters on monster_loot_search_type=0

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1406,7 +1406,7 @@ static int32 mob_ai_sub_hard_lootsearch(struct block_list *bl,va_list ap)
 	}
 	else if( !battle_config.monster_loot_search_type ){
 		// Stop walking immediately if item is no longer on the ground.
-		unit_stop_walking( &md->bl, USW_FIXPOS );
+		unit_stop_walking_soon(md->bl, USW_FIXPOS);
 	}
 
 	return 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8232

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Looters will now fully benefit from the previous fixes even if monster_loot_search_type is set to 0
- Follow-up to 78a2bab
- Related to #8232

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
