### PR TITLE
Poison React

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4876,7 +4876,7 @@ Body:
       - Level: 9
         Time: 60000
       - Level: 10
-        Time: 65000
+        Time: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4877,6 +4877,7 @@ Body:
         Time: 60000
       - Level: 10
         Time: 60000
+    Duration2: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5112,6 +5112,7 @@ Body:
         Time: 60000
       - Level: 10
         Time: 60000
+    Duration2: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5111,7 +5111,7 @@ Body:
       - Level: 9
         Time: 60000
       - Level: 10
-        Time: 65000
+        Time: 60000
     Requires:
       SpCost:
         - Level: 1

--- a/doc/status_change.txt
+++ b/doc/status_change.txt
@@ -107,8 +107,11 @@ SC_ENCPOISON	(EFST_ENCHANTPOISON)
 	val1:
 
 SC_POISONREACT	(EFST_POISONREACT)
-	desc: Increase ATK by (100+30*Skill Lv))%; Counter physical attack with Envenoms skill
-	val1:
+	desc: Blocks poison attacks; Increases damage by (30*Skill Lv)% after block; Counters non-poison attacks with Envenom 5 autocast
+	val1: Skill level
+	val2: Number of Envenom autocasts
+	val3: Chance to autocast Envenom on hit / Poison chance after block
+	val4: 0=Poison Block Mode; 1=Damage Boost Mode
 
 SC_QUAGMIRE	(EFST_QUAGMIRE)
 	desc: Removes Increase AGI, Twhohand Quicken, Wind Walk, Adrenaline Rush, Attention Concentrate, Cart Boost, True Sight, Magnetic Field & Onehand Quicken skill effect; Movement Speed -50; Decrease AGI & DEX by (10*Skill Lv) but can't below 75% for players and 50% for mobs

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -4650,7 +4650,7 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 #endif
 		if (!skill_id || skill_id == KN_AUTOCOUNTER) {
 			if (status_change_entry* sce = sc->getSCE(SC_POISONREACT); sce != nullptr && sce->val4 == 1) {
-				// Damage boost from poison react (bonus depends on level learned)
+				// Damage boost from poison react (for players bonus depends on level learned)
 				if (sd != nullptr)
 					skillratio += 30 * pc_checkskill(sd, AS_POISONREACT);
 				else
@@ -10525,7 +10525,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 		}
 	}
 
-	// Poison React counter activates on normal poison attacks as well as attacks from poison-element enemies
+	// Poison React counter activates on attacks from poison-element enemies as well as normal poison attacks
 	if (tsc != nullptr && ((src->type != BL_PC && sstatus->def_ele == ELE_POISON) || sstatus->rhw.ele == ELE_POISON)) {
 		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && sce->val4 == 0) {
 			// Next normal attack will receive a damage boost

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7358,6 +7358,16 @@ static void battle_calc_weapon_final_atk_modifiers(struct Damage* wd, struct blo
 			status_change_end(target, SC_REJECTSWORD);
 	}
 
+	// Poison React Envenom Level 5 Autocast
+	if (tsc != nullptr && wd->damage > 0) {
+		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && rnd_chance_official(sce->val3, 100)) {
+			if (status_check_skilluse(target, src, TF_POISON, 0))
+				skill_attack(BF_WEAPON, target, target, src, TF_POISON, 5, gettick(), 0);
+			if (--sce->val2 <= 0)
+				status_change_end(target, SC_POISONREACT);
+		}
+	}
+
 	if( tsc && tsc->getSCE(SC_CRESCENTELBOW) && wd->flag&BF_SHORT && rnd()%100 < tsc->getSCE(SC_CRESCENTELBOW)->val2 ) {
 		//ATK [{(Target HP / 100) x Skill Level} x Caster Base Level / 125] % + [Received damage x {1 + (Skill Level x 0.2)}]
 		int64 rdamage = 0;
@@ -8035,17 +8045,6 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 		wd.damage += battle_calc_cardfix(BF_WEAPON, src, target, nk, right_element, left_element, wd.damage, 0, wd.flag);
 		if(is_attack_left_handed(src, skill_id))
 			wd.damage2 += battle_calc_cardfix(BF_WEAPON, src, target, nk, right_element, left_element, wd.damage2, 1, wd.flag);
-	}
-
-	// For some reason the Envenom autocast from Poison React happens at this point rather than after attack motion
-	if (tsc != nullptr && wd.damage + wd.damage2 > 0) {
-		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && rnd_chance_official(sce->val3, 100)) {
-			// Cast Envenom Level 5
-			if (status_check_skilluse(target, src, TF_POISON, 0))
-				skill_attack(BF_WEAPON, target, target, src, TF_POISON, 5, gettick(), 0);
-			if (--sce->val2 <= 0)
-				status_change_end(target, SC_POISONREACT);
-		}
 	}
 
 	// only do 1 dmg to plant, no need to calculate rest

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -4541,16 +4541,6 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 				wd->div_ = 3;
 			}
 			break;
-#ifdef RENEWAL
-		case AS_POISONREACT:
-			skill_lv = pc_checkskill(sd, TF_DOUBLE);
-			if (skill_lv > 0) {
-				if(rnd()%100 < (7 * skill_lv)) {
-					wd->div_++;
-				}
-			}
-		break;
-#endif
 		case NW_SPIRAL_SHOOTING:
 			if (sd && sd->weapontype1 == W_GRENADE)
 				wd->div_ += 1;
@@ -4659,6 +4649,14 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			skillratio += 200;
 #endif
 		if (!skill_id || skill_id == KN_AUTOCOUNTER) {
+			if (sc->getSCE(SC_POISONREACT) != nullptr && sc->getSCE(SC_POISONREACT)->val4 == 1) {
+				// Damage boost from poison react (bonus depends on level learned)
+				if (sd != nullptr)
+					skillratio += 30 * pc_checkskill(sd, AS_POISONREACT);
+				else
+					skillratio += 30 * sc->getSCE(SC_POISONREACT)->val1;
+				status_change_end(src, SC_POISONREACT);
+			}
 			if (sc->getSCE(SC_CRUSHSTRIKE)) {
 				if (sd) { //ATK [{Weapon Level * (Weapon Upgrade Level + 6) * 100} + (Weapon ATK) + (Weapon Weight)]%
 					int16 index = sd->equip_index[EQI_HAND_R];
@@ -4763,9 +4761,6 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			break;
 		case AS_GRIMTOOTH:
 			skillratio += 20 * skill_lv;
-			break;
-		case AS_POISONREACT:
-			skillratio += 30 * skill_lv;
 			break;
 		case AS_SONICBLOW:
 #ifdef RENEWAL
@@ -10517,6 +10512,20 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 		}
 	}
 
+	// Poison React counter activates on normal poison attacks as well as attacks from poison-element enemies
+	if (tsc != nullptr && (sstatus->def_ele == ELE_POISON || sstatus->rhw.ele == ELE_POISON)) {
+		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && sce->val4 == 0) {
+			// Next normal attack will receive a damage boost
+			sce->val4 = 1;
+
+			// The target will start attacking instead of the source
+			if (tsd != nullptr)
+				clif_movetoattack(*tsd, *src);
+
+			return ATK_BLOCK;
+		}
+	}
+
 	if( tsc && tsc->getSCE(SC_BLADESTOP_WAIT) &&
 #ifndef RENEWAL
 		status_get_class_(src) != CLASS_BOSS &&
@@ -11041,20 +11050,12 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 
 	if (tsc) {
 		if (damage > 0 && tsc->getSCE(SC_POISONREACT) &&
-			(rnd()%100 < tsc->getSCE(SC_POISONREACT)->val3
-			|| sstatus->def_ele == ELE_POISON) &&
-//			check_distance_bl(src, target, tstatus->rhw.range+1) && Doesn't checks range! o.O;
+			rnd()%100 < tsc->getSCE(SC_POISONREACT)->val3 &&
 			status_check_skilluse(target, src, TF_POISON, 0)
 		) {	//Poison React
 			struct status_change_entry *sce = tsc->getSCE(SC_POISONREACT);
-			if (sstatus->def_ele == ELE_POISON) {
-				sce->val2 = 0;
-				skill_attack(BF_WEAPON,target,target,src,AS_POISONREACT,sce->val1,tick,0);
-			} else {
-				skill_attack(BF_WEAPON,target,target,src,TF_POISON, 5, tick, 0);
-				--sce->val2;
-			}
-			if (sce->val2 <= 0)
+			skill_attack(BF_WEAPON, target, target, src, TF_POISON, 5, tick, 0);
+			if (--sce->val2 <= 0)
 				status_change_end(target, SC_POISONREACT);
 		}
 	}

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -4655,9 +4655,9 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 					skillratio += 30 * pc_checkskill(sd, AS_POISONREACT);
 				else
 					skillratio += 30 * sce->val1;
-				// This attack has a 50% chance to cause poison
+				// This attack has a chance to cause poison
 				// TODO: Effect should be delayed by attack motion
-				sc_start2(src, target, SC_POISON, 50, sce->val1, src->id, skill_get_time2(AS_POISONREACT, sce->val1));
+				sc_start2(src, target, SC_POISON, sce->val3, sce->val1, src->id, skill_get_time2(AS_POISONREACT, sce->val1));
 				status_change_end(src, SC_POISONREACT);
 			}
 			if (sc->getSCE(SC_CRUSHSTRIKE)) {
@@ -7363,6 +7363,7 @@ static void battle_calc_weapon_final_atk_modifiers(struct Damage* wd, struct blo
 		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && rnd_chance_official(sce->val3, 100)) {
 			if (status_check_skilluse(target, src, TF_POISON, 0))
 				skill_attack(BF_WEAPON, target, target, src, TF_POISON, 5, gettick(), 0);
+			// Counter is reduced even if the autocast fails
 			if (--sce->val2 <= 0)
 				status_change_end(target, SC_POISONREACT);
 		}

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -10527,7 +10527,7 @@ enum damage_lv battle_weapon_attack(struct block_list* src, struct block_list* t
 	}
 
 	// Poison React counter activates on normal poison attacks as well as attacks from poison-element enemies
-	if (tsc != nullptr && (sstatus->def_ele == ELE_POISON || sstatus->rhw.ele == ELE_POISON)) {
+	if (tsc != nullptr && ((src->type != BL_PC && sstatus->def_ele == ELE_POISON) || sstatus->rhw.ele == ELE_POISON)) {
 		if (status_change_entry* sce = tsc->getSCE(SC_POISONREACT); sce != nullptr && sce->val4 == 0) {
 			// Next normal attack will receive a damage boost
 			sce->val4 = 1;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10766,11 +10766,7 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			}
 			break;
 		case SC_POISONREACT:
-#ifdef RENEWAL
-			val2 = (val1 + 1) / 2; // Number of Envenom autocasts
-#else
 			val2 = val1 / 2; // Number of Envenom autocasts
-#endif
 			val3 = 50; // Chance to autocast Envenom on hit
 			val4 = 0; // 0: Counter Mode; 1: Damage Boost Mode
 			break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10767,11 +10767,12 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			break;
 		case SC_POISONREACT:
 #ifdef RENEWAL
-			val2= (val1 + 1) / 2;
+			val2 = (val1 + 1) / 2; // Number of Envenom autocasts
 #else
-			val2=(val1+1)/2 + val1/10; // Number of counters [Skotlex]
+			val2 = val1 / 2; // Number of Envenom autocasts
 #endif
-			val3=50; // + 5*val1; // Chance to counter. [Skotlex]
+			val3 = 50; // Chance to autocast Envenom on hit
+			val4 = 0; // 0: Counter Mode; 1: Damage Boost Mode
 			break;
 		case SC_MAGICROD:
 			val2 = val1*20; // SP gained

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10767,8 +10767,8 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			break;
 		case SC_POISONREACT:
 			val2 = val1 / 2; // Number of Envenom autocasts
-			val3 = 50; // Chance to autocast Envenom on hit
-			val4 = 0; // 0: Counter Mode; 1: Damage Boost Mode
+			val3 = 50; // Chance to autocast Envenom on hit / Poison chance of attack after block
+			val4 = 0; // 0: Poison Block Mode; 1: Damage Boost Mode
 			break;
 		case SC_MAGICROD:
 			val2 = val1*20; // SP gained


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7279

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (most fixes are for pre-re, but skill works almost identical in both)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Poison React can now counter normal poison attacks (e.g. Poison Knife, Rusty Arrow, Enchant Poison)
  * Poison armor will no longer trigger this counter, but it still triggers on poison-element monsters
- When Poison React counters an attack, that attack is now blocked
- The counter of Poison React is now a damage buff that increases the damage of the next normal attack
  * It will attempt to trigger a counterattack (makes you move closer if not in range)
  * Adds 30% to skill ratio of the next normal attack per level learned, regardless of level used (for PC)
  * The buff also adds a 50% poison chance to the next normal attack (60s base duration)
- Number of Envenom 5 Autocasts is now 1:1:1:2:2:3:3:4:4:5 (applies to both pre-re and re)
  * Level 1 technically has 0, but it activates at least once before the status change ends
- Envenom 5 Autocasts can now also be triggered by weapon skills
- Duration of Poison React is now capped to 60 seconds
- Fixes #7279

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
