### PR TITLE
Zero damage Skills Breaking SC

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -3993,6 +3993,7 @@ Body:
       BlEffect: true
       DisplayPc: true
       StopAttacking: true
+      RemoveOnDamaged: true
     MinDuration: 10000
     EndOnStart:
       Deepsleep: true

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -4152,6 +4152,7 @@ Body:
       BlEffect: true
       DisplayPc: true
       StopAttacking: true
+      RemoveOnDamaged: true
     MinDuration: 10000
     EndOnStart:
       Deepsleep: true

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -319,7 +319,7 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 	if (target == nullptr)
 		return 0;
 
-	int32 dmg_change;
+	int32 dmg_change = 0;
 	map_session_data* sd = nullptr;
 
 	t_tick delay = battle_calc_walkdelay(*target, damage, div_, tick);
@@ -331,7 +331,7 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 		dmg_change = status_fix_spdamage(src, target, damage, delay, skill_id);
 	else if (sd && battle_check_coma(*sd, *target, (e_battle_flag)attack_type))
 		dmg_change = status_damage(src, target, damage, 0, delay, 16, skill_id); // Coma attack
-	else
+	else if (dmg_lv > ATK_BLOCK)
 		dmg_change = status_fix_damage(src, target, damage, delay, skill_id);
 	if (attack_type && !status_isdead(*target) && additional_effects)
 		skill_additional_effect(src, target, skill_id, skill_lv, attack_type, dmg_lv, tick);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -319,6 +319,10 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 	if (target == nullptr)
 		return 0;
 
+	// SP damage does not trigger anything, just substracts SP
+	if (isspdamage)
+		return status_zap(target, 0, damage, 0);
+
 	int32 dmg_change = 0;
 	map_session_data* sd = nullptr;
 
@@ -327,9 +331,7 @@ int32 battle_damage(struct block_list *src, struct block_list *target, int64 dam
 	if (src)
 		sd = BL_CAST(BL_PC, src);
 	map_freeblock_lock();
-	if (isspdamage)
-		dmg_change = status_fix_spdamage(src, target, damage, delay, skill_id);
-	else if (sd && battle_check_coma(*sd, *target, (e_battle_flag)attack_type))
+	if (sd && battle_check_coma(*sd, *target, (e_battle_flag)attack_type))
 		dmg_change = status_damage(src, target, damage, 0, delay, 16, skill_id); // Coma attack
 	else if (dmg_lv > ATK_BLOCK)
 		dmg_change = status_fix_damage(src, target, damage, delay, skill_id);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1784,8 +1784,6 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 						break;
 				}
 			}
-			if( tsc->getSCE(SC_VOICEOFSIREN) )
-				status_change_end(bl,SC_VOICEOFSIREN);
 		}
 
 		if (tsc->getSCE(SC_SOUNDOFDESTRUCTION))

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2777,7 +2777,7 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 //Call when a mob has received damage.
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage)
 {
-	if (src && damage > 0) { //Store total damage...
+	if (src) { //Store total damage...
 		//Log damage
 		mob_log_damage(md, src, static_cast<int64>(damage));
 	}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2777,7 +2777,7 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 //Call when a mob has received damage.
 void mob_damage(struct mob_data *md, struct block_list *src, int32 damage)
 {
-	if (src) { //Store total damage...
+	if (src != nullptr) { //Store total damage...
 		//Log damage
 		mob_log_damage(md, src, static_cast<int64>(damage));
 	}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -8516,7 +8516,7 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 			uint8 ap_burn[5] = { 20, 30, 50, 60, 70 };
 
 			clif_skill_nodamage(src, *bl, skill_id, skill_lv);
-			status_fix_apdamage(src, bl, ap_burn[skill_lv - 1], 0, skill_id);
+			status_zap(bl, 0, 0, ap_burn[skill_lv - 1]);
 		} else if (sd)
 			clif_skill_fail( *sd, skill_id, USESKILL_FAIL );
 		break;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1554,9 +1554,10 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 			for (const auto &it : status_db) {
 				sc_type type = static_cast<sc_type>(it.first);
 
-				// Wink Charm checks for damage so it doesn't end itself
+				// For non-players, Wink Charm, Voice of Siren and Deep Sleep end only when damage was dealt (e.g. Wink Charm does not end itself)
+				// For players, these status changes end even if no damage was dealt (e.g. Provoke ends them on players but not on monsters)
 				// Other status changes end even on 0 damage (e.g. Wink Charm ends Freeze)
-				if (type == SC_WINKCHARM && hp == 0)
+				if ((type == SC_WINKCHARM || type == SC_VOICEOFSIREN || type == SC_DEEPSLEEP) && target->type != BL_PC && hp == 0)
 					continue;
 
 				if (sc->getSCE(type) && it.second->flag[SCF_REMOVEONDAMAGED]) {

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1537,6 +1537,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 		ap = status->ap;
 	}
 
+	// If no damage is dealt and the damage was passive
 	if (hp == 0 && sp == 0 && ap == 0 && (flag&1))
 		return 0;
 
@@ -1547,6 +1548,7 @@ int32 status_damage(struct block_list *src,struct block_list *target,int64 dhp, 
 	if (hp && battle_config.invincible_nodamage && src && sc && sc->getSCE(SC_INVINCIBLE))
 		hp = 1;
 
+	// If the damage is not passive
 	if (!(flag&1)) {
 		if( sc ) {
 			struct status_change_entry *sce;

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3519,14 +3519,6 @@ static int32 status_damage( struct block_list *src, struct block_list *target, i
 static int32 status_fix_damage( struct block_list *src, struct block_list *target, int64 hp, t_tick walkdelay, uint16 skill_id ){
 	return status_damage( src, target, hp, 0, walkdelay, 0, skill_id );
 }
-//Define for standard SP damage attacks.
-static int32 status_fix_spdamage( struct block_list *src, struct block_list *target, int64 sp, t_tick walkdelay, uint16 skill_id ){
-	return status_damage( src, target, 0, sp, walkdelay, 1, skill_id );
-}
-//Define for standard AP damage attacks.
-static int32 status_fix_apdamage( struct block_list *src, struct block_list *target, int64 ap, t_tick walkdelay, uint16 skill_id ){
-	return status_damage( src, target, 0, 0, ap, walkdelay, 1, skill_id );
-}
 //Define for standard HP/SP/AP damage triggers.
 static int32 status_zap( struct block_list* bl, int64 hp, int64 sp, int64 ap = 0 ){
 	return status_damage( nullptr, bl, hp, sp, ap, 0, 1, 0 );

--- a/src/map/status.hpp
+++ b/src/map/status.hpp
@@ -3521,11 +3521,11 @@ static int32 status_fix_damage( struct block_list *src, struct block_list *targe
 }
 //Define for standard SP damage attacks.
 static int32 status_fix_spdamage( struct block_list *src, struct block_list *target, int64 sp, t_tick walkdelay, uint16 skill_id ){
-	return status_damage( src, target, 0, sp, walkdelay, 0, skill_id );
+	return status_damage( src, target, 0, sp, walkdelay, 1, skill_id );
 }
 //Define for standard AP damage attacks.
 static int32 status_fix_apdamage( struct block_list *src, struct block_list *target, int64 ap, t_tick walkdelay, uint16 skill_id ){
-	return status_damage( src, target, 0, 0, ap, walkdelay, 0, skill_id );
+	return status_damage( src, target, 0, 0, ap, walkdelay, 1, skill_id );
 }
 //Define for standard HP/SP/AP damage triggers.
 static int32 status_zap( struct block_list* bl, int64 hp, int64 sp, int64 ap = 0 ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Related to #9209 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Zero damage skills like Wink Charm can now break status changes that break on damage
- Zero damage skills like Wink Charm now count as Exp Tap even if disabled for "Nodamage" skills
- Unified special behavior of Wink Charm, Voice of Siren and Deep Sleep
  * For PC: These status changes end on zero damage skills
  * For Non-PC: These status changes only end when actual damage was dealt
- Ensured that existing behavior for damage skills is not affected
  * When an attack misses, is blocked or is fully resisted, no damage event will be triggered
  * SP/AP damage will never break status changes that break on damage
- Currently the only zero damage skill implemented is Wink Charm, but can easily be expanded to other skills
- SP/AP damage will no longer trigger anything (status effects, autocasts, etc.)
- Related to #9209

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
