### PR TITLE
Position Synchronization Improvements

### DIFF
--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -171,8 +171,13 @@ bool unit_walktoxy_nextcell(block_list& bl, bool sendMove, t_tick tick) {
 		return true;
 
 	// Reached end of walkpath
-	if (ud->walkpath.path_pos >= ud->walkpath.path_len)
+	if (ud->walkpath.path_pos >= ud->walkpath.path_len) {
+		// We need to send the reply to the client even if already at the target cell
+		// This allows the client to synchronize the position correctly
+		if (sendMove && bl.type == BL_PC)
+			clif_walkok(reinterpret_cast<map_session_data&>(bl));
 		return false;
+	}
 
 	// Monsters first check for a chase skill and if they didn't use one if their target is in range each cell after checking for a chase skill
 	if (bl.type == BL_MOB) {
@@ -699,9 +704,6 @@ static TIMER_FUNC(unit_walktoxy_timer)
 				map_foreachinmap(unit_walktoxy_ontouch, nd->bl.m, BL_PC, nd);
 			break;
 	}
-
-	if(tid == INVALID_TIMER) // A directly invoked timer is from battle_stop_walking, therefore the rest is irrelevant.
-		return 0;
 
 	int32 speed;
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Follow-up to b7b6812

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- The client will now be correctly notified again when it reached the end of the walkpath
  * The scenario of the player already being on the target cell from the start was not considered
  * Follow-up to b7b6812
- Fixed the "end of walkpath" events not being triggered when the end of walkpath was reached by damage
  * This can happen because getting hit moves you to the closest cell center, which could be forward
  * The event is needed here as it checks for a target in attack range and sends a fixpos packet before the attack

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
