### PR TITLE
Prevent Freeing Data Too Early

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2144,6 +2144,9 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 	{
 		int32 stop_flag = USW_FIXPOS|USW_RELEASE_TARGET;
 
+		// Source may die due to reflect damage
+		map_freeblock_lock();
+
 		// Hiding is a special case because it prevents normal attacks but allows skill usage
 		// TODO: Some other states also have this behavior and should be investigated
 		// TODO: EFST_AUTOCOUNTER, EFST_BLADESTOP, NPC_SR_CURSEDCIRCLE
@@ -2165,6 +2168,7 @@ static bool mob_ai_sub_hard(struct mob_data *md, t_tick tick)
 			unit_stop_walking(md, stop_flag);
 
 		//Target still in attack range, no need to chase the target
+		map_freeblock_unlock();
 		return true;
 	}
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9407 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed a few issues where the code didn't consider that an attacker could die from reflect damage
- Ensure we only call map_freeblock_unlock right before we return from a function
  * This prevents the risk of accessing pointers that point to already freed data
- Fixes #9407

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
