### PR TITLE
Random Target Mode vs. Blind

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -171,7 +171,7 @@ static int32 battle_getenemy_sub(struct block_list *bl, va_list ap)
 	if (status_isdead(*bl))
 		return 0;
 
-	if (!status_check_visibility(target, bl, true))
+	if (!status_check_visibility(target, bl, false))
 		return 0;
 
 	if (battle_check_target(target, bl, BCT_ENEMY) > 0) {

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1271,7 +1271,7 @@ static int32 mob_can_changetarget(struct mob_data* md, struct block_list* target
  */
 bool mob_randomtarget(mob_data& md, int32& target_id) {
 	if (!status_has_mode(&md.status, MD_RANDOMTARGET))
-		return true;
+		return true; // Keep current target
 
 	// Pick a random visible target
 	block_list* target = battle_getenemy(&md, DEFAULT_ENEMY_TYPE((&md)), md.status.rhw.range);

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -1267,18 +1267,23 @@ static int32 mob_can_changetarget(struct mob_data* md, struct block_list* target
  * Randomizes the target ID of a monster if it has the given mode
  * @param bl Unit that is going to attack
  * @param target_id Target ID to modify
+ * @return Whether a target was found (true) or not (false)
  */
-void mob_randomtarget(mob_data& md, int32& target_id) {
+bool mob_randomtarget(mob_data& md, int32& target_id) {
 	if (!status_has_mode(&md.status, MD_RANDOMTARGET))
-		return;
+		return true;
 
-	int32 search_size = md.status.rhw.range;
-	if (md.sc.hasSCE(SC_BLIND))
-		search_size = 1;
+	// Pick a random visible target
+	block_list* target = battle_getenemy(&md, DEFAULT_ENEMY_TYPE((&md)), md.status.rhw.range);
+	if (target == nullptr)
+		return false;
 
-	block_list* target = battle_getenemy(&md, DEFAULT_ENEMY_TYPE((&md)), search_size);
-	if (target != nullptr)
-		target_id = target->id;
+	// Check if target is in shoot range
+	if (!battle_check_range(&md, target, md.status.rhw.range))
+		return false;
+
+	target_id = target->id;
+	return true;
 }
 
 /*==========================================

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -525,7 +525,7 @@ bool mob_ai_sub_hard_attacktimer(mob_data &md, t_tick tick);
 TIMER_FUNC(mob_attacked);
 TIMER_FUNC(mob_norm_attacked);
 int32 mob_target(struct mob_data *md,struct block_list *bl,int32 dist);
-void mob_randomtarget(mob_data& md, int32& target_id);
+bool mob_randomtarget(mob_data& md, int32& target_id);
 int32 mob_unlocktarget(struct mob_data *md, t_tick tick);
 struct mob_data* mob_spawn_dataset(struct spawn_data *data);
 int32 mob_spawn(struct mob_data *md);

--- a/src/map/unit.cpp
+++ b/src/map/unit.cpp
@@ -2892,11 +2892,11 @@ int32 unit_attack(struct block_list *src,int32 target_id,int32 continuous)
 
 	nullpo_ret(ud = unit_bl2ud(src));
 
-	// Check for special monster random target mode
-	if (src->type == BL_MOB) {
-		mob_data& md = *static_cast<mob_data*>(src);
-		mob_randomtarget(md, target_id);
-	}
+	mob_data* md = BL_CAST(BL_MOB, src);
+
+	// Check for special monster random target mode, function might overwrite the original target
+	if (md != nullptr && !mob_randomtarget(*md, target_id))
+		return 0; //TODO: This should prevent monsters from stopping
 
 	target = map_id2bl(target_id);
 	if( target == nullptr || status_isdead(*target) ) {
@@ -2953,10 +2953,8 @@ int32 unit_attack(struct block_list *src,int32 target_id,int32 continuous)
 
 	// Monster state is set regardless of whether the attack is executed now or later
 	// The check is here because unit_attack can be called from both the monster AI and the walking logic
-	if (src->type == BL_MOB) {
-		mob_data& md = reinterpret_cast<mob_data&>(*src);
-		mob_setstate(md, MSS_BERSERK);
-	}
+	if (md != nullptr)
+		mob_setstate(*md, MSS_BERSERK);
 
 	return 0;
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9396 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Monsters can now target random targets outside their view range (1 if blind) with normal attacks
  * When blinded, a monster will still switch its main target (for skills) to the target next to it
- When the random target picked is not in shoot range, the monster will stay in its current mode
- Minor code optimizations
- Follow-up to 4d68187 and fb6fdd1
- Fixes #9396

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
