### PR TITLE
Bladestop Range Check Fix

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10520,7 +10520,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 #ifndef RENEWAL
 		status_get_class_(src) != CLASS_BOSS &&
 #endif
-		(src->type == BL_PC || distance_bl(src, target) <= 2) )
+		(src->type == BL_PC || check_distance_bl(src, target, 2)) )
 	{
 		uint16 skill_lv = tsc->getSCE(SC_BLADESTOP_WAIT)->val1;
 		int32 duration = skill_get_time2(MO_BLADESTOP,skill_lv);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10520,7 +10520,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 #ifndef RENEWAL
 		status_get_class_(src) != CLASS_BOSS &&
 #endif
-		(src->type == BL_PC || tsd == nullptr || distance_bl(src, target) <= (tsd->status.weapon == W_FIST ? 1 : 2)) )
+		(src->type == BL_PC || distance_bl(src, target) <= 2) )
 	{
 		uint16 skill_lv = tsc->getSCE(SC_BLADESTOP_WAIT)->val1;
 		int32 duration = skill_get_time2(MO_BLADESTOP,skill_lv);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #697 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Bladestop now always has a range of 2 when the attacker is a non-player regardless of weapon used
- Bladestop has an unlimited range as long as the attacker is a player
- Fixes #697

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
