### PR TITLE
Charge Attack Knockback Immunity and Distance Calculation

### DIFF
--- a/src/map/path.cpp
+++ b/src/map/path.cpp
@@ -490,6 +490,17 @@ bool check_distance_client(int32 dx, int32 dy, int32 distance)
 }
 
 /**
+ * Returns distance using the mathematical calculation for length of a line
+ * @param dx: Horizontal distance
+ * @param dy: Vertical distance
+ * @return Mathematical distance
+ */
+double distance_math(int32 dx, int32 dy)
+{
+	return std::sqrt(dx * dx + dy * dy);
+}
+
+/**
  * The client uses a circular distance instead of the square one. The circular distance
  * is only used by units sending their attack commands via the client (not monsters).
  * @param dx: Horizontal distance
@@ -498,7 +509,7 @@ bool check_distance_client(int32 dx, int32 dy, int32 distance)
  */
 int32 distance_client(int32 dx, int32 dy)
 {
-	double temp_dist = sqrt((double)(dx*dx + dy*dy));
+	double temp_dist = distance_math(dx, dy);
 
 	//Bonus factor used by client
 	//This affects even horizontal/vertical lines so they are one cell longer than expected

--- a/src/map/path.hpp
+++ b/src/map/path.hpp
@@ -49,6 +49,10 @@ struct shootpath_data {
 #define check_distance_client_blxy(bl, x1, y1, distance) check_distance_client((bl)->x-(x1), (bl)->y-(y1), distance)
 #define check_distance_client_xy(x0, y0, x1, y1, distance) check_distance_client((x0)-(x1), (y0)-(y1), distance)
 
+#define distance_math_bl(bl1, bl2) distance_math((bl1)->x - (bl2)->x, (bl1)->y - (bl2)->y)
+#define distance_math_blxy(bl, x1, y1) distance_math((bl)->x-(x1), (bl)->y-(y1))
+#define distance_math_xy(x0, y0, x1, y1) distance_math((x0)-(x1), (y0)-(y1))
+
 #define distance_client_bl(bl1, bl2) distance_client((bl1)->x - (bl2)->x, (bl1)->y - (bl2)->y)
 #define distance_client_blxy(bl, x1, y1) distance_client((bl)->x-(x1), (bl)->y-(y1))
 #define distance_client_xy(x0, y0, x1, y1) distance_client((x0)-(x1), (y0)-(y1))
@@ -66,6 +70,7 @@ bool path_search_long(struct shootpath_data *spd,int16 m,int16 x0,int16 y0,int16
 bool check_distance(int32 dx, int32 dy, int32 distance);
 uint32 distance(int32 dx, int32 dy);
 bool check_distance_client(int32 dx, int32 dy, int32 distance);
+double distance_math(int32 dx, int32 dy);
 int32 distance_client(int32 dx, int32 dy);
 
 bool direction_diagonal( enum directions direction );

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5493,7 +5493,8 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 #ifdef RENEWAL
 		int32 dist = skill_get_blewcount(skill_id, skill_lv);
 #else
-		uint32 dist = distance_bl(src, bl);
+		// Charge attack in pre-renewal calculates the distance mathetically
+		uint32 dist = static_cast<uint32>(sqrt((src->x - bl->x) * (src->x - bl->x) + (src->y - bl->y) * (src->y - bl->y)));
 #endif
 		uint8 dir = map_calc_dir(bl, src->x, src->y);
 

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5498,8 +5498,8 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 		uint8 dir = map_calc_dir(bl, src->x, src->y);
 
 		// teleport to target (if not on WoE grounds)
-		if (skill_check_unit_movepos(5, src, bl->x, bl->y, 0, 1))
-			skill_blown(src, src, 1, (dir+4)%8, BLOWN_NONE); //Target position is actually one cell next to the target
+		if (skill_check_unit_movepos(5, src, bl->x + dirx[dir], bl->y + diry[dir], 0, true))
+			clif_blown(src);
 
 		// cause damage and knockback if the path to target was a straight one
 		if (path) {

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -5494,7 +5494,7 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 		int32 dist = skill_get_blewcount(skill_id, skill_lv);
 #else
 		// Charge attack in pre-renewal calculates the distance mathetically
-		uint32 dist = static_cast<uint32>(sqrt((src->x - bl->x) * (src->x - bl->x) + (src->y - bl->y) * (src->y - bl->y)));
+		int32 dist = static_cast<int32>(distance_math_bl(src, bl));
 #endif
 		uint8 dir = map_calc_dir(bl, src->x, src->y);
 
@@ -5511,9 +5511,6 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 #endif
 				skill_blown(src, bl, dist, dir, BLOWN_NONE);
 			}
-			//HACK: since knockback officially defaults to the left, the client also turns to the left... therefore,
-			// make the caster look in the direction of the target
-			unit_setdir(src, (dir+4)%8);
 		}
 
 		}

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2398,9 +2398,8 @@ int32 unit_skilluse_id2(struct block_list *src, int32 target_id, uint16 skill_id
 #ifndef RENEWAL_CAST
 		case KN_CHARGEATK:
 		{
-			uint32 k = (distance_bl(src,target)-1)/3; //Range 0-3: 500ms, Range 4-6: 1000ms, Range 7+: 1500ms
-			if(k > 2)
-				k = 2;
+			int32 k = static_cast<int32>(distance_math_bl(src, target));
+			k = cap_value((k - 1) / 3, 0, 2); //Range 0-3: 500ms, Range 4-6: 1000ms, Range 7+: 1500ms
 			casttime += casttime * k;
 		}
 		break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (distance fix only applies to pre-re)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed Charge Attack moving you incorrectly and causing position lag when you're knockback immune
  * This for example happened when you equipped an RSX-0806 card
  * Removed direction hack that's no longer needed with after this update
- Fixed distance calculation (used for damage, cast time and knockback determination in pre-re)

Hint: The issue was that we used "skill_blown" to move the caster "one cell back" to the right target cell instead of just calculating the correct target coordinates directly.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
