### PR TITLE
Path Check for Unit Skills with Range (e.g. Earthquake)

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -146,7 +146,8 @@ gvg_traps_target_all: 1
 //alchemist_summon_setting: 15
 
 // Whether placed down skills will check walls (Note 1)
-// (ex. Storm Gust cast against a wall will not hit the other side.) 
+// (ex. Storm Gust cast against a wall will not hit the other side.)
+// Skills that don't have the "WallCheck" unit flag ignore this setting.
 skill_wall_check: yes
 
 // When cloaking, Whether the wall is checked or not. (Note 1)

--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -147,7 +147,7 @@ gvg_traps_target_all: 1
 
 // Whether placed down skills will check walls (Note 1)
 // (ex. Storm Gust cast against a wall will not hit the other side.)
-// Skills that don't have the "WallCheck" unit flag ignore this setting.
+// Skills that don't have the "PathCheck" unit flag ignore this setting.
 skill_wall_check: yes
 
 // When cloaking, Whether the wall is checked or not. (Note 1)

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -15453,8 +15453,6 @@ Body:
           Size: 13
       Interval: 300
       Target: Enemy
-      Flag:
-        PathCheck: true
   - Id: 654
     Name: NPC_FIREBREATH
     Description: Fire Breath

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -15842,8 +15842,6 @@ Body:
           Size: 13
       Interval: 300
       Target: Enemy
-      Flag:
-        PathCheck: true
   - Id: 654
     Name: NPC_FIREBREATH
     Description: Fire Breath

--- a/doc/skill_db.txt
+++ b/doc/skill_db.txt
@@ -913,7 +913,7 @@ NoEnemy				- If battle_config::defunit_not_enemy is enabled, the Target is chang
 NoReiteration		- Spell cannot be stacked.
 NoFootSet			- Spell cannot be cast near/on targets.
 NoOverlap			- Spell effects do not overlap.
-PathCheck			- Only cells in a shootable path will be placed. If not set, effects apply through walls.
+PathCheck			- Only cells in a shootable path will be placed. If not set, effects apply through walls for ranged units.
 NoPc				- Spell cannot affect players.
 NoMob				- Spell cannot affect mobs.
 Skill				- Spell can affect skills.

--- a/doc/skill_db.txt
+++ b/doc/skill_db.txt
@@ -913,7 +913,7 @@ NoEnemy				- If battle_config::defunit_not_enemy is enabled, the Target is chang
 NoReiteration		- Spell cannot be stacked.
 NoFootSet			- Spell cannot be cast near/on targets.
 NoOverlap			- Spell effects do not overlap.
-PathCheck			- Only cells with a shootable path will be placed.
+PathCheck			- Only cells in a shootable path will be placed. If not set, effects apply through walls.
 NoPc				- Spell cannot affect players.
 NoMob				- Spell cannot affect mobs.
 Skill				- Spell can affect skills.

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -22574,7 +22574,10 @@ static int32 skill_unit_timer_sub(DBKey key, DBData *data, va_list ap)
 
 	if( unit->range >= 0 && group->interval != -1 )
 	{
-		map_foreachinrange(skill_unit_timer_sub_onplace, bl, unit->range, group->bl_flag, bl,tick);
+		if (skill_get_unit_flag(group->skill_id, UF_PATHCHECK))
+			map_foreachinrange(skill_unit_timer_sub_onplace, bl, unit->range, group->bl_flag, bl, tick);
+		else
+			map_foreachinallrange(skill_unit_timer_sub_onplace, bl, unit->range, group->bl_flag, bl, tick);
 
 		if(unit->range == -1) //Unit disabled, but it should not be deleted yet.
 			group->unit_id = UNT_USED_TRAPS;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Related to #9334 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed skills that don't have the "PathCheck" flag still not being able to work through walls
  * This mainly affects unit skills where each unit has a range greater than 1
  * Removed "PathCheck" flag from Earthquake
  * Earthquake and Evil Land can now hit through walls
- Slightly extended documentation
- Related to #9334

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
