### PR TITLE
Official Wink Charm Implementation

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -16932,7 +16932,7 @@ Body:
     CastTime: 1000
     AfterCastActDelay: 2000
     Duration1: 10000
-    Duration2: 17000
+    Duration2: 30000
     Requires:
       SpCost: 40
     Status: WinkCharm

--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -1725,6 +1725,8 @@ Body:
   - Status: Winkcharm
     Icon: EFST_DC_WINKCHARM
     DurationLookup: DC_WINKCHARM
+    States:
+      NoCastCond: true
     Flags:
       RemoveOnDamaged: true
       Debuff: true

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -18538,7 +18538,7 @@ Body:
     CastTime: 800
     AfterCastActDelay: 2000
     Duration1: 10000
-    Duration2: 17000
+    Duration2: 18000
     FixedCastTime: 200
     Requires:
       SpCost: 40

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1729,6 +1729,8 @@ Body:
   - Status: Winkcharm
     Icon: EFST_DC_WINKCHARM
     DurationLookup: DC_WINKCHARM
+    States:
+      NoCastCond: true
     Flags:
       RemoveOnDamaged: true
       Debuff: true

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9450,23 +9450,20 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 
 	case DC_WINKCHARM:
 		if( dstsd ) {
-			clif_skill_nodamage(src,*bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,10,7,skill_get_time2(skill_id,skill_lv)));
+			if (sc_start(src, bl, SC_CONFUSION, 10, 7, skill_get_time2(skill_id, skill_lv)))
+				sc_start(src, bl, type, 100, skill_lv, skill_get_time(skill_id, skill_lv));
 #ifdef RENEWAL
 			sc_start(src, bl, SC_HALLUCINATION, 30, skill_lv, skill_get_time(skill_id, skill_lv)); // TODO: Confirm success rate and duration
 #endif
 		} else
 		if( dstmd )
 		{
-			if( status_get_lv(src) > status_get_lv(bl)
-			&&  (tstatus->race == RC_DEMON || tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_PLAYER_HUMAN || tstatus->race == RC_PLAYER_DORAM || tstatus->race == RC_ANGEL)
-			&&  !status_has_mode(tstatus,MD_STATUSIMMUNE) )
-				clif_skill_nodamage(src,*bl,skill_id,skill_lv, sc_start2(src,bl,type,(status_get_lv(src) - status_get_lv(bl)) + 40, skill_lv, src->id, skill_get_time(skill_id, skill_lv)));
-			else
-			{
-				clif_skill_nodamage(src,*bl,skill_id,skill_lv,false);
-				if(sd) clif_skill_fail( *sd, skill_id );
+			if (sc_start2(src, bl, type, (status_get_lv(src) - status_get_lv(bl)) + 40, skill_lv, src->id, skill_get_time(skill_id, skill_lv))) {
+				// This triggers a 0 damage event and might make the monster switch target to caster
+				battle_damage(src, bl, 0, 1, skill_lv, 0, ATK_DEF, BF_WEAPON|BF_LONG|BF_NORMAL, true, tick, false);
 			}
 		}
+		clif_skill_nodamage(src, *bl, skill_id, skill_lv);
 		break;
 
 #ifdef RENEWAL
@@ -13722,6 +13719,16 @@ static int8 skill_castend_id_check(struct block_list *src, struct block_list *ta
 				status_data* tstatus = status_get_status_data(*target);
 				if (!battle_check_undead(tstatus->race, tstatus->def_ele))
 					return USESKILL_FAIL_MAX;
+			}
+			break;
+		case DC_WINKCHARM:
+			{
+				status_data* tstatus = status_get_status_data(*target);
+				if (tstatus->race == RC_DEMON || tstatus->race == RC_DEMIHUMAN || tstatus->race == RC_ANGEL)
+					break;
+				if (tstatus->race == RC_PLAYER_HUMAN || tstatus->race == RC_PLAYER_DORAM)
+					break;
+				return USESKILL_FAIL_LEVEL;
 			}
 			break;
 		case PR_LEXDIVINA:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -2115,19 +2115,6 @@ bool status_check_skilluse(struct block_list *src, struct block_list *target, ui
 		)
 			return false;
 
-		if (sc->getSCE(SC_WINKCHARM) && target && !flag) { // Prevents skill usage
-			block_list *wink_target = map_id2bl(sc->getSCE(SC_WINKCHARM)->val2);
-
-			if (wink_target != nullptr) {
-				unit_data *wink_ud = unit_bl2ud(src);
-				if (wink_ud != nullptr && wink_ud->walktimer == INVALID_TIMER)
-					unit_walktobl(src, map_id2bl(sc->getSCE(SC_WINKCHARM)->val2), 3, 1);
-				clif_emotion( *src, ET_THROB );
-				return false;
-			} else
-				status_change_end(src, SC_WINKCHARM);
-		}
-
 		if (sc->getSCE(SC_BLADESTOP)) {
 			switch (sc->getSCE(SC_BLADESTOP)->val1) {
 				case 5:
@@ -5679,6 +5666,12 @@ void status_calc_state( block_list& bl, status_change& sc, std::shared_ptr<s_sta
 		status_calc_state_sub( bl, sc, start, scdb, sc.cant.cast, SCS_NOCAST, SCS_NOCASTCOND, []( block_list& bl, status_change& sc, bool& restriction, const sc_type type, const status_change_entry& sce ) -> bool {
 			// Check the specific conditions
 			switch( type ){
+				case SC_WINKCHARM:
+					if (bl.type != BL_PC) {
+						restriction = true;
+					}
+					break;
+
 				case SC_OBLIVIONCURSE:
 					if( sce.val3 == 1 ){
 						restriction = true;
@@ -9566,6 +9559,9 @@ static int32 status_get_sc_interval(enum sc_type type)
 		case SC_KILLING_AURA:
 		case SC_BOSSMAPINFO:
 			return 1000;
+		case SC_WINKCHARM:
+		case SC_VOICEOFSIREN:
+			return 2250;
 		case SC_BURNING:
 		case SC_PYREXIA:
 			return 3000;
@@ -12045,9 +12041,10 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 		case SC_HARMONIZE:
 			val2 = 5 + 5 * val1;
 			break;
+		case SC_WINKCHARM:
 		case SC_VOICEOFSIREN:
-			val4 = tick / 2000;
-			tick_time = 2000; // [GodLesZ] tick time
+			tick_time = status_get_sc_interval(type);
+			val4 = tick - tick_time; // Remaining time
 			break;
 		case SC_DEEPSLEEP:
 			val4 = tick / 2000;
@@ -13786,6 +13783,11 @@ int32 status_change_end( struct block_list* bl, enum sc_type type, int32 tid ){
 				}
 			}
 			break;
+		case SC_WINKCHARM:
+			if (bl->type == BL_MOB) {
+				mob_unlocktarget(static_cast<mob_data*>(bl), gettick());
+			}
+			break;
 		case SC_TENSIONRELAX:
 			if (sc && (sc->getSCE(SC_WEIGHT50) || sc->getSCE(SC_WEIGHT90)))
 				status_get_regen_data(bl)->state.overweight = true; // Add the overweight flag back
@@ -14676,11 +14678,10 @@ TIMER_FUNC(status_change_timer){
 		}
 		break;
 
+	case SC_WINKCHARM:
 	case SC_VOICEOFSIREN:
-		if( --(sce->val4) >= 0 ) {
+		if (sce->val4 >= 0) {
 			clif_emotion( *bl, ET_THROB );
-			sc_timer_next(2000 + tick);
-			return 0;
 		}
 		break;
 

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2230,6 +2230,13 @@ int32 unit_skilluse_id2(struct block_list *src, int32 target_id, uint16 skill_id
 
 				sd->skill_id_old = skill_id;
 				break;
+			case BA_PANGVOICE:
+			case DC_WINKCHARM:
+				if (status_get_class_(target) == CLASS_BOSS) {
+					clif_skill_fail(*sd, skill_id, USESKILL_FAIL_TOTARGET);
+					return 0;
+				}
+				break;
 			case WL_WHITEIMPRISON:
 				if( battle_check_target(src,target,BCT_SELF|BCT_ENEMY) < 0 ) {
 					clif_skill_fail( *sd, skill_id, USESKILL_FAIL_TOTARGET );
@@ -3357,6 +3364,9 @@ bool unit_can_attack(struct block_list *bl, int32 target_id) {
 		return true;
 
 	if (sc->cant.attack || (sc->getSCE(SC_VOICEOFSIREN) && sc->getSCE(SC_VOICEOFSIREN)->val2 == target_id))
+		return false;
+
+	if (bl->type != BL_PC && sc->hasSCE(SC_WINKCHARM) && sc->getSCE(SC_WINKCHARM)->val2 == target_id)
 		return false;
 
 	return true;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9379 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Wink Charm no longer spams the client with hundreds of emotions and move commands
- Complete re-implementation of Wink Charm
  * Wink Charm blocks skill casting for non-players
  * Wink Charm blocks attacks on the caster for non-players
  * Wink Charm no longer makes the target move towards the caster, but can trigger aggro like a damage skill
  * Wink Charm can trigger additional effects just like a ranged weapon attack
  * Wink Charm can no longer target bosses, but bosses can now be affected by it (Aliza Card)
  * When Wink Charm fails due to invalid target, it will no longer consume SP nor set aftercast delay
  * When the target is valid, Wink Charm now always shows the animation, even if the status is resisted
  * When Wink Charm ends, the affected monster will drop its target
- Wink Charm can still cause Confusion to players at low chance
  * When Confusion succeeds, players will also do the heart emotion for 10 seconds
  * Confusion now lasts 30s in pre-re and 18+2s in re
- Properly integrated SC_WINKCHARM and SC_VOICEOFSIREN into the interval status change system
  * Both skills show the heart emotion every 2250ms
- Pang Voice shares the boss target block logic with Wink Charm
- Fixes #9379

**TODO**: Check why confusion is not working, exp tap, cast cancel, check renewal

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
