### PR TITLE
Linked AL_HOLYLIGHT castend required sp fix

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19780,6 +19780,10 @@ void skill_consume_requirement(map_session_data *sd, uint16 skill_id, uint16 ski
 			case MC_IDENTIFY:
 				require.sp = 0;
 				break;
+			case AL_HOLYLIGHT:
+				if(sd->sc.getSCE(SC_SPIRIT) && sd->sc.getSCE(SC_SPIRIT)->val2 == SL_PRIEST)
+					require.sp *= 5;
+				break;
 			case MO_KITRANSLATION:
 				//Spiritual Bestowment only uses spirit sphere when giving it to someone
 				require.spiritball = 0;
@@ -20125,10 +20129,6 @@ struct s_skill_condition skill_get_requirement(map_session_data* sd, uint16 skil
 #else
 				req.zeny -= req.zeny*10/100;
 #endif
-			break;
-		case AL_HOLYLIGHT:
-			if(sc && sc->getSCE(SC_SPIRIT) && sc->getSCE(SC_SPIRIT)->val2 == SL_PRIEST)
-				req.sp *= 5;
 			break;
 		case SL_SMA:
 		case SL_STUN:


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#9405
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
When linked the x5 sp cost is not a skill requirement anymore, i.e it won't prevent skill casting/resolution, but will consume any available SP up to the new increased cost.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
