### PR TITLE
Cloaking / Power Maximize on Monsters

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10748,8 +10748,14 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			clif_emotion( *bl, ET_SWEAT );
 			break;
 		case SC_MAXIMIZEPOWER:
-			tick_time = val2 = tick>0?tick:60000;
-			tick = INFINITE_TICK; // Duration sent to the client should be infinite
+			if (sd == nullptr) {
+				// Duration is 10 seconds for monsters on all levels
+				tick = 10000;
+			}
+			else {
+				tick_time = val2 = tick>0?tick:10000;
+				tick = INFINITE_TICK; // Duration sent to the client should be infinite
+			}
 			break;
 		case SC_EDP:
 			val2 = (val1 + 1) / 2 + 2; // Chance to Poison enemies.
@@ -11139,10 +11145,15 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			if (map_flag_gvg2(bl->m) || map_getmapflag(bl->m, MF_BATTLEGROUND)) val4 *= 5;
 			break;
 		case SC_CLOAKING:
-			if (!sd) // Monsters should be able to walk with no penalties. [Skotlex]
+			if (sd == nullptr) {
+				// Monsters have no walk penalties and the status change lasts for 10 seconds
 				val1 = 10;
-			tick_time = val2 = tick>0?tick:60000; // SP consumption rate.
-			tick = INFINITE_TICK; // Duration sent to the client should be infinite
+				tick = 10000;
+			}
+			else {
+				tick_time = val2 = tick>0?tick:10000; // SP consumption rate.
+				tick = INFINITE_TICK; // Duration sent to the client should be infinite
+			}
 			val3 = 0; // Unused, previously walk speed adjustment
 			// val4&1 signals the presence of a wall.
 			// val4&2 makes cloak not end on normal attacks [Skotlex]
@@ -14029,7 +14040,7 @@ TIMER_FUNC(status_change_timer){
 	switch(type) {
 	case SC_MAXIMIZEPOWER:
 	case SC_CLOAKING:
-		if(!status_charge(bl, 0, 1))
+		if(!status_damage(nullptr, bl, 0, 1, 0, 3, 0))
 			break; // Not enough SP to continue.
 		sc_timer_next(sce->val2+tick);
 		return 0;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10748,13 +10748,13 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			clif_emotion( *bl, ET_SWEAT );
 			break;
 		case SC_MAXIMIZEPOWER:
-			if (sd == nullptr) {
-				// Duration is 10 seconds for monsters on all levels
-				tick = 10000;
+			if (bl->type&BL_CONSUME) {
+				tick_time = val2 = tick>0?tick:10000; // SP consumption interval
+				tick = INFINITE_TICK; // Duration sent to the client should be infinite
 			}
 			else {
-				tick_time = val2 = tick>0?tick:10000;
-				tick = INFINITE_TICK; // Duration sent to the client should be infinite
+				// If unit cannot consume SP, the duration is fixed to 10 seconds
+				tick = 10000;
 			}
 			break;
 		case SC_EDP:
@@ -11145,14 +11145,14 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			if (map_flag_gvg2(bl->m) || map_getmapflag(bl->m, MF_BATTLEGROUND)) val4 *= 5;
 			break;
 		case SC_CLOAKING:
-			if (sd == nullptr) {
-				// Monsters have no walk penalties and the status change lasts for 10 seconds
-				val1 = 10;
-				tick = 10000;
+			if (bl->type&BL_CONSUME) {
+				tick_time = val2 = tick>0?tick:10000; // SP consumption interval
+				tick = INFINITE_TICK; // Duration sent to the client should be infinite
 			}
 			else {
-				tick_time = val2 = tick>0?tick:10000; // SP consumption rate.
-				tick = INFINITE_TICK; // Duration sent to the client should be infinite
+				// If unit cannot consume SP, there are no walk penalties and the duration is fixed to 10 seconds
+				val1 = 10;
+				tick = 10000;
 			}
 			val3 = 0; // Unused, previously walk speed adjustment
 			// val4&1 signals the presence of a wall.


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9316 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Fixed duration of Cloaking / Power Maximize being infinite for monsters
  * The duration is now fixed to 10 seconds
- Fixes #9316

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
