### PR TITLE
Loot Priority in Party Item Share Mode

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6088,7 +6088,6 @@ bool pc_takeitem(map_session_data *sd,struct flooritem_data *fitem)
 {
 	int32 flag = 0;
 	t_tick tick = gettick();
-	struct party_data *p = nullptr;
 
 	nullpo_ret(sd);
 	nullpo_ret(fitem);
@@ -6099,12 +6098,8 @@ bool pc_takeitem(map_session_data *sd,struct flooritem_data *fitem)
 	if (sd->sc.cant.pickup)
 		return false;
 
-	bool share = false;
-	if (sd->status.party_id) {
-		p = party_search(sd->status.party_id);
-		if (p != nullptr && (p->party.item&1))
-			share = true;
-	}
+	party_data* p = party_search(sd->status.party_id);
+	bool share = (p != nullptr && (p->party.item&1));
 
 	// Time the player needs to wait until the item can be taken
 	// By default the player needs to wait for top, second and third attacker loot priority times

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6099,8 +6099,12 @@ bool pc_takeitem(map_session_data *sd,struct flooritem_data *fitem)
 	if (sd->sc.cant.pickup)
 		return false;
 
-	if (sd->status.party_id)
+	bool share = false;
+	if (sd->status.party_id) {
 		p = party_search(sd->status.party_id);
+		if (p != nullptr && (p->party.item&1))
+			share = true;
+	}
 
 	// Time the player needs to wait until the item can be taken
 	// By default the player needs to wait for top, second and third attacker loot priority times
@@ -6111,15 +6115,15 @@ bool pc_takeitem(map_session_data *sd,struct flooritem_data *fitem)
 		// Top attacker or no attacker, no wait time
 		item_get_tick = 0;
 	}
-	else if (fitem->second_get_charid > 0 && fitem->second_get_charid == sd->status.char_id) {
+	else if (fitem->second_get_charid > 0 && fitem->second_get_charid == sd->status.char_id && !share) {
 		// Second top attacker, needs to wait for top attacker
 		item_get_tick = fitem->first_get_tick;
 	}
-	else if (fitem->third_get_charid > 0 && fitem->third_get_charid == sd->status.char_id) {
+	else if (fitem->third_get_charid > 0 && fitem->third_get_charid == sd->status.char_id && !share) {
 		// Third top attacker, needs to wait for top and second attacker
 		item_get_tick = fitem->second_get_tick;
 	}
-	else if (p != nullptr && p->party.item&1) {
+	else if (share) {
 		// Party member loot priority
 		map_session_data* first_sd = nullptr;
 		map_session_data* second_sd = nullptr;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Follow-up to 7d6d40b and 04bb999

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- Fixed loot priority being wrong when second/third top attacker are in an item share party with the top/second attacker
- Follow-up to 7d6d40b and 04bb999

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
