### PR TITLE
Status Changes on Equip Switch

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1170,6 +1170,7 @@ Body:
     Flags:
       NoSave: true
       RequireWeapon: true
+      RemoveOnUnequipWeapon: true
       RemoveOnHermode: true
   - Status: Parrying
     Icon: EFST_PARRYING
@@ -1192,6 +1193,7 @@ Body:
       Quicken: true
     Flags:
       NoSave: true
+      RemoveOnUnequip: true
       RemoveOnHermode: true
   - Status: Tensionrelax
     Icon: EFST_TENSIONRELAX

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1199,6 +1199,7 @@ Body:
     Flags:
       NoSave: true
       RequireWeapon: true
+      RemoveOnUnequipWeapon: true
       RemoveOnHermode: true
   - Status: Parrying
     Icon: EFST_PARRYING

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -12246,7 +12246,6 @@ static void pc_unequipitem_sub(map_session_data *sd, int32 n, int32 flag) {
 	}
 
 	if (flag & 1 || status_calc) {
-		pc_checkallowskill(sd);
 		status_calc_pc(sd, SCO_FORCE);
 	}
 
@@ -12291,7 +12290,7 @@ static void pc_unequipitem_sub(map_session_data *sd, int32 n, int32 flag) {
  *  0 - only unequip
  *  1 - calculate status after unequipping
  *  2 - force unequip
- *  4 - unequip by switching equipment
+ *  4 - equip switch (do not end status changes based on weapon/armor requirements)
  * @return True on success or false on failure
  */
 bool pc_unequipitem(map_session_data *sd, int32 n, int32 flag) {
@@ -12386,12 +12385,6 @@ bool pc_unequipitem(map_session_data *sd, int32 n, int32 flag) {
 	if (pos & EQP_ARMOR) {
 		status_db.removeByStatusFlag(&sd->bl, { SCF_REMOVEONUNEQUIPARMOR });
 	}
-
-	// On equipment change
-#ifndef RENEWAL
-	if (!(flag&4))
-		status_change_end(&sd->bl, SC_CONCENTRATION);
-#endif
 
 	// On ammo change
 	if (sd->inventory_data[n]->type == IT_AMMO && (sd->inventory_data[n]->nameid != ITEMID_SILVER_BULLET || sd->inventory_data[n]->nameid != ITEMID_PURIFICATION_BULLET || sd->inventory_data[n]->nameid != ITEMID_SILVER_BULLET_))


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9314 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixes status changes ending when switching equips even if the new equip still fulfills the requirements
  * This also improves performance due to removing a duplicate call in several cases
- Moved hardcoded exception for SC_CONCENTRATION to status.yml
- Aura Blade ends when a weapon is switched or unequipped
- Follow-up to 3c36814 and bf9a3b4
- Fixes #9314

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
