### PR TITLE
Delay Setting of Attacked ID

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -331,15 +331,16 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 	if (dmg_lv > ATK_BLOCK && attack_type && additional_effects)
 		skill_counter_additional_effect(src, target, skill_id, skill_lv, attack_type, tick);
 	// This is the last place where we have access to the actual damage type, so any monster events depending on type must be placed here
-	if (src != nullptr && target->type == BL_MOB && additional_effects) {
+	// These events trigger when the attack connects
+	if (src != nullptr && target->type == BL_MOB && dmg_lv > ATK_BLOCK) {
 		mob_data& md = *reinterpret_cast<mob_data*>(target);
 
-		// Trigger monster skill condition for non-skill attacks.
+		// Trigger monster skill conditions
 		if (src != target && !status_isdead(*target)) {
 			if (damage > 0)
 				mobskill_event(&md, src, tick, attack_type, damage);
 			if (skill_id > 0)
-				mobskill_event(&md, src, tick, MSC_SKILLUSED | (skill_id << 16));
+				mobskill_event(&md, src, tick, MSC_SKILLUSED | (skill_id << 16), damage);
 		}
 
 		// Prepare corresponding attacked event that occurs at the end of the calculated walk delay

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -123,8 +123,8 @@ int64 battle_calc_gvg_damage(struct block_list *src,struct block_list *bl,int64 
 int64 battle_calc_bg_damage(struct block_list *src,struct block_list *bl,int64 damage,uint16 skill_id,int32 flag);
 int64 battle_calc_pk_damage(block_list &src, block_list &bl, int64 damage, uint16 skill_id, int32 flag);
 
-int32 battle_damage(struct block_list *src, struct block_list *target, int64 damage, int16 div_, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, uint16 attack_type, bool additional_effects, t_tick tick, bool spdamage);
-int32 battle_delay_damage (t_tick tick, int32 amotion, struct block_list *src, struct block_list *target, int32 attack_type, uint16 skill_id, uint16 skill_lv, int64 damage, enum damage_lv dmg_lv, int16 div_, bool additional_effects, bool spdamage);
+int32 battle_damage(struct block_list *src, struct block_list *target, int64 damage, int16 div_, uint16 skill_lv, uint16 skill_id, enum damage_lv dmg_lv, uint16 attack_type, bool additional_effects, t_tick tick, bool isspdamage, bool is_norm_attacked = false);
+int32 battle_delay_damage (t_tick tick, int32 amotion, struct block_list *src, struct block_list *target, int32 attack_type, uint16 skill_id, uint16 skill_lv, int64 damage, enum damage_lv dmg_lv, int16 div_, bool additional_effects, bool isspdamage, bool is_norm_attacked = false);
 int32 battle_fix_damage(struct block_list* src, struct block_list* target, int64 damage, int16 div_, uint16 skill_id);
 
 int32 battle_calc_chorusbonus(map_session_data *sd);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1243,7 +1243,11 @@ static int32 mob_can_changetarget(struct mob_data* md, struct block_list* target
 		case MSS_BERSERK:
 			if (!(mode&MD_CHANGETARGETMELEE))
 				return 0;
-			if (!(battle_config.mob_ai&0x80) && md->norm_attacked_id != target->id)
+			// If the special normal attacked event occured, always change target in berserk state
+			if (md->norm_attacked_id == target->id)
+				return 1;
+			// If the special setting to switch target even on skills is set, we need to verify the range here
+			if (!(battle_config.mob_ai&0x80))
 				return 0;
 			return (battle_config.mob_ai&0x4 || check_distance_bl(&md->bl, target, md->status.rhw.range+1));
 		case MSS_RUSH:
@@ -2232,6 +2236,86 @@ bool mob_ai_sub_hard_attacktimer(mob_data &md, t_tick tick)
 	return true;
 }
 
+/**
+ * Sets attacked ID based on bl type of attacker
+ * Then calls the mob AI to process it immediately
+ * @param src_id: ID of attacker
+ * @param target_id: ID of attacked monster
+ * @param tick: Current tick
+ * @param is_norm_attacked: When true, sets a special normal attacked ID to trigger a target change in attack state
+ */
+void mob_set_attacked_id(int32 src_id, int32 target_id, t_tick tick, bool is_norm_attacked) {
+	block_list* src = map_id2bl(src_id);
+	if (src == nullptr)
+		return;
+
+	mob_data* md = map_id2md(target_id);
+	if (md == nullptr)
+		return;
+
+	switch (src->type)
+	{
+		case BL_PET:
+		{
+			struct pet_data& pd = *reinterpret_cast<pet_data*>(src);
+			if (pd.master)
+			{
+				// Let mobs retaliate against the pet's master
+				md->attacked_id = pd.master->bl.id;
+			}
+			break;
+		}
+		case BL_MOB:
+		{
+			struct mob_data& md2 = *reinterpret_cast<mob_data*>(src);
+			// Let players decide whether to retaliate versus the master or the mob
+			if (md2.master_id && battle_config.retaliate_to_master)
+				md->attacked_id = md2.master_id;
+			else
+				md->attacked_id = src->id;
+			break;
+		}
+		default:
+			// Retaliate against attacker
+			md->attacked_id = src->id;
+			break;
+	}
+
+	if (is_norm_attacked)
+		md->norm_attacked_id = md->attacked_id;
+
+	// Need to call mob AI routine immediately, otherwise the attacked ID might get overwritten before it is processed
+	mob_ai_sub_hard(md, tick);
+}
+
+/**
+ * Timer that triggers after walk delay when a monster was attacked by skills or from outside [attack range+1]
+ * Sets attacked ID and calls the mob AI to process it immediately
+ * @param tid: Timer ID
+ * @param tick: Current tick
+ * @param id: ID of attacked monster
+ * @param data: ID of attacker
+ * @return 0
+ */
+TIMER_FUNC(mob_attacked) {
+	mob_set_attacked_id(data, id, tick, false);
+	return 0;
+}
+
+/**
+ * Timer that triggers after walk delay when a berserk-state monster was attacked by a normal attack from within [attack range+1]
+ * Same as mob_attacked, but sets a special normal attacked ID to trigger a target change in attack state
+ * @param tid: Timer ID
+ * @param tick: Current tick
+ * @param id: ID of attacked monster
+ * @param data: ID of attacker
+ * @return 0
+ */
+TIMER_FUNC(mob_norm_attacked) {
+	mob_set_attacked_id(data, id, tick, true);
+	return 0;
+}
+
 static int32 mob_ai_sub_hard_timer(struct block_list *bl,va_list ap)
 {
 	struct mob_data *md = (struct mob_data*)bl;
@@ -2590,8 +2674,6 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 		{
 			map_session_data *sd = (TBL_PC*)src;
 			char_id = sd->status.char_id;
-			if( damage )
-				md->attacked_id = src->id;
 			break;
 		}
 		case BL_HOM:
@@ -2600,8 +2682,6 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 			flag = MDLF_HOMUN;
 			if( hd->master )
 				char_id = hd->master->status.char_id;
-			if( damage )
-				md->attacked_id = src->id;
 			break;
 		}
 		case BL_MER:
@@ -2609,8 +2689,6 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 			s_mercenary_data *mer = (TBL_MER*)src;
 			if( mer->master )
 				char_id = mer->master->status.char_id;
-			if( damage )
-				md->attacked_id = src->id;
 			break;
 		}
 		case BL_PET:
@@ -2618,11 +2696,7 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 			struct pet_data *pd = (TBL_PET*)src;
 			flag = MDLF_PET;
 			if( pd->master )
-			{
 				char_id = pd->master->status.char_id;
-				if( damage ) //Let mobs retaliate against the pet's master [Skotlex]
-					md->attacked_id = pd->master->bl.id;
-			}
 			break;
 		}
 		case BL_MOB:
@@ -2634,13 +2708,6 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 				if( msd )
 					char_id = msd->status.char_id;
 			}
-			if( !damage )
-				break;
-			//Let players decide whether to retaliate versus the master or the mob. [Skotlex]
-			if( md2->master_id && battle_config.retaliate_to_master )
-				md->attacked_id = md2->master_id;
-			else
-				md->attacked_id = src->id;
 			break;
 		}
 		case BL_ELEM:
@@ -2648,12 +2715,10 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 			s_elemental_data *ele = (TBL_ELEM*)src;
 			if( ele->master )
 				char_id = ele->master->status.char_id;
-			if( damage )
-				md->attacked_id = src->id;
 			break;
 		}
 		default: //For all unhandled types.
-			md->attacked_id = src->id;
+			break;
 	}
 
 	//Self damage increases tap bonus
@@ -7231,6 +7296,8 @@ void do_init_mob(void){
 	add_timer_func_list(mob_spawn_guardian_sub,"mob_spawn_guardian_sub");
 	add_timer_func_list(mob_respawn,"mob_respawn");
 	add_timer_func_list(mvptomb_delayspawn,"mvptomb_delayspawn");
+	add_timer_func_list(mob_attacked, "mob_attacked");
+	add_timer_func_list(mob_norm_attacked, "mob_norm_attacked");
 	add_timer_interval(gettick()+MIN_MOBTHINKTIME,mob_ai_hard,0,0,MIN_MOBTHINKTIME);
 	add_timer_interval(gettick()+MIN_MOBTHINKTIME*10,mob_ai_lazy,0,0,MIN_MOBTHINKTIME*10);
 }

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2259,7 +2259,7 @@ void mob_set_attacked_id(int32 src_id, int32 target_id, t_tick tick, bool is_nor
 		case BL_MOB:
 		{
 			struct mob_data& md2 = *reinterpret_cast<mob_data*>(src);
-			// Let players decide whether to retaliate versus the master or the mob
+			// Config to decide whether to retaliate versus the master or the mob
 			if (md2.master_id && battle_config.retaliate_to_master)
 				md->attacked_id = md2.master_id;
 			else

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -521,6 +521,8 @@ int32 mob_randomwalk(struct mob_data *md,t_tick tick);
 int32 mob_warpchase(struct mob_data *md, struct block_list *target);
 void mob_setstate(mob_data& md, MobSkillState skillstate);
 bool mob_ai_sub_hard_attacktimer(mob_data &md, t_tick tick);
+TIMER_FUNC(mob_attacked);
+TIMER_FUNC(mob_norm_attacked);
 int32 mob_target(struct mob_data *md,struct block_list *bl,int32 dist);
 int32 mob_unlocktarget(struct mob_data *md, t_tick tick);
 struct mob_data* mob_spawn_dataset(struct spawn_data *data);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -4031,22 +4031,6 @@ int64 skill_attack (int32 attack_type, struct block_list* src, struct block_list
 				skill_counter_additional_effect(src, bl, skill_id, skill_lv, dmg.flag, tick);
 		} else
 			battle_delay_damage(tick, dmg.amotion, src, bl, dmg.flag, skill_id, skill_lv, damage, dmg.dmg_lv, dmg.div_, additional_effects, false);
-	} else {
-		// Trigger monster skill condition for damage skills with no amotion.
-		if (bl->type == BL_MOB && src != bl && !status_isdead(*bl)) {
-			if (damage > 0)
-				mobskill_event(BL_CAST(BL_MOB, bl), src, tick, dmg.flag);
-			if (skill_id > 0)
-				mobskill_event(BL_CAST(BL_MOB, bl), src, tick, MSC_SKILLUSED | (skill_id << 16));
-		}
-	}
-
-	// Trigger monster skill condition for damage skills.
-	if (bl->type == BL_MOB && src != bl && !status_isdead(*bl)) {
-		if (damage > 0)
-			mobskill_event(BL_CAST(BL_MOB, bl), src, tick, dmg.flag, damage);
-		if (skill_id > 0)
-			mobskill_event(BL_CAST(BL_MOB, bl), src, tick, MSC_SKILLUSED | (skill_id << 16), damage);
 	}
 
 	if (tsc  && skill_id != NPC_EVILLAND && skill_id != SP_SOULEXPLOSION && skill_id != SJ_NOVAEXPLOSING


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #1656 (preparation for final fix)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Implemented official system for setting the attacked ID
  * The attacked ID will now be set only after waiting for the calculated walk delay
  * The monster AI is processed immediately after setting it
- Changed the rules for setting the norm_attacked_id
  * These conditions are checked at the beginning of the attack instead of when the damage is applied or later
  * Monster must be hit by a normal attack
  * Monster needs to be in Berserk state
  * Monster needs to have a different target currently
  * Attacker is within AttackRange+1
  * Setting norm_attacked_id makes monsters switch target in Berserk state (if they have the mode to do so)
- Unified code and fixed the condition for monster skill and attacked events to occur
  * Does no longer require damage to be dealt, but requires the attack to connect
  * Removed duplicate monster skill event triggers (event was triggered 3 times per attack instead of once)
  * Follow-up to 36b9b94, 77b4b3c, 4800b5b and cad5cab
- Related to #1656

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
