### PR TITLE
Roundhouse Kick Effect + SC_NOACTION

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -11285,6 +11285,7 @@ Body:
     Element: Weapon
     SplashArea: 1
     Knockback: 2
+    Duration1: 5000
     Duration2: 2000
     Requires:
       SpCost:

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -6814,3 +6814,22 @@ Body:
     Script: |
       bonus bAspdRate, getstatus(SC_ACARAJE, 1);
       bonus bHit, getstatus(SC_ACARAJE, 2);
+  - Status: Noaction
+    Icon: EFST_NOACTION
+    DurationLookup: TK_TURNKICK
+    States:
+      NoMove: true
+      NoPickItem: true
+      NoCast: true
+      NoAttack: true
+      NoInteract: true
+    Flags:
+      NoRemoveOnDead: true
+      NoClearbuff: true
+      NoDispell: true
+      NoBanishingBuster: true
+      NoClearance: true
+      NoSave: true
+      StopAttacking: true
+      StopCasting: true
+      BossResist: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -11565,6 +11565,7 @@ Body:
     Element: Weapon
     SplashArea: 1
     Knockback: 2
+    Duration1: 4500
     Duration2: 2000
     Requires:
       SpCost:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -9772,3 +9772,22 @@ Body:
       .@val1 = getstatus(SC_CONTENTS_35, 1);
       bonus bMatk, .@val1;
       bonus bBaseAtk, .@val1;
+  - Status: Noaction
+    Icon: EFST_NOACTION
+    DurationLookup: TK_TURNKICK
+    States:
+      NoMove: true
+      NoPickItem: true
+      NoCast: true
+      NoAttack: true
+      NoInteract: true
+    Flags:
+      NoRemoveOnDead: true
+      NoClearbuff: true
+      NoDispell: true
+      NoBanishingBuster: true
+      NoClearance: true
+      NoSave: true
+      StopAttacking: true
+      StopCasting: true
+      BossResist: true

--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -1972,6 +1972,7 @@
 	export_constant(SC_SBUNSHIN);
 	export_constant(SC_CONTENTS_34);
 	export_constant(SC_CONTENTS_35);
+	export_constant(SC_NOACTION);
 
 /// Do not modify code below this, until the end of the API hook, since it will be automatically generated again
 /// @APIHOOK_START(EFST_CONST)

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1781,6 +1781,13 @@ int32 skill_additional_effect( struct block_list* src, struct block_list *bl, ui
 		}
 		break;
 	case TK_TURNKICK:
+		// Note: attack_type is passed as BF_WEAPON for the actual target, BF_MISC for the splash-affected mobs.
+		if (attack_type&BF_MISC) {
+			sc_start(src, bl, SC_STUN, 200, skill_lv, skill_get_time(skill_id, skill_lv));
+			clif_specialeffect(bl, EF_SPINEDBODY, AREA);
+			sc_start(src, bl, SC_NOACTION, 100, 1, skill_get_time2(skill_id, skill_lv));
+		}
+		break;
 	case MO_BALKYOUNG: //Note: attack_type is passed as BF_WEAPON for the actual target, BF_MISC for the splash-affected mobs.
 		if(attack_type&BF_MISC) //70% base stun chance...
 			sc_start(src,bl,SC_STUN,70,skill_lv,skill_get_time2(skill_id,skill_lv));
@@ -6432,14 +6439,17 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 
 	case TK_TURNKICK:
 	case MO_BALKYOUNG: //Active part of the attack. Skill-attack [Skotlex]
-	{
 		skill_area_temp[1] = bl->id; //NOTE: This is used in skill_castend_nodamage_id to avoid affecting the target.
-		if (skill_attack(BF_WEAPON,src,src,bl,skill_id,skill_lv,tick,flag))
+		if (skill_attack(BF_WEAPON, src, src, bl, skill_id, skill_lv, tick, flag)) {
+			int32 target_flag = BL_CHAR;
+			if (skill_id == TK_TURNKICK)
+				target_flag = BL_MOB;
+
 			map_foreachinallrange(skill_area_sub,bl,
-				skill_get_splash(skill_id, skill_lv),BL_CHAR,
+				skill_get_splash(skill_id, skill_lv),target_flag,
 				src,skill_id,skill_lv,tick,flag|BCT_ENEMY|1,
 				skill_castend_nodamage_id);
-	}
+		}
 		break;
 	case CH_PALMSTRIKE: //	Palm Strike takes effect 1sec after casting. [Skotlex]
 	//	clif_skill_nodamage(src,*bl,skill_id,skill_lv,false); //Can't make this one display the correct attack animation delay :/

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -1424,6 +1424,7 @@ enum sc_type : int16 {
 
 	SC_CONTENTS_34,
 	SC_CONTENTS_35,
+	SC_NOACTION,
 
 	SC_MAX, //Automatically updated max, used in for's to check we are within bounds.
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9266 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Added a new status change SC_NOACTION
  * It prevents moving, attacking, casting, using items and sitting
  * This status change is given by a lot of skills for which we are currently using delay variables
- Implemented correct splash effect of Roundhouse Kick
  * Only works on monsters
  * Stuns with a base chance of 200% and a base duration of 5 seconds
  * Gives the SC_NOACTION status change for 2 seconds
  * Shows a "unit is turned around" animation
- Fixes #9266

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
