### PR TITLE
Trap Code Improvements and Fixes

### DIFF
--- a/conf/battle/skill.conf
+++ b/conf/battle/skill.conf
@@ -326,6 +326,12 @@ dancing_weaponswitch_fix: yes
 // 3: 1+2
 skill_trap_type: 0
 
+// Trap Multi Trigger (Note 1)
+// Until episode 11.2, traps would trigger for each unit on them within the same interval
+// Enable this if you want to restore this old behavior
+// This setting is only recommended for pre-renewal as traps deal a lot more damage in renewal
+multi_trigger_trap: no
+
 // Area of Bowling Bash chain reaction (pre-renewal only)
 // 0: Use official gutter line system
 // 1: Gutter line system without demi gutter bug

--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -4244,7 +4244,6 @@ Body:
     Range: 3
     Hit: Single
     HitCount: 1
-    SplashArea: 1
     Duration1:
       - Level: 1
         Time: 200000
@@ -4330,7 +4329,6 @@ Body:
     Range: 3
     Hit: Single
     HitCount: 1
-    SplashArea: 1
     Duration1:
       - Level: 1
         Time: 150000
@@ -4347,7 +4345,7 @@ Body:
       SpCost: 12
       ItemCost:
         - Item: Booby_Trap
-          Amount: 2
+          Amount: 1
     Unit:
       Id: Flasher
       Range: 1
@@ -4407,7 +4405,7 @@ Body:
       SpCost: 10
       ItemCost:
         - Item: Booby_Trap
-          Amount: 2
+          Amount: 1
     Unit:
       Id: Freezingtrap
       Range: 1

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -11976,6 +11976,7 @@ static const struct _battle_data {
 	{ "homunculus_S_max_level",             &battle_config.hom_S_max_level,                 150,    0,      MAX_LEVEL,      },
 	{ "mob_size_influence",                 &battle_config.mob_size_influence,              0,      0,      1,              },
 	{ "skill_trap_type",                    &battle_config.skill_trap_type,                 0,      0,      3,              },
+	{ "multi_trigger_trap",                 &battle_config.multi_trigger_trap,              0,      0,      1,              },
 	{ "allow_consume_restricted_item",      &battle_config.allow_consume_restricted_item,   1,      0,      1,              },
 	{ "allow_equip_restricted_item",        &battle_config.allow_equip_restricted_item,     1,      0,      1,              },
 	{ "max_walk_path",                      &battle_config.max_walk_path,                   17,     1,      MAX_WALKPATH,   },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -565,6 +565,7 @@ struct Battle_Config
 
 	int32 mob_size_influence; // Enable modifications on earned experience, drop rates and monster status depending on monster size. [mkbu95]
 	int32 skill_trap_type;
+	int32 multi_trigger_trap;
 	int32 allow_consume_restricted_item;
 	int32 allow_equip_restricted_item;
 	int32 max_walk_path;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9356 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Unified trap code and made in work even for single-target traps
  * Land Mine properly disappears after 1500ms again and is blocked by Manhole
- Sandman and Freezing Trap now have their AoE centered around the unit that activated the trap
- Flasher and Shockwave Trap now only hit the target that activated the trap (pre-re)
- Flasher and Freezing Trap now only required 1 trap (pre-re)
- Added a config to restored traditional behavior of trap multi-activation for each unit
- Fixes #9356

**TODO:** Extra tests for renewal required. Also check if animations are working as intended.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
