### PR TITLE
Correct Determination of Loot Priority and MVP Reward

### DIFF
--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -398,6 +398,7 @@ struct mob_data {
 	uint16 damagetaken;
 
 	e_mob_bosstype get_bosstype();
+	map_session_data* get_mvp();
 };
 
 class MobAvailDatabase : public YamlDatabase {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8847 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- The MVP Reward is now granted to the player that has the highest [dmg + dmg_tanked] value
  * It is not influenced by the first attacker bonus
- Fixed loot priority not properly considering first attacker and slaves
  * There is now a 30% of total damage bonus for the first person in the damage log
  * Damage dealt by players and their slaves is now added together
- Exp rewards are unaffected by this and work as previously
- Fixes #8847

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
