### PR TITLE
No Loot Protection Times for player-dropped items

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6108,8 +6108,8 @@ bool pc_takeitem(map_session_data *sd,struct flooritem_data *fitem)
 	// This applies even if there are no second or third top attackers
 	t_tick item_get_tick = fitem->third_get_tick;
 
-	if (fitem->first_get_charid > 0 && fitem->first_get_charid == sd->status.char_id) {
-		// Top attacker, no wait time
+	if (fitem->first_get_charid == 0 || fitem->first_get_charid == sd->status.char_id) {
+		// Top attacker or no attacker, no wait time
 		item_get_tick = 0;
 	}
 	else if (fitem->second_get_charid > 0 && fitem->second_get_charid == sd->status.char_id) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9269 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed player-dropped items also having loot protection times
- Follow-up to 7d6d40b
- Fixes #9269

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
