### PR TITLE
Overweight checks cleanup and fixes

### DIFF
--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -60,15 +60,16 @@ natural_healsp_interval: 8000
 // Automatic healing skill's time interval. (in milliseconds)
 natural_heal_skill_interval: 10000
 
-// The maximum weight for a character to carry before the it stops healing naturally. (in %)
-// For renewal: Requires client 20171025 or newer to display properly
+// The maximum weight for a character to carry before it stops healing naturally. (Note 2)
+// Depending on this configuration you may need to change the corresponding TGA image file
+// in your data in order to show the proper percentage in the status icon.
 // Default on official servers: 50 for Pre-renewal, 70 for Renewal
 //natural_heal_weight_rate: 70
 
-// The maximum weight for a character to get an item from item boxes. (in %)
+// The maximum weight for a character to get an item from item boxes. (Note 2)
 open_box_weight_rate: 70
 
-// The maximum weight for a character to carry before entering the major overweight state. (in %)
+// The maximum weight for a character to carry before entering the major overweight state. (Note 2)
 // In this state the character cannot heal naturally, attack or use skills.
 major_overweight_rate: 90
 

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -60,10 +60,17 @@ natural_healsp_interval: 8000
 // Automatic healing skill's time interval. (in milliseconds)
 natural_heal_skill_interval: 10000
 
-// The maximum weight for a character to carry when the character stops healing naturally. (in %)
+// The maximum weight for a character to carry before the it stops healing naturally. (in %)
 // For renewal: Requires client 20171025 or newer to display properly
-natural_heal_weight_rate: 50
-natural_heal_weight_rate_renewal: 70
+// Default on official servers: 50 for Pre-renewal, 70 for Renewal
+//natural_heal_weight_rate: 70
+
+// The maximum weight for a character to get an item from item boxes. (in %)
+open_box_weight_rate: 70
+
+// The maximum weight for a character to carry before entering the major overweight state. (in %)
+// In this state the character cannot heal naturally, attack or use skills.
+major_overweight_rate: 90
 
 // Maximum atk speed. (Default 190, Highest allowed 199)
 max_aspd: 190

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -67,7 +67,8 @@ natural_heal_skill_interval: 10000
 //natural_heal_weight_rate: 70
 
 // The maximum weight for a character to get an item from item boxes. (Note 2)
-open_box_weight_rate: 70
+// Default on official servers: 70 for Pre-renewal, 90 for Renewal
+//open_box_weight_rate: 90
 
 // The maximum weight for a character to carry before entering the major overweight state. (Note 2)
 // In this state the character cannot heal naturally, attack or use skills.

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -662,6 +662,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
+    EndOnStart:
+      Weight90: true
   - Status: Weight90
     Icon: EFST_WEIGHTOVER90
     Flags:
@@ -673,6 +675,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
+    EndOnStart:
+      Weight50: true
   - Status: Aspdpotion0
     Icon: EFST_ATTHASTE_POTION1
     CalcFlags:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -689,6 +689,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
+    EndOnStart:
+      Weight90: true
   - Status: Weight90
     Icon: EFST_WEIGHTOVER90
     Flags:
@@ -700,6 +702,8 @@ Body:
       NoBanishingBuster: true
       NoClearance: true
       NoForcedEnd: true
+    EndOnStart:
+      Weight50: true
   - Status: Aspdpotion0
     Icon: EFST_ATTHASTE_POTION1
     CalcFlags:

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11615,8 +11615,10 @@ static const struct _battle_data {
 	{ "natural_heal_skill_interval",        &battle_config.natural_heal_skill_interval,     10000,  NATURAL_HEAL_INTERVAL, INT_MAX, },
 #ifdef RENEWAL
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        70,     0,      100             },
+	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            90,     0,      100             },
 #else
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        50,     0,      100             },
+	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            70,     0,      100             },
 #endif
 	{ "arrow_decrement",                    &battle_config.arrow_decrement,                 1,      0,      2,              },
 	{ "ammo_unequip",                       &battle_config.ammo_unequip,                    1,      0,      1,              },
@@ -12124,7 +12126,6 @@ static const struct _battle_data {
 #endif
 	{ "loot_range",                         &battle_config.loot_range,                      12,     1,      MAX_WALKPATH,   },
 	{ "assist_range",                       &battle_config.assist_range,                    11,     1,      MAX_WALKPATH,   },
-	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            70,     0,      100             },
 	{ "major_overweight_rate",              &battle_config.major_overweight_rate,           90,     0,      100             },
 
 #include <custom/battle_config_init.inc>

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5498,7 +5498,7 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			if (wd->miscflag&4) { // ATK [(Skill Level x 150) + (1000 x Target current weight / Maximum weight) + (Target Base Level x 5) x (Caster Base Level / 150)] %
 				skillratio += -100 + 150 * skill_lv + status_get_lv(target) * 5;
 				if (tsd && tsd->weight)
-					skillratio += 100 * tsd->weight / tsd->max_weight;
+					skillratio += pc_getpercentweight(*tsd);
 				RE_LVL_DMOD(150);
 			} else {
 				if (status_get_class_(target) == CLASS_BOSS)
@@ -11613,8 +11613,11 @@ static const struct _battle_data {
 	{ "natural_healhp_interval",            &battle_config.natural_healhp_interval,         6000,   NATURAL_HEAL_INTERVAL, INT_MAX, },
 	{ "natural_healsp_interval",            &battle_config.natural_healsp_interval,         8000,   NATURAL_HEAL_INTERVAL, INT_MAX, },
 	{ "natural_heal_skill_interval",        &battle_config.natural_heal_skill_interval,     10000,  NATURAL_HEAL_INTERVAL, INT_MAX, },
+#ifdef RENEWAL
+	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        70,     0,      100             },
+#else
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        50,     0,      100             },
-	{ "natural_heal_weight_rate_renewal",   &battle_config.natural_heal_weight_rate_renewal,70,     0,      100             },
+#endif
 	{ "arrow_decrement",                    &battle_config.arrow_decrement,                 1,      0,      2,              },
 	{ "ammo_unequip",                       &battle_config.ammo_unequip,                    1,      0,      1,              },
 	{ "ammo_check_weapon",                  &battle_config.ammo_check_weapon,               1,      0,      1,              },
@@ -12121,6 +12124,8 @@ static const struct _battle_data {
 #endif
 	{ "loot_range",                         &battle_config.loot_range,                      12,     1,      MAX_WALKPATH,   },
 	{ "assist_range",                       &battle_config.assist_range,                    11,     1,      MAX_WALKPATH,   },
+	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            70,     0,      100             },
+	{ "major_overweight_rate",              &battle_config.major_overweight_rate,           90,     0,      100             },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -283,7 +283,6 @@ struct Battle_Config
 	int32 natural_healsp_interval;
 	int32 natural_heal_skill_interval;
 	int32 natural_heal_weight_rate;
-	int32 natural_heal_weight_rate_renewal;
 	int32 arrow_decrement;
 	int32 ammo_unequip;
 	int32 ammo_check_weapon;
@@ -771,6 +770,8 @@ struct Battle_Config
 	int32 alchemist_summon_setting;
 	int32 loot_range;
 	int32 assist_range;
+	int32 open_box_weight_rate;
+	int32 major_overweight_rate;
 
 #include <custom/battle_config_struct.inc>
 };

--- a/src/map/buyingstore.cpp
+++ b/src/map/buyingstore.cpp
@@ -215,7 +215,7 @@ int8 buyingstore_create( map_session_data* sd, int32 zenylimit, unsigned char re
 		return 5;
 	}
 
-	if( (sd->max_weight*90)/100 < weight )
+	if( pc_getpercentweight(*sd) >= battle_config.major_overweight_rate )
 	{// not able to carry all wanted items without getting overweight (90%)
 		sd->buyingstore.slots = 0;
 		clif_buyingstore_open_failed(sd, BUYINGSTORE_CREATE_OVERWEIGHT, weight);

--- a/src/map/buyingstore.cpp
+++ b/src/map/buyingstore.cpp
@@ -215,7 +215,7 @@ int8 buyingstore_create( map_session_data* sd, int32 zenylimit, unsigned char re
 		return 5;
 	}
 
-	if( pc_getpercentweight(*sd) >= battle_config.major_overweight_rate )
+	if( pc_getpercentweight(*sd, weight) >= battle_config.major_overweight_rate )
 	{// not able to carry all wanted items without getting overweight (90%)
 		sd->buyingstore.slots = 0;
 		clif_buyingstore_open_failed(sd, BUYINGSTORE_CREATE_OVERWEIGHT, weight);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -3647,7 +3647,7 @@ static void clif_longlongpar_change(map_session_data& sd, uint16 varId, int64 am
 void clif_updatestatus( map_session_data& sd, enum _sp type ){
 	switch(type){
 		case SP_WEIGHT:
-			pc_updateweightstatus(&sd);
+			pc_updateweightstatus(sd);
 			clif_par_change(sd, type, sd.weight);
 			break;
 		case SP_MAXWEIGHT:
@@ -21999,11 +21999,7 @@ void clif_weight_limit( map_session_data* sd ){
 
 	WFIFOHEAD(fd, packet_len(0xADE));
 	WFIFOW(fd, 0) = 0xADE;
-#ifdef RENEWAL
-	WFIFOL(fd, 2) = battle_config.natural_heal_weight_rate_renewal;
-#else
 	WFIFOL(fd, 2) = battle_config.natural_heal_weight_rate;
-#endif
 	WFIFOSET(fd, packet_len(0xADE));
 #endif
 }
@@ -24435,7 +24431,7 @@ void clif_parse_item_reform_start( int32 fd, map_session_data* sd ){
 void clif_enchantwindow_open( map_session_data& sd, uint64 clientLuaIndex ){
 #if PACKETVER_RE_NUM >= 20211103 || PACKETVER_MAIN_NUM >= 20220330
 	// Hardcoded clientside check
-	if( sd.weight > ( ( sd.max_weight * 70 ) / 100 ) ){
+	if( pc_getpercentweight(sd) >= 70 ){
 		clif_msg_color( sd, MSI_ENCHANT_FAILED_OVER_WEIGHT, color_table[COLOR_RED] );
 		sd.state.item_enchant_index = 0;
 		return;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2993,7 +2993,7 @@ void pc_updateweightstatus(map_session_data& sd)
 
 
 	// Update overweight status
-	sd.regen.state.overweight = new_overweight;
+	sd.regen.state.overweight = new_overweight != 0;
 }
 
 int32 pc_disguise(map_session_data *sd, int32 class_)
@@ -6283,7 +6283,6 @@ bool pc_isUseitem(map_session_data *sd,int32 n)
 	// Safe check type cash disappear when overweight [Napster]
 	if( item->flag.group || item->type == IT_CASH ){
 		// Check if the player is not overweighted
-		// On official servers both renewal and pre-renewal check for 70% overweight
 		if (pc_getpercentweight(*sd) >= battle_config.open_box_weight_rate) {
 #ifdef RENEWAL
 			clif_msg_color( *sd, MSI_PICKUP_FAILED_ITEMCREATE, color_table[COLOR_RED] );

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2942,9 +2942,9 @@ uint64 pc_calc_skilltree_normalize_job( map_session_data *sd ){
 	return c;
 }
 
-uint8 pc_getpercentweight(map_session_data &sd)
+uint16 pc_getpercentweight(map_session_data &sd)
 {
-	return static_cast<uint8>(sd.weight * 100 / sd.max_weight);
+	return static_cast<uint16>(sd.weight * 100 / sd.max_weight);
 }
 
 /*==========================================
@@ -2957,7 +2957,7 @@ uint8 pc_getpercentweight(map_session_data &sd)
 void pc_updateweightstatus(map_session_data &sd)
 {
 	uint8 old_overweight = (sd.sc.getSCE(SC_WEIGHT90) != nullptr) ? 2 : (sd.sc.getSCE(SC_WEIGHT50) != nullptr) ? 1 : 0;
-	uint8 overweight_percent = pc_getpercentweight(sd);
+	uint16 overweight_percent = pc_getpercentweight(sd);
 	uint8 new_overweight = (overweight_percent >= battle_config.major_overweight_rate) ? 2 : (overweight_percent >= battle_config.natural_heal_weight_rate) ? 1 : 0;
 
 	// No change

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2971,18 +2971,11 @@ void pc_updateweightstatus(map_session_data& sd)
 	if( old_overweight == new_overweight )
 		return;
 
-	// Stop old status change
-	switch (old_overweight) {
-	case 1:
+	switch (new_overweight) {
+	case 0:
 		status_change_end(&sd.bl, SC_WEIGHT50);
-		break;
-	case 2:
 		status_change_end(&sd.bl, SC_WEIGHT90);
 		break;
-	}
-
-	// Start new status change
-	switch (new_overweight) {
 	case 1:
 		sc_start(&sd.bl, &sd.bl, SC_WEIGHT50, 100, 0, 0);
 		break;
@@ -2990,7 +2983,6 @@ void pc_updateweightstatus(map_session_data& sd)
 		sc_start(&sd.bl, &sd.bl, SC_WEIGHT90, 100, 0, 0);
 		break;
 	}
-
 
 	// Update overweight status
 	sd.regen.state.overweight = new_overweight != 0;

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2942,9 +2942,16 @@ uint64 pc_calc_skilltree_normalize_job( map_session_data *sd ){
 	return c;
 }
 
-uint16 pc_getpercentweight(map_session_data &sd)
+/**
+ * Calculate the weight percentage of a player
+ * @param sd: Player data
+ * @param weight: (optional) Weight to check, if 0, player's current weight is used
+ */
+uint16 pc_getpercentweight(map_session_data& sd, uint32 weight)
 {
-	return static_cast<uint16>(sd.weight * 100 / sd.max_weight);
+	if (weight == 0)
+		weight = sd.weight;
+	return static_cast<uint16>(weight * 100 / sd.max_weight);
 }
 
 /*==========================================
@@ -2954,7 +2961,7 @@ uint16 pc_getpercentweight(map_session_data &sd)
  * 2: major overweight 90%
  * It's assumed that SC_WEIGHT50 and SC_WEIGHT90 are only started/stopped here.
  */
-void pc_updateweightstatus(map_session_data &sd)
+void pc_updateweightstatus(map_session_data& sd)
 {
 	uint8 old_overweight = (sd.sc.getSCE(SC_WEIGHT90) != nullptr) ? 2 : (sd.sc.getSCE(SC_WEIGHT50) != nullptr) ? 1 : 0;
 	uint16 overweight_percent = pc_getpercentweight(sd);

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2956,7 +2956,7 @@ uint8 pc_getpercentweight(map_session_data &sd)
  */
 void pc_updateweightstatus(map_session_data &sd)
 {
-	uint8 old_overweight = (sd.sc.getSCE(SC_WEIGHT90)) ? 2 : (sd.sc.getSCE(SC_WEIGHT50)) ? 1 : 0;
+	uint8 old_overweight = (sd.sc.getSCE(SC_WEIGHT90) != nullptr) ? 2 : (sd.sc.getSCE(SC_WEIGHT50) != nullptr) ? 1 : 0;
 	uint8 overweight_percent = pc_getpercentweight(sd);
 	uint8 new_overweight = (overweight_percent >= battle_config.major_overweight_rate) ? 2 : (overweight_percent >= battle_config.natural_heal_weight_rate) ? 1 : 0;
 

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1469,7 +1469,7 @@ bool pc_isequipped(map_session_data *sd, t_itemid nameid);
 enum adopt_responses pc_try_adopt(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 bool pc_adoption(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 
-uint8 pc_getpercentweight(map_session_data& sd);
+uint16 pc_getpercentweight(map_session_data& sd);
 void pc_updateweightstatus(map_session_data &sd);
 
 bool pc_addautobonus(std::vector<std::shared_ptr<s_autobonus>> &bonus, const char *script, int16 rate, uint32 dur, uint16 atk_type, const char *o_script, uint32 pos, bool onskill);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1189,9 +1189,6 @@ static bool pc_cant_act( map_session_data* sd ){
 #define pc_isfalcon(sd)       ( (sd)->sc.option&OPTION_FALCON )
 #define pc_isriding(sd)       ( (sd)->sc.option&OPTION_RIDING )
 #define pc_isinvisible(sd)    ( (sd)->sc.option&OPTION_INVISIBLE )
-#define pc_is50overweight(sd) ( (sd)->weight * 100 >= (sd)->max_weight * battle_config.natural_heal_weight_rate )
-#define pc_is70overweight(sd) ( (sd)->weight * 100 >= (sd)->max_weight * battle_config.natural_heal_weight_rate_renewal )
-#define pc_is90overweight(sd) ( (sd)->weight * 10 >= (sd)->max_weight * 9 )
 
 static inline bool pc_hasprogress(map_session_data *sd, enum e_wip_block progress) {
 	return sd == nullptr || (sd->state.workinprogress&progress) == progress;
@@ -1472,7 +1469,8 @@ bool pc_isequipped(map_session_data *sd, t_itemid nameid);
 enum adopt_responses pc_try_adopt(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 bool pc_adoption(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 
-void pc_updateweightstatus(map_session_data *sd);
+uint8 pc_getpercentweight(map_session_data& sd);
+void pc_updateweightstatus(map_session_data &sd);
 
 bool pc_addautobonus(std::vector<std::shared_ptr<s_autobonus>> &bonus, const char *script, int16 rate, uint32 dur, uint16 atk_type, const char *o_script, uint32 pos, bool onskill);
 void pc_exeautobonus(map_session_data &sd, std::vector<std::shared_ptr<s_autobonus>> *bonus, std::shared_ptr<s_autobonus> autobonus);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1469,8 +1469,8 @@ bool pc_isequipped(map_session_data *sd, t_itemid nameid);
 enum adopt_responses pc_try_adopt(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 bool pc_adoption(map_session_data *p1_sd, map_session_data *p2_sd, map_session_data *b_sd);
 
-uint16 pc_getpercentweight(map_session_data& sd);
-void pc_updateweightstatus(map_session_data &sd);
+uint16 pc_getpercentweight(map_session_data& sd, uint32 weight = 0);
+void pc_updateweightstatus(map_session_data& sd);
 
 bool pc_addautobonus(std::vector<std::shared_ptr<s_autobonus>> &bonus, const char *script, int16 rate, uint32 dur, uint16 atk_type, const char *o_script, uint32 pos, bool onskill);
 void pc_exeautobonus(map_session_data &sd, std::vector<std::shared_ptr<s_autobonus>> *bonus, std::shared_ptr<s_autobonus> autobonus);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18454,7 +18454,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 			return true;
 	}
 
-	if( sc != nullptr && sc->getSCE(SC_WEIGHT90) ) {
+	if( sc != nullptr && sc->getSCE(SC_WEIGHT90) != nullptr ) {
 		clif_skill_fail( sd, skill_id, USESKILL_FAIL_WEIGHTOVER );
 		return false;
 	}
@@ -19494,7 +19494,7 @@ bool skill_check_condition_castend( map_session_data& sd, uint16 skill_id, uint1
 	if (sc->empty())
 		sc = nullptr;
 
-	if (sc != nullptr && sc->getSCE(SC_WEIGHT90)) {
+	if ( sc != nullptr && sc->getSCE(SC_WEIGHT90) != nullptr ) {
 		clif_skill_fail(sd, skill_id, USESKILL_FAIL_WEIGHTOVER);
 		return false;
 	}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18454,7 +18454,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 			return true;
 	}
 
-	if( pc_is90overweight(&sd) ) {
+	if( sc != nullptr && sc->getSCE(SC_WEIGHT90) ) {
 		clif_skill_fail( sd, skill_id, USESKILL_FAIL_WEIGHTOVER );
 		return false;
 	}
@@ -19191,11 +19191,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 			}
 			break;
 		case ST_RECOVER_WEIGHT_RATE:
-#ifdef RENEWAL
-			if(pc_is70overweight(&sd)) {
-#else
-			if(pc_is50overweight(&sd)) {
-#endif
+			if( pc_getpercentweight(sd) >= battle_config.natural_heal_weight_rate ) {
 				clif_skill_fail( sd, skill_id );
 				return false;
 			}
@@ -19494,14 +19490,14 @@ bool skill_check_condition_castend( map_session_data& sd, uint16 skill_id, uint1
 	if( sd.skillitem == skill_id && !sd.skillitem_keep_requirement ) // Casting finished (Item skill or Hocus-Pocus)
 		return true;
 
-	if( pc_is90overweight(&sd) ) {
-		clif_skill_fail( sd, skill_id, USESKILL_FAIL_WEIGHTOVER );
-		return false;
-	}
-
 	status_change* sc = &sd.sc;
 	if (sc->empty())
 		sc = nullptr;
+
+	if (sc != nullptr && sc->getSCE(SC_WEIGHT90)) {
+		clif_skill_fail(sd, skill_id, USESKILL_FAIL_WEIGHTOVER);
+		return false;
+	}
 
 	// perform skill-specific checks (and actions)
 	switch( skill_id ) {

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19191,7 +19191,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 			}
 			break;
 		case ST_RECOVER_WEIGHT_RATE:
-			if( pc_getpercentweight(sd) >= battle_config.natural_heal_weight_rate ) {
+			if( sc != nullptr && (sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr) ) {
 				clif_skill_fail( sd, skill_id );
 				return false;
 			}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19191,7 +19191,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 			}
 			break;
 		case ST_RECOVER_WEIGHT_RATE:
-			if( sc != nullptr && (sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr) ) {
+			if( sd.regen.state.overweight ) {
 				clif_skill_fail( sd, skill_id );
 				return false;
 			}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13418,8 +13418,8 @@ int32 status_change_end(struct block_list* bl, enum sc_type type, int32 tid)
 			}
 			break;
 		case SC_TENSIONRELAX:
-			if (regen_data *regen = status_get_regen_data(bl); regen != nullptr && regen->state.overweight)
-				regen->state.overweight = true; // Add the overweight flag back
+			if (sc && (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90)))
+				status_get_regen_data(bl)->state.overweight = true; // Add the overweight flag back
 			break;
 		case SC_MONSTER_TRANSFORM:
 		case SC_ACTIVE_MONSTER_TRANSFORM:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5381,7 +5381,7 @@ void status_calc_regen_rate(struct block_list *bl, struct regen_data *regen, sta
 		regen->flag &= ~RGN_SP;
 
 	if (sc->getSCE(SC_TENSIONRELAX)) {
-		if ( sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr )
+		if (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90))
 			regen->state.overweight = 0; // 1x HP regen
 		else {
 			regen->rate.hp += 200;
@@ -13418,7 +13418,7 @@ int32 status_change_end(struct block_list* bl, enum sc_type type, int32 tid)
 			}
 			break;
 		case SC_TENSIONRELAX:
-			if ( sc != nullptr && ( sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr ) )
+			if (sc && (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90)))
 				status_get_regen_data(bl)->state.overweight = 1; // Add the overweight flag back
 			break;
 		case SC_MONSTER_TRANSFORM:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5381,7 +5381,7 @@ void status_calc_regen_rate(struct block_list *bl, struct regen_data *regen, sta
 		regen->flag &= ~RGN_SP;
 
 	if (sc->getSCE(SC_TENSIONRELAX)) {
-		if (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90))
+		if ( sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr )
 			regen->state.overweight = 0; // 1x HP regen
 		else {
 			regen->rate.hp += 200;
@@ -13418,7 +13418,7 @@ int32 status_change_end(struct block_list* bl, enum sc_type type, int32 tid)
 			}
 			break;
 		case SC_TENSIONRELAX:
-			if (sc && (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90)))
+			if ( sc != nullptr && ( sc->getSCE(SC_WEIGHT50) != nullptr || sc->getSCE(SC_WEIGHT90) != nullptr ) )
 				status_get_regen_data(bl)->state.overweight = 1; // Add the overweight flag back
 			break;
 		case SC_MONSTER_TRANSFORM:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3647,7 +3647,7 @@ bool status_calc_weight(map_session_data *sd, enum e_status_calc_weight_opt flag
 		clif_updatestatus(*sd, SP_WEIGHT);
 	if (b_max_weight != sd->max_weight) {
 		clif_updatestatus(*sd, SP_MAXWEIGHT);
-		pc_updateweightstatus(sd);
+		pc_updateweightstatus(*sd);
 	}
 
 	return true;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5381,8 +5381,8 @@ void status_calc_regen_rate(struct block_list *bl, struct regen_data *regen, sta
 		regen->flag &= ~RGN_SP;
 
 	if (sc->getSCE(SC_TENSIONRELAX)) {
-		if (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90))
-			regen->state.overweight = 0; // 1x HP regen
+		if (regen->state.overweight)
+			regen->state.overweight = false; // 1x HP regen
 		else {
 			regen->rate.hp += 200;
 			if (regen->sregen)
@@ -13418,8 +13418,8 @@ int32 status_change_end(struct block_list* bl, enum sc_type type, int32 tid)
 			}
 			break;
 		case SC_TENSIONRELAX:
-			if (sc && (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90)))
-				status_get_regen_data(bl)->state.overweight = 1; // Add the overweight flag back
+			if (regen_data *regen = status_get_regen_data(bl); regen != nullptr && regen->state.overweight)
+				regen->state.overweight = true; // Add the overweight flag back
 			break;
 		case SC_MONSTER_TRANSFORM:
 		case SC_ACTIVE_MONSTER_TRANSFORM:

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3413,7 +3413,7 @@ struct regen_data {
 	struct {
 		unsigned walk:1; //Can you regen even when walking?
 		unsigned gc:1;	//Tags when you should have double regen due to GVG castle
-		unsigned overweight :2; //overweight state (1: 50%, 2: 90%)
+		bool overweight; //overweight state
 		unsigned block :2; //Block regen flag (1: Hp, 2: Sp)
 	} state;
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
* Replaced specific weight checks pc_is50overweight, pc_is70overweight and pc_is90overweight with pc_getpercentweight() function and configurable battle conf parameters.
* Unified natural_heal_weight_rate battle conf
* Fixed open box weight check, it's actually 70% by default on pre-re and  90% on renewal
* Cleanup of pc_updateweightstatus() function
* Replaced some weight checks with status SC_WEIGHT90 / SC_WEIGHT50 status checks
* Used new pc_getpercentweight() function where possible.
* Changed overweight regen state to bool and updated some checks that previously checked for SC_WEIGHT50 and SC_WEIGHT90 instead
* Added EndOnStart values on status.yml for SC_WEIGHT50 and SC_WEIGHT90 to cancel out each other 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
