### PR TITLE
Fixed SCB_REGEN not calling status_calc_regen

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5653,6 +5653,7 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 		status->vit = status_calc_vit(&bl, sc, b_status->vit);
 		flag.set(SCB_DEF2);
 		flag.set(SCB_MDEF2);
+		flag.set(SCB_REGEN);
 		if( bl.type&(BL_PC|BL_HOM|BL_MER|BL_ELEM) )
 			flag.set(SCB_MAXHP);
 		if( bl.type == BL_HOM )
@@ -5663,6 +5664,7 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 		status->int_ = status_calc_int(&bl, sc, b_status->int_);
 		flag.set(SCB_MATK);
 		flag.set(SCB_MDEF2);
+		flag.set(SCB_REGEN);
 		if( bl.type&(BL_PC|BL_HOM|BL_MER|BL_ELEM) )
 			flag.set(SCB_MAXSP);
 		if( bl.type == BL_HOM )
@@ -5986,6 +5988,8 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 			status->hp = status->max_hp;
 			if( sd ) clif_updatestatus(*sd,SP_HP);
 		}
+
+		flag.set( SCB_REGEN );
 	}
 
 	if(flag[SCB_MAXSP]) {
@@ -6004,6 +6008,8 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 			status->sp = status->max_sp;
 			if( sd ) clif_updatestatus(*sd,SP_SP);
 		}
+
+		flag.set( SCB_REGEN );
 	}
 
 	if(flag[SCB_MATK]) {
@@ -6284,11 +6290,10 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 	}
 #endif
 
-	if((flag[SCB_VIT] || flag[SCB_MAXHP] || flag[SCB_INT] || flag[SCB_MAXSP]) && bl.type & BL_REGEN)
-		status_calc_regen(&bl, status, status_get_regen_data(&bl));
-
-	if(flag[SCB_REGEN] && bl.type & BL_REGEN)
+	if( flag[SCB_REGEN] && bl.type&BL_REGEN ){
+		status_calc_regen( &bl, status, status_get_regen_data( &bl ) );
 		status_calc_regen_rate(&bl, status_get_regen_data(&bl), sc);
+	}
 }
 
 /**


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
When a status change has the SCB_REGEN flag set, now also status_calc_regen will be called and not only status_calc_regen_rate.