### PR TITLE
Remove Exp Tap Bonus from No Damage Skills

### DIFF
--- a/conf/battle/exp.conf
+++ b/conf/battle/exp.conf
@@ -45,6 +45,11 @@ exp_bonus_attacker: 25
 // (eg: if set at 5, the max bonus is 4*bonus-per-char regardless of attackers)
 exp_bonus_max_attacker: 12
 
+// Should casting skill that deal no damage still make you count as an attacker? (Note 1)
+// Setting this to yes makes skills like Lex Aeterna increase the exp a monster gives.
+// Officially you need to deal damage for it to count. 
+exp_bonus_nodamage_attacker: no
+
 // MVP bonus exp rate. (Note 2)
 mvp_exp_rate: 100
 

--- a/conf/battle/exp.conf
+++ b/conf/battle/exp.conf
@@ -45,7 +45,7 @@ exp_bonus_attacker: 25
 // (eg: if set at 5, the max bonus is 4*bonus-per-char regardless of attackers)
 exp_bonus_max_attacker: 12
 
-// Should casting skill that deal no damage still make you count as an attacker? (Note 1)
+// Should casting skills that deal no damage still make you count as an attacker? (Note 1)
 // Setting this to yes makes skills like Lex Aeterna increase the exp a monster gives.
 // Officially you need to deal damage for it to count. 
 exp_bonus_nodamage_attacker: no

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11788,6 +11788,7 @@ static const struct _battle_data {
 	{ "exp_calc_type",                      &battle_config.exp_calc_type,                   0,      0,      2,              },
 	{ "exp_bonus_attacker",                 &battle_config.exp_bonus_attacker,              25,     0,      INT_MAX,        },
 	{ "exp_bonus_max_attacker",             &battle_config.exp_bonus_max_attacker,          12,     2,      INT_MAX,        },
+	{ "exp_bonus_nodamage_attacker",        &battle_config.exp_bonus_nodamage_attacker,     0,      0,      1,              },
 	{ "min_skill_delay_limit",              &battle_config.min_skill_delay_limit,           100,    10,     INT_MAX,        },
 	{ "amotion_min_skill_delay",            &battle_config.amotion_min_skill_delay,         0,      0,      1,              },
 	{ "default_walk_delay",                 &battle_config.default_walk_delay,              300,    0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -431,6 +431,7 @@ struct Battle_Config
 	int32 exp_calc_type;
 	int32 exp_bonus_attacker;
 	int32 exp_bonus_max_attacker;
+	int32 exp_bonus_nodamage_attacker;
 	int32 min_skill_delay_limit;
 	int32 amotion_min_skill_delay;
 	int32 default_walk_delay;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13649,7 +13649,8 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 	}
 
 	if (dstmd) { //Mob skill event for no damage skills (damage ones are handled in battle_damage/skill_attack) [Skotlex]
-		mob_log_damage(dstmd, src, 0); //Log interaction (counts as 'attacker' for the exp bonus)
+		if (battle_config.exp_bonus_nodamage_attacker != 0)
+			mob_log_damage(dstmd, src, 0); //Log interaction (counts as 'attacker' for the exp bonus)
 		mobskill_event(dstmd, src, tick, MSC_SKILLUSED|(skill_id<<16));
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9206 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- By default skills that don't deal damage no longer count towards the exp tap bonus
- Added an option to re-enable this feature
- Fixes #9206

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
