### PR TITLE
Restore Pre-Renewal Cast Sensor Behavior

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2452,7 +2452,11 @@ int32 unit_skilluse_id2(struct block_list *src, int32 target_id, uint16 skill_id
 	// In official this is triggered even if no cast time.
 	clif_skillcasting(src, src->id, target_id, 0,0, skill_id, skill_lv, skill_get_ele(skill_id, skill_lv), casttime);
 
-	if (sd && target->type == BL_MOB) {
+	if (sd && target->type == BL_MOB
+#ifndef RENEWAL
+		&& (casttime > 0 || combo)
+#endif
+	) {
 		TBL_MOB *md = (TBL_MOB*)target;
 
 		mobskill_event(md, src, tick, -1); // Cast targetted skill event.

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2452,9 +2452,9 @@ int32 unit_skilluse_id2(struct block_list *src, int32 target_id, uint16 skill_id
 	// In official this is triggered even if no cast time.
 	clif_skillcasting(src, src->id, target_id, 0,0, skill_id, skill_lv, skill_get_ele(skill_id, skill_lv), casttime);
 
-	if (sd && target->type == BL_MOB
+	if (sd != nullptr && target->type == BL_MOB
 #ifndef RENEWAL
-		&& (casttime > 0 || combo)
+		&& (casttime > 0 || combo > 0)
 #endif
 	) {
 		TBL_MOB *md = (TBL_MOB*)target;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9252 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- In pre-re, cast sensor now only triggers again when the skill has a cast time
  * This got broken in 60b0ed9 but was a valid change for renewal
- Fixes #9252

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
