### PR TITLE
Fixed instance timer

### DIFF
--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -1235,9 +1235,7 @@ void do_reload_instance(void)
 				instance_addnpc(idata);
 
 			// Create new keep timer
-			std::shared_ptr<s_instance_db> db = instance_db.find(idata->id);
-
-			if (db != nullptr) {
+			if (std::shared_ptr<s_instance_db> db = instance_db.find(idata->id); db != nullptr) {
 				// Save the expire time
 				idata->keep_limit = time(nullptr) + db->limit;
 

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -1237,8 +1237,15 @@ void do_reload_instance(void)
 			// Create new keep timer
 			std::shared_ptr<s_instance_db> db = instance_db.find(idata->id);
 
-			if (db)
+			if (db != nullptr) {
+				// Save the expire time
 				idata->keep_limit = time(nullptr) + db->limit;
+
+				// Recreate a timer and save the associated timer ID
+				if (idata->keep_timer != INVALID_TIMER)
+					delete_timer(idata->keep_timer, instance_delete_timer);
+				idata->keep_timer = add_timer(gettick() + db->limit * 1000, instance_delete_timer, it.first, 0);
+			}
 		}
 	}
 


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

This PR makes it so that the instance timer is recreated when the NPC script is reloaded, assuming that was the original intention.

Example : 
GM used `reloadscript` when a player spent 3 hours inside MD endless tower (`TimeLimit: 14400`)
Before the fix : remaining time in the instance = 4h - 3 h = 1h
After the fix : remaining time in the instance = 4h

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
