### PR TITLE
Config for First Attacker Loot Priority Bonus

### DIFF
--- a/conf/battle/drops.conf
+++ b/conf/battle/drops.conf
@@ -13,6 +13,14 @@ item_auto_get: no
 // How long does it take for an item to disappear from the floor after it is dropped? (in milliseconds)
 flooritem_lifetime: 60000
 
+// Bonus to loot priority for first attacker (Note 2)
+// The first person in the damage log of a monster that is alive and on the same map gains a loot priority bonus
+// Officially 30% of the total damage to a monster is added to this person's damage when calculating loot priority
+// If you set this to 0 then loot priority will be solely calculated based on most damage dealt
+// If you set this to 100 (max) then the first person in the damage log will always get first loot priority
+// Loot priority determines how early a person can loot an item (see settings below)
+first_attack_loot_bonus: 30
+
 // Grace time during which only the person who did the most damage to a monster can get the item? (in milliseconds)
 item_first_get_time: 3000
 

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11558,6 +11558,7 @@ static const struct _battle_data {
 	{ "attribute_recover",                  &battle_config.attr_recover,                    1,      0,      1,              },
 	{ "flooritem_lifetime",                 &battle_config.flooritem_lifetime,              60000,  1000,   INT_MAX,        },
 	{ "item_auto_get",                      &battle_config.item_auto_get,                   0,      0,      1,              },
+	{ "first_attack_loot_bonus",            &battle_config.first_attack_loot_bonus,         30,     0,      100,            },
 	{ "item_first_get_time",                &battle_config.item_first_get_time,             3000,   0,      INT_MAX,        },
 	{ "item_second_get_time",               &battle_config.item_second_get_time,            1000,   0,      INT_MAX,        },
 	{ "item_third_get_time",                &battle_config.item_third_get_time,             1000,   0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -187,6 +187,7 @@ struct Battle_Config
 	int32 attr_recover;
 	int32 item_auto_get;
 	int32 flooritem_lifetime;
+	int32 first_attack_loot_bonus;
 	int32 item_first_get_time;
 	int32 item_second_get_time;
 	int32 item_third_get_time;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2963,8 +2963,8 @@ int32 mob_dead(struct mob_data *md, struct block_list *src, int32 type)
 	}
 
 	if (!lootdmg.empty()) {
-		// First player in the damage log gets 30% of total damage as bonus for loot priority
-		lootdmg[0].damage += (total_damage * 30) / 100;
+		// Officially, the first player in the damage log gets 30% of total damage as bonus for loot priority
+		lootdmg[0].damage += (total_damage * battle_config.first_attack_loot_bonus) / 100;
 
 		// Sort list by damage now and determine top 3 damage dealers
 		std::sort(lootdmg.begin(), lootdmg.end(), [](s_dmg_entry& a, s_dmg_entry& b) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: It's a feature

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Added a config to set the loot priority bonus of the first person in the damage log

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
