### PR TITLE
Status Change Start Delay Timer

### DIFF
--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10096,7 +10096,7 @@ struct delay_status {
  * @return 0
  */
 TIMER_FUNC(status_change_start_timer) {
-	struct delay_status* dat = reinterpret_cast<delay_status*>(data);
+	delay_status* dat = reinterpret_cast<delay_status*>(data);
 
 	if (dat != nullptr) {
 		block_list* src = nullptr;
@@ -10222,7 +10222,7 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 				return 0;
 			else if (type == SC_STONEWAIT) {
 				// Stonewait has a unique handling where the delay is actually duration until stone kicks in
-				val3 = max(1, tick - delay); // Petrify time
+				val3 = std::max<int32>(1, tick - delay); // Petrify time
 				tick = delay;
 				delay = 0;
 			}
@@ -10284,7 +10284,7 @@ int32 status_change_start_post_delay(block_list* src, block_list* bl, sc_type ty
 	// Check for immunities / sc fails
 	switch (type) {
 		case SC_VACUUM_EXTREME:
-			if (sc && sc->getSCE(SC_VACUUM_EXTREME_POSTDELAY) && sc->getSCE(SC_VACUUM_EXTREME_POSTDELAY)->val2 == val2) // Ignore post delay from other vacuum (this will make stack effect enabled)
+			if (sc != nullptr && sc->hasSCE(SC_VACUUM_EXTREME_POSTDELAY) && sc->getSCE(SC_VACUUM_EXTREME_POSTDELAY)->val2 == val2) // Ignore post delay from other vacuum (this will make stack effect enabled)
 				return 0;
 			break;
 		case SC_ALL_RIDING:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -64,7 +64,7 @@ struct s_delay_status {
 
 int32 delay_status_index = 0;
 // delay_status : delay_status_index -> data
-std::unordered_map<uint32, std::shared_ptr<s_delay_status>> delay_status;
+std::unordered_map<int32, std::shared_ptr<s_delay_status>> delay_status;
 
 int16 current_equip_item_index; /// Contains inventory index of an equipped item. To pass it into the EQUP_SCRIPT [Lupus]
 uint32 current_equip_combo_pos; /// For combo items we need to save the position of all involved items here

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10227,11 +10227,15 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 			if (battle_check_undead(status->race, status->def_ele) != 0 && !(flag&SCSTART_NOAVOID))
 				return 0;
 			else if (type == SC_STONEWAIT) {
-				// Stonewait has a unique handling where the delay is actually duration until stone kicks in
+				// Stonewait has a unique handling where the delay is actually the duration until stone kicks in
 				val3 = std::max<int32>(1, tick - delay); // Petrify time
 				tick = delay;
 				delay = 0;
 			}
+			break;
+		case SC_BLEEDING:
+			// Bleeding always starts immediately
+			delay = 0;
 			break;
 		case SC_BURNING:
 			// Level 2 Fire Element is immune
@@ -10254,7 +10258,12 @@ int32 status_change_start(struct block_list* src, struct block_list* bl,enum sc_
 	entry->val2 = val2;
 	entry->val3 = val3;
 	entry->val4 = val4;
+#ifdef RENEWAL
+	// In renewal, the delay is substracted from the duration
+	entry->tick = std::max<int32>(1, tick - delay);
+#else
 	entry->tick = tick;
+#endif
 	entry->flag = flag;
 
 	int32 index = delay_status_index++;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Related to various issues reported (doesn't fix any, but opens the way to fix them)

For example related to: #1141 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- It is now possible to delay the start of any status change
  * Split status_change_start into status_change_start and status_change_start_post_delay
  * status_change_start handles everything that needs to happen before the delay
  * status_change_start_post_delay handles everything that needs to happen after the delay
  * Added struct s_delay_status to pass all status change data to a timer
  * Added status_change_start_timer to handle the delay
  * OPT1 and OPT2 status changes have most their conditions checked before the delay
  * If the target dies during the delay, the status change is not applied
  * Bleeding always ignores the delay
  * In renewal the delay is subtracted from the total duration
- Code improvements

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
