### PR TITLE
Monster Name Cut Off Fix

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -4933,6 +4933,8 @@ s_mob_db::s_mob_db()
 	this->option = {};
 	this->skill = {};
 	this->damagetaken = 100;
+	this->group_id = {};
+	this->title = {};
 }
 
 /**


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Follow-up to 51bbb13

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed monster names of bosses being cut off seemingly randomly
- group_id and title of monsters are now properly initialized
- Follow-up to 51bbb13

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
