### PR TITLE
Infinite Endure Config

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -46,8 +46,13 @@ damage_walk_delay_rate: 100
 multihit_delay: 80
 
 // Damaged delay rate for players (Note 2)
-// (Setting to no/0  will be like always endure)
+// This affects the damage delay that is sent to the client and is the base value for the walk delay.
 player_damage_delay_rate: 100
+
+// Always have endure? (Note 3)
+// The unit types defined here cannot be stopped by damage.
+// Please note that this makes it impossible to display critical hits on these unit types.
+infinite_endure: 0
 
 // Should race or element be used to consider someone undead?
 // 0 = element undead

--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -51,7 +51,8 @@ player_damage_delay_rate: 100
 
 // Always have endure? (Note 3)
 // The unit types defined here cannot be stopped by damage.
-// Please note that this makes it impossible to display critical hits on these unit types.
+// Please note that criticals can't be displayed on targets with endure due to a client limitation.
+// That means this setting makes it impossible to display critical hits on these unit types.
 infinite_endure: 0
 
 // Should race or element be used to consider someone undead?

--- a/conf/battle/monster.conf
+++ b/conf/battle/monster.conf
@@ -122,8 +122,8 @@ monster_active_enable: yes
 // 2: always use the mob_db JName column (original Kro mob name)
 override_mob_names: 0
 
-// Monster damage delay rate (Note 1)
-// Setting to no/0 is like they always have endure.
+// Monster damage delay rate (Note 2)
+// This affects the damage delay that is sent to the client and is the base value for the walk delay.
 monster_damage_delay_rate: 100
 
 // Looting monster actions.

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11578,6 +11578,7 @@ static const struct _battle_data {
 	{ "pc_damage_walk_delay_rate",          &battle_config.pc_walk_delay_rate,              20,     0,      INT_MAX,        },
 	{ "damage_walk_delay_rate",             &battle_config.walk_delay_rate,                 100,    0,      INT_MAX,        },
 	{ "multihit_delay",                     &battle_config.multihit_delay,                  80,     0,      INT_MAX,        },
+	{ "infinite_endure",                    &battle_config.infinite_endure,                 BL_NUL, BL_NUL, BL_ALL,         },
 	{ "quest_skill_learn",                  &battle_config.quest_skill_learn,               0,      0,      1,              },
 	{ "quest_skill_reset",                  &battle_config.quest_skill_reset,               0,      0,      1,              },
 	{ "basic_skill_check",                  &battle_config.basic_skill_check,               1,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -229,6 +229,7 @@ struct Battle_Config
 	int32 pc_walk_delay_rate; //Adjusts can't walk delay after being hit for players. [Skotlex]
 	int32 walk_delay_rate; //Adjusts can't walk delay after being hit. [Skotlex]
 	int32 multihit_delay;  //Adjusts can't walk delay per hit on multi-hitting skills. [Skotlex]
+	int32 infinite_endure; // Always have endure
 	int32 quest_skill_learn;
 	int32 quest_skill_reset;
 	int32 basic_skill_check;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -9278,6 +9278,10 @@ int32 status_isimmune(struct block_list *bl)
  */
 bool status_isendure(block_list& bl, t_tick tick, bool visible)
 {
+	// If bl type is set to always have endure, we don't need to check anything else
+	if (battle_config.infinite_endure&bl.type)
+		return true;
+
 	// Officially the bonus "no_walk_delay" is actually just SC_ENDURE with unlimited duration.
 	// Endure is forbidden on some maps, but the bonus is still set to true on such maps.
 	// That's why we need to check it here and disable the bonus to correctly mimic official behavior.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9235 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Added config that allows to make certain bl types always have the endure effect
- Updated comment on damage_delay_rate configs that no longer grant endure since 420ebb2
- Fixes #9235

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
