### PR TITLE
Added a hasSCE function

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1171,6 +1171,10 @@ status_change::status_change(){
 	this->lastStatus = { SC_NONE, nullptr };
 }
 
+bool status_change::hasSCE( enum sc_type type ){
+	return this->getSCE( type ) != nullptr;
+}
+
 /**
  * Accessor for a status_change_entry in a status_change
  */

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3476,6 +3476,7 @@ private:
 public:
 	status_change();
 
+	bool hasSCE( enum sc_type type );
 	status_change_entry* getSCE( enum sc_type type );
 	status_change_entry* getSCE( uint32 type );
 	status_change_entry* createSCE( enum sc_type type );


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
This prevents to always call getSCE and have to check it for nullptr.
It should be used when it is only necessary to know, if a BL has a status active or not.
If you want to access values of a SCE you should still use getSCE and store the returned pointer.
