### PR TITLE
Implemented official MRes/Res formula

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -7898,8 +7898,8 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 			res = static_cast<decltype(res)>(res - ignore_res * res / 100.0);
 
 			// Apply damage reduction.
-			wd.damage = static_cast<decltype(wd.damage)>(wd.damage - res / (res + 400.0) * 80.0 / 100.0 * wd.damage);
-			wd.damage2 = static_cast<decltype(wd.damage2)>(wd.damage2 - res / (res + 400.0) * 80.0 / 100.0 * wd.damage2);
+			wd.damage -= static_cast<decltype(wd.damage)>(static_cast<float>(res / (res + 400.0)) * 80.0 / 100.0 * static_cast<double>(wd.damage));
+			wd.damage2 -= static_cast<decltype(wd.damage2)>(static_cast<float>(res / (res + 400.0)) * 80.0 / 100.0 * static_cast<double>(wd.damage2));
 		}
 
 #else
@@ -9372,7 +9372,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 
 			mres = static_cast<decltype(mres)>(mres - ignore_mres * mres / 100.0);
 
-			ad.damage = static_cast<decltype(ad.damage)>(ad.damage - mres / (mres + 400.0) * 80.0 / 100.0 * ad.damage);
+			ad.damage -= static_cast<decltype(ad.damage)>(static_cast<float>(mres / (mres + 400.0)) * 80.0 / 100.0 * static_cast<double>(ad.damage));
 		}
 #endif
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Implemented official MRes/Res formula. The formula is basically the same for all unit types and for MRes and Res.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

Additional test
```
mob id : 21524 (Shining Seaweed)

-------------------------------------------

Cold bolt (1 hit)
                KRO           RA PR
no equipment    479           479


Destructive Hurricane level 5
                 KRO         RA PR
no equipment     228176      228090

-------------------------------------------

Destructive Hurricane
// no equipment

damage = status_base_matk_min = 938
// SMATK
damage = damage + damage * sstatus->smatk / 100 = 938 + 938 * 51 / 100 = 1416
// Skill ratio
damage = damage * skillratio / 100 = 1416 * ((600 + 2850 * skill_lv + 5 * sstatus->spl) * BaseLevel / 100) / 100 = 1416 * ((600 + 2850 * 5 + 5 * 124) * 266 / 100) / 100
       = 1416 * 41150 / 100 = 582684
// MRes
damage = static_cast<int64>(damage - mres / (mres + 400.0) * 80.0 / 100.0 * damage) = static_cast<int64>(582684 - 136 / (136 + 400.0) * 80.0 / 100.0 * 582684)
       = static_cast<int64>(582684 - 118276,155223) = 464407
// MDef
damage = damage * (1000 + mdef) / (1000 + mdef * 10) - mdef2 = 464407 * (1000 + 130) / (1000 + 130 * 10) - 75 = 228090
```