### PR TITLE
Deprecated Clang versions below 13.0

### DIFF
--- a/.github/workflows/analysis_codeql.yml
+++ b/.github/workflows/analysis_codeql.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
           # The ubuntu-latest label currently points to ubuntu-20.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
           gcc: ['10']

--- a/.github/workflows/build_servers_clang.yml
+++ b/.github/workflows/build_servers_clang.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
           # The ubuntu-latest label currently points to ubuntu-24.04.
           # Available: ubuntu-24.04, ubuntu-22.04
-          os: [ubuntu-latest]
+          os: [ubuntu-22.04]
           # Version list can be found on https://github.com/marketplace/actions/install-clang
-          clang: ['6.0', '7', '8', '9', '10', '11'] #, '12', '13']
+          clang: ['13','14','15','16','17','18','19','20']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_servers_clang.yml
+++ b/.github/workflows/build_servers_clang.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
-          os: [ubuntu-20.04]
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
+          os: [ubuntu-latest]
           # Version list can be found on https://github.com/marketplace/actions/install-clang
           clang: ['6.0', '7', '8', '9', '10', '11'] #, '12', '13']
 

--- a/.github/workflows/build_servers_cmake.yml
+++ b/.github/workflows/build_servers_cmake.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/build_servers_gcc.yml
+++ b/.github/workflows/build_servers_gcc.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
           gcc: ['9', '10', '11', '12']

--- a/.github/workflows/build_servers_modes.yml
+++ b/.github/workflows/build_servers_modes.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
           gcc: ['11']

--- a/.github/workflows/build_servers_packetversions.yml
+++ b/.github/workflows/build_servers_packetversions.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
           gcc: ['11']

--- a/.github/workflows/build_servers_vip.yml
+++ b/.github/workflows/build_servers_vip.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Older versions of GCC are not available via unaltered aptitude repo lists.
           gcc: ['11']

--- a/.github/workflows/npc_db_validation.yml
+++ b/.github/workflows/npc_db_validation.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          # The ubuntu-latest label currently points to ubuntu-22.04.
-          # Available: ubuntu-22.04, ubuntu-20.04
+          # The ubuntu-latest label currently points to ubuntu-24.04.
+          # Available: ubuntu-24.04, ubuntu-22.04
           os: [ubuntu-latest]
           # Only a single version of GCC is required for validating NPC scripts and database changes.
           gcc: ['11']

--- a/src/common/core.cpp
+++ b/src/common/core.cpp
@@ -32,8 +32,8 @@
 #ifndef DEPRECATED_COMPILER_SUPPORT
 	#if defined( _MSC_VER ) && _MSC_VER < 1914
 		#error "Visual Studio versions older than Visual Studio 2017 are not officially supported anymore"
-	#elif defined( __clang__ ) && __clang_major__ < 6
-		#error "clang versions older than clang 6.0 are not officially supported anymore"
+	#elif defined( __clang__ ) && __clang_major__ < 13
+		#error "clang versions older than clang 13.0 are not officially supported anymore"
 	#elif !defined( __clang__ ) && defined( __GNUC__ ) && __GNUC__ < 6
 		#error "GCC versions older than GCC 6 are not officially supported anymore"
 	#endif


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 

Ubuntu 20.04 LTS runner will be removed on 2025-04-15.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

Because of this it was necessary to:

1. Update the Clang workflow to Ubuntu 22.04 (Jammy Jellyfish).
2. Deprecate Clang compiler versions below 13.0, since we cannot rely on Continuous Integration anymore.
