### PR TITLE
Fixed mob_reload_itemmob_data

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -7023,7 +7023,7 @@ void mob_reload_itemmob_data(void) {
 		}
 
 		for( const std::shared_ptr<s_mob_drop>& entry : pair.second->dropitem ){
-			if( entry->nameid )
+			if( !entry->nameid )
 				continue;
 
 			item_data* id = itemdb_search(entry->nameid);


### PR DESCRIPTION
* **Addressed Issue(s)**: 

mob_reload_itemmob_data was skipping all entries after `@reloaditemdb` instead of relinking drops

* **Server Mode**: 

both
