### PR TITLE
[WIP] feat/refac: Migrate Produce Database to YAML

### DIFF
--- a/db/re/produce_db.yml
+++ b/db/re/produce_db.yml
@@ -46,5 +46,7 @@ Header:
 
 Footer:
   Imports:
-  - Path: db/re/skill_produce_db.yml
-  - Path: db/re/skill_changematerial_db.yml
+  # - Path: db/re/skill_produce_db.yml
+  # - Path: db/re/skill_changematerial_db.yml
+  - Path: db/re/skill_produce_db_v2.yml
+  - Path: db/re/skill_changematerial_db_v2.yml

--- a/db/re/skill_changematerial_db_v2.yml
+++ b/db/re/skill_changematerial_db_v2.yml
@@ -1,0 +1,962 @@
+###########################################################################
+# Item Produce Database
+###########################################################################
+#
+# Item Produce Settings
+#
+###########################################################################
+# - Product         AegisName of the produced item.
+#   Group           Number which determines what kind of a crafting window will pop-up.
+#   SkillName       Skill name required. (Default: null)
+#   SkillLevel      Skill level required. (Default: 1)
+#   Consumed:       List of items consumed to produce the Product.
+#     - Item        AegisName of the consumed item.
+#       Amount      Amount required.
+#   NotConsumed:    List of items not consumed to produce the Product. (Optional)
+#     - Item        AegisName of the unconsumed item.
+#   BaseRate        Base rate (in n/10%) for Change Material (Group: 26). (Default: 1000)
+#   Make:           List of item amounts with their individual rate produced by Change Material (Group: 26). (Optional)
+#     - Amount      Amount of item created (unique to the list) for Change Material (Group: 26).
+#       Rate        Rate to create the Amount (in n/10%) for Change Material (Group: 26). (Default: 1000)
+###########################################################################
+
+Header:
+  Type: PRODUCE_DB
+  Version: 1
+
+Body:
+- Product: Sacred_Masque
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Grasshopper's_Leg
+    Amount: 45
+  - Item: Yoyo_Tail
+    Amount: 35
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Long_Hair
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Pencil_Case
+    Amount: 40
+  - Item: Tiger's_Skin
+    Amount: 5
+  Make:
+  - Amount: 4
+    Rate: 800
+  - Amount: 6
+    Rate: 200
+- Product: Phracon
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Glass_Bead
+    Amount: 40
+  - Item: Spawn
+    Amount: 45
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Lantern
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Blossom_Of_Maneater
+    Amount: 20
+  - Item: Solid_Shell
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 3
+- Product: Acorn
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Cactus_Needle
+    Amount: 30
+  - Item: Snail's_Shell
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Frozen_Heart
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Moth_Dust
+    Amount: 35
+  - Item: Raccoondog_Doll
+    Amount: 25
+  BaseRate: 800
+  Make:
+  - Amount: 6
+- Product: Horrendous_Mouth
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Dragon_Scale
+    Amount: 45
+  - Item: Stem
+    Amount: 45
+  BaseRate: 800
+  Make:
+  - Amount: 9
+- Product: Detrimindexta
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Chrysalis
+    Amount: 40
+  - Item: Flesh_Of_Clam
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 5
+- Product: Detonator
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Feather_Of_Birds
+    Amount: 25
+  - Item: Nose_Ring
+    Amount: 45
+  BaseRate: 800
+  Make:
+  - Amount: 7
+- Product: Tweezer
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Monkey_Doll
+    Amount: 5
+  - Item: Worm_Peelings
+    Amount: 40
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Petite_DiablOfs_Horn
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Resin
+    Amount: 10
+  - Item: Stone_Heart
+    Amount: 5
+  Make:
+  - Amount: 1
+- Product: Root_Of_Maneater
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Talon
+    Amount: 25
+  - Item: Tooth_Of_
+    Amount: 20
+  Make:
+  - Amount: 4
+    Rate: 800
+  - Amount: 6
+    Rate: 200
+- Product: Conch
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Gill
+    Amount: 5
+  - Item: Immortal_Heart
+    Amount: 25
+  BaseRate: 800
+  Make:
+  - Amount: 3
+- Product: Rotten_Scale
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Shell
+    Amount: 20
+  - Item: Thin_N'_Long_Tongue
+    Amount: 50
+  BaseRate: 800
+  Make:
+  - Amount: 7
+- Product: Elder_Pixie's_Beard
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bee_Sting
+    Amount: 35
+  - Item: Petite_DiablOfs_Wing
+    Amount: 45
+  Make:
+  - Amount: 8
+    Rate: 800
+  - Amount: 12
+    Rate: 200
+- Product: Lizard_Scruff
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Karvodailnirol
+    Amount: 15
+  - Item: Scale_Of_Snakes
+    Amount: 20
+  BaseRate: 800
+  Make:
+  - Amount: 3
+- Product: Emveretarcon
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Grasshopper_Doll
+    Amount: 40
+  - Item: Heart_Of_Mermaid
+    Amount: 5
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Chinese_Ink
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bear's_Foot
+    Amount: 20
+  - Item: Black_Ladle
+    Amount: 25
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Spiderweb
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Fin
+    Amount: 50
+  - Item: Slender_Snake
+    Amount: 35
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Reins
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Chonchon_Doll
+    Amount: 30
+  - Item: Stuffed_Doll
+    Amount: 50
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Wooden_Block
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Rotten_Bandage
+    Amount: 10
+  - Item: Single_Cell
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 2
+- Product: Tentacle
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Decayed_Nail
+    Amount: 40
+  - Item: Wild_Boar's_Mane
+    Amount: 5
+  Make:
+  - Amount: 4
+    Rate: 800
+  - Amount: 6
+    Rate: 200
+- Product: Mixture
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Posionous_Canine
+    Amount: 15
+  - Item: Powder_Of_Butterfly
+    Amount: 30
+  Make:
+  - Amount: 4
+    Rate: 800
+  - Amount: 6
+    Rate: 200
+- Product: Colorful_Shell
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Horn
+    Amount: 50
+  - Item: Zargon
+    Amount: 45
+  Make:
+  - Amount: 9
+    Rate: 800
+  - Amount: 13
+    Rate: 200
+- Product: Wing_Of_Moth
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Frozen_Rose
+    Amount: 20
+  - Item: Reptile_Tongue
+    Amount: 30
+  BaseRate: 800
+  Make:
+  - Amount: 5
+- Product: Nipper
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Earthworm_Peeling
+    Amount: 40
+  - Item: Sticky_Mucus
+    Amount: 25
+  Make:
+  - Amount: 6
+    Rate: 800
+  - Amount: 9
+    Rate: 200
+- Product: Turtle_Shell
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Fluff
+    Amount: 5
+  - Item: Poring_Doll
+    Amount: 40
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Nail_Of_Orc
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Garlet
+    Amount: 10
+  - Item: Raccoon_Leaf
+    Amount: 50
+  BaseRate: 800
+  Make:
+  - Amount: 6
+- Product: Dragon_Canine
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Osiris_Doll
+    Amount: 50
+  - Item: Sticky_Webfoot
+    Amount: 35
+  Make:
+  - Amount: 8
+    Rate: 800
+  - Amount: 12
+    Rate: 200
+- Product: Skirt_Of_Virgin
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Head_Of_Medusa
+    Amount: 35
+  - Item: Scales_Shell
+    Amount: 30
+  BaseRate: 800
+  Make:
+  - Amount: 6
+- Product: Dragon_Train
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Sharpened_Cuspid
+    Amount: 35
+  - Item: Tooth_Of_Bat
+    Amount: 25
+  BaseRate: 800
+  Make:
+  - Amount: 6
+- Product: Dokkaebi_Horn
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Lip_Of_Ancient_Fish
+    Amount: 25
+  - Item: Shining_Scales
+    Amount: 15
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Grit
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Crystal_Mirror
+    Amount: 35
+  - Item: Limb_Of_Mantis
+    Amount: 50
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Sharp_Scale
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Clam_Shell
+    Amount: 20
+  - Item: Horseshoe
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 3
+- Product: Short_Leg
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Claw_Of_Wolves
+    Amount: 20
+  - Item: Scell
+    Amount: 45
+  BaseRate: 800
+  Make:
+  - Amount: 6
+- Product: Starsand_Of_Witch
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Porcelain
+    Amount: 15
+  - Item: Insect_Feeler
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 2
+- Product: Fox_Tail
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Animal's_Skin
+    Amount: 10
+  - Item: Rouge
+    Amount: 15
+  Make:
+  - Amount: 2
+    Rate: 800
+  - Amount: 3
+    Rate: 200
+- Product: Cobold_Hair
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Jellopy
+    Amount: 45
+  - Item: Wedding_Bouquet
+    Amount: 20
+  Make:
+  - Amount: 6
+    Rate: 800
+  - Amount: 9
+    Rate: 200
+- Product: Jaws_Of_Ant
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Spore_Doll
+    Amount: 20
+  - Item: Witherless_Rose
+    Amount: 20
+  Make:
+  - Amount: 4
+    Rate: 800
+  - Amount: 6
+    Rate: 200
+- Product: Voucher_Of_Orcish_Hero
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Nail_Of_Mole
+    Amount: 45
+  - Item: Tree_Root
+    Amount: 5
+  BaseRate: 800
+  Make:
+  - Amount: 5
+- Product: Sacred_Marks
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Pumpkin_Head
+    Amount: 30
+  - Item: Scorpion's_Tail
+    Amount: 10
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Alchol
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Orcish_Voucher
+    Amount: 50
+  - Item: Skel_Bone
+    Amount: 40
+  BaseRate: 800
+  Make:
+  - Amount: 9
+- Product: Crap_Shell
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Baphomet_Doll
+    Amount: 50
+  - Item: Fish_Tail
+    Amount: 30
+  BaseRate: 800
+  Make:
+  - Amount: 8
+- Product: Tendon
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Feather
+    Amount: 5
+  - Item: Orcish_Cuspid
+    Amount: 25
+  BaseRate: 800
+  Make:
+  - Amount: 3
+- Product: Tiger_Footskin
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Pointed_Scale
+    Amount: 5
+  - Item: White_Platter
+    Amount: 20
+  BaseRate: 800
+  Make:
+  - Amount: 2
+- Product: Hinalle
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bunch_Of_Flowers
+    Amount: 45
+  - Item: Moustache_Of_Mole
+    Amount: 40
+  Make:
+  - Amount: 2
+    Rate: 200
+  - Amount: 4
+    Rate: 800
+- Product: Counteragent
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Evil_Horn
+    Amount: 15
+  - Item: Mementos
+    Amount: 30
+  BaseRate: 800
+  Make:
+  - Amount: 4
+- Product: Tooth_Of_Ancient_Fish
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bill_Of_Birds
+    Amount: 35
+  - Item: Transparent_Cloth
+    Amount: 30
+  Make:
+  - Amount: 6
+    Rate: 800
+  - Amount: 9
+    Rate: 200
+- Product: Rat_Tail
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Golden_Hair
+    Amount: 40
+  - Item: Mushroom_Spore
+    Amount: 35
+  Make:
+  - Amount: 7
+    Rate: 800
+  - Amount: 10
+    Rate: 200
+- Product: Coal
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Guard
+    Amount: 1
+  BaseRate: 500
+  Make:
+  - Amount: 1
+- Product: Steel
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Tsurugi
+    Amount: 1
+  Make:
+  - Amount: 10
+- Product: Cigar
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Orcish_Axe
+    Amount: 1
+  Make:
+  - Amount: 1
+- Product: Bone_Wand
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Broken_Farming_Utensil
+    Amount: 100
+  - Item: Clattering_Skull
+    Amount: 100
+  BaseRate: 200
+  Make:
+  - Amount: 1
+- Product: Cigar
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Orcish_Axe
+    Amount: 1
+  - Item: Orcish_Voucher
+    Amount: 100
+  Make:
+  - Amount: 1
+- Product: Starsand_Of_Witch
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Moth_Dust
+    Amount: 100
+  - Item: Scell
+    Amount: 100
+  BaseRate: 800
+  Make:
+  - Amount: 2
+- Product: Soft_Feather
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Feather
+    Amount: 30
+  - Item: Feather_Of_Birds
+    Amount: 30
+  Make:
+  - Amount: 1
+    Rate: 200
+- Product: Wind_Of_Verdure
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Ice_Piece
+    Amount: 100
+  Make:
+  - Amount: 1
+    Rate: 500
+- Product: Crystal_Blue
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Claw_Of_Wolves
+    Amount: 100
+  Make:
+  - Amount: 1
+    Rate: 500
+- Product: Soft_Silk_Cloth
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Transparent_Cloth
+    Amount: 10
+  Make:
+  - Amount: 2
+- Product: Transparent_Cloth
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Soft_Silk_Cloth
+    Amount: 2
+  Make:
+  - Amount: 5
+- Product: Boost500_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Boost500
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: Full_SwingK_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  - Item: Full_SwingK
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: Mana_Plus_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  - Item: Mana_Plus
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: Cure_Free_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Cure_Free
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: Stamina_Up_M_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  - Item: Stamina_Up_M
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: Digestive_F_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Digestive_F
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 10
+  - Item: Flexible_String
+    Amount: 10
+  Make:
+  - Amount: 1
+    Rate: 100
+  - Amount: 2
+    Rate: 250
+  - Amount: 5
+    Rate: 500
+- Product: HP_Inc_PotS_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: HP_Increase_PotionS
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: HP_Inc_PotM_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: HP_Increase_PotionM
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: HP_Inc_PotL_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: HP_Increase_PotionL
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: SP_Inc_PotS_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: SP_Increase_PotionS
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: SP_Inc_PotM_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: SP_Increase_PotionM
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: SP_Inc_PotL_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: SP_Increase_PotionL
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: En_White_PotZ_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: Enrich_White_PotionZ
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: Vitata500_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: Vitata500
+    Amount: 10
+  Make:
+  - Amount: 10
+- Product: En_Cel_Juice_To_Throw
+  Group: 26
+  SkillName: GN_CHANGEMATERIAL
+  SkillLevel: 1
+  Consumed:
+  - Item: Bottle_To_Throw
+    Amount: 10
+  - Item: Enrich_Celermine_Juice
+    Amount: 10
+  Make:
+  - Amount: 10

--- a/db/re/skill_produce_db_v2.yml
+++ b/db/re/skill_produce_db_v2.yml
@@ -1,0 +1,2683 @@
+###########################################################################
+# Item Produce Database
+###########################################################################
+#
+# Item Produce Settings
+#
+###########################################################################
+# - Product         AegisName of the produced item.
+#   Group           Number which determines what kind of a crafting window will pop-up.
+#   SkillName       Skill name required. (Default: null)
+#   SkillLevel      Skill level required. (Default: 1)
+#   Consumed:       List of items consumed to produce the Product.
+#     - Item        AegisName of the consumed item.
+#       Amount      Amount required.
+#   NotConsumed:    List of items not consumed to produce the Product. (Optional)
+#     - Item        AegisName of the unconsumed item.
+#   BaseRate        Base rate (in n/10%) for Change Material (Group: 26). (Default: 1000)
+#   Make:           List of item amounts with their individual rate produced by Change Material (Group: 26). (Optional)
+#     - Amount      Amount of item created (unique to the list) for Change Material (Group: 26).
+#       Rate        Rate to create the Amount (in n/10%) for Change Material (Group: 26). (Default: 1000)
+###########################################################################
+
+Header:
+  Type: PRODUCE_DB
+  Version: 1
+
+Body:
+- Product: Sword
+  Group: 1
+  SkillName: BS_SWORD
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 2
+- Product: Falchion
+  Group: 1
+  SkillName: BS_SWORD
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 30
+- Product: Blade
+  Group: 1
+  SkillName: BS_SWORD
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 45
+  - Item: Tooth_Of_Bat
+    Amount: 25
+- Product: Knife
+  Group: 1
+  SkillName: BS_DAGGER
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 1
+  - Item: Jellopy
+    Amount: 10
+- Product: Cutter
+  Group: 1
+  SkillName: BS_DAGGER
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 25
+- Product: Main_Gauche
+  Group: 1
+  SkillName: BS_DAGGER
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 50
+- Product: Katana
+  Group: 1
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 1
+  Consumed:
+  - Item: Horrendous_Mouth
+    Amount: 15
+  - Item: Iron
+    Amount: 35
+- Product: Axe
+  Group: 1
+  SkillName: BS_AXE
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 10
+- Product: Battle_Axe
+  Group: 1
+  SkillName: BS_AXE
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 110
+- Product: Club
+  Group: 1
+  SkillName: BS_MACE
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 3
+- Product: Mace
+  Group: 1
+  SkillName: BS_MACE
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 30
+- Product: Waghnakh
+  Group: 1
+  SkillName: BS_KNUCKLE
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 160
+  - Item: Scarlet_Jewel
+    Amount: 1
+- Product: Javelin
+  Group: 1
+  SkillName: BS_SPEAR
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 3
+- Product: Spear
+  Group: 1
+  SkillName: BS_SPEAR
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 35
+- Product: Pike
+  Group: 1
+  SkillName: BS_SPEAR
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron
+    Amount: 70
+- Product: Lapier
+  Group: 2
+  SkillName: BS_SWORD
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 20
+- Product: Scimiter
+  Group: 2
+  SkillName: BS_SWORD
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 35
+- Product: Ring_Pommel_Saber
+  Group: 2
+  SkillName: BS_SWORD
+  SkillLevel: 2
+  Consumed:
+  - Item: Claw_Of_Wolves
+    Amount: 50
+  - Item: Steel
+    Amount: 40
+- Product: Dirk
+  Group: 2
+  SkillName: BS_DAGGER
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 17
+- Product: Dagger
+  Group: 2
+  SkillName: BS_DAGGER
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 30
+- Product: Stiletto
+  Group: 2
+  SkillName: BS_DAGGER
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 40
+- Product: Slayer
+  Group: 2
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 2
+  Consumed:
+  - Item: Decayed_Nail
+    Amount: 20
+  - Item: Steel
+    Amount: 25
+- Product: Bastard_Sword
+  Group: 2
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 45
+- Product: Hammer
+  Group: 2
+  SkillName: BS_AXE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 30
+- Product: Smasher
+  Group: 2
+  SkillName: BS_MACE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 20
+- Product: Flail
+  Group: 2
+  SkillName: BS_MACE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 33
+- Product: Chain
+  Group: 2
+  SkillName: BS_MACE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 45
+- Product: Knuckle_Duster
+  Group: 2
+  SkillName: BS_KNUCKLE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 50
+- Product: Hora
+  Group: 2
+  SkillName: BS_KNUCKLE
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 65
+- Product: Guisarme
+  Group: 2
+  SkillName: BS_SPEAR
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 25
+- Product: Glaive
+  Group: 2
+  SkillName: BS_SPEAR
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 40
+- Product: Partizan
+  Group: 2
+  SkillName: BS_SPEAR
+  SkillLevel: 2
+  Consumed:
+  - Item: Steel
+    Amount: 55
+- Product: Saber
+  Group: 3
+  SkillName: BS_SWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 8
+  - Item: Steel
+    Amount: 5
+  - Item: White_Jewel
+    Amount: 1
+- Product: Haedonggum
+  Group: 3
+  SkillName: BS_SWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Golden_Jewel
+    Amount: 1
+  - Item: Oridecon
+    Amount: 8
+  - Item: Steel
+    Amount: 10
+- Product: Tsurugi
+  Group: 3
+  SkillName: BS_SWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Dark_Red_Jewel
+    Amount: 1
+  - Item: Oridecon
+    Amount: 8
+  - Item: Steel
+    Amount: 15
+- Product: Flamberge
+  Group: 3
+  SkillName: BS_SWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Cardinal_Jewel_
+    Amount: 1
+  - Item: Oridecon
+    Amount: 16
+- Product: Gladius
+  Group: 3
+  SkillName: BS_DAGGER
+  SkillLevel: 3
+  Consumed:
+  - Item: Blue_Jewel
+    Amount: 1
+  - Item: Oridecon
+    Amount: 4
+  - Item: Steel
+    Amount: 40
+- Product: Damascus
+  Group: 3
+  SkillName: BS_DAGGER
+  SkillLevel: 3
+  Consumed:
+  - Item: Bluish_Green_Jewel
+    Amount: 1
+  - Item: Oridecon
+    Amount: 4
+  - Item: Steel
+    Amount: 60
+- Product: Two_Hand_Sword
+  Group: 3
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 12
+  - Item: Steel
+    Amount: 10
+- Product: Broad_Sword
+  Group: 3
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 12
+  - Item: Steel
+    Amount: 20
+- Product: Claymore
+  Group: 3
+  SkillName: BS_TWOHANDSWORD
+  SkillLevel: 3
+  Consumed:
+  - Item: Crystal_Jewel___
+    Amount: 1
+  - Item: Oridecon
+    Amount: 16
+  - Item: Steel
+    Amount: 20
+- Product: Buster
+  Group: 3
+  SkillName: BS_AXE
+  SkillLevel: 3
+  Consumed:
+  - Item: Orcish_Cuspid
+    Amount: 30
+  - Item: Oridecon
+    Amount: 4
+  - Item: Steel
+    Amount: 20
+- Product: Two_Handed_Axe
+  Group: 3
+  SkillName: BS_AXE
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 8
+  - Item: Steel
+    Amount: 10
+  - Item: Violet_Jewel
+    Amount: 1
+- Product: Morning_Star
+  Group: 3
+  SkillName: BS_MACE
+  SkillLevel: 3
+  Consumed:
+  - Item: Crystal_Jewel
+    Amount: 1
+  - Item: Steel
+    Amount: 85
+- Product: Sword_Mace
+  Group: 3
+  SkillName: BS_MACE
+  SkillLevel: 3
+  Consumed:
+  - Item: Sharp_Scale
+    Amount: 20
+  - Item: Steel
+    Amount: 100
+- Product: Stunner
+  Group: 3
+  SkillName: BS_MACE
+  SkillLevel: 3
+  Consumed:
+  - Item: Steel
+    Amount: 120
+  - Item: Voucher_Of_Orcish_Hero
+    Amount: 1
+- Product: Fist
+  Group: 3
+  SkillName: BS_KNUCKLE
+  SkillLevel: 3
+  Consumed:
+  - Item: Cardinal_Jewel
+    Amount: 10
+  - Item: Oridecon
+    Amount: 4
+- Product: Claw
+  Group: 3
+  SkillName: BS_KNUCKLE
+  SkillLevel: 3
+  Consumed:
+  - Item: Golden_Jewel
+    Amount: 10
+  - Item: Oridecon
+    Amount: 8
+- Product: Finger
+  Group: 3
+  SkillName: BS_KNUCKLE
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 4
+  - Item: White_Jewel
+    Amount: 10
+- Product: Trident
+  Group: 3
+  SkillName: BS_SPEAR
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 8
+  - Item: Skyblue_Jewel
+    Amount: 5
+  - Item: Steel
+    Amount: 10
+- Product: Halberd
+  Group: 3
+  SkillName: BS_SPEAR
+  SkillLevel: 3
+  Consumed:
+  - Item: Oridecon
+    Amount: 12
+  - Item: Steel
+    Amount: 10
+- Product: Lance
+  Group: 3
+  SkillName: BS_SPEAR
+  SkillLevel: 3
+  Consumed:
+  - Item: Cardinal_Jewel
+    Amount: 3
+  - Item: Evil_Horn
+    Amount: 2
+  - Item: Oridecon
+    Amount: 12
+- Product: Str_Dish01
+  Group: 11
+  Consumed:
+  - Item: Cooking_Oil
+    Amount: 1
+  - Item: Grasshopper's_Leg
+    Amount: 5
+  - Item: Old_Frying_Pan
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Int_Dish01
+  Group: 11
+  Consumed:
+  - Item: Grape
+    Amount: 3
+  - Item: Red_Potion
+    Amount: 2
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Vit_Dish01
+  Group: 11
+  Consumed:
+  - Item: Green_Herb
+    Amount: 10
+  - Item: Nipper
+    Amount: 10
+  - Item: Yellow_Potion
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Agi_Dish01
+  Group: 11
+  Consumed:
+  - Item: Chinese_Ink
+    Amount: 1
+  - Item: Grain
+    Amount: 1
+  - Item: Spawn
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Dex_Dish01
+  Group: 11
+  Consumed:
+  - Item: Grape
+    Amount: 2
+  - Item: Honey
+    Amount: 1
+  - Item: Red_Potion
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Luk_Dish01
+  Group: 11
+  Consumed:
+  - Item: Cooking_Oil
+    Amount: 1
+  - Item: Old_Frying_Pan
+    Amount: 1
+  - Item: Yoyo_Tail
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook01
+- Product: Str_Dish02
+  Group: 12
+  Consumed:
+  - Item: Green_Herb
+    Amount: 10
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Sticky_Webfoot
+    Amount: 20
+  - Item: Yellow_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Vit_Dish02
+  Group: 12
+  Consumed:
+  - Item: Delicious_Fish
+    Amount: 1
+  - Item: Fin
+    Amount: 5
+  - Item: Flesh_Of_Clam
+    Amount: 10
+  - Item: Gill
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Int_Dish02
+  Group: 12
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 5
+  - Item: Red_Herb
+    Amount: 10
+  - Item: Yellow_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Agi_Dish02
+  Group: 12
+  Consumed:
+  - Item: Carrot
+    Amount: 3
+  - Item: Grain
+    Amount: 1
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Pumpkin_Head
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Dex_Dish02
+  Group: 12
+  Consumed:
+  - Item: Cacao
+    Amount: 10
+  - Item: Milk
+    Amount: 1
+  - Item: Piece_Of_Cake
+    Amount: 1
+  - Item: White_Platter
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Luk_Dish02
+  Group: 12
+  Consumed:
+  - Item: Apple_Juice
+    Amount: 3
+  - Item: Carrot_Juice
+    Amount: 2
+  - Item: Grape_Juice
+    Amount: 1
+  - Item: Orange_Juice
+    Amount: 2
+  NotConsumed:
+  - Item: Cookbook02
+- Product: Dex_Dish03
+  Group: 13
+  Consumed:
+  - Item: Apple
+    Amount: 5
+  - Item: Banana
+    Amount: 5
+  - Item: Orange
+    Amount: 5
+  - Item: Strawberry
+    Amount: 5
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Int_Dish03
+  Group: 13
+  Consumed:
+  - Item: Honey
+    Amount: 2
+  - Item: White_Herb
+    Amount: 10
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Str_Dish03
+  Group: 13
+  Consumed:
+  - Item: Chilli
+    Amount: 5
+  - Item: Green_Herb
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Meat
+    Amount: 4
+  - Item: Old_Frying_Pan
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Vit_Dish03
+  Group: 13
+  Consumed:
+  - Item: Conch
+    Amount: 10
+  - Item: Flesh_Of_Clam
+    Amount: 20
+  - Item: Honey
+    Amount: 1
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Agi_Dish03
+  Group: 13
+  Consumed:
+  - Item: Cheese
+    Amount: 10
+  - Item: Nice_Sweet_Potato
+    Amount: 5
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Tentacle
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Luk_Dish03
+  Group: 13
+  Consumed:
+  - Item: Baked_Yam
+    Amount: 1
+  - Item: Nice_Sweet_Potato
+    Amount: 10
+  - Item: Sweet_Potato
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook03
+- Product: Int_Dish04
+  Group: 14
+  Consumed:
+  - Item: Alchol
+    Amount: 2
+  - Item: Grape
+    Amount: 5
+  - Item: Lemon
+    Amount: 4
+  - Item: Orange
+    Amount: 10
+  - Item: Strawberry
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Vit_Dish04
+  Group: 14
+  Consumed:
+  - Item: Chinese_Ink
+    Amount: 20
+  - Item: Old_Frying_Pan
+    Amount: 1
+  - Item: Soft_Leaf
+    Amount: 10
+  - Item: Tentacle
+    Amount: 30
+  - Item: White_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Str_Dish04
+  Group: 14
+  Consumed:
+  - Item: Green_Herb
+    Amount: 3
+  - Item: Lemon
+    Amount: 1
+  - Item: Meat
+    Amount: 5
+  - Item: Red_Herb
+    Amount: 3
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Yellow_Herb
+    Amount: 2
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Dex_Dish04
+  Group: 14
+  Consumed:
+  - Item: Bread
+    Amount: 5
+  - Item: Cheese
+    Amount: 10
+  - Item: Meat
+    Amount: 1
+  - Item: Milk
+    Amount: 15
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Yellow_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Agi_Dish04
+  Group: 14
+  Consumed:
+  - Item: Carrot
+    Amount: 10
+  - Item: Grain
+    Amount: 3
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Ice_Piece
+    Amount: 10
+  - Item: Pumpkin_Head
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Luk_Dish04
+  Group: 14
+  Consumed:
+  - Item: Delicious_Fish
+    Amount: 5
+  - Item: Lip_Of_Ancient_Fish
+    Amount: 10
+  - Item: Raccoon_Leaf
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 2
+  - Item: White_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook04
+- Product: Int_Dish05
+  Group: 15
+  Consumed:
+  - Item: Alchol
+    Amount: 2
+  - Item: Blue_Potion
+    Amount: 1
+  - Item: Fruit_Of_Mastela
+    Amount: 4
+  - Item: Lemon
+    Amount: 2
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Str_Dish05
+  Group: 15
+  Consumed:
+  - Item: Carrot
+    Amount: 3
+  - Item: Cooking_Oil
+    Amount: 1
+  - Item: Grain
+    Amount: 1
+  - Item: Honey
+    Amount: 2
+  - Item: Sweet_Potato
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Dex_Dish05
+  Group: 15
+  Consumed:
+  - Item: Great_Leaf
+    Amount: 6
+  - Item: Leaflet_Of_Aloe
+    Amount: 3
+  - Item: Leaflet_Of_Hinal
+    Amount: 2
+  - Item: Sharp_Leaf
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Agi_Dish05
+  Group: 15
+  Consumed:
+  - Item: Leaflet_Of_Hinal
+    Amount: 10
+  - Item: Pot
+    Amount: 1
+  - Item: Pumpkin_Head
+    Amount: 20
+  - Item: Red_Herb
+    Amount: 10
+  - Item: Wing_Of_Red_Bat
+    Amount: 20
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Vit_Dish05
+  Group: 15
+  Consumed:
+  - Item: Bun
+    Amount: 20
+  - Item: Green_Herb
+    Amount: 20
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Red_Spice
+    Amount: 1
+  - Item: Yellow_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Luk_Dish05
+  Group: 15
+  Consumed:
+  - Item: Cooking_Oil
+    Amount: 1
+  - Item: Great_Leaf
+    Amount: 10
+  - Item: Old_Frying_Pan
+    Amount: 2
+  - Item: Scorpion's_Tail
+    Amount: 20
+  - Item: Short_Leg
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook05
+- Product: Str_Dish06
+  Group: 16
+  Consumed:
+  - Item: Fruit_Of_Mastela
+    Amount: 1
+  - Item: Honey
+    Amount: 2
+  - Item: Meat
+    Amount: 10
+  - Item: Shining_Scales
+    Amount: 20
+  - Item: Yellow_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Int_Dish06
+  Group: 16
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Grape_Juice
+    Amount: 3
+  - Item: Mushroom
+    Amount: 3
+  - Item: Mushroom_Spore
+    Amount: 20
+  - Item: Red_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Dex_Dish06
+  Group: 16
+  Consumed:
+  - Item: Cheese
+    Amount: 10
+  - Item: Hard_Peach
+    Amount: 20
+  - Item: Milk
+    Amount: 10
+  - Item: Orange_Juice
+    Amount: 5
+  - Item: Piece_Of_Cake
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Agi_Dish06
+  Group: 16
+  Consumed:
+  - Item: Chilli
+    Amount: 20
+  - Item: Lemon
+    Amount: 20
+  - Item: Prawn
+    Amount: 20
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Vit_Dish06
+  Group: 16
+  Consumed:
+  - Item: Browny_Root
+    Amount: 20
+  - Item: Honey
+    Amount: 2
+  - Item: Mushroom
+    Amount: 1
+  - Item: Mushroom_Spore
+    Amount: 20
+  - Item: Root_Of_Maneater
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Luk_Dish06
+  Group: 16
+  Consumed:
+  - Item: Aloe
+    Amount: 1
+  - Item: Clover
+    Amount: 10
+  - Item: Reptile_Tongue
+    Amount: 5
+  - Item: Starsand_Of_Witch
+    Amount: 10
+  - Item: Thin_N'_Long_Tongue
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook06
+- Product: Str_Dish07
+  Group: 17
+  Consumed:
+  - Item: Coal
+    Amount: 2
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Live_Coal
+    Amount: 1
+  - Item: Meat
+    Amount: 10
+  - Item: White_Herb
+    Amount: 10
+  - Item: Wooden_Block
+    Amount: 15
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Int_Dish07
+  Group: 17
+  Consumed:
+  - Item: Honey
+    Amount: 2
+  - Item: Leaflet_Of_Hinal
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 4
+  - Item: White_Herb
+    Amount: 5
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Dex_Dish07
+  Group: 17
+  Consumed:
+  - Item: Amulet
+    Amount: 5
+  - Item: Bread
+    Amount: 10
+  - Item: Fruit_Of_Mastela
+    Amount: 5
+  - Item: Ment
+    Amount: 5
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Unripe_Apple
+    Amount: 2
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Agi_Dish07
+  Group: 17
+  Consumed:
+  - Item: Anolian_Skin
+    Amount: 10
+  - Item: Carrot
+    Amount: 10
+  - Item: Leaflet_Of_Aloe
+    Amount: 10
+  - Item: Pumpkin_Head
+    Amount: 10
+  - Item: Yellow_Herb
+    Amount: 10
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Vit_Dish07
+  Group: 17
+  Consumed:
+  - Item: Delicious_Fish
+    Amount: 2
+  - Item: Fish_Tail
+    Amount: 10
+  - Item: Leaflet_Of_Aloe
+    Amount: 5
+  - Item: Pet_Food
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  - Item: Wild_Boar's_Mane
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Luk_Dish07
+  Group: 17
+  Consumed:
+  - Item: Flesh_Of_Clam
+    Amount: 10
+  - Item: Gill
+    Amount: 5
+  - Item: Meat
+    Amount: 5
+  - Item: Mushroom
+    Amount: 10
+  - Item: Scales_Shell
+    Amount: 10
+  - Item: Soft_Leaf
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook07
+- Product: Str_Dish08
+  Group: 18
+  Consumed:
+  - Item: Bear's_Foot
+    Amount: 20
+  - Item: Carrot
+    Amount: 10
+  - Item: Leaflet_Of_Aloe
+    Amount: 2
+  - Item: Leaflet_Of_Hinal
+    Amount: 1
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Pumpkin_Head
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Int_Dish08
+  Group: 18
+  Consumed:
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 3
+  - Item: Leaflet_Of_Aloe
+    Amount: 10
+  - Item: Leaflet_Of_Hinal
+    Amount: 10
+  - Item: Prickly_Fruit
+    Amount: 4
+  - Item: Royal_Jelly
+    Amount: 6
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Dex_Dish08
+  Group: 18
+  Consumed:
+  - Item: Bread
+    Amount: 10
+  - Item: Cheese
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Meat
+    Amount: 5
+  - Item: Royal_Jelly
+    Amount: 2
+  - Item: Strawberry
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Agi_Dish08
+  Group: 18
+  Consumed:
+  - Item: Aloebera
+    Amount: 1
+  - Item: Carrot
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Leaflet_Of_Hinal
+    Amount: 10
+  - Item: Meat
+    Amount: 10
+  - Item: Pumpkin_Head
+    Amount: 10
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Vit_Dish08
+  Group: 18
+  Consumed:
+  - Item: Grain
+    Amount: 2
+  - Item: Leaf_Clothes
+    Amount: 20
+  - Item: Meat
+    Amount: 20
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Pumpkin_Head
+    Amount: 10
+  - Item: Rainbow_Carrot
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Luk_Dish08
+  Group: 18
+  Consumed:
+  - Item: Grain
+    Amount: 5
+  - Item: Leaf_Clothes
+    Amount: 10
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Red_Spice
+    Amount: 2
+  - Item: Strawberry
+    Amount: 10
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook08
+- Product: Str_Dish09
+  Group: 19
+  Consumed:
+  - Item: Cheese
+    Amount: 10
+  - Item: Chinese_Ink
+    Amount: 10
+  - Item: Coal
+    Amount: 2
+  - Item: Green_Herb
+    Amount: 30
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Pot
+    Amount: 1
+  - Item: Tendon
+    Amount: 40
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Int_Dish09
+  Group: 19
+  Consumed:
+  - Item: Alchol
+    Amount: 5
+  - Item: Blue_Potion
+    Amount: 2
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 10
+  - Item: Leaflet_Of_Aloe
+    Amount: 10
+  - Item: Orange
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 4
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Dex_Dish09
+  Group: 19
+  Consumed:
+  - Item: Alchol
+    Amount: 2
+  - Item: Grape_Juice
+    Amount: 5
+  - Item: Orange
+    Amount: 10
+  - Item: Red_Spice
+    Amount: 1
+  - Item: Strawberry
+    Amount: 10
+  - Item: Tropical_Banana
+    Amount: 1
+  - Item: Unripe_Apple
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Agi_Dish09
+  Group: 19
+  Consumed:
+  - Item: Meat
+    Amount: 10
+  - Item: Plain_Sauce
+    Amount: 4
+  - Item: Red_Herb
+    Amount: 5
+  - Item: Royal_Jelly
+    Amount: 5
+  - Item: Shoot
+    Amount: 20
+  - Item: White_Herb
+    Amount: 10
+  - Item: Yellow_Herb
+    Amount: 5
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Vit_Dish09
+  Group: 19
+  Consumed:
+  - Item: Dragon's_Skin
+    Amount: 10
+  - Item: Dragon_Train
+    Amount: 20
+  - Item: Fatty_Chubby_Earthworm
+    Amount: 1
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 3
+  - Item: Red_Spice
+    Amount: 1
+  - Item: Royal_Jelly
+    Amount: 6
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Luk_Dish09
+  Group: 19
+  Consumed:
+  - Item: Alchol
+    Amount: 2
+  - Item: Aloebera
+    Amount: 2
+  - Item: Animal_Blood
+    Amount: 1
+  - Item: Anodyne
+    Amount: 2
+  - Item: Apple_Juice
+    Amount: 10
+  - Item: Red_Spice
+    Amount: 1
+  - Item: Royal_Jelly
+    Amount: 6
+  NotConsumed:
+  - Item: Cookbook09
+- Product: Str_Dish10
+  Group: 20
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Aloebera
+    Amount: 2
+  - Item: Blue_Potion
+    Amount: 2
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 10
+  - Item: Pot
+    Amount: 1
+  - Item: Royal_Jelly
+    Amount: 5
+  - Item: Thin_N'_Long_Tongue
+    Amount: 20
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Int_Dish10
+  Group: 20
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 10
+  - Item: Leaflet_Of_Aloe
+    Amount: 5
+  - Item: Lemon
+    Amount: 5
+  - Item: Prickly_Fruit
+    Amount: 5
+  - Item: Root_Of_Maneater
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 5
+  - Item: Singing_Plant
+    Amount: 1
+  - Item: Yggdrasilberry
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Dex_Dish10
+  Group: 20
+  Consumed:
+  - Item: Alchol
+    Amount: 5
+  - Item: Center_Potion
+    Amount: 3
+  - Item: Ice_Piece
+    Amount: 10
+  - Item: Illusion_Flower
+    Amount: 1
+  - Item: Prickly_Fruit
+    Amount: 2
+  - Item: Royal_Jelly
+    Amount: 4
+  - Item: Spawns
+    Amount: 10
+  - Item: Yggdrasilberry
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Agi_Dish10
+  Group: 20
+  Consumed:
+  - Item: Aloebera
+    Amount: 2
+  - Item: Bitter_Herb
+    Amount: 3
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 3
+  - Item: Pot
+    Amount: 1
+  - Item: Royal_Jelly
+    Amount: 10
+  - Item: Scorpion's_Tail
+    Amount: 20
+  - Item: Scropion's_Nipper
+    Amount: 20
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Vit_Dish10
+  Group: 20
+  Consumed:
+  - Item: Amulet
+    Amount: 10
+  - Item: Anodyne
+    Amount: 2
+  - Item: Bitter_Herb
+    Amount: 2
+  - Item: Heart_Of_Mermaid
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 2
+  - Item: Immortal_Heart
+    Amount: 20
+  - Item: Mementos
+    Amount: 10
+  - Item: Seed_Of_Yggdrasil
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Luk_Dish10
+  Group: 20
+  Consumed:
+  - Item: Four_Leaf_Clover
+    Amount: 2
+  - Item: Fox_Tail
+    Amount: 10
+  - Item: Izidor
+    Amount: 2
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 4
+  - Item: Plain_Sauce
+    Amount: 1
+  - Item: Root_Of_Maneater
+    Amount: 10
+  - Item: Sharp_Leaf
+    Amount: 10
+  - Item: Yellow_Spice
+    Amount: 1
+  NotConsumed:
+  - Item: Cookbook10
+- Product: Iron
+  Group: 21
+  SkillName: BS_IRON
+  SkillLevel: 1
+  Consumed:
+  - Item: Iron_Ore
+    Amount: 1
+- Product: Steel
+  Group: 21
+  SkillName: BS_STEEL
+  SkillLevel: 1
+  Consumed:
+  - Item: Coal
+    Amount: 1
+  - Item: Iron
+    Amount: 5
+- Product: Star_Crumb
+  Group: 21
+  SkillName: BS_ENCHANTEDSTONE
+  SkillLevel: 1
+  Consumed:
+  - Item: Sparkling_Dust
+    Amount: 10
+- Product: Flame_Heart
+  Group: 21
+  SkillName: BS_ENCHANTEDSTONE
+  SkillLevel: 1
+  Consumed:
+  - Item: Boody_Red
+    Amount: 10
+- Product: Mistic_Frozen
+  Group: 21
+  SkillName: BS_ENCHANTEDSTONE
+  SkillLevel: 1
+  Consumed:
+  - Item: Crystal_Blue
+    Amount: 10
+- Product: Great_Nature
+  Group: 21
+  SkillName: BS_ENCHANTEDSTONE
+  SkillLevel: 1
+  Consumed:
+  - Item: Yellow_Live
+    Amount: 10
+- Product: Rough_Wind
+  Group: 21
+  SkillName: BS_ENCHANTEDSTONE
+  SkillLevel: 1
+  Consumed:
+  - Item: Wind_Of_Verdure
+    Amount: 10
+- Product: Red_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Red_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Yellow_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Yellow_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: White_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: White_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Blue_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 1
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Scell
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Red_Slim_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Cactus_Needle
+    Amount: 1
+  - Item: Empty_Cylinder
+    Amount: 1
+  - Item: Red_Potion
+    Amount: 1
+  NotConsumed:
+  - Item: Slim_Potion_Create_Book
+- Product: Yellow_Slim_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 1
+  - Item: Moustache_Of_Mole
+    Amount: 1
+  - Item: Yellow_Potion
+    Amount: 1
+  NotConsumed:
+  - Item: Slim_Potion_Create_Book
+- Product: White_Slim_Potion
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 1
+  - Item: Starsand_Of_Witch
+    Amount: 1
+  - Item: White_Potion
+    Amount: 1
+  NotConsumed:
+  - Item: Slim_Potion_Create_Book
+- Product: Holy_Water
+  Group: 22
+  SkillName: AL_HOLYWATER
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 1
+- Product: Poison_Bottle
+  Group: 22
+  SkillName: ASC_CDP
+  SkillLevel: 1
+  Consumed:
+  - Item: Bee_Sting
+    Amount: 1
+  - Item: Berserk_Potion
+    Amount: 1
+  - Item: Cactus_Needle
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Karvodailnirol
+    Amount: 1
+  - Item: Poison_Spore
+    Amount: 1
+  - Item: Posionous_Canine
+    Amount: 1
+- Product: Fire_Bottle
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Transparent_Cloth
+    Amount: 1
+  NotConsumed:
+  - Item: FireBottle_Create_Book
+- Product: Acid_Bottle
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Immortal_Heart
+    Amount: 1
+  NotConsumed:
+  - Item: Acid_Create_Book
+- Product: MenEater_Plant_Bottle
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blossom_Of_Maneater
+    Amount: 2
+  - Item: Empty_Bottle
+    Amount: 1
+  NotConsumed:
+  - Item: Plant_Create_Book
+- Product: Mini_Bottle
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Detonator
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Tendon
+    Amount: 1
+  NotConsumed:
+  - Item: Mine_Create_Book
+- Product: Coating_Bottle
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Heart_Of_Mermaid
+    Amount: 1
+  - Item: Tooth_Of_
+    Amount: 1
+  NotConsumed:
+  - Item: Coating_Create_Book
+- Product: Resist_Fire
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Lizard_Scruff
+    Amount: 2
+  - Item: Red_Gemstone
+    Amount: 1
+  NotConsumed:
+  - Item: Elemental_Potion_Book
+- Product: Resist_Water
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Gemstone
+    Amount: 1
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Heart_Of_Mermaid
+    Amount: 3
+  NotConsumed:
+  - Item: Elemental_Potion_Book
+- Product: Resist_Earth
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Large_Jellopy
+    Amount: 2
+  - Item: Yellow_Gemstone
+    Amount: 1
+  NotConsumed:
+  - Item: Elemental_Potion_Book
+- Product: Resist_Wind
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Gemstone
+    Amount: 1
+  - Item: Empty_Potion
+    Amount: 1
+  - Item: Moth_Dust
+    Amount: 3
+  NotConsumed:
+  - Item: Elemental_Potion_Book
+- Product: Anodyne
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Ment
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Aloebera
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Aloe
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Honey
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Alchol
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Empty_Cylinder
+    Amount: 1
+  - Item: Poison_Spore
+    Amount: 5
+  - Item: Stem
+    Amount: 5
+  NotConsumed:
+  - Item: Alcol_Create_Book
+- Product: Germination_Breed
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Life_Force_Pot
+    Amount: 1
+  - Item: Seed_Of_Life
+    Amount: 1
+  - Item: Yggdrasilberry_Dew
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Homun_F_Tablet
+  Group: 22
+  SkillName: AM_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 1
+  - Item: Seed_Of_Life
+    Amount: 1
+  - Item: Yellow_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Normal_Potion_Book
+- Product: Elemental_Fire
+  Group: 23
+  SkillName: SA_CREATECON
+  SkillLevel: 1
+  Consumed:
+  - Item: Boody_Red
+    Amount: 1
+  - Item: Scroll
+    Amount: 1
+- Product: Elemental_Water
+  Group: 23
+  SkillName: SA_CREATECON
+  SkillLevel: 1
+  Consumed:
+  - Item: Crystal_Blue
+    Amount: 1
+  - Item: Scroll
+    Amount: 1
+- Product: Elemental_Earth
+  Group: 23
+  SkillName: SA_CREATECON
+  SkillLevel: 1
+  Consumed:
+  - Item: Scroll
+    Amount: 1
+  - Item: Wind_Of_Verdure
+    Amount: 1
+- Product: Elemental_Wind
+  Group: 23
+  SkillName: SA_CREATECON
+  SkillLevel: 1
+  Consumed:
+  - Item: Scroll
+    Amount: 1
+  - Item: Yellow_Live
+    Amount: 1
+- Product: Ansila
+  Group: 24
+  SkillName: AB_ANCILLA
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Gemstone
+    Amount: 1
+- Product: Runstone_Nosiege
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 8
+  Consumed:
+  - Item: Broken_Armor_Piece
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Light_Granule
+    Amount: 1
+  - Item: Old_Magic_Circle
+    Amount: 1
+- Product: Runstone_Rhydo
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 7
+  Consumed:
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Light_Granule
+    Amount: 1
+  - Item: Red_Gemstone
+    Amount: 1
+- Product: Runstone_Verkana
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 9
+  Consumed:
+  - Item: Dullahan_Armor
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+- Product: Runstone_Isia
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 2
+  Consumed:
+  - Item: Burning_Heart
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+- Product: Runstone_Asir
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 5
+  Consumed:
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Light_Granule
+    Amount: 1
+  - Item: Ogre_Tooth
+    Amount: 1
+- Product: Runstone_Urj
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 6
+  Consumed:
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Honey
+    Amount: 1
+  - Item: Slender_Snake
+    Amount: 1
+- Product: Runstone_Turisus
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 1
+  Consumed:
+  - Item: Claw_Of_Desert_Wolf
+    Amount: 1
+  - Item: Cobold_Hair
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+- Product: Runstone_Pertz
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 3
+  Consumed:
+  - Item: Dragon_Canine
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Light_Granule
+    Amount: 1
+  - Item: Tangled_Chain
+    Amount: 1
+- Product: Runstone_Hagalas
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 4
+  Consumed:
+  - Item: Dragon's_Skin
+    Amount: 1
+  - Item: Elder_Branch
+    Amount: 1
+  - Item: Round_Shell
+    Amount: 1
+- Product: Runstone_Lux
+  Group: 24
+  SkillName: RK_RUNEMASTERY
+  SkillLevel: 10
+  Consumed:
+  - Item: Gold
+    Amount: 3
+  - Item: Light_Granule
+    Amount: 3
+- Product: Guillotine_Antidote
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 5
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 1
+  - Item: Green_Herb
+    Amount: 2
+  - Item: White_Herb
+    Amount: 1
+- Product: Poison_Paralysis
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 1
+  Consumed:
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Amoena
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+  - Item: Poison_Toad's_Skin
+    Amount: 20
+- Product: Poison_Leech
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 4
+  Consumed:
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Nerium
+    Amount: 1
+  - Item: Poison_Herb_Scopolia
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+- Product: Poison_Oblivion
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 9
+  Consumed:
+  - Item: Heart_Of_Mermaid
+    Amount: 10
+  - Item: Izidor
+    Amount: 1
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+- Product: Poison_Contamination
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 3
+  Consumed:
+  - Item: Decayed_Nail
+    Amount: 25
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Seratum
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+- Product: Poison_Numb
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 8
+  Consumed:
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Nerium
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+  - Item: Sticky_Poison
+    Amount: 10
+- Product: Poison_Fever
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 2
+  Consumed:
+  - Item: Anolian_Skin
+    Amount: 20
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Rantana
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+- Product: Poison_Laughing
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 7
+  Consumed:
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Herb_Makulata
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+  - Item: Poison_Spore
+    Amount: 10
+- Product: Poison_Fatigue
+  Group: 25
+  SkillName: GC_RESEARCHNEWPOISON
+  SkillLevel: 6
+  Consumed:
+  - Item: Izidor
+    Amount: 1
+  - Item: Medicine_Bowl
+    Amount: 1
+  - Item: Poison_Kit
+    Amount: 1
+  - Item: Sticky_Poison
+    Amount: 10
+- Product: Savage_BBQ
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Black_Charcoal
+    Amount: 1
+  - Item: Cooking_Skewer
+    Amount: 1
+  - Item: Melange_Pot
+    Amount: 1
+  - Item: Savage_Meat
+    Amount: 1
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Wug_Blood_Cocktail
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Cold_Ice
+    Amount: 2
+  - Item: Melange_Pot
+    Amount: 1
+  - Item: Wolf_Blood
+    Amount: 3
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Minor_Brisket
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Beef_Head_Meat
+    Amount: 2
+  - Item: Large_Cookpot
+    Amount: 1
+  - Item: Melange_Pot
+    Amount: 1
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Siroma_Icetea
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Comodo_Tropic_Fruit
+    Amount: 1
+  - Item: Ice_Crystal
+    Amount: 2
+  - Item: Ice_Fragment
+    Amount: 3
+  - Item: Melange_Pot
+    Amount: 1
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Drocera_Herb_Stew
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 3
+  - Item: Drocera_Tentacle
+    Amount: 3
+  - Item: Large_Cookpot
+    Amount: 1
+  - Item: Melange_Pot
+    Amount: 1
+  - Item: Red_Herb
+    Amount: 3
+  - Item: White_Herb
+    Amount: 3
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Petti_Tail_Noodle
+  Group: 27
+  SkillName: GN_MIX_COOKING
+  SkillLevel: 1
+  Consumed:
+  - Item: Cool_Gravy
+    Amount: 1
+  - Item: Fine_Noodle
+    Amount: 1
+  - Item: Melange_Pot
+    Amount: 1
+  - Item: Petti_Tail
+    Amount: 2
+  NotConsumed:
+  - Item: Mix_Cook_Book
+- Product: Seed_Of_Horny_Plant
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Prickly_Fruit
+    Amount: 10
+  NotConsumed:
+  - Item: Plant_Genetic_Grow
+- Product: Bloodsuck_Plant_Seed
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Root_Of_Maneater
+    Amount: 10
+  NotConsumed:
+  - Item: Plant_Genetic_Grow
+- Product: Bomb_Mushroom_Spore
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Gun_Powder
+    Amount: 2
+  - Item: Mushroom_Spore
+    Amount: 10
+  - Item: Poison_Spore
+    Amount: 5
+  NotConsumed:
+  - Item: Plant_Genetic_Grow
+- Product: HP_Increase_PotionS
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: Monster's_Feed
+    Amount: 5
+  - Item: White_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Increase_Stamina_Study
+- Product: HP_Increase_PotionM
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: White_Herb
+    Amount: 10
+  - Item: Yellow_Herb
+    Amount: 10
+  NotConsumed:
+  - Item: Increase_Stamina_Study
+- Product: HP_Increase_PotionL
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Fruit_Of_Mastela
+    Amount: 3
+  - Item: Holy_Water
+    Amount: 1
+  - Item: Hot_Sauce
+    Amount: 1
+  - Item: White_Herb
+    Amount: 15
+  NotConsumed:
+  - Item: Increase_Stamina_Study
+- Product: SP_Increase_PotionS
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Grape
+    Amount: 10
+  - Item: Lemon
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Vital_Drink_CB
+- Product: SP_Increase_PotionM
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 10
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Honey
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Vital_Drink_CB
+- Product: SP_Increase_PotionL
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 15
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 10
+  - Item: Sweet_Sauce
+    Amount: 1
+  NotConsumed:
+  - Item: Vital_Drink_CB
+- Product: Enrich_White_PotionZ
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Alchol
+    Amount: 1
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: White_Herb
+    Amount: 10
+  - Item: White_Potion
+    Amount: 20
+  NotConsumed:
+  - Item: Quality_Potion_Book
+- Product: Vitata500
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 10
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Grape
+    Amount: 10
+  - Item: Honey
+    Amount: 10
+  NotConsumed:
+  - Item: Quality_Potion_Book
+- Product: Enrich_Celermine_Juice
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Awakening_Potion
+    Amount: 5
+  - Item: Center_Potion
+    Amount: 5
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Hot_Sauce
+    Amount: 5
+  NotConsumed:
+  - Item: Quality_Potion_Book
+- Product: Cure_Free
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Fruit_Of_Mastela
+    Amount: 1
+  - Item: Green_Herb
+    Amount: 20
+  - Item: Leaf_Of_Yggdrasil
+    Amount: 1
+  - Item: Panacea
+    Amount: 5
+  NotConsumed:
+  - Item: Quality_Potion_Book
+- Product: Ref_T_Potion
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Gold
+    Amount: 5
+  - Item: Yggdrasilberry
+    Amount: 10
+- Product: Add_Atk_Potion
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Red_Herb
+    Amount: 45
+  - Item: Seed_Of_Yggdrasil
+    Amount: 5
+- Product: Add_Matk_Potion
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Blue_Herb
+    Amount: 15
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Seed_Of_Yggdrasil
+    Amount: 5
+- Product: Concentrated_R_P
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 5
+  - Item: High_RedPotion
+    Amount: 15
+- Product: Concentrated_B_P
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 5
+  - Item: High_BluePotion
+    Amount: 15
+- Product: Concentrated_G_P
+  Group: 29
+  SkillName: GN_S_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Empty_Cylinder
+    Amount: 10
+  - Item: Empty_Potion
+    Amount: 5
+  - Item: High_WhitePotion
+    Amount: 10
+  - Item: High_YelloPotion
+    Amount: 10
+- Product: Novice_Potion
+  Group: 30
+  Consumed:
+  - Item: Apple
+    Amount: 1
+  - Item: Red_Herb
+    Amount: 2
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: N_Magnifier
+  Group: 30
+  Consumed:
+  - Item: Jellopy
+    Amount: 1
+  - Item: Tree_Of_Archer_1
+    Amount: 3
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: N_Fly_Wing
+  Group: 30
+  Consumed:
+  - Item: Feather
+    Amount: 2
+  - Item: Fluff
+    Amount: 2
+  - Item: Jellopy
+    Amount: 2
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: N_Cutter
+  Group: 30
+  Consumed:
+  - Item: Phracon
+    Amount: 1
+  - Item: Shell
+    Amount: 10
+  - Item: Worm_Peelings
+    Amount: 10
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Unripe_Apple2
+  Group: 30
+  Consumed:
+  - Item: Apple
+    Amount: 1
+  - Item: Green_Herb
+    Amount: 1
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Four_Leaf_Clover
+  Group: 30
+  Consumed:
+  - Item: Clover
+    Amount: 200
+  - Item: Sticky_Mucus
+    Amount: 200
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Banana_Juice
+  Group: 30
+  Consumed:
+  - Item: Banana
+    Amount: 1
+  - Item: Milk
+    Amount: 1
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Apple_Juice
+  Group: 30
+  Consumed:
+  - Item: Apple
+    Amount: 1
+  - Item: Milk
+    Amount: 1
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Carrot_Juice
+  Group: 30
+  Consumed:
+  - Item: Carrot
+    Amount: 1
+  - Item: Milk
+    Amount: 1
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Grape_Juice
+  Group: 30
+  Consumed:
+  - Item: Grape
+    Amount: 1
+  - Item: Milk
+    Amount: 1
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Unripe_Apple
+  Group: 30
+  Consumed:
+  - Item: Apple
+    Amount: 10
+  - Item: Green_Herb
+    Amount: 20
+  - Item: Sticky_Mucus
+    Amount: 10
+  NotConsumed:
+  - Item: Novice_Combi_Book
+- Product: Device_Capsule
+  Group: 31
+  SkillName: MT_M_MACHINE
+  SkillLevel: 1
+  Consumed:
+  - Item: Magic_Gear_Fuel
+    Amount: 50
+  - Item: Oridecon_Hammer
+    Amount: 5
+  - Item: Portable_Furnace
+    Amount: 5
+  NotConsumed:
+  - Item: Device_M_Book
+- Product: Auto_Battle_Capsule
+  Group: 31
+  SkillName: MT_M_MACHINE
+  SkillLevel: 1
+  Consumed:
+  - Item: Magic_Gear_Fuel
+    Amount: 75
+  - Item: Oridecon_Hammer
+    Amount: 5
+  - Item: Portable_Furnace
+    Amount: 5
+  NotConsumed:
+  - Item: Device_M_Book
+- Product: Flame_Acid_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Acid_Bottle
+    Amount: 5
+  - Item: Beaker
+    Amount: 1
+  - Item: Boody_Red
+    Amount: 2
+  - Item: Fire_Bottle
+    Amount: 5
+- Product: Earth_Acid_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Acid_Bottle
+    Amount: 5
+  - Item: Beaker
+    Amount: 1
+  - Item: Fire_Bottle
+    Amount: 5
+  - Item: Yellow_Live
+    Amount: 2
+- Product: Gale_Acid_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Acid_Bottle
+    Amount: 5
+  - Item: Beaker
+    Amount: 1
+  - Item: Fire_Bottle
+    Amount: 5
+  - Item: Wind_Of_Verdure
+    Amount: 2
+- Product: Icicle_Acid_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Acid_Bottle
+    Amount: 5
+  - Item: Beaker
+    Amount: 1
+  - Item: Crystal_Blue
+    Amount: 2
+  - Item: Fire_Bottle
+    Amount: 5
+- Product: High_Coating_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Coating_Bottle
+    Amount: 10
+  - Item: Empty_Bottle
+    Amount: 5
+- Product: High_Plant_Bottle
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Bloodsuck_Plant_Seed
+    Amount: 2
+  - Item: Mandragora_Flowerpot
+    Amount: 5
+  - Item: MenEater_Plant_Bottle
+    Amount: 10
+  - Item: Seed_Of_Horny_Plant
+    Amount: 2
+- Product: Eye_Cleaner
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Green_Herb
+    Amount: 3
+  - Item: Holy_Water
+    Amount: 5
+  - Item: White_Herb
+    Amount: 3
+- Product: Ear_Cleaner
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Blue_Herb
+    Amount: 2
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Green_Herb
+    Amount: 3
+  - Item: Holy_Water
+    Amount: 5
+- Product: Tonics
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Holy_Water
+    Amount: 5
+  - Item: Royal_Jelly
+    Amount: 3
+  - Item: Yggdrasilberry
+    Amount: 2
+- Product: Mini_Extinguisher
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Crystal_Blue
+    Amount: 5
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Holy_Water
+    Amount: 5
+  - Item: Iron
+    Amount: 3
+- Product: Water_Of_Lucky
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Clover
+    Amount: 10
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Green_Herb
+    Amount: 3
+  - Item: Holy_Water
+    Amount: 5
+- Product: Strong_Antidote
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Green_Herb
+    Amount: 10
+  - Item: Holy_Water
+    Amount: 5
+  - Item: Poison_Bottle
+    Amount: 3
+- Product: High_Energy_Chocolate
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Cacao
+    Amount: 3
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 3
+  - Item: Seed_Of_Yggdrasil
+    Amount: 5
+- Product: Refined_Holy_Water
+  Group: 32
+  SkillName: BO_BIONIC_PHARMACY
+  SkillLevel: 1
+  Consumed:
+  - Item: Beaker
+    Amount: 1
+  - Item: Empty_Bottle
+    Amount: 10
+  - Item: Holy_Water
+    Amount: 10
+  - Item: Royal_Jelly
+    Amount: 3

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -30,6 +30,7 @@ private:
 	void parse( const ryml::Tree& rootNode );
 	void parseImports( const ryml::Tree& rootNode );
 	template <typename R> bool asType( const ryml::NodeRef& node, const std::string& name, R& out );
+	template <typename R> bool asType( const ryml::NodeRef& node, const std::string& name, R& out, R defaultValue );
 
 // These should be visible/usable by the implementation provider
 protected:
@@ -45,7 +46,8 @@ protected:
 
 	// Conversion functions
 	bool asBool(const ryml::NodeRef& node, const std::string &name, bool &out);
-	bool asInt16(const ryml::NodeRef& node, const std::string& name, int16& out );
+	bool asUInt8(const ryml::NodeRef& node, const std::string& name, uint8& out);
+	bool asInt16(const ryml::NodeRef& node, const std::string& name, int16& out);
 	bool asUInt16(const ryml::NodeRef& node, const std::string& name, uint16& out);
 	bool asInt32(const ryml::NodeRef& node, const std::string &name, int32 &out);
 	bool asUInt32(const ryml::NodeRef& node, const std::string &name, uint32 &out);
@@ -56,6 +58,11 @@ protected:
 	bool asString(const ryml::NodeRef& node, const std::string &name, std::string &out);
 	bool asUInt16Rate(const ryml::NodeRef& node, const std::string& name, uint16& out, uint16 maximum=10000);
 	bool asUInt32Rate(const ryml::NodeRef& node, const std::string& name, uint32& out, uint32 maximum=10000);
+	// Conversion with Default
+	bool asUInt8(const ryml::NodeRef& node, const std::string& name, uint8& out, uint8 defaultValue);
+	bool asUInt16(const ryml::NodeRef& node, const std::string& name, uint16& out, uint16 defaultValue);
+	bool asString(const ryml::NodeRef& node, const std::string &name, std::string &out, std::string defaultValue);
+	bool asUInt16Rate(const ryml::NodeRef& node, const std::string& name, uint16& out, uint16 maximum, uint16 defaultValue);
 
 	void setGenerator(bool shouldLoad);
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6292,6 +6292,9 @@ void clif_skill_estimation( map_session_data& sd, mob_data& md ){
 /// material id:
 ///     unused by the client
 void clif_skill_produce_mix_list( map_session_data& sd, int32 skill_id, int32 trigger ){
+
+	ShowInfo("PRODUCE MIX LIST skill_id=%d trigger=%d\n", skill_id, trigger);
+
 	// Avoid resending the menu
 	if( sd.menuskill_id == skill_id ){
 		return;
@@ -6306,22 +6309,20 @@ void clif_skill_produce_mix_list( map_session_data& sd, int32 skill_id, int32 tr
 	p->packetLength = sizeof( *p );
 
 	int32 count = 0;
-	for (const auto &itemlvit : skill_produce_db) {
-		for (const auto &datait : itemlvit.second->data) {
-			if (skill_can_produce_mix(&sd, datait.second->nameid, trigger, 1) != nullptr &&
-				(skill_id <= 0 || (skill_id > 0 && datait.second->req_skill == skill_id))
-				)
-			{
-				PACKET_ZC_MAKABLEITEMLIST_sub& entry = p->items[count];
+	for (const auto &recipes : skill_produce_db) {
 
-				entry.itemId = client_nameid( datait.second->nameid );
-				entry.material[0] = 0;
-				entry.material[1] = 0;
-				entry.material[2] = 0;
+		// ShowInfo("A RECIPE: recipe_id=%d\n", recipes.first);
 
-				p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
-				count++;
-			}
+		if (skill_can_produce_mix(&sd, recipes.second->product_id, trigger, 1) != nullptr && (skill_id <= 0 || (skill_id > 0 && recipes.second->req_skill == skill_id)) ) {
+			PACKET_ZC_MAKABLEITEMLIST_sub& entry = p->items[count];
+
+			entry.itemId = client_nameid( recipes.second->product_id );
+			entry.material[0] = 0;
+			entry.material[1] = 0;
+			entry.material[2] = 0;
+
+			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
+			count++;
 		}
 	}
 
@@ -6359,19 +6360,17 @@ void clif_cooking_list( map_session_data& sd, int32 trigger, uint16 skill_id, in
 	p->makeItem = list_type;
 
 	int32 count = 0;
-	for (const auto &itemlvit : skill_produce_db) {
-		for (const auto &datait : itemlvit.second->data) {
-			if( skill_can_produce_mix( &sd, datait.second->nameid, trigger, qty ) == nullptr ){
-				continue;
-			}
-
-			PACKET_ZC_MAKINGITEM_LIST_sub& entry = p->items[count];
-
-			entry.itemId = client_nameid( datait.second->nameid );
-
-			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
-			count++;
+	for (const auto &recipes : skill_produce_db) {
+		if( skill_can_produce_mix( &sd, recipes.second->product_id, trigger, qty ) == nullptr ){
+			continue;
 		}
+
+		PACKET_ZC_MAKINGITEM_LIST_sub& entry = p->items[count];
+
+		entry.itemId = client_nameid( recipes.second->product_id );
+
+		p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
+		count++;
 	}
 
 	if( count > 0 || skill_id == AM_PHARMACY ){
@@ -13125,7 +13124,7 @@ void clif_parse_ProduceMix(int32 fd,map_session_data *sd){
 		return;
 	}
 
-	std::shared_ptr<s_skill_produce_db_entry> produce = skill_can_produce_mix(sd,p->itemId,sd->menuskill_val, 1);
+	std::shared_ptr<s_skill_produce_db> produce = skill_can_produce_mix(sd,p->itemId,sd->menuskill_val, 1);
 
 	if( produce != nullptr )
 		skill_produce_mix(sd,0,p->itemId,p->material[0],p->material[1],p->material[2],1,produce);
@@ -13145,6 +13144,9 @@ void clif_parse_ProduceMix(int32 fd,map_session_data *sd){
 ///     7 = MT_M_MACHINE - Unconfirmed
 ///     8 = BO_BIONIC_PHARMACY - Unconfirmed
 void clif_parse_Cooking(int32 fd,map_session_data *sd) {
+
+	ShowInfo("PARSE COOKING\n");
+
 #if PACKETVER >= 20051010
 	if( sd == nullptr ){
 		return;
@@ -13164,7 +13166,7 @@ void clif_parse_Cooking(int32 fd,map_session_data *sd) {
 		return;
 	}
 
-	std::shared_ptr<s_skill_produce_db_entry> produce = skill_can_produce_mix(sd,p->itemId,sd->menuskill_val, amount);
+	std::shared_ptr<s_skill_produce_db> produce = skill_can_produce_mix(sd,p->itemId,sd->menuskill_val, amount);
 
 	if( produce != nullptr )
 		skill_produce_mix(sd,(p->type>1?sd->menuskill_id:0),p->itemId,0,0,0,amount,produce);
@@ -19576,19 +19578,20 @@ void clif_parse_debug(int32 fd,map_session_data *sd)
  * Server populates the window with avilable elemental converter options according to player's inventory
  *------------------------------------------*/
 void clif_elementalconverter_list( map_session_data& sd ){
+
+	ShowInfo("ELEMENTAL CONVERTER LIST\n");
+
 	PACKET_ZC_MAKINGARROW_LIST* p = reinterpret_cast<PACKET_ZC_MAKINGARROW_LIST*>( packet_buffer );
 
 	p->packetType = HEADER_ZC_MAKINGARROW_LIST;
 	p->packetLength = sizeof( *p );
 
 	int32 count = 0;
-	for (const auto &itemlvit : skill_produce_db) {
-		for (const auto &datait : itemlvit.second->data) {
-			if( skill_can_produce_mix( &sd, datait.second->nameid, 23, 1 ) ){
-				p->items[count].itemId = client_nameid( datait.second->nameid );
-				p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( p->items[0] ) );
-				count++;
-			}
+	for (const auto &recipes : skill_produce_db) {
+		if( skill_can_produce_mix( &sd, recipes.second->product_id, 23, 1 ) ){
+			p->items[count].itemId = client_nameid( recipes.second->product_id );
+			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( p->items[0] ) );
+			count++;
 		}
 	}
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -6295,12 +6295,13 @@ void clif_skill_produce_mix_list( map_session_data& sd, int32 skill_id, int32 tr
 
 	ShowInfo("PRODUCE MIX LIST skill_id=%d trigger=%d\n", skill_id, trigger);
 
-	// Avoid resending the menu
-	if( sd.menuskill_id == skill_id ){
-		return;
-	}
+	nullpo_retv(sd);
 
-	if (skill_id == GC_CREATENEWPOISON)
+	// Avoid resending the menu
+	if( sd.menuskill_id == skill_id )
+		return;
+
+	if (skill_id == GC_CREATENEWPOISON) //FIXME compatibility
 		skill_id = GC_RESEARCHNEWPOISON;
 
 	PACKET_ZC_MAKABLEITEMLIST* p = reinterpret_cast<PACKET_ZC_MAKABLEITEMLIST*>( packet_buffer );
@@ -6308,22 +6309,25 @@ void clif_skill_produce_mix_list( map_session_data& sd, int32 skill_id, int32 tr
 	p->packetType = HEADER_ZC_MAKABLEITEMLIST;
 	p->packetLength = sizeof( *p );
 
+	auto group_recipes = skill_produce_db.filterByGroup(trigger);
 	int32 count = 0;
-	for (const auto &recipes : skill_produce_db) {
+	for (const auto &[_, recipe] : group_recipes) {
 
-		// ShowInfo("A RECIPE: recipe_id=%d\n", recipes.first);
+		if (!skill_can_produce_mix(&sd, recipe->product_id, trigger, 1))
+			continue;
 
-		if (skill_can_produce_mix(&sd, recipes.second->product_id, trigger, 1) != nullptr && (skill_id <= 0 || (skill_id > 0 && recipes.second->req_skill == skill_id)) ) {
-			PACKET_ZC_MAKABLEITEMLIST_sub& entry = p->items[count];
+		if (skill_id > 0 && recipe->req_skill != skill_id)
+			continue;
 
-			entry.itemId = client_nameid( recipes.second->product_id );
-			entry.material[0] = 0;
-			entry.material[1] = 0;
-			entry.material[2] = 0;
+		PACKET_ZC_MAKABLEITEMLIST_sub& entry = p->items[count];
 
-			p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
-			count++;
-		}
+		entry.itemId = client_nameid( recipe->product_id );
+		entry.material[0] = 0;
+		entry.material[1] = 0;
+		entry.material[2] = 0;
+
+		p->packetLength += static_cast<decltype(p->packetLength)>( sizeof( entry ) );
+		count++;
 	}
 
 	clif_send( p, p->packetLength, &sd, SELF );

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -26157,234 +26157,110 @@ static bool skill_parse_row_nocastdb( char* split[], size_t columns, size_t curr
 	return true;
 }
 
-bool SkillProduceDatabase::addItemConsumed(const ryml::NodeRef& node, std::shared_ptr<s_skill_produce_db_entry> &entry, bool isConsumed) {
-	for (const auto &it : node) {
-		if (this->nodeExists(it, "Clear")) {
-			std::string item_name;
-
-			if (!this->asString(it, "Clear", item_name))
-				return 0;
-
-			std::shared_ptr<item_data> item = item_db.search_aegisname(item_name.c_str());
-
-			if (item == nullptr) {
-				this->invalidWarning(it["Clear"], "Item %s does not exist.\n", item_name.c_str());
-				return 0;
-			}
-
-			if (entry->materials.erase(item->nameid) == 0)
-				this->invalidWarning(it["Clear"], "Item %s was not defined.\n", item_name.c_str());
-
-			continue;
-		}
-
-		std::string item_name;
-
-		if (!this->asString(it, "Item", item_name))
-			return 0;
-
-		std::shared_ptr<item_data> item = item_db.search_aegisname(item_name.c_str());
-
-		if (item == nullptr) {
-			this->invalidWarning(it["Item"], "Item %s does not exist.\n", item_name.c_str());
-			return 0;
-		}
-
-		uint16 amount;
-
-		if (!isConsumed)
-			amount = 0;
-		else {
-			if (!this->asUInt16Rate(it, "Amount", amount, MAX_AMOUNT))
-				return 0;
-		}
-
-		entry->materials[item->nameid] = amount;
-	}
-	return 1;
-}
-
 const std::string SkillProduceDatabase::getDefaultLocation() {
 	return std::string(db_path) + "/produce_db.yml";
 }
 
-/**
- * Reads and parses an entry from the produce_db.
+/** Reads and parses an entry from the produce_db.
  * @param node: YAML node containing the entry.
  * @return count of successfully parsed rows
- */
+*/
 uint64 SkillProduceDatabase::parseBodyNode(const ryml::NodeRef &node) {
-	uint16 itemlv;
 
-	if (!this->asUInt16(node, "ItemLevel", itemlv))
+	if (!this->nodesExist(node, { "Product", "Group", "Consumed" }))
 		return 0;
 
-	std::shared_ptr<s_skill_produce_db> produce = this->find(itemlv);
+	std::string product_name;
+	if (!this->asString(node, "Product", product_name))
+		return 0;
+
+	std::shared_ptr<item_data> item = item_db.search_aegisname(product_name.c_str());
+	if (item == nullptr) {
+		this->invalidWarning(node["Product"], "Item %s does not exist.\n", product_name.c_str());
+		return 0;
+	}
+
+	std::shared_ptr<s_skill_produce_db> produce = this->find(item->nameid);
 	bool exists = produce != nullptr;
 
 	if (!exists) {
-		if (!this->nodesExist(node, { "Recipe" }))
-			return 0;
-
 		produce = std::make_shared<s_skill_produce_db>();
-		produce->itemlv = itemlv;
+		produce->product_id = item->nameid;
 	}
 
-	t_itemid nameid;
-	const ryml::NodeRef &subNode = node["Recipe"];
+	this->asUInt16(node, "Group", produce->group_id);
 
-	for (const auto &subit : subNode) {
-		std::string produced_name;
+	std::unordered_map<t_itemid, uint16> mats;
+	for (const auto& matsNode : node["Consumed"]) {
+		uint16 matAmount;
+		std::string matName;
+		std::shared_ptr<item_data> item;
 
-		if (this->nodeExists(subit, "Clear")) {
-			if (!this->asString(subit, "Clear", produced_name))
-				return 0;
-
-			std::shared_ptr<item_data> item = item_db.search_aegisname(produced_name.c_str());
-
-			if (item == nullptr) {
-				this->invalidWarning(subit["Clear"], "Item %s does not exist.\n", produced_name.c_str());
-				return 0;
-			}
-
-			nameid = item->nameid;
-
-			if (produce->data.erase(nameid) == 0)
-				this->invalidWarning(subit["Clear"], "Item %s was not defined.\n", produced_name.c_str());
-
-			continue;
-		}
-
-		if (!this->asString(subit, "Product", produced_name))
+		if (!this->nodesExist(matsNode, { "Item", "Amount" }))
 			return 0;
 
-		std::shared_ptr<item_data> item = item_db.search_aegisname(produced_name.c_str());
+		this->asString(matsNode, "Item",  matName);
+		this->asUInt16(matsNode, "Amount",  matAmount);
 
+		item = item_db.search_aegisname(matName.c_str());
 		if (item == nullptr) {
-			this->invalidWarning(subit["Product"], "Item %s does not exist.\n", produced_name.c_str());
+			this->invalidWarning(matsNode["Item"], "Item %s does not exist.\n", matName.c_str());
 			return 0;
 		}
 
-		nameid = item->nameid;
+		mats[item->nameid] = matAmount;
+	}
 
-		bool id_exists = produce->data.count(nameid) != 0;
-		std::shared_ptr<s_skill_produce_db_entry> entry;
+	std::string skill_name;
+	this->asString(node, "SkillName", skill_name, "");
+	produce->req_skill = !skill_name.empty() ? skill_name2id(skill_name.c_str()) : 0;
 
-		if (id_exists)
-			entry = produce->data[nameid];
-		else {
-			entry = std::make_shared<s_skill_produce_db_entry>();
-			entry->nameid = nameid;
-		}
+	this->asUInt8(node, "SkillLevel", produce->req_skill_lv, 1);
+	this->asUInt16Rate(node, "BaseRate", produce->base_rate, 1000, 1000);
 
-		entry->itemlv = itemlv;
+	if (this->nodeExists(node, "NotConsumed")) {
+		for (const auto& matsNode : node["NotConsumed"]) {
+			std::string matName;
+			std::shared_ptr<item_data> item;
 
-		if (this->nodeExists(subit, "BaseRate")) {	// note: BaseRate is only used for skill changematerial (itemlv 26)
-			uint16 baserate;
+			this->asString(matsNode, "Item",  matName);
 
-			if (!this->asUInt16Rate(subit, "BaseRate", baserate, 1000))
-				return 0;
-
-			entry->baserate = baserate;
-		} else {
-			if (!id_exists) {
-				entry->baserate = 1000;
-			}
-		}
-
-		if (this->nodeExists(subit, "Make")) {
-			const ryml::NodeRef &QuantityNode = subit["Make"];
-
-			for (const auto &Quantityit : QuantityNode) {
-				uint16 amount;
-
-				if (!this->asUInt16Rate(Quantityit, "Amount", amount, MAX_AMOUNT))
-					return 0;
-
-				uint16 rate;
-
-				if (this->nodeExists(Quantityit, "Rate")) {
-					if (!this->asUInt16(Quantityit, "Rate", rate))
-						return 0;
-
-					if (rate == 0) {
-						if (entry->qty.erase(amount) == 0)
-							this->invalidWarning(Quantityit["Rate"], "Amount %hu was not defined.\n", amount);
-						continue;
-					}
-					if (rate > 1000) {
-						this->invalidWarning(Quantityit["Rate"], "Rate %hu can't be higher than 1000, capping.\n", rate);
-						rate = 1000;
-					}
-				} else {
-					rate = 1000;
-				}
-
-				entry->qty[amount] = rate;
-			}
-		}
-
-		if (this->nodeExists(subit, "SkillName")) {
-			std::string skill_name;
-
-			if (!this->asString(subit, "SkillName", skill_name))
-				return 0;
-
-			uint16 skill_id = skill_name2id(skill_name.c_str());
-
-			if (!skill_id) {
-				this->invalidWarning(subit["SkillName"], "Invalid skill name \"%s\", skipping.\n", skill_name.c_str());
+			item = item_db.search_aegisname(matName.c_str());
+			if (item == nullptr) {
+				this->invalidWarning(matsNode["Item"], "Item %s does not exist.\n", matName.c_str());
 				return 0;
 			}
 
-			entry->req_skill = skill_id;
+			mats[item->nameid] = 0;
 		}
+	}
+	produce->materials = mats;
 
-		if (this->nodeExists(subit, "SkillLevel")) {
-			uint16 skill_lv;
+	if (this->nodeExists(node, "Make")) {
 
-			if (!this->asUInt16(subit, "SkillLevel", skill_lv))
+		std::unordered_map<uint16, uint16> qty;
+
+		for (const auto& matsNode : node["Make"]) {
+			uint16 matAmount;
+			uint16 matRate;
+
+			if (!this->nodeExists(matsNode, "Amount"))
 				return 0;
 
-			entry->req_skill_lv = static_cast<uint8>(skill_lv);
-		} else {
-			if (!id_exists) {
-				entry->req_skill_lv = 1;
-			}
+			this->asUInt16(matsNode, "Amount",  matAmount);
+			// TODO check why we have a default of 1000 even with BaseRate
+			this->asUInt16(matsNode, "Rate", matRate, 1000);
+
+			qty[matAmount] = matRate;
 		}
 
-		if (this->nodeExists(subit, "Consumed")) {
-			if (!this->addItemConsumed(subit["Consumed"], entry, true))
-				return 0;
-		}
-
-		if (this->nodeExists(subit, "NotConsumed")) {
-			if (!this->addItemConsumed(subit["NotConsumed"], entry, false))
-				return 0;
-		}
-
-		if (!id_exists) {
-			produce->data.insert({ nameid, entry });
-			this->total_id++;
-		}
+		produce->qty = qty;
 	}
 
 	if (!exists)
-		this->put(itemlv, produce);
+		this->put(item->nameid, produce);
 
 	return 1;
-}
-
-void SkillProduceDatabase::loadingFinished() {
-	for ( auto &produce : *this ) {
-		for ( auto &data : produce.second->data ) {
-			if (!data.second->qty.empty())
-				continue;
-			data.second->qty.insert({ 1, 1000 });
-		}
-	}
-
-	TypesafeYamlDatabase::loadingFinished();
 }
 
 const std::string SkillArrowDatabase::getDefaultLocation() {
@@ -26619,7 +26495,7 @@ static void skill_readdb(void) {
 		size_t n2 = strlen(db_path)+strlen(DBPATH)+strlen(dbsubpath[i])+1;
 		char* dbsubpath1 = (char*)aMalloc(n1+1);
 		char* dbsubpath2 = (char*)aMalloc(n2+1);
-
+		
 		if (i == 0) {
 			safesnprintf(dbsubpath1,n1,"%s%s",db_path,dbsubpath[i]);
 			safesnprintf(dbsubpath2,n2,"%s/%s%s",db_path,DBPATH,dbsubpath[i]);
@@ -26628,13 +26504,14 @@ static void skill_readdb(void) {
 			safesnprintf(dbsubpath2,n1,"%s%s",db_path,dbsubpath[i]);
 		}
 
+		// these two depend on skill_db to loaded
 		sv_readdb(dbsubpath2, "skill_nocast_db.txt"   , ',',   2,  2, -1, skill_parse_row_nocastdb, i > 0);
 		sv_readdb(dbsubpath1, "skill_damage_db.txt"         , ',',   4,  3+SKILLDMG_MAX, -1, skill_parse_row_skilldamage, i > 0);
-
+		
 		aFree(dbsubpath1);
 		aFree(dbsubpath2);
 	}
-
+	
 	abra_db.load();
 	magic_mushroom_db.load();
 	reading_spellbook_db.load();

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -20779,8 +20779,6 @@ void skill_weaponrefine( map_session_data& sd, int32 idx ){
 #endif
 	};
 
-	ShowInfo("SKILL WEAPONREFINE\n");
-
 	if (idx >= 0 && idx < MAX_INVENTORY)
 	{
 		struct item_data *ditem = sd.inventory_data[idx];
@@ -22958,111 +22956,117 @@ void skill_unit_move_unit_group(std::shared_ptr<s_skill_unit_group> group, int16
 	aFree(m_flag);
 }
 
-/** Checking product requirement in player's inventory.
+/** Checking recipe requirements
  * Checking if player has the item or not, the amount, and the weight limit.
  * @param sd Player
  * @param nameid Product requested
  * @param trigger Trigger criteria to match will 'group_id'
  * @param qty Amount of item will be created
- * @return nullptr If failed or s_skill_produce_db on success
+ * @return s_skill_produce_db on success, nullptr otherwise
  */
-std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty) {
+std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, uint16 trigger, int32 qty) {
 
 	ShowInfo("CAN PRODUCE MIX: nameid=%d trigger=%d qty=%d\n", nameid, trigger, qty);
 
-	if (sd == nullptr)
-		return nullptr;
+	nullpo_retr(nullptr, sd);
 
 	if (!nameid || !item_db.exists(nameid))
 		return nullptr;
 
-	std::shared_ptr<s_skill_produce_db> produce = nullptr;
-
-	for (const auto &recipes : skill_produce_db) {
-
-		// ShowInfo("B RECIPE: product_id=%d\n", recipes.first);
-
-		if (recipes.second->product_id != nameid)
-			continue;
-
-		if (recipes.second->req_skill > 0 && pc_checkskill(sd, recipes.second->req_skill) < recipes.second->req_skill_lv)
-			continue; // must iterate again to check other skills that produce it. [malufett]
-
-		if (recipes.second->req_skill > 0 && sd->menuskill_id > 0 && sd->menuskill_id != recipes.second->req_skill)
-			continue; // special case
-
-		ShowInfo("FOUND: product_id=%d\n", recipes.first);
-
-		produce = recipes.second;
-		break;
-	}
-	// TODO optimize?
-	// ShowInfo("PRINT CAGADO\n");
-	// ShowInfo("CAN PRODUCE id=%d\n", produce->product_id);
-
-	if (nameid == ITEMID_HOMUNCULUS_SUPPLEMENT) { // Temporary check since the produce_db specifically wants the Pharmacy skill to use
-		if (pc_checkskill(sd, AM_BIOETHICS) == 0)
-			return nullptr;
-	}
-
-	if (produce == nullptr)
+	std::shared_ptr<s_skill_produce_db> produce = skill_produce_db.find(nameid, trigger);
+	if (produce == nullptr) {
+		ShowDebug("RECIPE NOT FOUND pid=%d gid=%d\n", nameid, trigger);
 		return nullptr;
+	}
+
+	// if recipe requires a skill. check if player has the required skill lv [malufett]
+	uint8 skill_lv = pc_checkskill(sd, produce->req_skill);
+	if (produce->req_skill > 0 && skill_lv < produce->req_skill_lv) {
+		ShowError("REQUIRED SKILL LV ERROR: skill=%d req=%d has=%d\n", produce->req_skill, produce->req_skill_lv, skill_lv);
+		return nullptr;
+	}
+
+	// if triggered by skill, check if skill used is the required
+	if (produce->req_skill > 0 && sd->menuskill_id > 0 && sd->menuskill_id != produce->req_skill) {
+		ShowError("REQUIRED SKILL IS WRONG\n");
+		return nullptr;
+	}
+
+	//FIXME Temporary check since the produce_db specifically wants the Pharmacy skill to use
+	if (nameid == ITEMID_HOMUNCULUS_SUPPLEMENT && pc_checkskill(sd, AM_BIOETHICS) != 0) {
+		ShowError("HOMU SUPPLEMENT ERROR\n");
+		return nullptr;
+	}
 
 	// Cannot carry the produced stuff
-	if (pc_checkadditem(sd, nameid, qty) == CHKADDITEM_OVERAMOUNT)
+	if (pc_checkadditem(sd, nameid, qty) == CHKADDITEM_OVERAMOUNT) {
+		ShowError("NOT ENOUGH SPACE ERROR\n");
 		return nullptr;
+	}
 
-	// Matching the requested produce list
-	if (trigger >= 0) {
-		if (trigger > 20) { // Non-weapon, non-food item (itemlv must match)
-			if (produce->group_id != trigger)
-				return nullptr;
-		} else if (trigger > 10) { // Food (any item level between 10 and 20 will do)
-			if (produce->group_id <= 10 || produce->group_id > 20)
-				return nullptr;
-		} else { // Weapon (itemlv must be higher or equal)
-			if (produce->group_id > trigger)
-				return nullptr;
+	if (trigger > 20) { // Non-weapon, non-food item (itemlv must match)
+		if (produce->group_id != trigger) {
+			ShowError("TRIGGER ERROR > 20\n");
+			return nullptr;
+		}
+	} else if (trigger > 10) { // Food (any item level between 10 and 20 will do)
+		if (produce->group_id <= 10 || produce->group_id > 20) {
+			ShowError("TRIGGER ERROR > 10\n");
+			return nullptr;
+		}
+	} else if (trigger > 0) { // Weapon (itemlv must be higher or equal)
+		if (produce->group_id < trigger) {
+			ShowError("TRIGGER ERROR > 0\n");
+			return nullptr;
 		}
 	}
 
 	// Check on player's inventory
-	for (const auto &it : produce->materials) {
-		if (!item_db.exists(it.first))
-			return nullptr;
-		if (it.second == 0) {
-			if (pc_search_inventory(sd, it.first) < 0)
-				return nullptr;
-		} else {
-			uint16 idx, amt;
+	for (const auto &[mat_id, mat_amt] : produce->materials) {
 
-			for (idx = 0, amt = 0; idx < MAX_INVENTORY; idx++)
-				if (sd->inventory.u.items_inventory[idx].nameid == it.first)
-					amt += sd->inventory.u.items_inventory[idx].amount;
-			if (amt < qty * it.second)
-				return nullptr;
+		if (!item_db.exists(mat_id))
+			return nullptr;
+
+		// ensures player need at least 1 of each even for items with amount = 0 (not consumed)
+		uint16 req_amt = max(1, qty * mat_amt);
+
+		uint16 idx, amt;
+		if ((idx = pc_search_inventory(sd, mat_id)) == -1) {
+			ShowError("MAT NOT FOUND\n");
+			return nullptr;
+		}
+
+		amt = sd->inventory.u.items_inventory[idx].amount;
+		if (amt < req_amt) {
+			ShowError("NOT ENOUGH MATS\n");
+			return nullptr;
 		}
 	}
 
+	ShowInfo("CAN BE PRODUCED pid=%d gid=%d\n", nameid, trigger);
 	return produce;
 }
 
+//FIXME items that call this function directly (holy water, etc) need fixing
+// since the can produce mix called internally do not provide the group_id, which I made required
 /** Attempt to produce an item
  * @param sd Player
  * @param skill_id Skill used
  * @param nameid Requested product
- * @param slot1
- * @param slot2
- * @param slot3
+ * @param slot1 Modifier #1
+ * @param slot2 Modifier #2
+ * @param slot3 Modifier #3
  * @param qty Amount of requested item
- * @param s_skill_produce_db. (Optional. Assumed the requirements are complete, checked somewhere)
+ * @param s_skill_produce_db. Recipe to be produced (optional)
  * @return True is success, False if failed
  */
-bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce) {
+bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, uint16 slot1, uint16 slot2, uint16 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce) {
 
 	ShowInfo("SKILL PRODUCE MIX: skill_id=%d product_id=%d slot1=%d slot2=%d slot3=%d qty=%d\n",
 		skill_id, nameid, slot1, slot2, slot3, qty
 	);
+
+	int i;
 
 	nullpo_ret(sd);
 
@@ -23077,7 +23081,8 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	qty = max(1, qty);
 
 	if (produce == nullptr) {
-		produce = skill_can_produce_mix(sd,nameid,-1, qty);
+		//FIXME is called multiple times, could be improved
+		produce = skill_can_produce_mix(sd, nameid, 0, qty);
 		if( produce == nullptr )
 			return false;
 	}
@@ -23085,54 +23090,40 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	if (!skill_id) // A skill can be specified for some override cases.
 		skill_id = produce->req_skill;
 
-	else if( skill_id == GC_RESEARCHNEWPOISON ) // TODO why? second place this replacement appears
+	else if( skill_id == GC_RESEARCHNEWPOISON ) //FIXME replace old skill
 		skill_id = GC_CREATENEWPOISON;
 
-	int num_required = -1; // exclude the recipe
+	int num_required = -1; //FIXME check uses
+	
+	ShowInfo("CHECK MATERIALS\n");
+	for ( const auto &[mat_id, mat_amt] : produce->materials ) {
 
-	ShowInfo("Check materials\n");
-	// FIXME checking materials? can be improved
-	for ( const auto &it : produce->materials ) {
-		if (!item_db.exists(it.first)) { // should never happen since we are looking at the recipe direcly, and the player MUST have all the ingre
-			ShowInfo("MAT not found: mat_id=%d mat_qty=%d\n", it.first, it.second);
-			continue;
+		// should never happen since we are looking at the recipe direcly, and the player MUST have all items
+		if (!item_db.exists(mat_id)) { 
+			ShowError("skill_produce_mix: material id=%d does not exist\n", mat_id);
+			return false;
 		}
 
-		num_required++;
-		int16 qty_required;
+		// not using max(1, mat_amt) here, because items with amount=0 cannot be consumed
+		int16 amt_required = qty * mat_amt;
+		if (skill_id == RK_RUNEMASTERY) //FIXME check how runes are calling produce
+			amt_required = mat_amt; // ensures runes will always produce 1
 
-		if (skill_id == RK_RUNEMASTERY)
-			qty_required = it.second;
-		else
-			qty_required = static_cast<int16>(qty * it.second);
+		uint16 idx = pc_search_inventory(sd, mat_id);
+		if (idx == -1) {
+			ShowError("skill_produce_mix: material id=%d not found.\n");
+			return false;
+		}
 
-		ShowInfo("skill_id=%d qty_req=%d, qty*qty_req=%d\n", skill_id, qty_required, qty * it.second);
+		// deleting without checking amount, because it was checked before
+		pc_delitem(sd, idx, amt_required, 0, 0, LOG_TYPE_PRODUCE);
 
-		do {
-			int16 index = pc_search_inventory(sd, it.first);
-
-			if (index < 0) {
-				ShowError("skill_produce_mix: material item error.\n");
-				return false;
-			}
-
-			int16 inv_amount = sd->inventory.u.items_inventory[index].amount;
-
-			ShowInfo("inv_amount=%d qty_req=%d\n", inv_amount, qty_required);
-
-			inv_amount = min(inv_amount, qty_required);
-
-			pc_delitem(sd,index,inv_amount,0,0,LOG_TYPE_PRODUCE);
-
-			qty_required -= inv_amount;
-		
-			// why a loop here? amount should have been already checked before
-		} while( qty_required > 0 );
+		num_required++;		
 	}
 
 	int star_crumb = 0, ele = 0, flag = 0;
 
-	std::vector<int32> slots = { slot1, slot2, slot3 };	// TODO int32 to t_itemid ?
+	std::vector<t_itemid> slots = { slot1, slot2, slot3 };
 
 	std::unordered_map<t_itemid, int32> ele_table = {
 		{ ITEMID_FLAME_HEART, ELE_FIRE },
@@ -23198,9 +23189,9 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 		switch (skill_id) {
 			case BS_IRON:
 			case BS_STEEL:
-			case BS_ENCHANTEDSTONE: {
+			case BS_ENCHANTEDSTONE:
 				// Ores & Metals Refining - skill bonuses are straight from kRO website [DracoRPG]
-				int i = pc_checkskill(sd,skill_id);
+				i = pc_checkskill(sd,skill_id);
 				make_per = sd->status.job_level*20 + status->dex*10 + status->luk*10; //Base chance
 				switch (nameid) {
 					case ITEMID_IRON:
@@ -23217,7 +23208,6 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 						break;
 				}
 				break;
-			}
 			case ASC_CDP:
 				make_per = (2000 + 40*status->dex + 20*status->luk);
 				break;
@@ -23319,7 +23309,6 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				make_per = 3000 + 500 * pc_checkskill(sd,GC_RESEARCHNEWPOISON);
 				qty = 1+rnd()%pc_checkskill(sd,GC_RESEARCHNEWPOISON);
 				break;
-
 			case GN_CHANGEMATERIAL:
 				make_per = produce->base_rate * 10;
 				break;
@@ -23438,7 +23427,9 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				make_per = 100000;
 				break;
 			default:
-				if (sd->menuskill_id == AM_PHARMACY && sd->menuskill_val > 10 && sd->menuskill_val <= 20) {	//Assume Cooking Dish
+				if (sd->menuskill_id == AM_PHARMACY &&
+					sd->menuskill_val > 10 && sd->menuskill_val <= 20)
+				{	//Assume Cooking Dish
 					if (sd->menuskill_val >= 15) //Legendary Cooking Set.
 						make_per = 10000; //100% Success
 					else
@@ -23446,7 +23437,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 							+ 20  * (sd->status.base_level + 1)
 							+ 20  * (status->dex + 1)
 							+ 100 * (rnd()%(30+5*(sd->cook_mastery/400) - (6+sd->cook_mastery/80)) + (6+sd->cook_mastery/80))
-							- 400 * (produce->group_id - 11 + 1)	// TODO
+							- 400 * (produce->group_id - 11 + 1)
 							- 10  * (100 - status->luk + 1)
 							- 500 * (num_required - 1)
 							- 100 * (rnd()%4 + 1);
@@ -23460,7 +23451,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	if (sd->class_&JOBL_BABY) //if it's a Baby Class
 		make_per = (make_per * 50) / 100; //Baby penalty is 50% (bugreport:4847)
 
-	ShowInfo("Make chance make_per=%d", make_per);
+	ShowInfo("MAKE CHANCE: %d\n", make_per);
 
 	make_per = max(1, make_per);
 
@@ -23471,24 +23462,14 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 		struct item tmp_item = {0};
 
 		tmp_item.nameid = nameid;
+		tmp_item.amount = 1;
 		tmp_item.identify = 1;
-
 		if (is_equip_type) {
-			tmp_item.amount = 1;
 			tmp_item.card[0] = CARD0_FORGE;
 			tmp_item.card[1] = ((star_crumb*5)<<8)+ele;
 			tmp_item.card[2] = GetWord(sd->status.char_id,0); // CharId
-			tmp_item.card[3] = GetWord(sd->status.char_id,1); // ?
-
-			//		if(log_config.produce > 0)
-			//			log_produce(sd,nameid,slot1,slot2,slot3,1);
-			//TODO update PICKLOG
-			clif_produceeffect(sd,0,nameid);
-			clif_misceffect(*sd,NOTIFYEFFECT_REFINE_SUCCESS);
-			if (weapon_level >= 3 && ((ele > 0 ? 1 : 0) + star_crumb) >= 3) // Fame point system [DracoRPG]
-				pc_addfame(*sd, battle_config.fame_forge); // Success to forge a lv3 weapon with 3 additional ingredients = +10 fame point
-		}
-		else {
+			tmp_item.card[3] = GetWord(sd->status.char_id,1);
+		} else {
 			//Flag is only used on the end, so it can be used here. [Skotlex]
 			switch (skill_id) {
 				case BS_DAGGER:
@@ -23523,52 +23504,57 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				tmp_item.card[2] = GetWord(sd->status.char_id,0); // CharId
 				tmp_item.card[3] = GetWord(sd->status.char_id,1);
 			}
+		}
 
-			//		if(log_config.produce > 0)
-			//			log_produce(sd,nameid,slot1,slot2,slot3,1);
-			//TODO update PICKLOG
+		//		if(log_config.produce > 0)
+		//			log_produce(sd,nameid,slot1,slot2,slot3,1);
+		//TODO update PICKLOG
 
+		if (is_equip_type) {
+			clif_produceeffect(sd,0,nameid);
+			clif_misceffect( *sd, NOTIFYEFFECT_REFINE_SUCCESS );
+			if (weapon_level >= 3 && ((ele ? 1 : 0) + star_crumb) >= 3) // Fame point system [DracoRPG]
+				pc_addfame(*sd, battle_config.fame_forge); // Success to forge a lv3 weapon with 3 additional ingredients = +10 fame point
+		} else {
+			int32 fame = 0;
 			tmp_item.amount = 0;
 
-			if ((skill_id == GN_MIX_COOKING || skill_id == GN_MAKEBOMB || skill_id == GN_S_PHARMACY || skill_id == MT_M_MACHINE || skill_id == BO_BIONIC_PHARMACY) && make_per > 1)
-				tmp_item.amount = qty;
-			else {
-				int fame = 0;
-
-				for (int i = 0; i < qty; i++) {	//Apply quantity modifiers.
-					if (qty == 1 || rnd()%10000 < make_per) { //Success
-						tmp_item.amount++;
-						if (nameid < ITEMID_RED_SLIM_POTION || nameid > ITEMID_WHITE_SLIM_POTION)
-							continue;
-						if (skill_id != AM_PHARMACY &&
-							skill_id != AM_TWILIGHT1 &&
-							skill_id != AM_TWILIGHT2 &&
-							skill_id != AM_TWILIGHT3)
-							continue;
-						//Add fame as needed.
-						switch(++sd->potion_success_counter) {
-							case 3:
-								fame += battle_config.fame_pharmacy_3; // Success to prepare 3 Condensed Potions in a row
-								break;
-							case 5:
-								fame += battle_config.fame_pharmacy_5; // Success to prepare 5 Condensed Potions in a row
-								break;
-							case 7:
-								fame += battle_config.fame_pharmacy_7; // Success to prepare 7 Condensed Potions in a row
-								break;
-							case 10:
-								fame += battle_config.fame_pharmacy_10; // Success to prepare 10 Condensed Potions in a row
-								sd->potion_success_counter = 0;
-								break;
-						}
-					} else //Failure
-						sd->potion_success_counter = 0;
+			for (int i = 0; i < qty; i++) {	//Apply quantity modifiers.
+				if ((skill_id == GN_MIX_COOKING || skill_id == GN_MAKEBOMB || skill_id == GN_S_PHARMACY || skill_id == MT_M_MACHINE || skill_id == BO_BIONIC_PHARMACY) && make_per > 1) {
+					tmp_item.amount = qty;
+					break;
 				}
-
-				if (fame > 0)
-					pc_addfame(*sd, fame);
+				if (qty == 1 || rnd()%10000 < make_per) { //Success
+					tmp_item.amount++;
+					if (nameid < ITEMID_RED_SLIM_POTION || nameid > ITEMID_WHITE_SLIM_POTION)
+						continue;
+					if (skill_id != AM_PHARMACY &&
+						skill_id != AM_TWILIGHT1 &&
+						skill_id != AM_TWILIGHT2 &&
+						skill_id != AM_TWILIGHT3)
+						continue;
+					//Add fame as needed.
+					switch(++sd->potion_success_counter) {
+						case 3:
+							fame += battle_config.fame_pharmacy_3; // Success to prepare 3 Condensed Potions in a row
+							break;
+						case 5:
+							fame += battle_config.fame_pharmacy_5; // Success to prepare 5 Condensed Potions in a row
+							break;
+						case 7:
+							fame += battle_config.fame_pharmacy_7; // Success to prepare 7 Condensed Potions in a row
+							break;
+						case 10:
+							fame += battle_config.fame_pharmacy_10; // Success to prepare 10 Condensed Potions in a row
+							sd->potion_success_counter = 0;
+							break;
+					}
+				} else //Failure
+					sd->potion_success_counter = 0;
 			}
 
+			if (fame)
+				pc_addfame(*sd, fame);
 			//Visual effects and the like.
 			switch (skill_id) {
 				case AM_PHARMACY:
@@ -23595,11 +23581,9 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 			}
 		}
 
-		if (tmp_item.amount > 0) { // Success from first roll (BaseRate)
-			
+		if (skill_id == GN_CHANGEMATERIAL && tmp_item.amount) { //Success 
 			ShowInfo("Deliver Item\n");
-
-			bool is_produce_success = false;
+			int32 j, k = 0, l;
 			bool isStackable = itemdb_isstackable(tmp_item.nameid);
 
 			for ( const auto &qtyit : produce->qty ) {
@@ -23607,52 +23591,53 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 					continue;
 				uint16 total_qty = qty * qtyit.first;
 				tmp_item.amount = (isStackable ? total_qty : 1);
-
 				for ( int32 i = 0; i < total_qty; i += tmp_item.amount ) {
-					e_additem_result flag_item = pc_additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE);
-
-					if (flag_item != ADDITEM_SUCCESS)
+					enum e_additem_result flag = pc_additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE);
+					if (flag != ADDITEM_SUCCESS)
 						continue;
-					clif_additem(sd,0,0,flag_item);
+					clif_additem(sd,0,0,flag);
 					if( battle_config.skill_drop_items_full ){
-						map_addflooritem(&tmp_item,tmp_item.amount,sd->m,sd->x,sd->y,0,0,0,0,0);
+						map_addflooritem(&tmp_item,tmp_item.amount,sd->m,sd->x,sd->y,0,0,0,4,0);
 					}
 				}
-				is_produce_success = true;
+				k++;
 			}
 
-			if (is_produce_success) { // Success from second roll (additional Rate / amount)
-
-				ShowInfo("SECOND ROLL\n");
-
-				switch (skill_id) {
+			if (k) {
+				clif_produceeffect(sd,6,nameid);
+				clif_misceffect( *sd, NOTIFYEFFECT_PHARMACY_SUCCESS );
+				clif_msg_skill( *sd, skill_id, MSI_SKILL_SUCCESS );
+				return true;
+			}
+		} else if (tmp_item.amount) { //Success
+			if ((flag = pc_additem(sd,&tmp_item,tmp_item.amount,LOG_TYPE_PRODUCE))) {
+				clif_additem(sd,0,0,flag);
+				if( battle_config.skill_drop_items_full ){
+					map_addflooritem(&tmp_item,tmp_item.amount,sd->m,sd->x,sd->y,0,0,0,4,0);
+				}
+			}
+			switch (skill_id) {
 					case RK_RUNEMASTERY:
 						clif_produceeffect(sd, 4, nameid);
-						clif_misceffect(*sd, NOTIFYEFFECT_PHARMACY_SUCCESS);
+						clif_misceffect( *sd, NOTIFYEFFECT_PHARMACY_SUCCESS );
 						break;
 					case GN_MIX_COOKING:
 					case GN_MAKEBOMB:
 					case GN_S_PHARMACY:
 						clif_produceeffect(sd, 6, nameid);
-						clif_misceffect(*sd, NOTIFYEFFECT_PHARMACY_SUCCESS);
-						clif_msg_skill(*sd, skill_id, MSI_SKILL_SUCCESS);
+						clif_misceffect( *sd, NOTIFYEFFECT_PHARMACY_SUCCESS );
+						clif_msg_skill( *sd, skill_id, MSI_SKILL_SUCCESS );
 						break;
 					case MT_M_MACHINE:
 						clif_produceeffect(sd, 0, nameid);
-						clif_misceffect(*sd, NOTIFYEFFECT_REFINE_SUCCESS);
-						clif_msg_skill(*sd, skill_id, MSI_SKILL_SUCCESS);
+						clif_misceffect( *sd, NOTIFYEFFECT_REFINE_SUCCESS );
+						clif_msg_skill( *sd, skill_id, MSI_SKILL_SUCCESS );
 						break;
 					case BO_BIONIC_PHARMACY:
 						clif_produceeffect(sd, 2, nameid);
-						clif_misceffect(*sd, NOTIFYEFFECT_PHARMACY_SUCCESS);
-						clif_msg_skill(*sd, skill_id, MSI_SKILL_SUCCESS);
+						clif_misceffect( *sd, NOTIFYEFFECT_PHARMACY_SUCCESS );
+						clif_msg_skill( *sd, skill_id, MSI_SKILL_SUCCESS );
 						break;
-					case GN_CHANGEMATERIAL:
-						clif_produceeffect(sd,6, nameid);
-						clif_misceffect(*sd, NOTIFYEFFECT_PHARMACY_SUCCESS);
-						clif_msg_skill(*sd, skill_id, MSI_SKILL_SUCCESS);
-						break;
-				}
 			}
 			return true;
 		}
@@ -23662,12 +23647,12 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	//	if(log_config.produce)
 	//		log_produce(sd,nameid,slot1,slot2,slot3,0);
 	//TODO update PICKLOG
+
 	if (is_equip_type) {
 		ShowInfo("FAILED A\n");
 		clif_produceeffect(sd,1,nameid);
 		clif_misceffect( *sd, NOTIFYEFFECT_REFINE_FAILURE );
-	}
-	else {
+	} else {
 		ShowInfo("FAILED B\n");
 		switch (skill_id) {
 			case ASC_CDP: //25% Damage yourself, and display same effect as failed potion.
@@ -23696,7 +23681,6 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				if (qty == 0) {
 					int i;
 					struct item tmp_item = {0};
-
 					const t_itemid compensation[5] = { ITEMID_BLACK_LUMP, ITEMID_BLACK_HARD_LUMP, ITEMID_VERY_HARD_LUMP, ITEMID_BLACK_MASS, ITEMID_MYSTERIOUS_POWDER };
 					int32 rate = rnd() % 1000 + 1;
 
@@ -24093,7 +24077,7 @@ int32 skill_changematerial(map_session_data *sd, int32 n, uint16 *item_list) {
 		return 0;
 
 	// Search for objects that can be created.
-	for (const auto &[product_id, recipe] : skill_produce_db) {
+	for (const auto &[_, recipe] : skill_produce_db) {
 
 		if (recipe->group_id != target_group_id)
 			continue;
@@ -26205,8 +26189,42 @@ static bool skill_parse_row_nocastdb( char* split[], size_t columns, size_t curr
 	return true;
 }
 
+/**
+ * Default location for the produce db YAML file
+ * @return string path
+ */
 const std::string SkillProduceDatabase::getDefaultLocation() {
 	return std::string(db_path) + "/produce_db.yml";
+}
+
+/**
+ * Create a unique key composed of Product and Group info
+ * @param product_id Produced Item
+ * @param group_id Recipe Group
+ * @return Unique key
+ */
+uint64 SkillProduceDatabase::makeKey(t_itemid product_id, uint16 group_id) {
+	return (static_cast<uint64>( product_id ) << 32) | static_cast<uint64>( group_id );
+}
+
+/**
+ * Searches for a recipe based on the Product and Group
+ * @param product_id Produced Item
+ * @param group_id Recipe Group (Optional, but faster lookup if provided)
+ * @return s_skill_produce_db if found or nullptr
+ */
+std::shared_ptr<s_skill_produce_db> SkillProduceDatabase::find( t_itemid product_id, uint16 group_id ) {
+
+	if (group_id)
+		return this->find( this->makeKey( product_id, group_id ) );
+
+	// tries a matching key by iterating groups
+	for (uint8 gid = 1; gid < UINT8_MAX; gid++) { //FIXME find a better way to determine the number of groups
+		auto recipe = this->find( this->makeKey(product_id, gid) );
+		if (recipe) return recipe; // returns first match
+	}
+
+	return nullptr;
 }
 
 /** Reads and parses an entry from the produce_db.
@@ -26219,6 +26237,8 @@ uint64 SkillProduceDatabase::parseBodyNode(const ryml::NodeRef &node) {
 		return 0;
 
 	std::string product_name;
+	uint16 group_id;
+
 	if (!this->asString(node, "Product", product_name))
 		return 0;
 
@@ -26228,15 +26248,20 @@ uint64 SkillProduceDatabase::parseBodyNode(const ryml::NodeRef &node) {
 		return 0;
 	}
 
-	std::shared_ptr<s_skill_produce_db> produce = this->find(item->nameid);
+	this->asUInt16(node, "Group", group_id);
+
+	uint64 key = this->makeKey(item->nameid, group_id);
+	ShowDebug("MAKE KEY pdi=%d gid=%d id=%016llx\n", item->nameid, group_id, key);
+
+	std::shared_ptr<s_skill_produce_db> produce = this->find(item->nameid, group_id);
 	bool exists = produce != nullptr;
 
 	if (!exists) {
 		produce = std::make_shared<s_skill_produce_db>();
+		produce->id = key;
 		produce->product_id = item->nameid;
+		produce->group_id = group_id;
 	}
-
-	this->asUInt16(node, "Group", produce->group_id);
 
 	std::unordered_map<t_itemid, uint16> mats;
 	for (const auto& matsNode : node["Consumed"]) {
@@ -26306,9 +26331,27 @@ uint64 SkillProduceDatabase::parseBodyNode(const ryml::NodeRef &node) {
 	}
 
 	if (!exists)
-		this->put(item->nameid, produce);
+		this->put(key, produce);
+
+	// ShowInfo("RECIPE: id=%016llx pid=%d gid=%d skid=%d sklv=%d\n",
+	// 	produce->id,
+	// 	produce->product_id,
+	// 	produce->group_id,
+	// 	produce->req_skill,
+	// 	produce->req_skill_lv
+	// );
 
 	return 1;
+}
+
+std::unordered_map<uint64, std::shared_ptr<s_skill_produce_db>> SkillProduceDatabase::filterByGroup(uint16 group_id) {
+	std::unordered_map<uint64, std::shared_ptr<s_skill_produce_db>> result;
+
+	for (const auto &[key, recipe] : this->data)
+		if (recipe->group_id == group_id)
+			result.emplace(key, recipe);
+
+	return result;
 }
 
 const std::string SkillArrowDatabase::getDefaultLocation() {

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -20779,6 +20779,8 @@ void skill_weaponrefine( map_session_data& sd, int32 idx ){
 #endif
 	};
 
+	ShowInfo("SKILL WEAPONREFINE\n");
+
 	if (idx >= 0 && idx < MAX_INVENTORY)
 	{
 		struct item_data *ditem = sd.inventory_data[idx];
@@ -22956,39 +22958,47 @@ void skill_unit_move_unit_group(std::shared_ptr<s_skill_unit_group> group, int16
 	aFree(m_flag);
 }
 
-/**
- * Checking product requirement in player's inventory.
+/** Checking product requirement in player's inventory.
  * Checking if player has the item or not, the amount, and the weight limit.
  * @param sd Player
  * @param nameid Product requested
- * @param trigger Trigger criteria to match will 'ItemLv'
+ * @param trigger Trigger criteria to match will 'group_id'
  * @param qty Amount of item will be created
- * @return nullptr If failed or s_skill_produce_db_entry on success
+ * @return nullptr If failed or s_skill_produce_db on success
  */
-std::shared_ptr<s_skill_produce_db_entry> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty)
-{
+std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty) {
+
+	ShowInfo("CAN PRODUCE MIX: nameid=%d trigger=%d qty=%d\n", nameid, trigger, qty);
+
 	if (sd == nullptr)
 		return nullptr;
 
 	if (!nameid || !item_db.exists(nameid))
 		return nullptr;
 
-	std::shared_ptr<s_skill_produce_db_entry> produce = nullptr;
+	std::shared_ptr<s_skill_produce_db> produce = nullptr;
 
-	for (const auto &itemlvit : skill_produce_db) {
-		for (const auto &datait : itemlvit.second->data) {
-			if (datait.second->nameid != nameid)
-				continue;
-			if (datait.second->req_skill > 0 && pc_checkskill(sd, datait.second->req_skill) < datait.second->req_skill_lv)
-				continue; // must iterate again to check other skills that produce it. [malufett]
-			if (datait.second->req_skill > 0 && sd->menuskill_id > 0 && sd->menuskill_id != datait.second->req_skill)
-				continue; // special case
-			produce = datait.second;
-			break;
-		}
-		if (produce != nullptr)
-			break;
+	for (const auto &recipes : skill_produce_db) {
+
+		// ShowInfo("B RECIPE: product_id=%d\n", recipes.first);
+
+		if (recipes.second->product_id != nameid)
+			continue;
+
+		if (recipes.second->req_skill > 0 && pc_checkskill(sd, recipes.second->req_skill) < recipes.second->req_skill_lv)
+			continue; // must iterate again to check other skills that produce it. [malufett]
+
+		if (recipes.second->req_skill > 0 && sd->menuskill_id > 0 && sd->menuskill_id != recipes.second->req_skill)
+			continue; // special case
+
+		ShowInfo("FOUND: product_id=%d\n", recipes.first);
+
+		produce = recipes.second;
+		break;
 	}
+	// TODO optimize?
+	// ShowInfo("PRINT CAGADO\n");
+	// ShowInfo("CAN PRODUCE id=%d\n", produce->product_id);
 
 	if (nameid == ITEMID_HOMUNCULUS_SUPPLEMENT) { // Temporary check since the produce_db specifically wants the Pharmacy skill to use
 		if (pc_checkskill(sd, AM_BIOETHICS) == 0)
@@ -23005,17 +23015,16 @@ std::shared_ptr<s_skill_produce_db_entry> skill_can_produce_mix(map_session_data
 	// Matching the requested produce list
 	if (trigger >= 0) {
 		if (trigger > 20) { // Non-weapon, non-food item (itemlv must match)
-			if (produce->itemlv != trigger)
+			if (produce->group_id != trigger)
 				return nullptr;
 		} else if (trigger > 10) { // Food (any item level between 10 and 20 will do)
-			if (produce->itemlv <= 10 || produce->itemlv > 20)
+			if (produce->group_id <= 10 || produce->group_id > 20)
 				return nullptr;
 		} else { // Weapon (itemlv must be higher or equal)
-			if (produce->itemlv > trigger)
+			if (produce->group_id > trigger)
 				return nullptr;
 		}
 	}
-
 
 	// Check on player's inventory
 	for (const auto &it : produce->materials) {
@@ -23038,8 +23047,7 @@ std::shared_ptr<s_skill_produce_db_entry> skill_can_produce_mix(map_session_data
 	return produce;
 }
 
-/**
- * Attempt to produce an item
+/** Attempt to produce an item
  * @param sd Player
  * @param skill_id Skill used
  * @param nameid Requested product
@@ -23047,11 +23055,15 @@ std::shared_ptr<s_skill_produce_db_entry> skill_can_produce_mix(map_session_data
  * @param slot2
  * @param slot3
  * @param qty Amount of requested item
- * @param s_skill_produce_db_entry. (Optional. Assumed the requirements are complete, checked somewhere)
+ * @param s_skill_produce_db. (Optional. Assumed the requirements are complete, checked somewhere)
  * @return True is success, False if failed
  */
-bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db_entry> produce)
-{
+bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce) {
+
+	ShowInfo("SKILL PRODUCE MIX: skill_id=%d product_id=%d slot1=%d slot2=%d slot3=%d qty=%d\n",
+		skill_id, nameid, slot1, slot2, slot3, qty
+	);
+
 	nullpo_ret(sd);
 
 	if (!item_db.exists(nameid))
@@ -23072,14 +23084,19 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 
 	if (!skill_id) // A skill can be specified for some override cases.
 		skill_id = produce->req_skill;
-	else if( skill_id == GC_RESEARCHNEWPOISON )
+
+	else if( skill_id == GC_RESEARCHNEWPOISON ) // TODO why? second place this replacement appears
 		skill_id = GC_CREATENEWPOISON;
 
 	int num_required = -1; // exclude the recipe
 
+	ShowInfo("Check materials\n");
+	// FIXME checking materials? can be improved
 	for ( const auto &it : produce->materials ) {
-		if (!item_db.exists(it.first))
+		if (!item_db.exists(it.first)) { // should never happen since we are looking at the recipe direcly, and the player MUST have all the ingre
+			ShowInfo("MAT not found: mat_id=%d mat_qty=%d\n", it.first, it.second);
 			continue;
+		}
 
 		num_required++;
 		int16 qty_required;
@@ -23088,6 +23105,8 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 			qty_required = it.second;
 		else
 			qty_required = static_cast<int16>(qty * it.second);
+
+		ShowInfo("skill_id=%d qty_req=%d, qty*qty_req=%d\n", skill_id, qty_required, qty * it.second);
 
 		do {
 			int16 index = pc_search_inventory(sd, it.first);
@@ -23098,14 +23117,18 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 			}
 
 			int16 inv_amount = sd->inventory.u.items_inventory[index].amount;
+
+			ShowInfo("inv_amount=%d qty_req=%d\n", inv_amount, qty_required);
+
 			inv_amount = min(inv_amount, qty_required);
 
 			pc_delitem(sd,index,inv_amount,0,0,LOG_TYPE_PRODUCE);
 
 			qty_required -= inv_amount;
+		
+			// why a loop here? amount should have been already checked before
 		} while( qty_required > 0 );
 	}
-
 
 	int star_crumb = 0, ele = 0, flag = 0;
 
@@ -23118,6 +23141,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 		{ ITEMID_GREAT_NATURE, ELE_EARTH },
 	};
 
+	ShowInfo("Check catalysts\n");
 	for ( const auto &it : slots ) {	// Note that qty should always be one if you are using these!
 		if (it <= 0)
 			continue;
@@ -23139,9 +23163,13 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	int make_per = 0;
 	struct status_data *status = status_get_status_data(*sd);
 	
+	ShowInfo("is_equip_type=%d\n", is_equip_type);
 	if (is_equip_type) {	// Weapon Forging - skill bonuses are straight from kRO website, other things from a jRO calculator [DracoRPG]
+
 		make_per = 5000 + ((sd->class_&JOBL_THIRD) ? 1400 : sd->status.job_level*20) + status->dex*10 + status->luk*10; // Base
+
 		make_per += pc_checkskill(sd,skill_id)*500; // Smithing skills bonus: +5/+10/+15
+
 		// Weaponry Research bonus: +1/+2/+3/+4/+5/+6/+7/+8/+9/+10
 		make_per += pc_checkskill(sd,BS_WEAPONRESEARCH)*100;
 		//  Oridecon Research bonus (custom): +1/+2/+3/+4/+5
@@ -23162,6 +23190,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 		else if (pc_search_inventory(sd,ITEMID_GOLDEN_ANVIL) > -1)   make_per+= 500; // Golden Anvil: +5
 		else if (pc_search_inventory(sd,ITEMID_ORIDECON_ANVIL) > -1) make_per+= 300; // Oridecon Anvil: +3
 		else if (pc_search_inventory(sd,ITEMID_ANVIL) > -1)          make_per+= 0; // Anvil: +0?
+
 		if (battle_config.wp_rate != 100)
 			make_per = make_per * battle_config.wp_rate / 100;
 	}
@@ -23290,9 +23319,11 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				make_per = 3000 + 500 * pc_checkskill(sd,GC_RESEARCHNEWPOISON);
 				qty = 1+rnd()%pc_checkskill(sd,GC_RESEARCHNEWPOISON);
 				break;
+
 			case GN_CHANGEMATERIAL:
-				make_per = produce->baserate * 10;
+				make_per = produce->base_rate * 10;
 				break;
+
 			case GN_S_PHARMACY: {
 					int32 difficulty = (620 - 20 * skill_lv); // (620 - 20 * Skill Level)
 					std::vector<int32> production_count = { 7, 8, 8, 9, 9, 10, 10, 11, 11, 12 };
@@ -23415,7 +23446,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 							+ 20  * (sd->status.base_level + 1)
 							+ 20  * (status->dex + 1)
 							+ 100 * (rnd()%(30+5*(sd->cook_mastery/400) - (6+sd->cook_mastery/80)) + (6+sd->cook_mastery/80))
-							- 400 * (produce->itemlv - 11 + 1)	// TODO
+							- 400 * (produce->group_id - 11 + 1)	// TODO
 							- 10  * (100 - status->luk + 1)
 							- 500 * (num_required - 1)
 							- 100 * (rnd()%4 + 1);
@@ -23429,9 +23460,14 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	if (sd->class_&JOBL_BABY) //if it's a Baby Class
 		make_per = (make_per * 50) / 100; //Baby penalty is 50% (bugreport:4847)
 
+	ShowInfo("Make chance make_per=%d", make_per);
+
 	make_per = max(1, make_per);
 
 	if (qty > 1 || rnd()%10000 < make_per){ //Success, or crafting multiple items.
+
+		ShowInfo("SUCCESS\n");
+
 		struct item tmp_item = {0};
 
 		tmp_item.nameid = nameid;
@@ -23442,7 +23478,7 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 			tmp_item.card[0] = CARD0_FORGE;
 			tmp_item.card[1] = ((star_crumb*5)<<8)+ele;
 			tmp_item.card[2] = GetWord(sd->status.char_id,0); // CharId
-			tmp_item.card[3] = GetWord(sd->status.char_id,1);
+			tmp_item.card[3] = GetWord(sd->status.char_id,1); // ?
 
 			//		if(log_config.produce > 0)
 			//			log_produce(sd,nameid,slot1,slot2,slot3,1);
@@ -23551,15 +23587,18 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 					clif_misceffect( *sd, NOTIFYEFFECT_REFINE_SUCCESS );
 					break;
 				default: //Those that don't require a skill?
-					if (produce->itemlv > 10 && produce->itemlv <= 20) { //Cooking items.
+					if (produce->group_id > 10 && produce->group_id <= 20) { //Cooking items.
 						clif_specialeffect(sd, EF_COOKING_OK, AREA);
-						pc_setparam(sd, SP_COOKMASTERY, sd->cook_mastery + ( 1 << ( (produce->itemlv - 11) / 2 ) ) * 5);
+						pc_setparam(sd, SP_COOKMASTERY, sd->cook_mastery + ( 1 << ( (produce->group_id - 11) / 2 ) ) * 5);
 					}
 					break;
 			}
 		}
 
 		if (tmp_item.amount > 0) { // Success from first roll (BaseRate)
+			
+			ShowInfo("Deliver Item\n");
+
 			bool is_produce_success = false;
 			bool isStackable = itemdb_isstackable(tmp_item.nameid);
 
@@ -23583,6 +23622,9 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 			}
 
 			if (is_produce_success) { // Success from second roll (additional Rate / amount)
+
+				ShowInfo("SECOND ROLL\n");
+
 				switch (skill_id) {
 					case RK_RUNEMASTERY:
 						clif_produceeffect(sd, 4, nameid);
@@ -23611,8 +23653,8 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 						clif_msg_skill(*sd, skill_id, MSI_SKILL_SUCCESS);
 						break;
 				}
-				return true;
 			}
+			return true;
 		}
 	}
 
@@ -23620,12 +23662,13 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 	//	if(log_config.produce)
 	//		log_produce(sd,nameid,slot1,slot2,slot3,0);
 	//TODO update PICKLOG
-
 	if (is_equip_type) {
+		ShowInfo("FAILED A\n");
 		clif_produceeffect(sd,1,nameid);
 		clif_misceffect( *sd, NOTIFYEFFECT_REFINE_FAILURE );
 	}
 	else {
+		ShowInfo("FAILED B\n");
 		switch (skill_id) {
 			case ASC_CDP: //25% Damage yourself, and display same effect as failed potion.
 				status_percent_damage(nullptr, sd, -25, 0, true);
@@ -23700,10 +23743,10 @@ bool skill_produce_mix(map_session_data *sd, uint16 skill_id, t_itemid nameid, i
 				clif_msg_skill( *sd, skill_id, MSI_SKILL_FAIL );
 				break;
 			default:
-				if (produce->itemlv > 10 && produce->itemlv <= 20 ) { //Cooking items.
+				if (produce->group_id > 10 && produce->group_id <= 20 ) { //Cooking items.
 					clif_specialeffect(sd, EF_COOKING_FAIL, AREA);
 					// todo: What in the world is this calculation
-					pc_setparam(sd, SP_COOKMASTERY, sd->cook_mastery - ( 1 << ((produce->itemlv - 11) / 2) ) - ( ( ( 1 << ((produce->itemlv - 11) / 2) ) >> 1 ) * 3 ));
+					pc_setparam(sd, SP_COOKMASTERY, sd->cook_mastery - ( 1 << ((produce->group_id - 11) / 2) ) - ( ( ( 1 << ((produce->group_id - 11) / 2) ) >> 1 ) * 3 ));
 				}
 				break;
 		}
@@ -24036,31 +24079,36 @@ int32 skill_elementalanalysis( map_session_data& sd, int32 n, uint16 skill_lv, u
 }
 
 int32 skill_changematerial(map_session_data *sd, int32 n, uint16 *item_list) {
+
+	ShowInfo("SKILL CHANGEMATERIAL\n");
+
 	int32 k, c, qty = 0, amount;
 	t_itemid nameid;
 
 	nullpo_ret(sd);
 	nullpo_ret(item_list);
 
-	uint16 item_lv = 26;
-	std::shared_ptr<s_skill_produce_db> produce = skill_produce_db.find(item_lv);
-	if (produce == nullptr || produce->data.empty())
+	uint16 target_group_id = 26;
+	if (skill_produce_db.empty())
 		return 0;
 
 	// Search for objects that can be created.
-	for (const auto &datait : produce->data) {
-		std::shared_ptr<s_skill_produce_db_entry> data = datait.second;
+	for (const auto &[product_id, recipe] : skill_produce_db) {
 
-		if (!item_db.exists(data->nameid))
+		if (recipe->group_id != target_group_id)
+			continue;
+
+		if (!item_db.exists(recipe->product_id))
 			return 0;
-		if (data->materials.empty())
+
+		if (recipe->materials.empty())
 			return 0;
 
 		qty = 0;
 		do {
 			c = 0;
 			// Verification of overlap between the objects required and the list submitted.
-			for (const auto &mat : data->materials) {
+			for (const auto &mat : recipe->materials) {
 				for( k = 0; k < n; k++ ) {
 					int idx = item_list[k*2]-2;
 
@@ -24079,10 +24127,10 @@ int32 skill_changematerial(map_session_data *sd, int32 n, uint16 *item_list) {
 				}
 			}
 			qty++;
-		} while(n == data->materials.size() && c == n);
+		} while(n == recipe->materials.size() && c == n);
 		qty--;
 		if ( qty > 0 ) {
-			skill_produce_mix(sd,GN_CHANGEMATERIAL,datait.second->nameid,0,0,0,qty, datait.second);
+			skill_produce_mix(sd,GN_CHANGEMATERIAL,recipe->product_id,0,0,0,qty,recipe);
 			return 1;
 		}
 	}

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -448,6 +448,7 @@ enum e_dance_overlap : int32 {
 
 /// Create Database item
 struct s_skill_produce_db {
+	uint64 id;				/// Unique ID
 	t_itemid product_id; 	/// Product ID
 	uint16 group_id;		/// Group ID
 	uint16 req_skill; 		/// Required Skill
@@ -458,14 +459,18 @@ struct s_skill_produce_db {
 	std::unordered_map<uint16, uint16> qty;			/// amount, rate
 };
 
-class SkillProduceDatabase : public TypesafeYamlDatabase<t_itemid, s_skill_produce_db> {
+class SkillProduceDatabase : public TypesafeYamlDatabase<uint64, s_skill_produce_db> {
+protected:
+	uint64 makeKey(t_itemid product_id, uint16 group_id);
 public:
-	SkillProduceDatabase() : TypesafeYamlDatabase("PRODUCE_DB", 1) {
-
-	}
+	SkillProduceDatabase() : TypesafeYamlDatabase("PRODUCE_DB", 1) {}
 
 	const std::string getDefaultLocation() override;
 	uint64 parseBodyNode(const ryml::NodeRef& node) override;
+
+	using TypesafeYamlDatabase::find; // to avoid errors with overloading
+	std::shared_ptr<s_skill_produce_db> find( t_itemid product_id, uint16 group_id );
+	std::unordered_map<uint64, std::shared_ptr<s_skill_produce_db>> filterByGroup(uint16 group_id);
 };
 
 extern SkillProduceDatabase skill_produce_db;
@@ -643,8 +648,8 @@ bool skill_isNotOk_mercenary( uint16 skill_id, s_mercenary_data& md);
 bool skill_isNotOk_npcRange(struct block_list *src, uint16 skill_id, uint16 skill_lv, int32 pos_x, int32 pos_y);
 
 // Item creation
-std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty);
-bool skill_produce_mix( map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce = nullptr );
+std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, uint16 trigger, int32 qty);
+bool skill_produce_mix( map_session_data *sd, uint16 skill_id, t_itemid nameid, uint16 slot1, uint16 slot2, uint16 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce = nullptr );
 
 bool skill_arrow_create( map_session_data *sd, t_itemid nameid);
 

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -448,25 +448,38 @@ enum e_dance_overlap : int32 {
 
 /// Create Database item
 struct s_skill_produce_db_entry {
-	t_itemid nameid; /// Product ID
-	uint16 req_skill; /// Required Skill
-	uint16 req_skill_lv, /// Required Skill Level
-		itemlv; /// Item Level
-	std::unordered_map<t_itemid, uint16> materials;
+	t_itemid nameid; //FIXME compatibility
+	uint16 itemlv; //FIXME compatibility
+	uint16 baserate; //FIXME compatibility
 
-	// additional rates/quantity data for skill_changematerial 
-	uint16 baserate;
-	std::unordered_map<uint16, uint16> qty;
+	t_itemid product_id; 	/// Product ID
+	uint16 req_skill; 		/// Required Skill
+	uint8 req_skill_lv; 	/// Required Skill Level
+	std::unordered_map<t_itemid, uint16> materials; /// item_id, amount
+
+	// additional rates/quantity data for skill_changematerial
+	uint16 base_rate;
+	std::unordered_map<uint16, uint16> qty; /// amount, rate
 };
 
 struct s_skill_produce_db {
-	uint16 itemlv; /// Item Level
-	std::unordered_map<t_itemid, std::shared_ptr<s_skill_produce_db_entry>> data;	/// item, entry
+	uint16 itemlv; //FIXME compatibility
+	std::unordered_map<t_itemid, std::shared_ptr<s_skill_produce_db_entry>> data; /// item_id, entry //FIXME compatibility
+
+	t_itemid product_id; 	/// Product ID
+	uint16 group_id;		/// Group ID
+	uint16 req_skill; 		/// Required Skill
+	uint8 req_skill_lv; 	/// Required Skill Level
+	std::unordered_map<t_itemid, uint16> materials; /// item_id, amount
+
+	// additional rates/quantity data for skill_changematerial
+	uint16 base_rate;
+	std::unordered_map<uint16, uint16> qty; /// amount, rate
 };
 
 class SkillProduceDatabase : public TypesafeYamlDatabase<uint16, s_skill_produce_db> {
 private:
-	uint16 total_id = 0;
+	uint16 total_id = 0; //FIXME needed?
 
 public:
 	SkillProduceDatabase() : TypesafeYamlDatabase("PRODUCE_DB", 1) {
@@ -474,7 +487,10 @@ public:
 	}
 
 	const std::string getDefaultLocation() override;
+
 	uint64 parseBodyNode(const ryml::NodeRef& node) override;
+	uint64 parseRecipesNode(const ryml::NodeRef& node, uint16 group_id);
+
 	bool addItemConsumed(const ryml::NodeRef& node, std::shared_ptr<s_skill_produce_db_entry> &entry, bool isConsumed);
 	void loadingFinished() override;
 };

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -447,52 +447,25 @@ enum e_dance_overlap : int32 {
 };
 
 /// Create Database item
-struct s_skill_produce_db_entry {
-	t_itemid nameid; //FIXME compatibility
-	uint16 itemlv; //FIXME compatibility
-	uint16 baserate; //FIXME compatibility
-
-	t_itemid product_id; 	/// Product ID
-	uint16 req_skill; 		/// Required Skill
-	uint8 req_skill_lv; 	/// Required Skill Level
-	std::unordered_map<t_itemid, uint16> materials; /// item_id, amount
-
-	// additional rates/quantity data for skill_changematerial
-	uint16 base_rate;
-	std::unordered_map<uint16, uint16> qty; /// amount, rate
-};
-
 struct s_skill_produce_db {
-	uint16 itemlv; //FIXME compatibility
-	std::unordered_map<t_itemid, std::shared_ptr<s_skill_produce_db_entry>> data; /// item_id, entry //FIXME compatibility
-
 	t_itemid product_id; 	/// Product ID
 	uint16 group_id;		/// Group ID
 	uint16 req_skill; 		/// Required Skill
 	uint8 req_skill_lv; 	/// Required Skill Level
-	std::unordered_map<t_itemid, uint16> materials; /// item_id, amount
+	std::unordered_map<t_itemid, uint16> materials;	/// item_id, amount
 
-	// additional rates/quantity data for skill_changematerial
-	uint16 base_rate;
-	std::unordered_map<uint16, uint16> qty; /// amount, rate
+	uint16 base_rate;		/// Base Rate for change material
+	std::unordered_map<uint16, uint16> qty;			/// amount, rate
 };
 
-class SkillProduceDatabase : public TypesafeYamlDatabase<uint16, s_skill_produce_db> {
-private:
-	uint16 total_id = 0; //FIXME needed?
-
+class SkillProduceDatabase : public TypesafeYamlDatabase<t_itemid, s_skill_produce_db> {
 public:
 	SkillProduceDatabase() : TypesafeYamlDatabase("PRODUCE_DB", 1) {
 
 	}
 
 	const std::string getDefaultLocation() override;
-
 	uint64 parseBodyNode(const ryml::NodeRef& node) override;
-	uint64 parseRecipesNode(const ryml::NodeRef& node, uint16 group_id);
-
-	bool addItemConsumed(const ryml::NodeRef& node, std::shared_ptr<s_skill_produce_db_entry> &entry, bool isConsumed);
-	void loadingFinished() override;
 };
 
 extern SkillProduceDatabase skill_produce_db;
@@ -670,8 +643,8 @@ bool skill_isNotOk_mercenary( uint16 skill_id, s_mercenary_data& md);
 bool skill_isNotOk_npcRange(struct block_list *src, uint16 skill_id, uint16 skill_lv, int32 pos_x, int32 pos_y);
 
 // Item creation
-std::shared_ptr<s_skill_produce_db_entry> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty);
-bool skill_produce_mix( map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db_entry> produce = nullptr );
+std::shared_ptr<s_skill_produce_db> skill_can_produce_mix(map_session_data *sd, t_itemid nameid, int32 trigger, int32 qty);
+bool skill_produce_mix( map_session_data *sd, uint16 skill_id, t_itemid nameid, int32 slot1, int32 slot2, int32 slot3, int32 qty, std::shared_ptr<s_skill_produce_db> produce = nullptr );
 
 bool skill_arrow_create( map_session_data *sd, t_itemid nameid);
 


### PR DESCRIPTION
* **Addressed Issue(s)**: 
  - #7768
  - #8126

* **Server Mode**: 
  - Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

# **Description of Pull Request**:

Current state of the code requires testing the recipes in game. Also, I left a bunch of debug and info messages to help me track the errors. Once I am confident the code is working fine, I'll do a clean-up.

## Changes
- Convert the Produce and Changematerial DB to YAML.
- Refactor the produce workflow to work with new class-based DB.
- Overall improvements on storing and searching for recipes. 

Continuing the work started in the other PR. I propose a different structure for the YAML recipes.

```yaml
- Product
  Group
  SkillName
  SkillLevel
  Consumed:
    - Item
      Amount
  NotConsumed:
    - Item
  BaseRate
  Make:
    - Amount
      Rate
```

Required:
- Product: Aegis name of the produced item
- Group: Number which determines what kind of crafting it is
- Consumed: List of Item/Amount required (as we don't have "empty" crafts)

Optional:
- SkillName: Required skill. Defaults to empty for crafts like cooking.
- SkillLevel: Required skill level. Defaults to 1 if not specified
- NotConsumed: For items like guides which are not consumed.
- BaseRate: Used for GN_CHANGEMATERIAL skill, which can produce a variable amount of the product
- Make: List of Amount/Rate if recipe produces an item with variable amounts

