### PR TITLE
Magic Mushroom Cast Cancel

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14159,7 +14159,7 @@ TIMER_FUNC(status_change_timer){
 						break;
 
 					unit_stop_attack(bl);
-					unit_skillcastcancel(bl, 1);
+					unit_skillcastcancel(bl, 0);
 
 					switch (skill_get_casttype(mushroom_skill_id)) { // Magic Mushroom skills are buffs or area damage
 					case CAST_GROUND:

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -3362,7 +3362,7 @@ bool unit_can_attack(struct block_list *bl, int32 target_id) {
  * Cancels a skill's cast
  * @param bl: Object to cancel cast
  * @param type: Cancel check flag
- *	&1: Cast-Cancel invoked
+ *	&1: Cancel skill stored in sd->skill_id_old instead (used when invoked by Sage skill "Cast Cancel")
  *	&2: Cancel only if skill is cancellable
  * @return Success(1); Fail(0);
  */


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9267 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed status change Magic Mushroom not canceling previous cast properly
- Improved function comment for unit_skillcastcancel
- Fixes #9267

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
