### PR TITLE
Pang Voice and Wink Charm Duration and Chances

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -16916,7 +16916,7 @@ Body:
     Hit: Single
     CastTime: 1000
     AfterCastActDelay: 2000
-    Duration1: 17000
+    Duration1: 30000
     Requires:
       SpCost: 20
   - Id: 1011

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -18520,8 +18520,7 @@ Body:
     Hit: Single
     CastTime: 800
     AfterCastActDelay: 2000
-    Duration1: 17000
-    Duration2: 120000
+    Duration1: 10000
     FixedCastTime: 200
     Requires:
       SpCost: 40
@@ -18540,7 +18539,6 @@ Body:
     CastTime: 800
     AfterCastActDelay: 2000
     Duration1: 10000
-    Duration2: 18000
     FixedCastTime: 200
     Requires:
       SpCost: 40

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -9442,17 +9442,22 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 		break;
 
 	case BA_PANGVOICE:
-		clif_skill_nodamage(src,*bl,skill_id,skill_lv, sc_start(src,bl,SC_CONFUSION,70,7,skill_get_time(skill_id,skill_lv)));
 #ifdef RENEWAL
-		sc_start(src, bl, SC_BLEEDING, 30, skill_lv, skill_get_time2(skill_id, skill_lv)); // TODO: Confirm success rate
+		// In Renewal it causes Confusion and Bleeding to 100% base chance
+		sc_start(src, bl, SC_CONFUSION, 100, skill_lv, skill_get_time(skill_id, skill_lv));
+		sc_start(src, bl, SC_BLEEDING, 100, skill_lv, skill_get_time(skill_id, skill_lv));
+#else
+		// In Pre-renewal it causes Confusion to 70% base chance
+		sc_start(src, bl, SC_CONFUSION, 70, skill_lv, skill_get_time(skill_id, skill_lv));
 #endif
+		clif_skill_nodamage(src, *bl, skill_id, skill_lv);
 		break;
 
 	case DC_WINKCHARM:
 		if( dstsd ) {
 #ifdef RENEWAL
 			// In Renewal it causes Confusion and Hallucination to 100% base chance
-			sc_start(src, bl, SC_CONFUSION, 100, skill_lv, skill_get_time2(skill_id, skill_lv));
+			sc_start(src, bl, SC_CONFUSION, 100, skill_lv, skill_get_time(skill_id, skill_lv));
 			sc_start(src, bl, SC_HALLUCINATION, 100, skill_lv, skill_get_time(skill_id, skill_lv));
 #else
 			// In Pre-Renewal it only causes Wink Charm, if Confusion was successfully started


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9400 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both (mostly renewal affected)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Pang Voice now causes Confusion for 30s in pre-re
- Pang Voice now causes Confusion to 100% for 10+2s in renewal
- Pang Voice now causes Bleeding to 100% for 10+12s in renewal
- Pang Voice animation now plays even if Confusion fails to apply
- Wink Charm now causes Confusion to players for 10+2s in renewal
- Fixes #9400

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
