### PR TITLE
Defender on Devotee Equip Requirement

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -7363,6 +7363,9 @@ static void pc_checkallowskill(map_session_data *sd)
 		}
 
 		if (flag[SCF_REQUIRESHIELD]) { // Skills requiring a shield
+			// Only crusader-type classes require a shield for Defender
+			if (status == SC_DEFENDER && (sd->class_&MAPID_UPPERMASK) != MAPID_CRUSADER)
+				continue;
 			if (sd->sc.getSCE(status) && sd->status.shield <= 0)
 				status_change_end(&sd->bl, status);
 		}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9351 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Devotees no longer lose the transferred Defender buff when they change equipment and don't have a shield
  * All Crusader-types still require a shield for Defender
  * Devotees still lose Defender when the devoting Crusader-type unequips their shield
- Fixes #9351

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
