### PR TITLE
Legacy Walk Delay Behavior for Firewall, Sanctuary and Blaze Shield

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8196,13 +8196,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 				// Fire and undead units hit by firewall cannot be stopped for 2 seconds
 				if (unit_data* ud = unit_bl2ud(target); ud != nullptr)
 					ud->endure_tick = gettick() + 2000;
-				break;
 			}
-			[[fallthrough]];
-		case NJ_KAENSIN:
-		case PR_SANCTUARY:
-			// TODO: This code is a temporary workaround because right now we stop monsters for their dmotion which is not official
-			ad.dmotion = 1;
 			break;
 	}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1643,7 +1643,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 
 	if( status->hp || (flag&8) ) { // Still lives or has been dead before this damage.
 		if (t_tick tick = gettick(); walkdelay > 0 && !status_isendure(*target, tick, false))
-			unit_set_walkdelay(target, tick, walkdelay, 0);
+			unit_set_walkdelay(target, tick, walkdelay, 0, skill_id);
 		return (int32)(hp+sp+ap);
 	}
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -1980,9 +1980,10 @@ void unit_set_castdelay(unit_data& ud, t_tick tick, int32 casttime) {
  * @param type: Type of delay
  *	0: Damage induced delay; Do not change previous delay
  *	1: Skill induced delay; Walk delay can only be increased, not decreased
+ * @param skill_id: ID of skill that dealt damage (type 0 only)
  * @return Success(1); Fail(0);
  */
-int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type)
+int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type, uint16 skill_id)
 {
 	struct unit_data *ud = unit_bl2ud(bl);
 
@@ -2010,6 +2011,16 @@ int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32
 			unit_stop_walking( bl, USW_MOVE_FULL_CELL );
 			return 0;
 		}
+
+		switch (skill_id) {
+			case MG_FIREWALL:
+			case PR_SANCTUARY:
+			case NJ_KAENSIN:
+				// When using legacy walk delay, these skills should just stop the target
+				delay = 1;
+				break;
+		}
+
 		//Immune to being stopped for double the flinch time
 		if (DIFF_TICK(ud->canmove_tick, tick-delay) > 0)
 			return 0;

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -151,7 +151,7 @@ int32 unit_is_walking(struct block_list *bl);
 
 // Delay functions
 void unit_set_attackdelay(block_list& bl, t_tick tick, e_delay_event event);
-int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type);
+int32 unit_set_walkdelay(struct block_list *bl, t_tick tick, t_tick delay, int32 type, uint16 skill_id = 0);
 
 t_tick unit_get_walkpath_time(struct block_list& bl);
 t_tick unit_escape(struct block_list *bl, struct block_list *target, int16 dist, uint8 flag = 0);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Restoration of a custom feature

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Restored legacy walk delay behavior for Firewall, Sanctuary and Blaze Shield
  * Walk delay is not applied by these skills
  * Targets will continue walking again almost immediately after being hit
  * This ensures that the legacy walk delay behavior is the same as before the official implementation
- Follow-up to f59fd6d and 503a3ff

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
