### PR TITLE
Restored INF in clif_skillinfo

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -5853,7 +5853,7 @@ void clif_skillup( map_session_data& sd, uint16 skill_id, uint16 lv, uint16 rang
 /// Updates a skill in the skill tree
 /// 07e1 <skill id>.W <type>.L <level>.W <sp cost>.W <attack range>.W <upgradable>.B (ZC_SKILLINFO_UPDATE2)
 /// 0b33 <skill id>.W <type>.L <level>.W <sp cost>.W <attack range>.W <upgradable>.B <level2>.W (ZC_SKILLINFO_UPDATE3)
-void clif_skillinfo( map_session_data& sd, uint16 skill_id ){
+void clif_skillinfo( map_session_data& sd, uint16 skill_id, int32 inf ){
 #if PACKETVER >= 20090715
 	uint16 idx = skill_get_index(skill_id);
 
@@ -5868,7 +5868,11 @@ void clif_skillinfo( map_session_data& sd, uint16 skill_id ){
 	p.level = sd.status.skill[idx].lv;
 	p.sp = static_cast<decltype(p.sp)>( skill_get_sp( skill_id,sd.status.skill[idx].lv ) );
 	p.range2 = static_cast<decltype(p.range2)>( skill_get_range2( &sd.bl,skill_id,sd.status.skill[idx].lv,false ) );
-	p.inf = skill_get_inf( skill_id );
+	if( inf == INF_PASSIVE_SKILL ){
+		p.inf = skill_get_inf( skill_id );
+	}else{
+		p.inf = inf;
+	}
 
 	if( sd.status.skill[idx].flag == SKILL_FLAG_PERMANENT && sd.status.skill[idx].lv < skill_tree_get_max( skill_id, sd.status.class_ ) ){
 		p.upFlag = true;

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -14,6 +14,7 @@
 
 #include "packets.hpp"
 #include "script.hpp"
+#include "skill.hpp"
 #include "trade.hpp"
 
 struct Channel;
@@ -970,7 +971,7 @@ void clif_class_change( block_list& bl, int32 class_, enum send_target target = 
 
 void clif_skillinfoblock(map_session_data *sd);
 void clif_skillup( map_session_data& sd, uint16 skill_id, uint16 lv, uint16 range, bool upgradable );
-void clif_skillinfo( map_session_data& sd, uint16 skill_id );
+void clif_skillinfo( map_session_data& sd, uint16 skill_id, int32 inf = INF_PASSIVE_SKILL );
 void clif_addskill(map_session_data& sd, uint16 skill_id);
 void clif_deleteskill(map_session_data& sd, uint16 skill_id, bool skip_infoblock = false);
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3251,23 +3251,23 @@ void skill_combo_toggle_inf(struct block_list* bl, uint16 skill_id, int32 inf){
 		case CH_TIGERFIST:
 		case CH_CHAINCRUSH:
 			if( sd != nullptr ){
-				clif_skillinfo( *sd, MO_EXTREMITYFIST );
+				clif_skillinfo( *sd, MO_EXTREMITYFIST, inf );
 			}
 			break;
 		case TK_JUMPKICK:
 			if( sd != nullptr ){
-				clif_skillinfo( *sd, TK_JUMPKICK );
+				clif_skillinfo( *sd, TK_JUMPKICK, inf );
 			}
 			break;
 		case MO_TRIPLEATTACK:
 			if( sd != nullptr && pc_checkskill( sd, SR_DRAGONCOMBO) > 0 ){
-				clif_skillinfo( *sd, SR_DRAGONCOMBO );
+				clif_skillinfo( *sd, SR_DRAGONCOMBO, inf );
 			}
 			break;
 		case SR_FALLENEMPIRE:
 			if (sd != nullptr){
-				clif_skillinfo( *sd, SR_GATEOFHELL );
-				clif_skillinfo( *sd, SR_TIGERCANNON );
+				clif_skillinfo( *sd, SR_GATEOFHELL, inf );
+				clif_skillinfo( *sd, SR_TIGERCANNON, inf );
 			}
 			break;
 	}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -12932,19 +12932,19 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 		case SC_COMBO:
 			switch(sce->val1) {
 			case TK_STORMKICK:
-				skill_combo_toggle_inf(bl, TK_JUMPKICK, 0);
+				skill_combo_toggle_inf( bl, TK_JUMPKICK, INF_PASSIVE_SKILL );
 				clif_skill_nodamage(bl,*bl,TK_READYSTORM,1);
 				break;
 			case TK_DOWNKICK:
-				skill_combo_toggle_inf(bl, TK_JUMPKICK, 0);
+				skill_combo_toggle_inf( bl, TK_JUMPKICK, INF_PASSIVE_SKILL );
 				clif_skill_nodamage(bl,*bl,TK_READYDOWN,1);
 				break;
 			case TK_TURNKICK:
-				skill_combo_toggle_inf(bl, TK_JUMPKICK, 0);
+				skill_combo_toggle_inf( bl, TK_JUMPKICK, INF_PASSIVE_SKILL );
 				clif_skill_nodamage(bl,*bl,TK_READYTURN,1);
 				break;
 			case TK_COUNTER:
-				skill_combo_toggle_inf(bl, TK_JUMPKICK, 0);
+				skill_combo_toggle_inf( bl, TK_JUMPKICK, INF_PASSIVE_SKILL );
 				clif_skill_nodamage(bl,*bl,TK_READYCOUNTER,1);
 				break;
 			default: // Rest just toggle inf to enable autotarget
@@ -13314,7 +13314,7 @@ int32 status_change_end(struct block_list* bl, enum sc_type type, int32 tid)
 			}
 			break;
 		case SC_COMBO:
-			skill_combo_toggle_inf(bl,sce->val1,0);
+			skill_combo_toggle_inf( bl, sce->val1, INF_PASSIVE_SKILL );
 			break;
 		case SC_MARIONETTE:
 		case SC_MARIONETTE2: // Marionette target


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
In fb066e9 the possibility to manually force set INF was accidentally removed.
This causes combos to not work correctly.

Thanks to @Playtester
