### PR TITLE
Improved documentation of chclif_send_auth_result

### DIFF
--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -456,7 +456,20 @@ void chclif_mmo_char_send(int32 fd, struct char_session_data* sd){
  * result :
  *  1 : Server closed
  *  2 : Someone has already logged in with this id
- *  8 : already online
+ *  3 : Time gap between client and server
+ *  4 : Server is overpopulated
+ *  5 : You are underaged and cannot join this server
+ *  6 : You didn't pay for this account
+ *  7 : Server is overpopulated
+ *  8 : Already online
+ *  9 : IP capacity of Internet Cafe is full
+ * 10 : Out of available playing time
+ * 11 : Your account is suspended
+ * 12 : Connection is terminated due to changes to the billing policy
+ * 13 : Connection is terminated because your IP doesn't match authorized Ip
+ * 14 : Connection is terminated to prevent charging from your account's play time
+ * 15 : Disconnected from server!
+ * 
  */
 void chclif_send_auth_result(int32 fd,char result){
 	WFIFOHEAD(fd,3);


### PR DESCRIPTION
* **Server Mode**: Both

* **Description of Pull Request**:

It updates the `chclif_send_auth_result` function to include additional authentication result cases. The following error cods have been added:

- 3: Time gap between client and server
- 4: Server is overpopulated
- 5: You are underaged and cannot join this server
- 6: You didn't pay for this account
- 7: Server is overpopulated
- 9: IP capacity of Internet Cafe is full
- 10: Out of available playing time
- 11: Your account is suspended
- 12: Connection is terminated due to changes to the billing policy
- 13: Connection is terminated because your IP doesn't match authorized IP
- 14: Connection is terminated to prevent charging from your account's play time
- 15: Disconnected from server!
