### PR TITLE
Fixed Meister ABR AI

### DIFF
--- a/db/re/mob_db.yml
+++ b/db/re/mob_db.yml
@@ -108812,7 +108812,7 @@ Body:
     AttackMotion: 864
     ClientAttackMotion: 648
     DamageMotion: 1440
-#   Ai: 
+    Ai: Abr_Offensive
   - Id: 20835
     AegisName: ABR_DUAL_CANNON
     Name: ABR Duel Cannon
@@ -108837,7 +108837,7 @@ Body:
     AttackMotion: 768
     ClientAttackMotion: 576
     DamageMotion: 1008
-#   Ai: 
+    Ai: Abr_Offensive
   - Id: 20836
     AegisName: ABR_MOTHER_NET
     Name: ABR Mother Net
@@ -108862,7 +108862,7 @@ Body:
     AttackMotion: 1008
     ClientAttackMotion: 672
     DamageMotion: 576
-#   Ai: 
+    Ai: Abr_Passive
   - Id: 20837
     AegisName: ABR_INFINITY
     Name: ABR Infinity
@@ -108887,7 +108887,7 @@ Body:
     AttackMotion: 1728
     ClientAttackMotion: 840
     DamageMotion: 1008
-#   Ai: 
+    Ai: Abr_Offensive
 #  - Id: 20838
 #    AegisName: ELEMETAL_MASTER_S1
 #  - Id: 20839

--- a/doc/mob_db_mode_list.txt
+++ b/doc/mob_db_mode_list.txt
@@ -142,6 +142,11 @@ Aegis/rA (description)
 26: 0xB695 (aggressive, change-target melee/chase, cast sensor idle/chase, chase-change target, random target)
 27: 0x8084 (aggressive, immobile, random target)
 
+Special AI:
+
+ABR_PASSIVE: 0x0021 (passive, does not walk randomly, can't attack)
+ABR_OFFENSIVE: 0x00A5 (aggressive, does not walk randomly)
+
 Aegis Class Types
 -------------------------------------------------------------------------------
 

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -176,6 +176,9 @@ enum e_aegis_monstertype : uint16 {
 	MONSTER_TYPE_25 = 0x1,
 	MONSTER_TYPE_26 = 0xB695,
 	MONSTER_TYPE_27 = 0x8084,
+	// Special AI
+	MONSTER_TYPE_ABR_PASSIVE = 0x21,
+	MONSTER_TYPE_ABR_OFFENSIVE = 0xA5,
 };
 
 /// Aegis monster class types

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -3527,6 +3527,8 @@
 	export_constant(MONSTER_TYPE_25);
 	export_constant(MONSTER_TYPE_26);
 	export_constant(MONSTER_TYPE_27);
+	export_constant(MONSTER_TYPE_ABR_PASSIVE);
+	export_constant(MONSTER_TYPE_ABR_OFFENSIVE);
 
 	/* classes */
 	export_constant(CLASS_NONE);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8916 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Added two new AI modes ABR_PASSIVE and ABR_OFFENSIVE
- Mother Net now uses ABR_PASSIVE, the other auto battle robots use ABR_OFFENSIVE
- This fixes the issue that the auto battle robots didn't attack or move with their master
- Fixes #8916

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
