### PR TITLE
Random Target Fail and Wink Charm Movement

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2142,8 +2142,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	// Normal attack / berserk skill is only used when target is in range
 	if (battle_check_range(md, tbl, md->status.rhw.range))
 	{
-		// Stop and make sure there is no chase target when already in attack range
-		unit_stop_walking(md, USW_FIXPOS|USW_RELEASE_TARGET);
+		e_unit_attack atk_result = ATTACK_FAIL;
 
 		// Hiding is a special case because it prevents normal attacks but allows skill usage
 		// TODO: Some other states also have this behavior and should be investigated
@@ -2152,7 +2151,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			// Target within range and potentially able to use normal attack, engage
 			if (md->ud.target != tbl->id || md->ud.attacktimer == INVALID_TIMER)
 			{ //Only attack if no more attack delay left
-				unit_attack(md, tbl->id, 1);
+				atk_result = unit_attack(md, tbl->id, 1);
 			}
 		}
 		else {
@@ -2160,6 +2159,11 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			// This results in the monster going into an attack state despite not attacking
 			mob_setstate(*md, MSS_BERSERK);
 		}
+
+		// Stop and make sure there is no chase target when attack was not skipped
+		if (atk_result != ATTACK_SKIP)
+			unit_stop_walking(md, USW_FIXPOS|USW_RELEASE_TARGET);
+
 		//Target still in attack range, no need to chase the target
 		return true;
 	}

--- a/src/map/unit.hpp
+++ b/src/map/unit.hpp
@@ -120,6 +120,13 @@ enum e_delay_event {
 	DELAY_EVENT_PARRY, /// Parry activated
 };
 
+/// Enum for unit_attack
+enum e_unit_attack {
+	ATTACK_SUCCESS = 0, /// Unit is attacking, switch to attack mode
+	ATTACK_FAIL = 1, /// Unit tried to attack but failed, switch to idle mode
+	ATTACK_SKIP = 2, /// Attack was skipped completely, do not stop the unit from moving
+};
+
 // PC, MOB, PET
 
 // Does walk action for unit
@@ -159,7 +166,7 @@ bool unit_can_reach_bl(struct block_list *bl,struct block_list *tbl, int32 range
 // Unit attack functions
 int32 unit_stopattack(struct block_list *bl, va_list ap);
 void unit_stop_attack(struct block_list *bl);
-int32 unit_attack(struct block_list *src,int32 target_id,int32 continuous);
+e_unit_attack unit_attack(struct block_list *src,int32 target_id,int32 continuous);
 int32 unit_cancel_combo(struct block_list *bl);
 bool unit_can_attack(struct block_list *bl, int32 target_id);
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9398 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- A monsters that fails finding a random target will no longer stop moving
- A monster affect by Wink Charm getting into attack range of its charmer will no longer stop moving
- Fixes #9398

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
