### PR TITLE
True Hitlock System / Monster Walk Delay Fixes

### DIFF
--- a/conf/battle/battle.conf
+++ b/conf/battle/battle.conf
@@ -32,8 +32,16 @@ critical_rate: 100
 // animation unless you customize their AI (see monster_ai 0x2000 in monster.conf)
 attack_walk_delay: 0
 
+// Use legacy walk delay when damaged system? (Note 3)
+// Officially, when getting hit, you just get stopped on the nearest cell center.
+// The walk delay only affects the time a monster reacts to the damage in this case.
+// The legacy system prevents move commands for the walk delay duration completely, but it
+// only applies if the target was previously able to move for at least the delay duration.
+damage_walk_delay: 0
+
 // Move-delay adjustment after being hit. (Note 2)
 // The 'can't walk' delay after being hit is calculated as a percentage of the damage animation duration.
+// For monsters, this delay also determines how long it takes until they react to an attacker.
 pc_damage_walk_delay_rate: 20
 damage_walk_delay_rate: 100
 
@@ -41,6 +49,7 @@ damage_walk_delay_rate: 100
 // When hit by a multi-hitting skill like Lord of Vermillion or Jupitel Thunder, characters will be 
 // unable to move for an additional "(number of hits -1) * multihit_delay" milliseconds.
 // Please note that skills that deal more than 10 hits are only considered as 2-hit-skills.
+// This delay is also added to the time a monster waits until it reacts to an attacker.
 // Official: 200
 // Legacy Athena: 80
 multihit_delay: 200

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -267,10 +267,6 @@ static t_tick battle_calc_walkdelay(block_list& bl, int64 damage, int16 div_, t_
 	if (div_ == 0)
 		return 0;
 
-	// Check if unit can be stopped by damage
-	if (status_isendure(bl, tick, false))
-		return 0;
-
 	t_tick delay = status_get_status_data(bl)->dmotion;	
 
 	// Multi-hit skills mean higher delays
@@ -11862,6 +11858,7 @@ static const struct _battle_data {
 	{ "default_walk_delay",                 &battle_config.default_walk_delay,              300,    0,      INT_MAX,        },
 	{ "no_skill_delay",                     &battle_config.no_skill_delay,                  BL_MOB, BL_NUL, BL_ALL,         },
 	{ "attack_walk_delay",                  &battle_config.attack_walk_delay,               BL_NUL, BL_NUL, BL_ALL,         },
+	{ "damage_walk_delay",                  &battle_config.damage_walk_delay,               BL_NUL, BL_NUL, BL_ALL,         },
 	{ "require_glory_guild",                &battle_config.require_glory_guild,             0,      0,      1,              },
 	{ "idle_no_share",                      &battle_config.idle_no_share,                   0,      0,      INT_MAX,        },
 	{ "party_even_share_bonus",             &battle_config.party_even_share_bonus,          0,      0,      INT_MAX,        },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -439,6 +439,7 @@ struct Battle_Config
 	int32 default_walk_delay;
 	int32 no_skill_delay;
 	int32 attack_walk_delay;
+	int32 damage_walk_delay;
 	int32 require_glory_guild;
 	int32 idle_no_share;
 	int32 party_update_interval;

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2275,6 +2275,9 @@ void mob_set_attacked_id(int32 src_id, int32 target_id, t_tick tick, bool is_nor
 	if (is_norm_attacked)
 		md->norm_attacked_id = md->attacked_id;
 
+	// As it was attacked, monster leaves aggressive mode
+	md->state.aggressive = 0;
+
 	// Need to call mob AI routine immediately, otherwise the attacked ID might get overwritten before it is processed
 	mob_ai_sub_hard(md, tick);
 }
@@ -2752,8 +2755,6 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage)
 {
 	if (src && damage > 0) { //Store total damage...
-		if ((src != &md->bl) && md->state.aggressive) //No longer aggressive, change to retaliate AI.
-			md->state.aggressive = 0;
 		//Log damage
 		mob_log_damage(md, src, static_cast<int64>(damage));
 	}

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1642,8 +1642,9 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	}
 
 	if( status->hp || (flag&8) ) { // Still lives or has been dead before this damage.
-		if (walkdelay)
-			unit_set_walkdelay(target, gettick(), walkdelay, 0);
+		t_tick tick = gettick();
+		if (walkdelay && !status_isendure(*target, tick, false))
+			unit_set_walkdelay(target, tick, walkdelay, 0);
 		return (int32)(hp+sp+ap);
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1642,8 +1642,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	}
 
 	if( status->hp || (flag&8) ) { // Still lives or has been dead before this damage.
-		t_tick tick = gettick();
-		if (walkdelay && !status_isendure(*target, tick, false))
+		if (t_tick tick = gettick(); walkdelay > 0 && !status_isendure(*target, tick, false))
 			unit_set_walkdelay(target, tick, walkdelay, 0);
 		return (int32)(hp+sp+ap);
 	}

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2004,9 +2004,9 @@ int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32
 			if (md.state.can_escape == 1)
 				return 0;
 		}
-		// Don't set walk delays when already trapped.
-		if (!unit_can_move(bl)) {
-			// Unit might still be moving even though it can't move
+		// Trapped or legacy walk delay system disabled
+		if (!unit_can_move(bl) || !(bl->type&battle_config.damage_walk_delay)) {
+			// Stop on the closest cell center
 			unit_stop_walking( bl, USW_MOVE_FULL_CELL );
 			return 0;
 		}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #1656 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Made the legacy walk delay system optional
  * Officially, getting hit just stops you on the closest cell center
- Endure no longer causes the "monster attacked" to trigger immediately
  * It still prevents legacy walk delay and getting stopped by hits
- Fixed aggressive mode being disabled too early when hit
- Follow-up to 499d852
- Fixes #1656

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
