### PR TITLE
Correction count of inventory slots of a player

### DIFF
--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1642,7 +1642,7 @@ ACMD_FUNC(itemreset)
 	int32 i;
 	nullpo_retr(-1, sd);
 
-	for (i = 0; i < MAX_INVENTORY; i++) {
+	for (i = 0; i < sd->status.inventory_slots; i++) {
 		if (sd->inventory.u.items_inventory[i].amount && sd->inventory.u.items_inventory[i].equip == 0 && !itemdb_ishatched_egg(&sd->inventory.u.items_inventory[i])) {
 			pc_delitem(sd, i, sd->inventory.u.items_inventory[i].amount, 0, 0, LOG_TYPE_COMMAND);
 		}
@@ -5121,7 +5121,7 @@ ACMD_FUNC(repairall)
 	nullpo_retr(-1, sd);
 
 	count = 0;
-	for (i = 0; i < MAX_INVENTORY; i++) {
+	for (i = 0; i < sd->status.inventory_slots; i++) {
 		if (sd->inventory.u.items_inventory[i].nameid && sd->inventory.u.items_inventory[i].attribute == 1 && !itemdb_ishatched_egg(&sd->inventory.u.items_inventory[i])) {
 			sd->inventory.u.items_inventory[i].attribute = 0;
 			clif_produceeffect(sd, 0, sd->inventory.u.items_inventory[i].nameid);
@@ -6138,7 +6138,7 @@ ACMD_FUNC(dropall)
 		}
 	}
 
-	for( i = 0; i < MAX_INVENTORY; i++ ) {
+	for( i = 0; i < sd->status.inventory_slots; i++ ) {
 		if( sd->inventory.u.items_inventory[i].amount ) {
 			std::shared_ptr<item_data> id = item_db.find(sd->inventory.u.items_inventory[i].nameid);
 
@@ -6247,7 +6247,7 @@ ACMD_FUNC(storeall)
 		}
 	}
 
-	for (i = 0; i < MAX_INVENTORY; i++) {
+	for (i = 0; i < sd->status.inventory_slots; i++) {
 		if (sd->inventory.u.items_inventory[i].amount) {
 			if(sd->inventory.u.items_inventory[i].equip != 0)
 				pc_unequipitem(sd, i, 3);
@@ -7878,7 +7878,7 @@ ACMD_FUNC(identify)
 
 	nullpo_retr(-1, sd);
 
-	for(i=num=0;i<MAX_INVENTORY;i++){
+	for(i=num=0;i< sd->status.inventory_slots;i++){
 		if(sd->inventory.u.items_inventory[i].nameid > 0 && sd->inventory.u.items_inventory[i].identify != 1) {
 			num++;
 		}
@@ -9593,7 +9593,7 @@ ACMD_FUNC(itemlist)
 	} else if( strcmp(parent_cmd, "itemlist") == 0 ) {
 		location = "inventory";
 		items = sd->inventory.u.items_inventory;
-		size = MAX_INVENTORY;
+		size = sd->status.inventory_slots;
 	} else
 		return 1;
 

--- a/src/map/chrif.cpp
+++ b/src/map/chrif.cpp
@@ -1039,14 +1039,14 @@ int32 chrif_divorceack(uint32 char_id, int32 partner_id) {
 
 	if( ( sd = map_charid2sd(char_id) ) != nullptr && sd->status.partner_id == partner_id ) {
 		sd->status.partner_id = 0;
-		for(i = 0; i < MAX_INVENTORY; i++)
+		for(i = 0; i < sd->status.inventory_slots; i++)
 			if (sd->inventory.u.items_inventory[i].nameid == WEDDING_RING_M || sd->inventory.u.items_inventory[i].nameid == WEDDING_RING_F)
 				pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_OTHER);
 	}
 
 	if( ( sd = map_charid2sd(partner_id) ) != nullptr && sd->status.partner_id == char_id ) {
 		sd->status.partner_id = 0;
-		for(i = 0; i < MAX_INVENTORY; i++)
+		for(i = 0; i < sd->status.inventory_slots; i++)
 			if (sd->inventory.u.items_inventory[i].nameid == WEDDING_RING_M || sd->inventory.u.items_inventory[i].nameid == WEDDING_RING_F)
 				pc_delitem(sd, i, 1, 0, 0, LOG_TYPE_OTHER);
 	}

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -2289,7 +2289,7 @@ void clif_selllist( map_session_data& sd){
 	packet->packetType = HEADER_ZC_PC_SELL_ITEMLIST;
 	packet->packetLength = sizeof( *packet );
 
-	for( int32 i = 0, c = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0, c = 0; i < sd.status.inventory_slots; i++ ){
 		if( sd.inventory.u.items_inventory[i].nameid <= 0 ){
 			continue;
 		}
@@ -2859,7 +2859,7 @@ void clif_additem( map_session_data *sd, int32 n, int32 amount, unsigned char fa
 	if( fail ){
 		p = {};
 	}else{
-		if( n < 0 || n >= MAX_INVENTORY || sd->inventory.u.items_inventory[n].nameid == 0 || sd->inventory_data[n] == nullptr ){
+		if( n < 0 || n >= sd->status.inventory_slots || sd->inventory.u.items_inventory[n].nameid == 0 || sd->inventory_data[n] == nullptr ){
 			return;
 		}
 
@@ -3084,7 +3084,7 @@ void clif_inventorylist( map_session_data *sd ){
 
 	storage_sortitem( sd->storage.u.items_inventory, ARRAYLENGTH( sd->storage.u.items_inventory ) );
 
-	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0; i < sd->status.inventory_slots; i++ ){
 		if( sd->inventory.u.items_inventory[i].nameid == 0 || sd->inventory_data[i] == nullptr ){
 			continue;
 		}
@@ -3150,7 +3150,7 @@ void clif_inventorylist( map_session_data *sd ){
 #endif
 /* on 20120925 onwards this is a field on clif_item_equip/normal */
 #if PACKETVER >= 20111122 && PACKETVER < 20120925
-	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0; i < sd->status.inventory_slots; i++ ){
 		if( sd->inventory.u.items_inventory[i].nameid == 0 || sd->inventory_data[i] == nullptr )
 			continue;
 
@@ -4472,7 +4472,7 @@ void clif_useitemack( map_session_data *sd, int32 index, int32 amount, bool ok )
 		return;
 	}
 
-	if( index < 0 || index >= MAX_INVENTORY || sd->inventory.u.items_inventory[index].nameid == 0 || sd->inventory_data[index] == nullptr ){
+	if( index < 0 || index >= sd->status.inventory_slots || sd->inventory.u.items_inventory[index].nameid == 0 || sd->inventory_data[index] == nullptr ){
 		return;
 	}
 
@@ -4771,7 +4771,7 @@ void clif_tradeadditem( map_session_data* sd, map_session_data* tsd, int32 index
 	if( index ){
 		index = server_index( index );
 
-		if( index >= MAX_INVENTORY || sd->inventory.u.items_inventory[index].nameid == 0 || sd->inventory_data[index] == nullptr ){
+		if( index >= sd->status.inventory_slots || sd->inventory.u.items_inventory[index].nameid == 0 || sd->inventory_data[index] == nullptr ){
 			return;
 		}
 
@@ -7033,17 +7033,17 @@ void clif_use_card(map_session_data *sd,int32 idx)
 	int32 fd=sd->fd;
 
 	nullpo_retv(sd);
-	if (idx < 0 || idx >= MAX_INVENTORY) //Crash-fix from bad packets.
+	if (idx < 0 || idx >= sd->status.inventory_slots) //Crash-fix from bad packets.
 		return;
 
 	if (!sd->inventory_data[idx] || sd->inventory_data[idx]->type != IT_CARD)
 		return; //Avoid parsing invalid item indexes (no card/no item)
 
 	ep=sd->inventory_data[idx]->equip;
-	WFIFOHEAD(fd,MAX_INVENTORY * 2 + 4);
+	WFIFOHEAD(fd, sd->status.inventory_slots * 2 + 4);
 	WFIFOW(fd,0)=0x17b;
 
-	for(i=c=0;i<MAX_INVENTORY;i++){
+	for(i=c=0;i< sd->status.inventory_slots;i++){
 		int32 j;
 
 		if(sd->inventory_data[i] == nullptr)
@@ -7111,9 +7111,9 @@ void clif_item_identify_list(map_session_data *sd)
 
 	fd=sd->fd;
 
-	WFIFOHEAD(fd,MAX_INVENTORY * 2 + 4);
+	WFIFOHEAD(fd, sd->status.inventory_slots * 2 + 4);
 	WFIFOW(fd,0)=0x177;
-	for(i=c=0;i<MAX_INVENTORY;i++){
+	for(i=c=0;i<sd->status.inventory_slots;i++){
 		if(sd->inventory.u.items_inventory[i].nameid > 0 && !sd->inventory.u.items_inventory[i].identify){
 			WFIFOW(fd,c*2+4)=client_index(i);
 			c++;
@@ -7155,7 +7155,7 @@ void clif_item_repair_list( map_session_data& sd, map_session_data& dstsd, uint1
 
 	size_t c = 0;
 
-	for( size_t i = 0; i < MAX_INVENTORY; i++ ){
+	for( size_t i = 0; i < sd.status.inventory_slots; i++ ){
 		if( dstsd.inventory.u.items_inventory[i].nameid > 0 && dstsd.inventory.u.items_inventory[i].attribute != 0 && !itemdb_ishatched_egg( &dstsd.inventory.u.items_inventory[i] ) ){ // && skill_can_repair(sd,nameid)){
 			p->items[c].index = static_cast<decltype( p->items[0].index )>( i );
 			p->items[c].itemId = client_nameid( dstsd.inventory.u.items_inventory[i].nameid );
@@ -7231,7 +7231,7 @@ void clif_item_refine_list( map_session_data& sd ){
 #endif
 
 	int32 count = 0;
-	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0; i < sd.status.inventory_slots; i++ ){
 		if( sd.inventory.u.items_inventory[i].nameid > 0 && sd.inventory.u.items_inventory[i].refine < skill_lv &&
 			sd.inventory_data[i] != nullptr && sd.inventory_data[i]->type == IT_WEAPON &&
 			sd.inventory.u.items_inventory[i].identify && sd.inventory_data[i]->weapon_level >= 1 &&
@@ -8204,9 +8204,9 @@ void clif_sendegg(map_session_data *sd)
 		clif_displaymessage(fd, msg_txt(sd,666));
 		return;
 	}
-	WFIFOHEAD(fd, MAX_INVENTORY * 2 + 4);
+	WFIFOHEAD(fd, sd->status.inventory_slots * 2 + 4);
 	WFIFOW(fd,0)=0x1a6;
-	for(i=0,n=0;i<MAX_INVENTORY;i++){
+	for(i=0,n=0;i<sd->status.inventory_slots;i++){
 		if(sd->inventory.u.items_inventory[i].nameid == 0 || sd->inventory_data[i] == nullptr ||
 		   sd->inventory_data[i]->type != IT_PETEGG ||
 		   sd->inventory.u.items_inventory[i].amount <= 0)
@@ -12029,7 +12029,7 @@ void clif_parse_UseItem(int32 fd, map_session_data *sd)
 		sd->idletime_mer = last_tick;
 	n = RFIFOW(fd,packet_db[RFIFOW(fd,0)].pos[0])-2;
 
-	if(n <0 || n >= MAX_INVENTORY)
+	if(n <0 || n >= sd->status.inventory_slots)
 		return;
 	if (!pc_useitem(sd,n))
 		clif_useitemack(sd,n,0,false); //Send an empty ack packet or the client gets stuck.
@@ -12049,7 +12049,7 @@ void clif_parse_EquipItem( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -13366,7 +13366,7 @@ void clif_parse_ItemIdentify(int32 fd,map_session_data *sd) {
 	// - Invalid item index
 	// - Invalid item ID or item doesn't exist
 	// - Item is already identified
-	if ( idx >= MAX_INVENTORY ||
+	if ( idx >= sd->status.inventory_slots ||
 		sd->inventory.u.items_inventory[idx].nameid == 0 || sd->inventory_data[idx] == nullptr ||
 		sd->inventory.u.items_inventory[idx].identify) {// cancel pressed
 			sd->state.workinprogress = WIP_DISABLE_NONE;
@@ -13440,7 +13440,7 @@ void clif_parse_UseCard(int32 fd,map_session_data *sd)
 	const PACKET_CZ_REQ_ITEMCOMPOSITION_LIST* p = reinterpret_cast<PACKET_CZ_REQ_ITEMCOMPOSITION_LIST*>( RFIFOP( fd, 0 ) );
 	uint16 idx = server_index( p->index );
 
-	if( idx >= MAX_INVENTORY ){
+	if( idx >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -13463,11 +13463,11 @@ void clif_parse_InsertCard(int32 fd,map_session_data *sd)
 	uint16 card_idx = server_index( p->index_card );
 	uint16 equip_idx = server_index( p->index_equip );
 
-	if( card_idx >= MAX_INVENTORY ){
+	if( card_idx >= sd->status.inventory_slots){
 		return;
 	}
 
-	if( equip_idx >= MAX_INVENTORY ){
+	if( equip_idx >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -13558,7 +13558,7 @@ void clif_parse_MoveToKafra(int32 fd, map_session_data *sd)
 
 	item_index = RFIFOW(fd,info->pos[0])-2;
 	item_amount = RFIFOL(fd,info->pos[1]);
-	if (item_index < 0 || item_index >= MAX_INVENTORY || item_amount < 1)
+	if (item_index < 0 || item_index >= sd->status.inventory_slots || item_amount < 1)
 		return;
 	if( sd->inventory.u.items_inventory[item_index].equipSwitch ){
 		clif_msg( *sd, MSI_SWAP_EQUIPITEM_UNREGISTER_FIRST );
@@ -16668,7 +16668,7 @@ void clif_parse_Mail_setattach(int32 fd, map_session_data *sd){
 
 	if( !chrif_isconnected() )
 		return;
-	if (amount < 0 || server_index(idx) >= MAX_INVENTORY)
+	if (amount < 0 || server_index(idx) >= sd->status.inventory_slots)
 		return;
 
 	if (sd->inventory_data[server_index(idx)] == nullptr)
@@ -16914,7 +16914,7 @@ void clif_parse_Auction_setitem(int32 fd, map_session_data *sd){
 	if( sd->auction.amount > 0 )
 		sd->auction.amount = 0;
 
-	if( idx < 0 || idx >= MAX_INVENTORY ) {
+	if( idx < 0 || idx >= sd->status.inventory_slots) {
 		ShowWarning("Character %s trying to set invalid item index in auctions.\n", sd->status.name);
 		return;
 	}
@@ -19644,7 +19644,7 @@ void clif_magicdecoy_list( map_session_data& sd, uint16 skill_lv, int16 x, int16
 	p->packetLength = sizeof( *p );
 
 	size_t count = 0;
-	for( size_t i = 0; i < MAX_INVENTORY; i++ ){
+	for( size_t i = 0; i < sd.status.inventory_slots; i++ ){
 		if( itemdb_group.item_exists( IG_ELEMENT, sd.inventory.u.items_inventory[i].nameid ) ){
 			p->items[count].itemId = client_nameid( sd.inventory.u.items_inventory[i].nameid );
 			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( p->items[0] ) );
@@ -19673,7 +19673,7 @@ void clif_poison_list( map_session_data& sd, uint16 skill_lv ){
 	p->packetLength = sizeof( *p );
 
 	size_t count = 0;
-	for( size_t i = 0; i < MAX_INVENTORY; i++ ){
+	for( size_t i = 0; i < sd.status.inventory_slots; i++ ){
 		if( itemdb_group.item_exists( IG_POISON, sd.inventory.u.items_inventory[i].nameid ) ){
 			p->items[count].itemId = client_nameid( sd.inventory.u.items_inventory[i].nameid );
 			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( p->items[0] ) );
@@ -19816,7 +19816,7 @@ void clif_parse_MoveItem( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -21082,8 +21082,8 @@ static bool clif_merge_item_has_pair(map_session_data *sd, struct item *it) {
 
 	nullpo_retr(false, sd);
 
-	ARR_FIND(0, MAX_INVENTORY, i, (it_ = &sd->inventory.u.items_inventory[i]) && it->nameid == it_->nameid && it->bound == it_->bound && memcmp(it_, it, sizeof(struct item)) != 0);
-	if (i < MAX_INVENTORY)
+	ARR_FIND(0, sd->status.inventory_slots, i, (it_ = &sd->inventory.u.items_inventory[i]) && it->nameid == it_->nameid && it->bound == it_->bound && memcmp(it_, it, sizeof(struct item)) != 0);
+	if (i < sd->status.inventory_slots)
 		return true;
 
 	return false;
@@ -21125,7 +21125,7 @@ void clif_merge_item_open( map_session_data& sd ){
 	int32 n = 0;
 
 	// Get entries
-	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0; i < sd.status.inventory_slots; i++ ){
 		struct item* it = &sd.inventory.u.items_inventory[i];
 
 		if( !clif_merge_item_check( sd.inventory_data[i], it ) ){
@@ -21167,7 +21167,7 @@ void clif_parse_merge_item_req( int32 fd, map_session_data* sd ){
 
 	uint16 idx_main = server_index( p->indices[0] );
 
-	if( idx_main >= MAX_INVENTORY ){
+	if( idx_main >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -21182,7 +21182,7 @@ void clif_parse_merge_item_req( int32 fd, map_session_data* sd ){
 	for( int32 i = 1; i < count; i++ ){
 		uint16 idx = server_index( p->indices[i] );
 
-		if( idx >= MAX_INVENTORY ){
+		if( idx >= sd->status.inventory_slots){
 			return;
 		}
 
@@ -21354,7 +21354,7 @@ void clif_parse_Oneclick_Itemidentify(int32 fd, map_session_data *sd) {
 	// - Invalid item index
 	// - Invalid item ID or item doesn't exist
 	// - Item is already identified
-	if (idx < 0 || idx >= MAX_INVENTORY ||
+	if (idx < 0 || idx >= sd->status.inventory_slots ||
 		sd->inventory.u.items_inventory[idx].nameid == 0 || sd->inventory_data[idx] == nullptr ||
 		sd->inventory.u.items_inventory[idx].identify)
 			return;
@@ -22195,7 +22195,7 @@ void clif_parse_equipswitch_remove( int32 fd, map_session_data* sd ){
 	}
 
 	// Check if the index is valid
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -22234,7 +22234,7 @@ void clif_parse_equipswitch_add( int32 fd, map_session_data* sd ){
 		return;
 	}
 
-	if( index >= MAX_INVENTORY || sd->inventory_data[index] == nullptr ){
+	if( index >= sd->status.inventory_slots || sd->inventory_data[index] == nullptr ){
 		return;
 	}
 
@@ -22310,7 +22310,7 @@ void clif_parse_equipswitch_request_single( int32 fd, map_session_data* sd ){
 	}
 
 	// Check if the index is valid
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -22546,7 +22546,7 @@ void clif_parse_refineui_add( int32 fd, map_session_data* sd ){
 	}
 
 	// Check if the index is valid
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -22573,7 +22573,7 @@ void clif_parse_refineui_refine( int32 fd, map_session_data* sd ){
 	}
 
 	// Check if the index is valid
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -23537,7 +23537,7 @@ void clif_parse_laphine_synthesis( int32 fd, map_session_data* sd ){
 	for( size_t i = 0; i < count; i++ ){
 		int16 index = server_index( p->items[i].index );
 
-		if( index >= MAX_INVENTORY ){
+		if( index >= sd->status.inventory_slots){
 			return;
 		}
 
@@ -23691,7 +23691,7 @@ void clif_parse_laphine_upgrade( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -23877,7 +23877,7 @@ void clif_parse_enchantgrade_add( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY || sd->inventory_data[index] == nullptr ){
+	if( index >= sd->status.inventory_slots || sd->inventory_data[index] == nullptr ){
 		return;
 	}
 
@@ -23971,7 +23971,7 @@ void clif_parse_enchantgrade_start( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY || sd->inventory_data[index] == nullptr ){
+	if( index >= sd->status.inventory_slots || sd->inventory_data[index] == nullptr ){
 		return;
 	}
 
@@ -24249,7 +24249,7 @@ void clif_parse_item_reform_start( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -24473,7 +24473,7 @@ void clif_parse_enchantwindow_general( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -24602,7 +24602,7 @@ void clif_parse_enchantwindow_perfect( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -24702,7 +24702,7 @@ void clif_parse_enchantwindow_upgrade( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -24799,7 +24799,7 @@ void clif_parse_enchantwindow_reset( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 
@@ -24923,7 +24923,7 @@ void clif_parse_itempackage_select( int32 fd, map_session_data* sd ){
 
 	uint16 index = server_index( p->index );
 
-	if( index >= MAX_INVENTORY ){
+	if( index >= sd->status.inventory_slots){
 		return;
 	}
 

--- a/src/map/mail.cpp
+++ b/src/map/mail.cpp
@@ -44,7 +44,7 @@ int32 mail_removeitem(map_session_data *sd, int16 flag, int32 idx, int32 amount)
 
 	idx -= 2;
 
-	if( idx < 0 || idx >= MAX_INVENTORY )
+	if( idx < 0 || idx >= sd->status.inventory_slots)
 			return false;
 	if( amount <= 0 || amount > sd->inventory.u.items_inventory[idx].amount )
 			return false;
@@ -186,7 +186,7 @@ enum mail_attach_result mail_setitem(map_session_data *sd, int16 idx, uint32 amo
 
 		idx -= 2;
 
-		if( idx < 0 || idx >= MAX_INVENTORY || sd->inventory_data[idx] == nullptr )
+		if( idx < 0 || idx >= sd->status.inventory_slots || sd->inventory_data[idx] == nullptr )
 			return MAIL_ATTACH_ERROR;
 
 		if (itemdb_ishatched_egg(&sd->inventory.u.items_inventory[idx]))

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -2422,7 +2422,7 @@ static enum e_CASHSHOP_ACK npc_cashshop_process_payment(struct npc_data *nd, int
 					return ERROR_TYPE_PURCHASE_FAIL;
 				}
 
-				for (i = 0; i < MAX_INVENTORY && delete_amount > 0; i++) {
+				for (i = 0; i < sd->status.inventory_slots && delete_amount > 0; i++) {
 					struct item *it;
 					int32 amount = 0;
 
@@ -2607,7 +2607,7 @@ void npc_shop_currency_type(map_session_data *sd, struct npc_data *nd, int32 cos
 					clif_broadcast(&sd->bl, output, strlen(output) + 1, BC_BLUE,SELF);
 				}
 
-				for (i = 0; i < MAX_INVENTORY; i++) {
+				for (i = 0; i < sd->status.inventory_slots; i++) {
 					if (sd->inventory.u.items_inventory[i].amount > 0 && sd->inventory.u.items_inventory[i].nameid == id->nameid && pc_can_sell_item(sd, &sd->inventory.u.items_inventory[i], nd->subtype))
 						total += sd->inventory.u.items_inventory[i].amount;
 				}
@@ -3019,7 +3019,7 @@ uint8 npc_selllist(map_session_data* sd, int32 list_length, const PACKET_CZ_PC_S
 		idx    = item_list[i].index - 2;
 		amount = item_list[i].amount;
 
-		if( idx >= MAX_INVENTORY || idx < 0 || amount < 0 )
+		if( idx >= sd->status.inventory_slots || idx < 0 || amount < 0 )
 		{
 			return 1;
 		}
@@ -3145,7 +3145,7 @@ e_purchase_result npc_barter_purchase( map_session_data& sd, std::shared_ptr<s_n
 			if( itemdb_isstackable2( id.get() ) ){
 				int32 j;
 
-				for( j = 0; j < MAX_INVENTORY; j++ ){
+				for( j = 0; j < sd.status.inventory_slots; j++ ){
 					if( sd.inventory.u.items_inventory[j].nameid == requirement->nameid ){
 						// Equipped items are not taken into account
 						if( sd.inventory.u.items_inventory[j].equip != 0 ){
@@ -3182,14 +3182,14 @@ e_purchase_result npc_barter_purchase( map_session_data& sd, std::shared_ptr<s_n
 				}
 
 				// Required item not found
-				if( j == MAX_INVENTORY ){
+				if( j == sd.status.inventory_slots){
 					return e_purchase_result::PURCHASE_FAIL_GOODS;
 				}
 			}else{
 				for( int32 i = 0; i < (requirement->amount * amount); i++ ){
 					int32 j;
 
-					for( j = 0; j < MAX_INVENTORY; j++ ){
+					for( j = 0; j < sd.status.inventory_slots; j++ ){
 						if( sd.inventory.u.items_inventory[j].nameid == requirement->nameid ){
 							// Equipped items are not taken into account
 							if( sd.inventory.u.items_inventory[j].equip != 0 ){
@@ -3227,14 +3227,14 @@ e_purchase_result npc_barter_purchase( map_session_data& sd, std::shared_ptr<s_n
 					}
 
 					// Required item not found
-					if( j == MAX_INVENTORY ){
+					if( j == sd.status.inventory_slots){
 						// Maybe the refine level did not match
 						if( requirement->refine >= 0 ){
 							int32 refine;
 
 							// Try to find a higher refine level, going from the next lowest to the highest possible
 							for( refine = requirement->refine + 1; refine <= MAX_REFINE; refine++ ){
-								for( j = 0; j < MAX_INVENTORY; j++ ){
+								for( j = 0; j < sd.status.inventory_slots; j++ ){
 									if( sd.inventory.u.items_inventory[j].nameid == requirement->nameid ){
 										// Equipped items are not taken into account
 										if( sd.inventory.u.items_inventory[j].equip != 0 ){
@@ -3272,7 +3272,7 @@ e_purchase_result npc_barter_purchase( map_session_data& sd, std::shared_ptr<s_n
 								}
 
 								// If a match was found, make sure to cancel the loop
-								if( j < MAX_INVENTORY ){
+								if( j < sd.status.inventory_slots){
 									// Cancel the loop
 									break;
 								}
@@ -3307,7 +3307,7 @@ e_purchase_result npc_barter_purchase( map_session_data& sd, std::shared_ptr<s_n
 		return e_purchase_result::PURCHASE_FAIL_COUNT;
 	}
 
-	for( int32 i = 0; i < MAX_INVENTORY; i++ ){
+	for( int32 i = 0; i < sd.status.inventory_slots; i++ ){
 		if( requiredItems[i] > 0 ){
 			if( pc_delitem( &sd, i, requiredItems[i], 0, 0, LOG_TYPE_BARTER ) != 0 ){
 				return e_purchase_result::PURCHASE_FAIL_EXCHANGE_FAILED;

--- a/src/map/pet.cpp
+++ b/src/map/pet.cpp
@@ -1186,7 +1186,7 @@ int32 pet_select_egg(map_session_data *sd,int16 egg_index)
 {
 	nullpo_ret(sd);
 
-	if(egg_index < 0 || egg_index >= MAX_INVENTORY)
+	if(egg_index < 0 || egg_index >= sd->status.inventory_slots)
 		return 0; //Forged packet!
 
 	if(sd->state.trading)	//The player have trade in progress.
@@ -2198,7 +2198,7 @@ TIMER_FUNC(pet_skill_support_timer){
  * @return index of egg in player's inventory or -1 if the egg is not found.
  */
 int32 pet_egg_search(map_session_data* sd, int32 pet_id) {
-	for (int32 i = 0; i < MAX_INVENTORY; i++) {
+	for (int32 i = 0; i < sd->status.inventory_slots; i++) {
 		if (sd->inventory.u.items_inventory[i].card[0] == CARD0_PET &&
 			pet_id == MakeDWord(sd->inventory.u.items_inventory[i].card[1], sd->inventory.u.items_inventory[i].card[2]))
 			return i;
@@ -2227,7 +2227,7 @@ bool pet_evolution_requirements_check(map_session_data *sd, int16 pet_id) {
 
 	for (const auto &requirement : evo_data->second->requirements) {
 		int32 count = 0;
-		for (int32 i = 0; i < MAX_INVENTORY; i++) {
+		for (int32 i = 0; i < sd->status.inventory_slots; i++) {
 			if (sd->inventory.u.items_inventory[i].nameid == requirement.first) {
 				count += sd->inventory.u.items_inventory[i].amount;
 			}
@@ -2281,7 +2281,7 @@ void pet_evolution(map_session_data *sd, int16 pet_id) {
 
 	for (const auto &requirement : pet_db_ptr->evolution_data[pet_id]->requirements) {
 		int32 count = requirement.second;
-		for (int32 i = 0; i < MAX_INVENTORY; i++) {
+		for (int32 i = 0; i < sd->status.inventory_slots; i++) {
 			item *slot = &sd->inventory.u.items_inventory[i];
 			int32 deduction = min(requirement.second, slot->amount);
 			if (slot->nameid == requirement.first) {

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -7262,7 +7262,7 @@ BUILDIN_FUNC(countitem)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int32 count = script_countitem_sub(sd->inventory.u.items_inventory, id, MAX_INVENTORY, expanded, st, sd);
+	int32 count = script_countitem_sub(sd->inventory.u.items_inventory, id, sd->status.inventory_slots, expanded, st, sd);
 	if (count < 0) {
 		st->state = END;
 		return SCRIPT_CMD_FAILURE;
@@ -7466,7 +7466,7 @@ BUILDIN_FUNC(rentalcountitem)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	int32 count = script_countitem_sub(sd->inventory.u.items_inventory, id, MAX_INVENTORY, expanded, st, sd, true);
+	int32 count = script_countitem_sub(sd->inventory.u.items_inventory, id, sd->status.inventory_slots, expanded, st, sd, true);
 	if (count < 0) {
 		st->state = END;
 		return SCRIPT_CMD_FAILURE;
@@ -8453,7 +8453,7 @@ static bool buildin_delitem_search(map_session_data* sd, struct item* it, uint8 
 		}
 			break;
 		default: // TABLE_INVENTORY
-			size = MAX_INVENTORY;
+			size = sd->status.inventory_slots;
 			items = sd->inventory.u.items_inventory;
 			break;
 	}
@@ -8793,8 +8793,8 @@ BUILDIN_FUNC(delitemidx) {
 	}
 
 	int32 idx = script_getnum(st, 2);
-	if (idx < 0 || idx >= MAX_INVENTORY) {
-		ShowWarning("buildin_delitemidx: Index %d is out of the range 0-%d.\n", idx, MAX_INVENTORY - 1);
+	if (idx < 0 || idx >= sd->status.inventory_slots) {
+		ShowWarning("buildin_delitemidx: Index %d is out of the range 0-%d.\n", idx, sd->status.inventory_slots - 1);
 		script_pushint(st, false);
 		return SCRIPT_CMD_FAILURE;
 	}
@@ -9323,7 +9323,7 @@ BUILDIN_FUNC(getequipid)
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (i >= 0 && i < MAX_INVENTORY && sd->inventory_data[i])
+	if (i >= 0 && i < sd->status.inventory_slots && sd->inventory_data[i])
 		script_pushint(st, sd->inventory_data[i]->nameid);
 	else
 		script_pushint(st, -1);
@@ -9428,7 +9428,7 @@ BUILDIN_FUNC(getbrokenid)
 	}
 
 	num = script_getnum(st,2);
-	for(i = 0; i < MAX_INVENTORY; i++) {
+	for(i = 0; i < sd->status.inventory_slots; i++) {
 		if( sd->inventory.u.items_inventory[i].attribute == 1 && !itemdb_ishatched_egg( &sd->inventory.u.items_inventory[i] ) ){
 				brokencounter++;
 				if(num == brokencounter){
@@ -9457,7 +9457,7 @@ BUILDIN_FUNC(repair)
 		return SCRIPT_CMD_FAILURE;
 
 	num = script_getnum(st,2);
-	for(i = 0; i < MAX_INVENTORY; i++) {
+	for(i = 0; i < sd->status.inventory_slots; i++) {
 		if( sd->inventory.u.items_inventory[i].attribute == 1 && !itemdb_ishatched_egg( &sd->inventory.u.items_inventory[i] ) ){
 				repaircounter++;
 				if(num == repaircounter) {
@@ -9484,7 +9484,7 @@ BUILDIN_FUNC(repairall)
 	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
-	for(i = 0; i < MAX_INVENTORY; i++)
+	for(i = 0; i < sd->status.inventory_slots; i++)
 	{
 		if( sd->inventory.u.items_inventory[i].nameid && sd->inventory.u.items_inventory[i].attribute == 1 && !itemdb_ishatched_egg( &sd->inventory.u.items_inventory[i] ) ){
 			sd->inventory.u.items_inventory[i].attribute = 0;
@@ -15034,7 +15034,7 @@ BUILDIN_FUNC(getinventorylist)
 
 	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
-	for(i=0;i<MAX_INVENTORY;i++){
+	for(i=0;i< sd->status.inventory_slots;i++){
 		if(sd->inventory.u.items_inventory[i].nameid > 0 && sd->inventory.u.items_inventory[i].amount > 0){
 			pc_setreg(sd,reference_uid(add_str("@inventorylist_id"), j),sd->inventory.u.items_inventory[i].nameid);
 			pc_setreg(sd,reference_uid(add_str("@inventorylist_idx"), j),i);
@@ -15102,7 +15102,7 @@ BUILDIN_FUNC(clearitem)
 	if (!script_charid2sd(2,sd))
 		return SCRIPT_CMD_FAILURE;
 
-	for (i=0; i<MAX_INVENTORY; i++) {
+	for (i=0; i<sd->status.inventory_slots; i++) {
 		if (sd->inventory.u.items_inventory[i].amount) {
 			pc_delitem(sd, i, sd->inventory.u.items_inventory[i].amount, 0, 0, LOG_TYPE_SCRIPT);
 		}
@@ -16105,7 +16105,7 @@ BUILDIN_FUNC(checkequipedcard)
 		int32 n,i,c=0;
 		c=script_getnum(st,2);
 
-		for(i=0;i<MAX_INVENTORY;i++){
+		for(i=0;i<sd->status.inventory_slots;i++){
 			if(sd->inventory.u.items_inventory[i].nameid > 0 && sd->inventory.u.items_inventory[i].amount && sd->inventory_data[i]){
 				if (itemdb_isspecial(sd->inventory.u.items_inventory[i].card[0]))
 					continue;
@@ -16953,8 +16953,8 @@ BUILDIN_FUNC(equip) {
 	if (id != nullptr) {
 		int32 i;
 
-		ARR_FIND( 0, MAX_INVENTORY, i, sd->inventory.u.items_inventory[i].nameid == nameid );
-		if (i < MAX_INVENTORY) {
+		ARR_FIND( 0, sd->status.inventory_slots, i, sd->inventory.u.items_inventory[i].nameid == nameid );
+		if (i < sd->status.inventory_slots) {
 			pc_equipitem(sd,i,id->equip);
 			script_pushint(st,1);
 			return SCRIPT_CMD_SUCCESS;
@@ -23445,7 +23445,7 @@ BUILDIN_FUNC(countbound)
 	int32 i, k = 0;
 	int32 type = script_getnum(st,2);
 
-	for( i = 0; i < MAX_INVENTORY; i ++ ) {
+	for( i = 0; i < sd->status.inventory_slots; i ++ ) {
 		if( sd->inventory.u.items_inventory[i].nameid > 0 && (
 			(!type && sd->inventory.u.items_inventory[i].bound) || (type && sd->inventory.u.items_inventory[i].bound == type)
 			))
@@ -24135,7 +24135,7 @@ BUILDIN_FUNC(mergeitem2) {
 		}
 	}
 
-	for (i = 0; i < MAX_INVENTORY; i++) {
+	for (i = 0; i < sd->status.inventory_slots; i++) {
 		struct item *it = &sd->inventory.u.items_inventory[i];
 
 		if (!it || !it->unique_id || it->expire_time || !itemdb_isstackable(it->nameid))
@@ -26754,7 +26754,7 @@ BUILDIN_FUNC(getenchantgrade){
 		return SCRIPT_CMD_FAILURE;
 	}
 
-	if (index < 0 || index >= MAX_INVENTORY || sd->inventory.u.items_inventory[index].nameid == 0)
+	if (index < 0 || index >= sd->status.inventory_slots || sd->inventory.u.items_inventory[index].nameid == 0)
 		script_pushint(st, -1);
 	else
 		script_pushint(st, sd->inventory.u.items_inventory[index].enchantgrade);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18815,7 +18815,7 @@ bool skill_check_condition_castbegin( map_session_data& sd, uint16 skill_id, uin
 		case AB_ANCILLA: {
 				int32 count = 0;
 
-				for( i = 0; i < MAX_INVENTORY; i++ )
+				for( i = 0; i < sd.status.inventory_slots; i++ )
 					if( sd.inventory.u.items_inventory[i].nameid == ITEMID_ANCILLA )
 						count += sd.inventory.u.items_inventory[i].amount;
 				if( count >= 3 ) {
@@ -20589,7 +20589,7 @@ void skill_repairweapon( map_session_data& sd, int32 idx ){
 
 	if( idx == 0xFFFF ) // No item selected ('Cancel' clicked)
 		return;
-	if( idx < 0 || idx >= MAX_INVENTORY )
+	if( idx < 0 || idx >= sd.status.inventory_slots)
 		return; //Invalid index??
 
 	item = &target_sd->inventory.u.items_inventory[idx];
@@ -20640,7 +20640,7 @@ void skill_identify(map_session_data *sd, int32 idx)
 
 	sd->state.workinprogress = WIP_DISABLE_NONE;
 
-	if(idx >= 0 && idx < MAX_INVENTORY) {
+	if(idx >= 0 && idx < sd->status.inventory_slots) {
 		if(sd->inventory.u.items_inventory[idx].nameid > 0 && sd->inventory.u.items_inventory[idx].identify == 0 ){
 			failure = false;
 			sd->inventory.u.items_inventory[idx].identify = 1;
@@ -20663,7 +20663,7 @@ void skill_weaponrefine( map_session_data& sd, int32 idx ){
 #endif
 	};
 
-	if (idx >= 0 && idx < MAX_INVENTORY)
+	if (idx >= 0 && idx < sd.status.inventory_slots)
 	{
 		struct item_data *ditem = sd.inventory_data[idx];
 		struct item* item = &sd.inventory.u.items_inventory[idx];
@@ -22897,7 +22897,7 @@ int16 skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger
 		} else {
 			uint16 idx, amt;
 
-			for (idx = 0, amt = 0; idx < MAX_INVENTORY; idx++)
+			for (idx = 0, amt = 0; idx < sd->status.inventory_slots; idx++)
 				if (sd->inventory.u.items_inventory[idx].nameid == nameid_produce)
 					amt += sd->inventory.u.items_inventory[idx].amount;
 			if (amt < qty * skill_produce_db[i].mat_amount[j])
@@ -23844,7 +23844,7 @@ int32 skill_elementalanalysis( map_session_data& sd, int32 n, uint16 skill_lv, u
 
 		idx = item_list[i*2+0]-2;
 
-		if( idx < 0 || idx >= MAX_INVENTORY ){
+		if( idx < 0 || idx >= sd.status.inventory_slots){
 			return 1;
 		}
 
@@ -23923,7 +23923,7 @@ int32 skill_changematerial(map_session_data *sd, int32 n, uint16 *item_list) {
 						for( k = 0; k < n; k++ ) {
 							int32 idx = item_list[k*2+0]-2;
 
-							if( idx < 0 || idx >= MAX_INVENTORY ){
+							if( idx < 0 || idx >= sd->status.inventory_slots){
 								return 0;
 							}
 

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -3649,7 +3649,7 @@ bool status_calc_weight(map_session_data *sd, enum e_status_calc_weight_opt flag
 	if (flag&CALCWT_ITEM) {
 		sd->weight = 0; // Reset current weight
 
-		for(i = 0; i < MAX_INVENTORY; i++) {
+		for(i = 0; i < sd->status.inventory_slots; i++) {
 			if (!sd->inventory.u.items_inventory[i].nameid || sd->inventory_data[i] == nullptr)
 				continue;
 			sd->weight += sd->inventory_data[i]->weight * sd->inventory.u.items_inventory[i].amount;

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -337,7 +337,7 @@ void storage_storageadd(map_session_data* sd, struct s_storage *stor, int32 inde
 
 	nullpo_retv(sd);
 
-	result = storage_canAddItem(stor, index, sd->inventory.u.items_inventory, amount, MAX_INVENTORY);
+	result = storage_canAddItem(stor, index, sd->inventory.u.items_inventory, amount, sd->status.inventory_slots);
 	if (result == STORAGE_ADD_INVALID)
 		return;
 	else if (result == STORAGE_ADD_OK) {
@@ -879,7 +879,7 @@ void storage_guild_storageadd(map_session_data* sd, int32 index, int32 amount)
 	if( !stor->status || stor->amount > stor->max_amount )
 		return;
 
-	if( index < 0 || index >= MAX_INVENTORY )
+	if( index < 0 || index >= sd->status.inventory_slots)
 		return;
 
 	if( sd->inventory.u.items_inventory[index].nameid == 0 )

--- a/src/map/trade.cpp
+++ b/src/map/trade.cpp
@@ -192,12 +192,12 @@ int32 impossible_trade_check(map_session_data *sd)
 	}
 
 	// get inventory of player
-	memcpy(&inventory, &sd->inventory.u.items_inventory, sizeof(struct item) * MAX_INVENTORY);
+	memcpy(&inventory, &sd->inventory.u.items_inventory, sizeof(struct item) * sd->status.inventory_slots);
 
 	// remove this part: arrows can be trade and equipped
 	// re-added! [celest]
 	// remove equipped items (they can not be trade)
-	for (i = 0; i < MAX_INVENTORY; i++)
+	for (i = 0; i < sd->status.inventory_slots; i++)
 		if (inventory[i].nameid > 0 && inventory[i].equip && !(inventory[i].equip & EQP_AMMO))
 			memset(&inventory[i], 0, sizeof(struct item));
 
@@ -258,8 +258,8 @@ int32 trade_check(map_session_data *sd, map_session_data *tsd)
 		return 0;
 
 	// get inventory of player
-	memcpy(&inventory, &sd->inventory.u.items_inventory, sizeof(struct item) * MAX_INVENTORY);
-	memcpy(&inventory2, &tsd->inventory.u.items_inventory, sizeof(struct item) * MAX_INVENTORY);
+	memcpy(&inventory, &sd->inventory.u.items_inventory, sizeof(struct item) * sd->status.inventory_slots);
+	memcpy(&inventory2, &tsd->inventory.u.items_inventory, sizeof(struct item) * tsd->status.inventory_slots);
 
 	// check free slot in both inventory
 	for(trade_i = 0; trade_i < 10; trade_i++) {
@@ -274,9 +274,9 @@ int32 trade_check(map_session_data *sd, map_session_data *tsd)
 				return 0; // Quantity Exploit?
 
 			data = itemdb_search(inventory[n].nameid);
-			i = MAX_INVENTORY;
+			i = tsd->status.inventory_slots;
 			if (itemdb_isstackable2(data)) { // Stackable item.
-				for(i = 0; i < MAX_INVENTORY; i++)
+				for(i = 0; i < tsd->status.inventory_slots; i++)
 					if (inventory2[i].nameid == inventory[n].nameid &&
 						inventory2[i].card[0] == inventory[n].card[0] && inventory2[i].card[1] == inventory[n].card[1] &&
 						inventory2[i].card[2] == inventory[n].card[2] && inventory2[i].card[3] == inventory[n].card[3]) {
@@ -289,9 +289,9 @@ int32 trade_check(map_session_data *sd, map_session_data *tsd)
 					}
 			}
 
-			if (i == MAX_INVENTORY) { // look for an empty slot.
-				for(i = 0; i < MAX_INVENTORY && inventory2[i].nameid; i++);
-				if (i == MAX_INVENTORY)
+			if (i == tsd->status.inventory_slots) { // look for an empty slot.
+				for(i = 0; i < tsd->status.inventory_slots && inventory2[i].nameid; i++);
+				if (i == tsd->status.inventory_slots)
 					return 0;
 
 				memcpy(&inventory2[i], &inventory[n], sizeof(struct item));
@@ -312,10 +312,10 @@ int32 trade_check(map_session_data *sd, map_session_data *tsd)
 
 		// search if it's possible to add item (for full inventory)
 		data = itemdb_search(inventory2[n].nameid);
-		i = MAX_INVENTORY;
+		i = sd->status.inventory_slots;
 
 		if (itemdb_isstackable2(data)) {
-			for(i = 0; i < MAX_INVENTORY; i++)
+			for(i = 0; i < sd->status.inventory_slots; i++)
 				if (inventory[i].nameid == inventory2[n].nameid &&
 					inventory[i].card[0] == inventory2[n].card[0] && inventory[i].card[1] == inventory2[n].card[1] &&
 					inventory[i].card[2] == inventory2[n].card[2] && inventory[i].card[3] == inventory2[n].card[3]) {
@@ -328,9 +328,9 @@ int32 trade_check(map_session_data *sd, map_session_data *tsd)
 				}
 		}
 
-		if (i == MAX_INVENTORY) {
-			for(i = 0; i < MAX_INVENTORY && inventory[i].nameid; i++);
-			if (i == MAX_INVENTORY)
+		if (i == sd->status.inventory_slots) {
+			for(i = 0; i < sd->status.inventory_slots && inventory[i].nameid; i++);
+			if (i == sd->status.inventory_slots)
 				return 0;
 
 			memcpy(&inventory[i], &inventory2[n], sizeof(struct item));
@@ -371,7 +371,7 @@ void trade_tradeadditem(map_session_data *sd, int16 index, int16 amount)
 	}
 
 	// Item checks...
-	if( index < 0 || index >= MAX_INVENTORY )
+	if( index < 0 || index >= sd->status.inventory_slots)
 		return;
 	if( amount < 0 || amount > sd->inventory.u.items_inventory[index].amount )
 		return;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  
Using ```MAX_INVENTORY``` to check player inventory slots is always at maximum even they only have 100 slots as ```default``` in each player.
Related also to https://github.com/rathena/rathena/issues/9250

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  
Maybe it was missed during the implementation of inventory expansion.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
