### PR TITLE
Added missing trade checks

### DIFF
--- a/conf/battle/items.conf
+++ b/conf/battle/items.conf
@@ -142,3 +142,8 @@ min_shop_sell: 0
 // Shaman Hat on the other hand doesn't reduce monster damage at all (reduces magical damage in PVP)
 // This only affects items with bonus3 bSubEle and bonus3 bSubRace.
 cardfix_monster_physical: yes
+
+// Determines whether stackable items should be counted separately for inventory space when trading,
+// even if the other player already has that item.
+// (It is 'yes' on official servers)
+trade_count_stackable: yes

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -70,6 +70,10 @@ natural_heal_skill_interval: 10000
 // Default on official servers: 70 for Pre-renewal, 90 for Renewal
 //open_box_weight_rate: 90
 
+// The maximum weight for a character to receive items on a trade. (Note 2)
+// Default on official servers: 50 for Pre-renewal, 100 for Renewal
+//trade_weight_rate: 100
+
 // The maximum weight for a character to carry before entering the major overweight state. (Note 2)
 // In this state the character cannot heal naturally, attack or use skills.
 major_overweight_rate: 90

--- a/conf/battle/player.conf
+++ b/conf/battle/player.conf
@@ -70,10 +70,6 @@ natural_heal_skill_interval: 10000
 // Default on official servers: 70 for Pre-renewal, 90 for Renewal
 //open_box_weight_rate: 90
 
-// The maximum weight for a character to receive items on a trade. (Note 2)
-// Default on official servers: 50 for Pre-renewal, 100 for Renewal
-//trade_weight_rate: 100
-
 // The maximum weight for a character to carry before entering the major overweight state. (Note 2)
 // In this state the character cannot heal naturally, attack or use skills.
 major_overweight_rate: 90

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -12197,6 +12197,7 @@ static const struct _battle_data {
 	{ "loot_range",                         &battle_config.loot_range,                      12,     1,      MAX_WALKPATH,   },
 	{ "assist_range",                       &battle_config.assist_range,                    11,     1,      MAX_WALKPATH,   },
 	{ "major_overweight_rate",              &battle_config.major_overweight_rate,           90,     0,      100             },
+	{ "trade_count_stackable",              &battle_config.trade_count_stackable,           1,      0,      1,              },
 
 #include <custom/battle_config_init.inc>
 };

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11685,9 +11685,11 @@ static const struct _battle_data {
 #ifdef RENEWAL
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        70,     0,      100             },
 	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            90,     0,      100             },
+	{ "trade_weight_rate",                  &battle_config.trade_weight_rate,               100,     0,      100             },
 #else
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        50,     0,      100             },
 	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            70,     0,      100             },
+	{ "trade_weight_rate",                  &battle_config.trade_weight_rate,               50,     0,      100             },
 #endif
 	{ "arrow_decrement",                    &battle_config.arrow_decrement,                 1,      0,      2,              },
 	{ "ammo_unequip",                       &battle_config.ammo_unequip,                    1,      0,      1,              },

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11685,11 +11685,9 @@ static const struct _battle_data {
 #ifdef RENEWAL
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        70,     0,      100             },
 	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            90,     0,      100             },
-	{ "trade_weight_rate",                  &battle_config.trade_weight_rate,               100,     0,      100             },
 #else
 	{ "natural_heal_weight_rate",           &battle_config.natural_heal_weight_rate,        50,     0,      100             },
 	{ "open_box_weight_rate",               &battle_config.open_box_weight_rate,            70,     0,      100             },
-	{ "trade_weight_rate",                  &battle_config.trade_weight_rate,               50,     0,      100             },
 #endif
 	{ "arrow_decrement",                    &battle_config.arrow_decrement,                 1,      0,      2,              },
 	{ "ammo_unequip",                       &battle_config.ammo_unequip,                    1,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -774,6 +774,7 @@ struct Battle_Config
 	int32 loot_range;
 	int32 assist_range;
 	int32 open_box_weight_rate;
+	int32 trade_weight_rate;
 	int32 major_overweight_rate;
 
 #include <custom/battle_config_struct.inc>

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -775,6 +775,7 @@ struct Battle_Config
 	int32 assist_range;
 	int32 open_box_weight_rate;
 	int32 major_overweight_rate;
+	int32 trade_count_stackable;
 
 #include <custom/battle_config_struct.inc>
 };

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -774,7 +774,6 @@ struct Battle_Config
 	int32 loot_range;
 	int32 assist_range;
 	int32 open_box_weight_rate;
-	int32 trade_weight_rate;
 	int32 major_overweight_rate;
 
 #include <custom/battle_config_struct.inc>

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -4815,6 +4815,10 @@ void clif_tradeitemok(map_session_data& sd, int32 index, e_exitem_add_result res
 	PACKET_ZC_ACK_ADD_EXCHANGE_ITEM p = {};
 	p.packetType = HEADER_ZC_ACK_ADD_EXCHANGE_ITEM;
 	p.index = client_index(index);
+#if PACKETVER < 20110705
+	if (result > EXITEM_ADD_FAILED_CLOSED)
+		result = EXITEM_ADD_FAILED_OVERWEIGHT;
+#endif
 	p.result = static_cast<uint8>(result);
 
 	clif_send(&p, sizeof(p), &sd.bl, SELF);

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -4808,6 +4808,8 @@ void clif_tradeadditem( map_session_data* sd, map_session_data* tsd, int32 index
 ///     0 = success
 ///     1 = overweight
 ///     2 = trade canceled
+///     3 = inventory full
+///     4 = stacked item amount exceeded
 void clif_tradeitemok(map_session_data& sd, int32 index, e_exitem_add_result result)
 {
 	PACKET_ZC_ACK_ADD_EXCHANGE_ITEM p = {};

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -720,6 +720,7 @@ public:
 			int16 index, amount;
 		} item[10];
 		int32 zeny, weight;
+		uint8 item_count;
 	} deal;
 
 	bool party_creating; // whether the char is requesting party creation

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -720,7 +720,7 @@ public:
 			int16 index, amount;
 		} item[10];
 		int32 zeny, weight;
-		uint8 item_count;
+		uint8 inventory_space;
 	} deal;
 
 	bool party_creating; // whether the char is requesting party creation

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -418,22 +418,14 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 
 	// Fail to add the item if the inventory is full
 	if (pc_inventoryblank(target_sd) <= trade_i) {
-#if PACKETVER >= 20110705
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERCOUNT);
-#else
-		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERWEIGHT);
-#endif
 		return;
 	}
 
 	// Fail to add the item if is stacked over the limit
 	if (itemdb_isstackable(item->nameid)) {
 		if (pc_checkadditem(target_sd, item->nameid, amount) == CHKADDITEM_OVERAMOUNT) {
-#if PACKETVER >= 20110705
 			clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_EACHITEM_OVERCOUNT);
-#else
-			clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERWEIGHT);
-#endif
 			return;
 		}
 	}

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -439,8 +439,7 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 	}
 
 	trade_weight = sd->inventory_data[index]->weight * amount;
-	// Fail to add the item if the weight limit is reached
-	if (pc_getpercentweight(*target_sd, target_sd->weight + sd->deal.weight + trade_weight) >= battle_config.trade_weight_rate) {
+	if( target_sd->weight + sd->deal.weight + trade_weight > target_sd->max_weight ) { // fail to add item -- the player was over weighted.
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERWEIGHT);
 		return;
 	}

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -417,13 +417,13 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 		return;
 	}
 
-	// Fail to add the item if the inventory is full
+	// Fail to add the item if the inventory will be full, even if the item is stackable and already exists in the inventory
 	if (pc_inventoryblank(target_sd) <= trade_i) {
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERCOUNT);
 		return;
 	}
 
-	// Fail to add the item if is stacked over the limit
+	// Fail to add the item if is stackable and adding the traded amount will exceed the maximum
 	if (itemdb_isstackable(item->nameid)) {
 		if (pc_checkadditem(target_sd, item->nameid, amount) == CHKADDITEM_OVERAMOUNT) {
 			clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_EACHITEM_OVERCOUNT);

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -413,6 +413,7 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 	// Locate a trade position
 	ARR_FIND( 0, 10, trade_i, sd->deal.item[trade_i].index == index || sd->deal.item[trade_i].amount == 0 );
 	if( trade_i == 10 ) { // No space left
+		// The client does not allow to add more than 10 items, and will show an error message.
 		return;
 	}
 

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -426,10 +426,10 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 
 	// Determines whether the item should be counted when checking for inventory space.
 	// If the 'trade_count_stackable' config is enabled, the item will be counted separately even if the recipient already has it.
-	bool count = battle_config.trade_count_stackable == 1 || add_item != CHKADDITEM_EXIST;
+	bool count = (battle_config.trade_count_stackable == 1) || (add_item != CHKADDITEM_EXIST);
 
 	// Fail to add the item if the inventory will be full
-	if (pc_inventoryblank(target_sd) < sd->deal.item_count + count) {
+	if (pc_inventoryblank(target_sd) < sd->deal.item_count + static_cast<uint8>(count)) {
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERCOUNT);
 		return;
 	}

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -426,10 +426,10 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 
 	// Determines whether the item should be counted when checking for inventory space.
 	// If the 'trade_count_stackable' config is enabled, the item will be counted separately even if the recipient already has it.
-	bool count = (battle_config.trade_count_stackable == 1) || (add_item != CHKADDITEM_EXIST);
+	bool count_stackable = (battle_config.trade_count_stackable == 1) || (add_item != CHKADDITEM_EXIST);
 
 	// Fail to add the item if the inventory will be full
-	if (pc_inventoryblank(target_sd) < sd->deal.item_count + static_cast<uint8>(count)) {
+	if (count_stackable && pc_inventoryblank(target_sd) < sd->deal.inventory_space + 1) {
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERCOUNT);
 		return;
 	}
@@ -454,8 +454,8 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 
 	sd->deal.weight += trade_weight;
 
-	if (count)
-		sd->deal.item_count++;
+	if (count_stackable)
+		sd->deal.inventory_space++;
 
 	clif_tradeitemok(*sd, index, EXITEM_ADD_SUCCEED); // Return the index as it was received
 	clif_tradeadditem(sd, target_sd, index+2, amount);

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -418,7 +418,7 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 
 	// Fail to add the item if the inventory is full
 	if (pc_inventoryblank(target_sd) <= trade_i) {
-#ifdef PACKETVER >= 20110705
+#if PACKETVER >= 20110705
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERCOUNT);
 #else
 		clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERWEIGHT);
@@ -429,7 +429,7 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 	// Fail to add the item if is stacked over the limit
 	if (itemdb_isstackable(item->nameid)) {
 		if (pc_checkadditem(target_sd, item->nameid, amount) == CHKADDITEM_OVERAMOUNT) {
-#ifdef PACKETVER >= 20110705
+#if PACKETVER >= 20110705
 			clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_EACHITEM_OVERCOUNT);
 #else
 			clif_tradeitemok(*sd, index, EXITEM_ADD_FAILED_OVERWEIGHT);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9250 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
- Adds a missing check for full inventory (it shows different messages depending on the client version)
- Adds a missing check for stacked items limit (it shows different messages depending on the client version)
- Removes previously commented message for item trade limit, as I confirmed it's client-side
- Adds a battle config for whether stackable items should be counted separately for inventory space even if the recipient already has that item

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
