### PR TITLE
Randomtarget Monster Mode Behavior

### DIFF
--- a/db/pre-re/mob_db.yml
+++ b/db/pre-re/mob_db.yml
@@ -33710,7 +33710,7 @@ Body:
     AttackDelay: 76
     AttackMotion: 384
     DamageMotion: 288
-    Ai: 21
+    Ai: 26
     Class: Boss
     Drops:
       - Item: Broken_Armor_Piece
@@ -34009,7 +34009,7 @@ Body:
     AttackMotion: 432
     ClientAttackMotion: 360
     DamageMotion: 360
-    Ai: 20
+    Ai: 26
     Modes:
       Detector: true
     Drops:
@@ -35140,7 +35140,7 @@ Body:
     AttackMotion: 576
     ClientAttackMotion: 336
     DamageMotion: 420
-    Ai: 21
+    Ai: 26
     Drops:
       - Item: Clattering_Skull
         Rate: 3000
@@ -35454,7 +35454,7 @@ Body:
     AttackMotion: 576
     ClientAttackMotion: 252
     DamageMotion: 480
-    Ai: 21
+    Ai: 26
     Class: Boss
   - Id: 1873
     AegisName: BEELZEBUB
@@ -38268,7 +38268,7 @@ Body:
     AttackMotion: 288
     ClientAttackMotion: 420
     DamageMotion: 576
-    Ai: 10
+    Ai: 27
     Class: Boss
   - Id: 1959
     AegisName: G_ENTWEIHEN_H
@@ -38295,7 +38295,7 @@ Body:
     AttackMotion: 288
     ClientAttackMotion: 420
     DamageMotion: 576
-    Ai: 10
+    Ai: 27
     Class: Boss
   - Id: 1960
     AegisName: G_ENTWEIHEN_M
@@ -38322,7 +38322,7 @@ Body:
     AttackMotion: 288
     ClientAttackMotion: 420
     DamageMotion: 576
-    Ai: 10
+    Ai: 27
     Class: Boss
   - Id: 1961
     AegisName: G_ENTWEIHEN_S

--- a/doc/mob_db_mode_list.txt
+++ b/doc/mob_db_mode_list.txt
@@ -87,7 +87,7 @@ Target Weak: Allows aggressive monsters to only be aggressive against
 	characters that are five levels below it's own level.
 	For example, a monster of level 104 will not pick fights with a level 99.
 
-Random Target: Picks a new random target in range on each attack / skill.
+Random Target: Picks a new random target in range for each normal attack.
 
 Ignore Melee: The mob will take 1 HP damage from physical attacks.
 

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1263,6 +1263,24 @@ static int32 mob_can_changetarget(struct mob_data* md, struct block_list* target
 	}
 }
 
+/**
+ * Randomizes the target ID of a monster if it has the given mode
+ * @param bl Unit that is going to attack
+ * @param target_id Target ID to modify
+ */
+void mob_randomtarget(mob_data& md, int32& target_id) {
+	if (!(md.status.mode&MD_RANDOMTARGET))
+		return;
+
+	int32 search_size = md.status.rhw.range;
+	if (md.sc.hasSCE(SC_BLIND))
+		search_size = 1;
+
+	block_list* target = battle_getenemy(&md.bl, DEFAULT_ENEMY_TYPE((&md)), search_size);
+	if (target != nullptr)
+		target_id = target->id;
+}
+
 /*==========================================
  * Determination for an attack of a monster
  *------------------------------------------*/
@@ -2119,8 +2137,8 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	// Normal attack / berserk skill is only used when target is in range
 	if (battle_check_range(&md->bl, tbl, md->status.rhw.range))
 	{
-		// Make sure there is no chase target when already in attack range
-		md->ud.target_to = 0;
+		// Stop and make sure there is no chase target when already in attack range
+		unit_stop_walking(&md->bl, USW_FIXPOS|USW_RELEASE_TARGET);
 
 		// Hiding is a special case because it prevents normal attacks but allows skill usage
 		// TODO: Some other states also have this behavior and should be investigated
@@ -2129,16 +2147,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			// Target within range and potentially able to use normal attack, engage
 			if (md->ud.target != tbl->id || md->ud.attacktimer == INVALID_TIMER)
 			{ //Only attack if no more attack delay left
-				if (!(mode&MD_RANDOMTARGET))
-					unit_attack(&md->bl,tbl->id,1);
-				else { // Attack once and find a new random target
-					int32 search_size = (view_range < md->status.rhw.range) ? view_range : md->status.rhw.range;
-					unit_attack(&md->bl, tbl->id, 0);
-					tbl = battle_getenemy(&md->bl, DEFAULT_ENEMY_TYPE(md), search_size);
-					if (tbl != nullptr) {
-						md->target_id = tbl->id;
-					}
-				}
+				unit_attack(&md->bl, tbl->id, 1);
 			}
 		}
 		else {
@@ -4233,7 +4242,6 @@ bool mobskill_use(struct mob_data *md, t_tick tick, int32 event, int64 damage)
 	struct block_list *bl;
 	struct mob_data *fmd = nullptr;
 	int32 i,j,n;
-	int16 skill_target;
 
 	nullpo_ret(md);
 
@@ -4341,11 +4349,10 @@ bool mobskill_use(struct mob_data *md, t_tick tick, int32 event, int64 damage)
 			continue; //Skill requisite failed to be fulfilled.
 
 		//Execute skill
-		skill_target = status_has_mode(&md->db->status,MD_RANDOMTARGET) ? MST_RANDOM : ms[i]->target;
 		if (skill_get_casttype(ms[i]->skill_id) == CAST_GROUND)
 		{	//Ground skill.
 			int16 x, y;
-			switch (skill_target) {
+			switch (ms[i]->target) {
 				case MST_RANDOM: //Pick a random enemy within skill range.
 					bl = battle_getenemy(&md->bl, DEFAULT_ENEMY_TYPE(md),
 						skill_get_range2(&md->bl, ms[i]->skill_id, ms[i]->skill_lv, true));
@@ -4381,10 +4388,10 @@ bool mobskill_use(struct mob_data *md, t_tick tick, int32 event, int64 damage)
 			x = bl->x;
 		  	y = bl->y;
 			// Look for an area to cast the spell around...
-			if (skill_target >= MST_AROUND5) {
-				j = skill_target >= MST_AROUND1?
-					(skill_target-MST_AROUND1) +1:
-					(skill_target-MST_AROUND5) +1;
+			if (ms[i]->target >= MST_AROUND5) {
+				j = ms[i]->target >= MST_AROUND1 ?
+					(ms[i]->target - MST_AROUND1) + 1 :
+					(ms[i]->target - MST_AROUND5) + 1;
 				map_search_freecell(&md->bl, md->bl.m, &x, &y, j, j, 3);
 			}
 			md->skill_idx = i;
@@ -4400,7 +4407,7 @@ bool mobskill_use(struct mob_data *md, t_tick tick, int32 event, int64 damage)
 			}
 		} else {
 			//Targetted skill
-			switch (skill_target) {
+			switch (ms[i]->target) {
 				case MST_RANDOM: //Pick a random enemy within skill range.
 					bl = battle_getenemy(&md->bl, DEFAULT_ENEMY_TYPE(md),
 						skill_get_range2(&md->bl, ms[i]->skill_id, ms[i]->skill_lv, true));

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -526,6 +526,7 @@ bool mob_ai_sub_hard_attacktimer(mob_data &md, t_tick tick);
 TIMER_FUNC(mob_attacked);
 TIMER_FUNC(mob_norm_attacked);
 int32 mob_target(struct mob_data *md,struct block_list *bl,int32 dist);
+void mob_randomtarget(mob_data& md, int32& target_id);
 int32 mob_unlocktarget(struct mob_data *md, t_tick tick);
 struct mob_data* mob_spawn_dataset(struct spawn_data *data);
 int32 mob_spawn(struct mob_data *md);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2885,6 +2885,12 @@ int32 unit_attack(struct block_list *src,int32 target_id,int32 continuous)
 
 	nullpo_ret(ud = unit_bl2ud(src));
 
+	// Check for special monster random target mode
+	if (src->type == BL_MOB) {
+		mob_data& md = *reinterpret_cast<mob_data*>(src);
+		mob_randomtarget(md, target_id);
+	}
+
 	target = map_id2bl(target_id);
 	if( target == nullptr || status_isdead(*target) ) {
 		unit_unattackable(src);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #8104 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (wrong modes only in pre-re)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- The randomtarget monster mode no longer causes skills to have a random target (fixes #8104)
  * Target skills will always go for the original target
  * Normal attacks will pick a random target, but will not change the monster's original target
  * Self/Support skills will now properly target self or friends
- Fixed an issue where a monster would continue moving when it found a new target in attack range
  * This was caused by setting target_to to 0 without stopping the movement
  * Follow up to f272ca6
- Added the correct "randomtarget" modes to pre-re monsters
  * These are already correctly set in renewal, but were not set in pre-re when the mode was implemented

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
