### PR TITLE
Added missing entries to pet_db for more pets, and some tame items

### DIFF
--- a/db/re/pet_db.yml
+++ b/db/re/pet_db.yml
@@ -3280,3 +3280,266 @@ Body:
 #         bonus2 bAddClass,Class_Normal,1;
 #      }
 #
+#  - Mob: DOMOVOI
+#    EggItem: Brownie_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL) {
+#         bonus2 bAddRace,RC_DemiHuman,1;
+#         bonus2 bMagicAddRace,RC_DemiHuman,1;
+#         bonus2 bSubRace,RC_DemiHuman,1;
+#      }
+#
+#  - Mob: WOODIE
+#    EggItem: Woodie_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMaxHP,75;
+#         bonus bLuk,2;
+#      }
+#
+#  - Mob: ELEPHANT
+#    EggItem: Elephant_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      bonus bDex,3;
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bDex,3;
+#      }
+#
+#  - Mob: GORILLA
+#    EggItem: Gorilla_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      bonus bStr,2;
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bBaseAtk,10;
+#      }
+#
+#  - Mob: LION
+#    EggItem: Lion_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      bonus bMaxSP,10;
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bInt,3;
+#      }
+#
+#  - Mob: RHINO
+#    EggItem: Rhino_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      bonus bMaxHP,100;
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bVit,3;
+#      }
+#
+#  - Mob: PAD_RUBYLIT
+#    EggItem: Rubylit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bBaseAtk,10;
+#      }
+#
+#  - Mob: PAD_SAPPHILIT
+#    EggItem: Sapphilit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMaxHP,100;
+#      }
+#
+#  - Mob: PAD_EMELIT
+#    EggItem: Emelit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMaxHP,50;
+#         bonus bMaxSP,25;
+#      }
+#
+#  - Mob: PAD_TOPALIT
+#    EggItem: Topalit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMaxSP,50;
+#      }
+#
+#  - Mob: PAD_AMELIT
+#    EggItem: Amelit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMatk,10;
+#      }
+#
+#  - Mob: PAD_MYTHLIT
+#    EggItem: Mythlit_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bAllStats,1;
+#      }
+#
+#  - Mob: PAD_TAMADORA
+#    EggItem: Tamadora_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL) {
+#         bonus3 bAutoSpell,"AL_HEAL",1,10;
+#         skill "AL_HEAL",1;
+#      }
+#      else if (.@i >= PET_INTIMATE_CORDIAL) {
+#         bonus3 bAutoSpell,"AL_HEAL",1,10;
+#      }
+#
+#  - Mob: ORK_HERO
+#    EggItem: Orc_Hero_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL) {
+#         bonus bBaseAtk,40;
+#      }
+#      else if (.@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bBaseAtk,30;
+#      }
+#      else if (.@i >= PET_INTIMATE_NEUTRAL) {
+#         bonus bBaseAtk,20;
+#      }
+#      else if (.@i >= PET_INTIMATE_AWKWARD || .@i >= PET_INTIMATE_SHY) {
+#         bonus bBaseAtk,10;
+#         bonus bDef,-3;
+#      }
+#
+#  - Mob: ORC_LORD
+#    EggItem: Orc_Lord_Egg
+#    FoodItem: Pet_Food   # unknown
+#    Fullness: 2   # unknown
+#    HungryDelay: 120   # unknown
+#    IntimacyFed: 15   # unknown
+#    CaptureRate: 0   # unknown
+#    SpecialPerformance: false   # unknown
+#    Script: >
+#      .@i = getpetinfo(PETINFO_INTIMATE);
+#
+#      if (.@i >= PET_INTIMATE_LOYAL) {
+#         bonus bMatk,20;
+#         bonus bBaseAtk,20;
+#      }
+#      else if (.@i >= PET_INTIMATE_CORDIAL) {
+#         bonus bMatk,15;
+#         bonus bBaseAtk,15;
+#      }
+#      else if (.@i >= PET_INTIMATE_NEUTRAL) {
+#         bonus bMatk,10;
+#         bonus bBaseAtk,10;
+#      }
+#      else if (.@i >= PET_INTIMATE_AWKWARD || .@i >= PET_INTIMATE_SHY) {
+#         bonus bBaseAtk,10;
+#         bonus bDef,-3;
+#      }

--- a/db/re/pet_db.yml
+++ b/db/re/pet_db.yml
@@ -762,6 +762,7 @@ Body:
           - Item: Alice_Card
             Amount: 1
   - Mob: EVENT_RICECAKE
+    TameItem: Mysterious_Rice_Powder
     EggItem: Rice_Cake_Egg
     FoodItem: Green_Herb
     Fullness: 3

--- a/db/re/pet_db.yml
+++ b/db/re/pet_db.yml
@@ -2425,6 +2425,7 @@ Body:
 #          - Item: Cookies_Bat
 #            Amount: 100
   - Mob: WILOW
+    #TameItem: Dew_Of_Old_Tree
     EggItem: Wilow_Egg
     FoodItem: Tree_Of_Archer_1
     Fullness: 2   # unknown
@@ -2442,6 +2443,7 @@ Body:
          bonus bInt,2;
       }
   - Mob: ROWEEN
+    #TameItem: Foul_Rotten_Meat
     EggItem: Roween_Egg
     FoodItem: Rotten_Meat
     Fullness: 2   # unknown
@@ -2556,12 +2558,13 @@ Body:
 #      }
 #
   - Mob: DARK_PRIEST
+    TameItem: Darkness_Bible
     EggItem: Dark_Priest_Egg
     FoodItem: Evil_Water
     Fullness: 2   # unknown
     HungryDelay: 120   # unknown
     IntimacyFed: 15   # unknown
-    CaptureRate: 0   # unknown
+    CaptureRate: 200   # unknown
     SpecialPerformance: false   # unknown
     Script: >
       .@i = getpetinfo(PETINFO_INTIMATE);

--- a/db/re/pet_db.yml
+++ b/db/re/pet_db.yml
@@ -3312,7 +3312,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bMaxHP,75;
 #         bonus bLuk,2;
 #      }
@@ -3330,7 +3330,7 @@ Body:
 #
 #      bonus bDex,3;
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bDex,3;
 #      }
 #
@@ -3347,7 +3347,7 @@ Body:
 #
 #      bonus bStr,2;
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bBaseAtk,10;
 #      }
 #
@@ -3364,7 +3364,7 @@ Body:
 #
 #      bonus bMaxSP,10;
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bInt,3;
 #      }
 #
@@ -3381,7 +3381,7 @@ Body:
 #
 #      bonus bMaxHP,100;
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bVit,3;
 #      }
 #
@@ -3396,7 +3396,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bBaseAtk,10;
 #      }
 #
@@ -3411,7 +3411,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bMaxHP,100;
 #      }
 #
@@ -3426,7 +3426,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bMaxHP,50;
 #         bonus bMaxSP,25;
 #      }
@@ -3442,7 +3442,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bMaxSP,50;
 #      }
 #
@@ -3457,7 +3457,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bMatk,10;
 #      }
 #
@@ -3472,7 +3472,7 @@ Body:
 #    Script: >
 #      .@i = getpetinfo(PETINFO_INTIMATE);
 #
-#      if (.@i >= PET_INTIMATE_LOYAL || .@i >= PET_INTIMATE_CORDIAL) {
+#      if (.@i >= PET_INTIMATE_CORDIAL) {
 #         bonus bAllStats,1;
 #      }
 #
@@ -3515,7 +3515,7 @@ Body:
 #      else if (.@i >= PET_INTIMATE_NEUTRAL) {
 #         bonus bBaseAtk,20;
 #      }
-#      else if (.@i >= PET_INTIMATE_AWKWARD || .@i >= PET_INTIMATE_SHY) {
+#      else {
 #         bonus bBaseAtk,10;
 #         bonus bDef,-3;
 #      }
@@ -3543,7 +3543,7 @@ Body:
 #         bonus bMatk,10;
 #         bonus bBaseAtk,10;
 #      }
-#      else if (.@i >= PET_INTIMATE_AWKWARD || .@i >= PET_INTIMATE_SHY) {
+#      else {
 #         bonus bBaseAtk,10;
 #         bonus bDef,-3;
 #      }


### PR DESCRIPTION
Should save someone some time, hopefully. There was lotsa missing pet entries

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
https://github.com/rathena/rathena/issues/9205
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Server Mode**: 
Renewal

* **Description of Pull Request**: 
Added commented entries for 15 pets missing entirely from pet_db so other people don't have to dig for them when implementing them. All these pets exist (fully or partially) in the RO Client by default, and as commented entries in mob_db, so this is a parity update. Also did my best to include all their scripts.
Also added some taming items. For the ones with commented scripts in item_db_usable for no reason, I also commented them here, since the usable item script is broken until someone uncomments it.