### PR TITLE
Harmonized minimum CMake version to 3.13

### DIFF
--- a/3rdparty/httplib/CMakeLists.txt
+++ b/3rdparty/httplib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
 if ( NOT ENABLE_WEB_SERVER )
     return()

--- a/3rdparty/json/CMakeLists.txt
+++ b/3rdparty/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
 set (JSON_INCLUDE_DIRS
     "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/3rdparty/rapidyaml/CMakeLists.txt
+++ b/3rdparty/rapidyaml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 include(./ext/c4core/cmake/c4Project.cmake)
 project(ryml
     DESCRIPTION "Rapid YAML parsing and emitting"

--- a/3rdparty/rapidyaml/ext/c4core/src/c4/ext/fast_float/CMakeLists.txt
+++ b/3rdparty/rapidyaml/ext/c4core/src/c4/ext/fast_float/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.13)
 
 project(fast_float VERSION 3.4.0 LANGUAGES CXX)
 option(FASTFLOAT_TEST "Enable tests" OFF)

--- a/3rdparty/yaml-cpp/CMakeLists.txt
+++ b/3rdparty/yaml-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
 ## start setting
 SET (this_target yaml-cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,8 @@
 #####################################################################
 
 
-#cmake_minimum_required( VERSION 2.8.4 )
-# Functional changes from 2.8.3 to 2.8.4:
-#   string(SUBSTRING) works with length -1 as "rest of string"
-#   changes to some CPack generators
-#   CYGWIN no longer defines WIN32
-#   CMP0017: Prefer files from the CMake module directory when including from there.
-# Update to 3.1 for CMAKE_CXX_STANDARD cross support definition
 set( CMAKE_LEGACY_CYGWIN_WIN32 0 )
-cmake_minimum_required( VERSION 3.1 )
+cmake_minimum_required( VERSION 3.13 )
 project( rAthena )
 if( CYGWIN )
 	unset( WIN32 )


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
c4core requires 3.13 and since this is a core dependency it does not make sense to set others to different values.
Should fix CI compilation.
