### PR TITLE
Loot Closest Item Feature Improvement

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1994,7 +1994,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	if (can_move && mode&MD_LOOTER && md->lootitems && DIFF_TICK(tick, md->ud.canact_tick) > 0 &&
 		(md->lootitem_count < LOOTITEM_SIZE || battle_config.monster_loot_type != 1))
 	{
-		if (!tbl) {
+		if (tbl == nullptr) {
 			// Search for items in loot range
 			map_foreachinshootrange(mob_ai_sub_hard_lootsearch, &md->bl, battle_config.loot_range, BL_ITEM, md, &tbl);
 		}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1404,10 +1404,6 @@ static int32 mob_ai_sub_hard_lootsearch(struct block_list *bl,va_list ap)
 		(*target) = bl;
 		md->target_id = bl->id;
 	}
-	else if( !battle_config.monster_loot_search_type ){
-		// Stop walking after 0.5-1.5 cells if item is no longer on the ground.
-		unit_stop_walking_soon(md->bl, gettick());
-	}
 
 	return 0;
 }
@@ -1993,10 +1989,21 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	}
 
 	// Scan area for targets
-	if (!tbl && can_move && mode&MD_LOOTER && md->lootitems && DIFF_TICK(tick, md->ud.canact_tick) > 0 &&
+
+	// Scan area for items to loot, avoid trying to loot if the mob is full and can't consume the items.
+	if (can_move && mode&MD_LOOTER && md->lootitems && DIFF_TICK(tick, md->ud.canact_tick) > 0 &&
 		(md->lootitem_count < LOOTITEM_SIZE || battle_config.monster_loot_type != 1))
-	{	// Scan area for items to loot, avoid trying to loot if the mob is full and can't consume the items.
-		map_foreachinshootrange (mob_ai_sub_hard_lootsearch, &md->bl, battle_config.loot_range, BL_ITEM, md, &tbl);
+	{
+		if (!tbl) {
+			// Search for items in loot range
+			map_foreachinshootrange(mob_ai_sub_hard_lootsearch, &md->bl, battle_config.loot_range, BL_ITEM, md, &tbl);
+		}
+		else if (tbl->type == BL_ITEM && battle_config.monster_loot_search_type == 0) {
+			// Looter already has a target item, but we want to check if there is an item that's closer
+			int16 dist = distance_bl(&md->bl, tbl) - 1;
+			if (dist > 0)
+				map_foreachinshootrange(mob_ai_sub_hard_lootsearch, &md->bl, dist, BL_ITEM, md, &tbl);
+		}
 	}
 
 	if ((mode&MD_AGGRESSIVE && (!tbl || slave_lost_target)) || md->state.skillstate == MSS_FOLLOW)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Feature Improvement

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When setting monster_loot_search_type to 0, monsters will now reliably switch to the closest item target
  * This works now even when a new item appears that is closer while the monster is already chasing an item
  * Does not apply when the monster already has a target that is not an item
- Removed previous code that shortened the walkpath but only worked in a few edge cases
  * Now uses the normal process of stopping when target is gone

Changes walkpath from:
![grafik](https://github.com/user-attachments/assets/3ea14412-5563-42e5-b4aa-5a4c6ecc5ef4)

To:
![grafik](https://github.com/user-attachments/assets/b3ac3333-a5a3-411e-a8a4-3fda6df76fcb)

(Assuming new item was dropped when monster is at "6" and monster_loot_search_type is set to 0.)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
