### PR TITLE
Multi-hit Delay Value Update

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -40,9 +40,10 @@ damage_walk_delay_rate: 100
 // Move-delay adjustment for multi-hitting attacks.
 // When hit by a multi-hitting skill like Lord of Vermillion or Jupitel Thunder, characters will be 
 // unable to move for an additional "(number of hits -1) * multihit_delay" milliseconds.
-// 80 is the setting that feels like Aegis (vs Sonic Blows)
-// 230 is the setting that makes walkdelay last until the last hit (vs Jupitel thunder)
-multihit_delay: 80
+// Please note that skills that deal more than 10 hits are only considered as 2-hit-skills.
+// Official: 200
+// Legacy Athena: 80
+multihit_delay: 200
 
 // Damaged delay rate for players (Note 2)
 // This affects the damage delay that is sent to the client and is the base value for the walk delay.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Related to #1656 (but doesn't fix it), follow-up to f59fd6d

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Updated multi-hit delay from 80ms to 200ms per hit beyond first
  * Officially this only applies to when a monster reacts to damage, but right now it's used as walk delay
  * If you already want to remove walk delay, you can set pc_damage_walk_delay_rate and damage_walk_delay_rate to 0

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
