### PR TITLE
Provoke by Non-PC / Demon Bane

### DIFF
--- a/doc/mob_skill_db_powerskill.txt
+++ b/doc/mob_skill_db_powerskill.txt
@@ -21,6 +21,7 @@ If it can't determine a trend it will fill with the last level defined.
 -------------------------------------------------------------------------------
 Skill | rAthena Lv | Explanation
 -------------------------------------------------------------------------------
+6,SM_PROVOKE          |10| Reduces DEF by 100%. No ATK bonus.
 7,SM_MAGNUM           |25| 9x9 AoE. 600% damage at all ranges.
 15,MG_FROSTDIVER      |40| 500% damage. 100% base chance.
 17,MG_FIREBALL        |43| 7x7 AoE. 1000% damage. (In pre-re, level is 93.)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2279,7 +2279,7 @@ int64 battle_addmastery(map_session_data *sd,struct block_list *target,int64 dmg
 	if((skill = pc_checkskill(sd,AL_DEMONBANE)) > 0 &&
 		target->type == BL_MOB && //This bonus doesn't work against players.
 		(battle_check_undead(status->race,status->def_ele) || status->race == RC_DEMON) )
-		damage += (skill*(int32)(3+(sd->status.base_level+1)*0.05));	// submitted by orn
+		damage += static_cast<int64>(skill * (sd->status.base_level / 20.0 + 3.0));
 	if( (skill = pc_checkskill(sd, RA_RANGERMAIN)) > 0 && (status->race == RC_BRUTE || status->race == RC_PLAYER_DORAM || status->race == RC_PLANT || status->race == RC_FISH) )
 		damage += (skill * 5);
 	if( (skill = pc_checkskill(sd,NC_RESEARCHFE)) > 0 && (status->def_ele == ELE_FIRE || status->def_ele == ELE_EARTH) )

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2279,7 +2279,7 @@ int64 battle_addmastery(map_session_data *sd,struct block_list *target,int64 dmg
 	if((skill = pc_checkskill(sd,AL_DEMONBANE)) > 0 &&
 		target->type == BL_MOB && //This bonus doesn't work against players.
 		(battle_check_undead(status->race,status->def_ele) || status->race == RC_DEMON) )
-		damage += static_cast<int64>(skill * (sd->status.base_level / 20.0 + 3.0));
+		damage += static_cast<decltype(damage)>(skill * (sd->status.base_level / 20.0 + 3.0));
 	if( (skill = pc_checkskill(sd, RA_RANGERMAIN)) > 0 && (status->race == RC_BRUTE || status->race == RC_PLAYER_DORAM || status->race == RC_PLANT || status->race == RC_FISH) )
 		damage += (skill * 5);
 	if( (skill = pc_checkskill(sd,NC_RESEARCHFE)) > 0 && (status->def_ele == ELE_FIRE || status->def_ele == ELE_EARTH) )

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -11649,8 +11649,14 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 			val3 = 5*val1; // Def2 reduction
 			break;
 		case SC_PROVOKE:
-			val2 = 2+3*val1; // Atk increase
-			val3 = 5+5*val1; // Def reduction.
+			if (src->type != BL_PC && val1 == 10) {
+				val2 = 0; // 0% Atk increase
+				val3 = 100; // 100% Def reduction
+			}
+			else {
+				val2 = 2 + 3 * val1; // Atk increase
+				val3 = 5 + 5 * val1; // Def reduction
+			}
 			// val4 signals autoprovoke.
 			break;
 		case SC_AVOID:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9469 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- When a non-PC uses level 10 Provoke, it now reduces DEF by 100% and does not increase damage
- Fixed small rounding issue with Demon Bane
- Fixes #9469

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
