### PR TITLE
Battle Damage Target Nullptr Check

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -334,7 +334,7 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 		mob_data& md = *reinterpret_cast<mob_data*>(target);
 
 		// Trigger monster skill condition for non-skill attacks.
-		if (!status_isdead(*target) && src != target) {
+		if (src != target && !status_isdead(*target)) {
 			if (damage > 0)
 				mobskill_event(&md, src, tick, attack_type, damage);
 			if (skill_id > 0)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -308,12 +308,13 @@ static t_tick battle_calc_walkdelay(block_list& bl, int64 damage, int16 div_, t_
 * @return HP+SP+AP (0 if HP/SP/AP remained unchanged)
 */
 int32 battle_damage(struct block_list *src, struct block_list *target, int64 damage, int16 div_, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, uint16 attack_type, bool additional_effects, t_tick tick, bool isspdamage) {
+	if (target == nullptr)
+		return 0;
+
 	int32 dmg_change;
 	map_session_data* sd = nullptr;
 
-	t_tick delay = 0;
-	if (target != nullptr)
-		delay = battle_calc_walkdelay(*target, damage, div_, tick);
+	t_tick delay = battle_calc_walkdelay(*target, damage, div_, tick);
 
 	if (src)
 		sd = BL_CAST(BL_PC, src);
@@ -330,21 +331,19 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 		skill_counter_additional_effect(src, target, skill_id, skill_lv, attack_type, tick);
 	// This is the last place where we have access to the actual damage type, so any monster events depending on type must be placed here
 	if (target->type == BL_MOB && additional_effects) {
-		mob_data *md = BL_CAST(BL_MOB, target);
+		mob_data& md = *reinterpret_cast<mob_data*>(target);
 
-		if (md != nullptr) {
-			// Trigger monster skill condition for non-skill attacks.
-			if (!status_isdead(*target) && src != target) {
-				if (damage > 0)
-					mobskill_event(md, src, tick, attack_type, damage);
-				if (skill_id > 0)
-					mobskill_event(md, src, tick, MSC_SKILLUSED | (skill_id << 16));
-			}
-
-			// Monsters differentiate whether they have been attacked by a skill or a normal attack
-			if (damage > 0 && (attack_type & BF_NORMAL))
-				md->norm_attacked_id = md->attacked_id;
+		// Trigger monster skill condition for non-skill attacks.
+		if (!status_isdead(*target) && src != target) {
+			if (damage > 0)
+				mobskill_event(&md, src, tick, attack_type, damage);
+			if (skill_id > 0)
+				mobskill_event(&md, src, tick, MSC_SKILLUSED | (skill_id << 16));
 		}
+
+		// Monsters differentiate whether they have been attacked by a skill or a normal attack
+		if (damage > 0 && (attack_type&BF_NORMAL))
+			md.norm_attacked_id = md.attacked_id;
 	}
 	map_freeblock_unlock();
 	return dmg_change;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Cleanup

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- The battle_damage function now exits early when target is a nullptr
  * This would have crashed the map server previously, but luckily there is no call where target is nullptr
- Cleaned up battle_damage function a little knowing that target cannot be nullptr

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
