### PR TITLE
Fixed SC_CRYSTALIZE

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -3827,8 +3827,8 @@ Body:
     Icon: EFST_COLD
     DurationLookup: SO_DIAMONDDUST
     States:
-      NoMoveCond: true
-      NoCastCond: true
+      NoMove: true
+      NoCast: true
       NoConsumeItem: true
       NoAttack: true
     Flags:
@@ -3839,11 +3839,15 @@ Body:
       RemoveOnLuxAnima: true
       BossResist: true
       StopWalking: true
+      StopWalking: true
+      StopCasting: true
+      SetStand: true
       Debuff: true
     Fail:
       Refresh: true
       Inspiration: true
       Warmer: true
+      Crystalize: true
   - Status: Striking
     Icon: EFST_STRIKING
     DurationLookup: SO_STRIKING

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -3981,8 +3981,8 @@ Body:
     Icon: EFST_COLD
     DurationLookup: SO_DIAMONDDUST
     States:
-      NoMoveCond: true
-      NoCastCond: true
+      NoMove: true
+      NoCast: true
       NoConsumeItem: true
       NoAttack: true
     Flags:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -5632,12 +5632,6 @@ void status_calc_state( block_list& bl, status_change& sc, std::shared_ptr<s_sta
 					// Does not do anything. SC_LONGING is just defined with SCS_NOMOVECOND to trigger a recalculation with the conditions under SC_DANCING above
 					break;
 
-				case SC_CRYSTALIZE:
-					if( bl.type != BL_MOB ){
-						restriction = true;
-					}
-					break;
-
 				default:
 					return false;
 			}


### PR DESCRIPTION
* **Addressed Issue(s)**:
```
[Error]: status_calc_state_sub: status "SC_CRYSTALIZE" is defined with "SCS_NOCASTCOND", but the condition is not implemented.
```

* **Server Mode**: Both

* **Description of Pull Request**: 
Crystalize had the NoCastCond flag in status.yml, but no source side condition was implemented. Actually this was wrong and it is unconditional.
Also it has been confirmed that the movement restriction is also applying for monsters, so also the movement restriction is unconditional.

Additionally synced pre-renewal and renewal flags in status.yml

Thanks to @Playtester
