### PR TITLE
Added a destructor to StringBuf

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -517,7 +517,7 @@ int32 char_mmo_char_tosql(uint32 char_id, struct mmo_charstatus* p){
 			strcat(save_status, " hotkeys");
 	}
 #endif
-	StringBuf_Destroy(&buf);
+
 	if (save_status[0]!='\0' && charserv_config.save_log)
 		ShowInfo("Saved char %d - %s:%s.\n", char_id, p->name, save_status);
 
@@ -589,7 +589,6 @@ int32 char_memitemdata_to_sql(const struct item items[], int32 max, int32 id, en
 	||  SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		return 1;
 	}
 
@@ -736,7 +735,6 @@ int32 char_memitemdata_to_sql(const struct item items[], int32 max, int32 id, en
 	}
 
 	ShowInfo("Saved %s (%d) data to table %s for %s: %d\n", printname, stor_id, tablename, selectoption, id);
-	StringBuf_Destroy(&buf);
 	aFree(flag);
 
 	return errors;
@@ -810,7 +808,6 @@ bool char_memitemdata_from_sql(struct s_storage* p, int32 max, int32 id, enum st
 		||	SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		return false;
 	}
 
@@ -842,8 +839,6 @@ bool char_memitemdata_from_sql(struct s_storage* p, int32 max, int32 id, enum st
 
 	p->amount = i;
 	ShowInfo("Loaded %s data from table %s for %s: %d (total: %d)\n", printname, tablename, selectoption, id, p->amount);
-
-	StringBuf_Destroy(&buf);
 
 	return true;
 }
@@ -1136,7 +1131,6 @@ int32 char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_
 
 	if (!load_everything) // For quick selection of data when displaying the char menu
 	{
-		StringBuf_Destroy(&msg_buf);
 		return 1;
 	}
 
@@ -1233,7 +1227,6 @@ int32 char_mmo_char_fromsql(uint32 char_id, struct mmo_charstatus* p, bool load_
 
 	memcpy( cp.get(), p, sizeof( struct mmo_charstatus ) );
 
-	StringBuf_Destroy(&msg_buf);
 	return 1;
 }
 

--- a/src/char/char_mapif.cpp
+++ b/src/char/char_mapif.cpp
@@ -532,7 +532,6 @@ int32 chmapif_parse_req_saveskillcooldown(int32 fd){
 			}
 			if( SQL_ERROR == Sql_QueryStr(sql_handle, StringBuf_Value(&buf)) )
 				Sql_ShowDebug(sql_handle);
-			StringBuf_Destroy(&buf);
 		}
 		RFIFOSKIP(fd, RFIFOW(fd, 2));
 	}
@@ -977,7 +976,6 @@ int32 chmapif_parse_save_scdata(int32 fd){
 			}
 			if( SQL_ERROR == Sql_QueryStr(sql_handle, StringBuf_Value(&buf)) )
 				Sql_ShowDebug(sql_handle);
-			StringBuf_Destroy(&buf);
 		}
 #endif
 		RFIFOSKIP(fd, RFIFOW(fd, 2));
@@ -1371,7 +1369,6 @@ int32 chmapif_bonus_script_save(int32 fd) {
 			if (SQL_ERROR == Sql_QueryStr(sql_handle,StringBuf_Value(&buf)))
 				Sql_ShowDebug(sql_handle);
 
-			StringBuf_Destroy(&buf);
 			ShowInfo("Bonus Script saved for CID=%d. Total: %d.\n", cid, count);
 		}
 		RFIFOSKIP(fd,RFIFOW(fd,2));

--- a/src/char/int_achievement.cpp
+++ b/src/char/int_achievement.cpp
@@ -48,7 +48,6 @@ struct achievement *mapif_achievements_fromsql(uint32 char_id, int32 *count)
 	||  SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		*count = 0;
 		return nullptr;
 	}
@@ -75,8 +74,6 @@ struct achievement *mapif_achievements_fromsql(uint32 char_id, int32 *count)
 			achievelog = (struct achievement *)aRealloc(achievelog, sizeof(struct achievement) * i);
 		}
 	}
-
-	StringBuf_Destroy(&buf);
 
 	ShowInfo("achievement load complete from DB - id: %d (total: %d)\n", char_id, *count);
 
@@ -139,11 +136,8 @@ bool mapif_achievement_add(uint32 char_id, struct achievement* ad)
 
 	if (SQL_ERROR == Sql_QueryStr(sql_handle, StringBuf_Value(&buf))) {
 		Sql_ShowDebug(sql_handle);
-		StringBuf_Destroy(&buf);
 		return false;
 	}
-
-	StringBuf_Destroy(&buf);
 
 	return true;
 }
@@ -177,11 +171,8 @@ bool mapif_achievement_update(uint32 char_id, struct achievement* ad)
 
 	if (SQL_ERROR == Sql_QueryStr(sql_handle, StringBuf_Value(&buf))) {
 		Sql_ShowDebug(sql_handle);
-		StringBuf_Destroy(&buf);
 		return false;
 	}
-
-	StringBuf_Destroy(&buf);
 
 	return true;
 }

--- a/src/char/int_auction.cpp
+++ b/src/char/int_auction.cpp
@@ -74,8 +74,6 @@ void auction_save( std::shared_ptr<struct auction_data> auction ){
 	{
 		SqlStmt_ShowDebug(stmt);
 	}
-
-	StringBuf_Destroy(&buf);
 }
 
 uint32 auction_create( std::shared_ptr<struct auction_data> auction ){
@@ -131,8 +129,6 @@ uint32 auction_create( std::shared_ptr<struct auction_data> auction ){
 
 		auction_db[auction->auction_id] = auction;
 	}
-
-	StringBuf_Destroy(&buf);
 
 	return auction->auction_id;
 }
@@ -203,8 +199,6 @@ void inter_auctions_fromsql(void)
 
 	if( SQL_ERROR == Sql_Query(sql_handle, StringBuf_Value(&buf)) )
 		Sql_ShowDebug(sql_handle);
-
-	StringBuf_Destroy(&buf);
 
 	while( SQL_SUCCESS == Sql_NextRow(sql_handle) )
 	{

--- a/src/char/int_guild.cpp
+++ b/src/char/int_guild.cpp
@@ -226,7 +226,6 @@ int32 inter_guild_tosql( mmo_guild &g, int32 flag ){
 		StringBuf_Printf(&buf, " WHERE `guild_id`=%d", g.guild_id);
 		if( SQL_ERROR == Sql_Query(sql_handle, "%s", StringBuf_Value(&buf)) )
 			Sql_ShowDebug(sql_handle);
-		StringBuf_Destroy(&buf);
 	}
 
 	if (flag&GS_MEMBER)
@@ -580,7 +579,6 @@ int32 inter_guildcastle_tosql( std::shared_ptr<struct guild_castle> gc ){
 	else if(charserv_config.save_log)
 		ShowInfo("Saved guild castle (%d)\n", gc->castle_id);
 
-	StringBuf_Destroy(&buf);
 	return 0;
 }
 
@@ -604,10 +602,8 @@ std::shared_ptr<struct guild_castle> inter_guildcastle_fromsql( int32 castle_id 
 	StringBuf_Printf(&buf, " FROM `%s` WHERE `castle_id`='%d'", schema_config.guild_castle_db, castle_id);
 	if (SQL_ERROR == Sql_Query(sql_handle, StringBuf_Value(&buf))) {
 		Sql_ShowDebug(sql_handle);
-		StringBuf_Destroy(&buf);
 		return nullptr;
 	}
-	StringBuf_Destroy(&buf);
 
 	gc = std::make_shared<struct guild_castle>();
 

--- a/src/char/int_mail.cpp
+++ b/src/char/int_mail.cpp
@@ -106,7 +106,6 @@ int32 mail_savemessage(struct mail_message* msg)
 	||  SQL_SUCCESS != stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		Sql_QueryStr( sql_handle, "ROLLBACK" );
 		return msg->id = 0;
 	} else
@@ -150,8 +149,6 @@ int32 mail_savemessage(struct mail_message* msg)
 		msg->id = 0;
 		Sql_QueryStr( sql_handle, "ROLLBACK" );
 	}
-
-	StringBuf_Destroy(&buf);
 
 	if( msg->id && SQL_ERROR == Sql_QueryStr( sql_handle, "COMMIT" ) ){
 		Sql_ShowDebug( sql_handle );
@@ -215,7 +212,6 @@ bool mail_loadmessage(int32 mail_id, struct mail_message* msg)
 	if( SQL_ERROR == Sql_Query(sql_handle, StringBuf_Value(&buf)) ){
 		Sql_ShowDebug(sql_handle);
 		Sql_FreeResult(sql_handle);
-		StringBuf_Destroy(&buf);
 		return false;
 	}
 
@@ -243,7 +239,6 @@ bool mail_loadmessage(int32 mail_id, struct mail_message* msg)
 		}
 	}
 
-	StringBuf_Destroy(&buf);
 	Sql_FreeResult(sql_handle);
 
 	return true;

--- a/src/char/int_storage.cpp
+++ b/src/char/int_storage.cpp
@@ -346,7 +346,6 @@ bool mapif_parse_itembound_retrieve(int32 fd)
 		SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		mapif_itembound_ack(fd,account_id,guild_id);
 		return true;
 	}
@@ -376,7 +375,6 @@ bool mapif_parse_itembound_retrieve(int32 fd)
 
 	ShowInfo("Found '" CL_WHITE "%d" CL_RESET "' guild bound item(s) from CID = " CL_WHITE "%d" CL_RESET ", AID = %d, Guild ID = " CL_WHITE "%d" CL_RESET ".\n", count, char_id, account_id, guild_id);
 	if (!count) { //No items found - No need to continue
-		StringBuf_Destroy(&buf);
 		mapif_itembound_ack(fd,account_id,guild_id);
 		return true;
 	}
@@ -390,7 +388,6 @@ bool mapif_parse_itembound_retrieve(int32 fd)
 		SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 		mapif_itembound_ack(fd,account_id,guild_id);
 		return true;
 	}
@@ -434,15 +431,10 @@ bool mapif_parse_itembound_retrieve(int32 fd)
 			SQL_ERROR == stmt.Execute() )
 		{
 			SqlStmt_ShowDebug(stmt);
-			StringBuf_Destroy(&buf);
-			StringBuf_Destroy(&buf2);
 			mapif_itembound_ack(fd,account_id,guild_id);
 			return true;
 		}
-		StringBuf_Destroy(&buf2);
 	}
-
-	StringBuf_Destroy(&buf);
 
 	char_unset_session_flag(account_id, 1);
 	return false;

--- a/src/common/showmsg.cpp
+++ b/src/common/showmsg.cpp
@@ -857,7 +857,6 @@ void ShowConfigWarning(config_setting_t *config, const char *string, ...)
 	va_start(ap, string);
 	_vShowMessage(MSG_WARNING, StringBuf_Value(&buf), ap);
 	va_end(ap);
-	StringBuf_Destroy(&buf);
 }
 void ShowDebug(const char *string, ...) {
 	va_list ap;

--- a/src/common/sql.cpp
+++ b/src/common/sql.cpp
@@ -433,7 +433,7 @@ void Sql_Free(Sql* self)
 	if( self )
 	{
 		Sql_FreeResult(self);
-		StringBuf_Destroy(&self->buf);
+		self->buf.~StringBuf();
 		if( self->keepalive != INVALID_TIMER ) delete_timer(self->keepalive, Sql_P_KeepaliveTimer);
 		Sql_Close(self);
 		aFree(self);
@@ -934,7 +934,6 @@ void SqlStmt::ShowDebug_(const char* debug_file, const unsigned long debug_line)
 /// Frees a SqlStmt.
 SqlStmt::~SqlStmt(){
 	this->FreeResult();
-	StringBuf_Destroy( &this->buf );
 	if( this->stmt != nullptr ){
 		mysql_stmt_close( this->stmt );
 		this->stmt = nullptr;

--- a/src/common/strlib.cpp
+++ b/src/common/strlib.cpp
@@ -978,6 +978,7 @@ StringBuf* _StringBuf_Malloc(const char *file, int32 line, const char *func)
 {
 	StringBuf* self;
 	self = (StringBuf *)aCalloc2(1, sizeof(StringBuf), file, line, func);
+	new (self) StringBuf();
 	_StringBuf_Init(file, line, func, self);
 	return self;
 }
@@ -1082,16 +1083,23 @@ void StringBuf_Clear(StringBuf* self)
 }
 
 /// Destroys the StringBuf
-void StringBuf_Destroy(StringBuf* self)
-{
-	aFree(self->buf_);
-	self->ptr_ = self->buf_ = 0;
-	self->max_ = 0;
+StringBuf::~StringBuf(){
+	if( this->buf_ != nullptr ){
+		aFree( this->buf_ );
+		this->buf_ = nullptr;
+	}
+	
+	this->ptr_ = nullptr;
+	this->max_ = 0;
 }
 
 // Frees a StringBuf returned by StringBuf_Malloc
 void StringBuf_Free(StringBuf* self)
 {
-	StringBuf_Destroy(self);
+	if( self == nullptr ){
+		return;
+	}
+
+	self->~StringBuf();
 	aFree(self);
 }

--- a/src/common/strlib.hpp
+++ b/src/common/strlib.hpp
@@ -140,8 +140,9 @@ struct StringBuf
 	char *buf_;
 	char *ptr_;
 	size_t max_;
+
+	~StringBuf();
 };
-typedef struct StringBuf StringBuf;
 
 StringBuf* _StringBuf_Malloc(const char *file, int32 line, const char *func);
 #define StringBuf_Malloc() _StringBuf_Malloc(ALC_MARK)
@@ -158,7 +159,6 @@ size_t _StringBuf_AppendStr(const char *file, int32 line, const char *func, Stri
 int32 StringBuf_Length(StringBuf* self);
 char* StringBuf_Value(StringBuf* self);
 void StringBuf_Clear(StringBuf* self);
-void StringBuf_Destroy(StringBuf* self);
 void StringBuf_Free(StringBuf* self);
 
 #endif /* STRLIB_HPP */

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -853,7 +853,6 @@ ACMD_FUNC(who) {
 			StringBuf_Printf(&buf, msg_txt(sd,56), count, mapdata->name); // %d players found in map '%s'.
 	}
 	clif_displaymessage(fd, StringBuf_Value(&buf));
-	StringBuf_Destroy(&buf);
 	return 0;
 }
 
@@ -1843,7 +1842,6 @@ ACMD_FUNC(help){
 
 		if (has_aliases)
 			clif_displaymessage(fd, StringBuf_Value(&buf));
-		StringBuf_Destroy(&buf);
 	}
 
 	// Display help contents
@@ -9743,8 +9741,6 @@ ACMD_FUNC(itemlist)
 		StringBuf_Printf(&buf, msg_txt(sd,1354), counter, count, location); // %d item(s) found in %d %s slots.
 
 	clif_displaymessage(fd, StringBuf_Value(&buf));
-
-	StringBuf_Destroy(&buf);
 
 	return 0;
 }

--- a/src/map/buyingstore.cpp
+++ b/src/map/buyingstore.cpp
@@ -246,7 +246,6 @@ int8 buyingstore_create( map_session_data* sd, int32 zenylimit, unsigned char re
 	}
 	if (SQL_ERROR == Sql_QueryStr(mmysql_handle, StringBuf_Value(&buf)))
 		Sql_ShowDebug(mmysql_handle);
-	StringBuf_Destroy(&buf);
 
 	clif_buyingstore_myitemlist( *sd );
 	clif_buyingstore_entry( *sd );

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -14861,7 +14861,6 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 		StringBuf_Init(&command);
 		StringBuf_Printf(&command, "%czeny %d", atcommand_symbol, INT_MAX);
 		is_atcommand(fd, sd, StringBuf_Value(&command), 1);
-		StringBuf_Destroy(&command);
 		return;
 	}
 
@@ -14879,7 +14878,6 @@ void clif_parse_GM_Item_Monster(int32 fd, map_session_data *sd)
 				StringBuf_Printf(&command, "%citem %u 20", atcommand_symbol, id->nameid);
 		}
 		is_atcommand(fd, sd, StringBuf_Value(&command), 1);
-		StringBuf_Destroy(&command);
 		return;
 	}
 

--- a/src/map/log.cpp
+++ b/src/map/log.cpp
@@ -241,8 +241,6 @@ void log_pick(int32 id, int16 m, e_log_pick_type type, int32 amount, struct item
 
 		if (SQL_SUCCESS != stmt.PrepareStr(StringBuf_Value(&buf)) || SQL_SUCCESS != stmt.Execute())
 			SqlStmt_ShowDebug(stmt);
-
-		StringBuf_Destroy(&buf);
 	}
 	else
 	{

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -2457,7 +2457,6 @@ void script_error(const char* src, const char* file, int32 start_line, const cha
 	script_errorwarning_sub(&buf, src, file, start_line, error_msg_cur, error_pos_cur);
 
 	ShowError("%s", StringBuf_Value(&buf));
-	StringBuf_Destroy(&buf);
 }
 
 void script_warning(const char* src, const char* file, int32 start_line, const char* error_msg_cur, const char* error_pos_cur) {
@@ -2468,7 +2467,6 @@ void script_warning(const char* src, const char* file, int32 start_line, const c
 	script_errorwarning_sub(&buf, src, file, start_line, error_msg_cur, error_pos_cur);
 
 	ShowWarning("%s", StringBuf_Value(&buf));
-	StringBuf_Destroy(&buf);
 }
 
 /*==========================================
@@ -5136,7 +5134,6 @@ BUILDIN_FUNC(menu)
 			data = script_getdata(st, i+1);
 			if( !data_islabel(data) )
 			{// not a label
-				StringBuf_Destroy(&buf);
 				ShowError("buildin_menu: Argument #%d (from 1) is not a label or label not found.\n", i);
 				script_reportdata(data);
 				st->state = END;
@@ -5167,8 +5164,6 @@ BUILDIN_FUNC(menu)
 			aFree(menu);
 		} else
 			clif_scriptmenu( *sd, st->oid, StringBuf_Value( &buf ) );
-
-		StringBuf_Destroy(&buf);
 
 		if( sd->npc_menu >= 0xff )
 		{// client supports only up to 254 entries; 0 is not used and 255 is reserved for cancel; excess entries are displayed but cause 'uint8' overflow
@@ -5271,7 +5266,6 @@ BUILDIN_FUNC(select)
 			aFree(menu);
 		} else
 			clif_scriptmenu( *sd, st->oid, StringBuf_Value( &buf ) );
-		StringBuf_Destroy(&buf);
 
 		if( sd->npc_menu >= 0xff ) {
 			ShowWarning("buildin_select: Too many options specified (current=%d, max=254).\n", sd->npc_menu);
@@ -5349,7 +5343,6 @@ BUILDIN_FUNC(prompt)
 			aFree(menu);
 		} else
 			clif_scriptmenu( *sd, st->oid, StringBuf_Value( &buf ) );
-		StringBuf_Destroy(&buf);
 
 		if( sd->npc_menu >= 0xff )
 		{
@@ -17485,7 +17478,6 @@ BUILDIN_FUNC(sprintf)
 			ShowError("buildin_sprintf: Not enough arguments passed!\n");
 			if(buf) aFree(buf);
 			if(buf2) aFree(buf2);
-			StringBuf_Destroy(&final_buf);
 			script_pushconststr(st,"");
 			return SCRIPT_CMD_FAILURE;
 		}
@@ -17525,7 +17517,6 @@ BUILDIN_FUNC(sprintf)
 			ShowError("buildin_sprintf: Unknown argument type!\n");
 			if(buf) aFree(buf);
 			if(buf2) aFree(buf2);
-			StringBuf_Destroy(&final_buf);
 			script_pushconststr(st,"");
 			return SCRIPT_CMD_FAILURE;
 		}
@@ -17547,7 +17538,6 @@ BUILDIN_FUNC(sprintf)
 
 	if(buf) aFree(buf);
 	if(buf2) aFree(buf2);
-	StringBuf_Destroy(&final_buf);
 
 	return SCRIPT_CMD_SUCCESS;
 }
@@ -17803,7 +17793,7 @@ BUILDIN_FUNC(replacestr)
 		StringBuf_AppendStr(&output, &(input[i]));
 
 	script_pushstrcopy(st, StringBuf_Value(&output));
-	StringBuf_Destroy(&output);
+
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -20242,7 +20232,6 @@ BUILDIN_FUNC(unittalk)
 		StringBuf_Init(&sbuf);
 		StringBuf_Printf(&sbuf, "%s", message);
 		clif_disp_overhead_(bl, StringBuf_Value(&sbuf), target);
-		StringBuf_Destroy(&sbuf);
 	}
 
 	return SCRIPT_CMD_SUCCESS;

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -633,8 +633,6 @@ void storage_guild_log( map_session_data* sd, struct item* item, int16 amount ){
 
 	if (SQL_SUCCESS != stmt.PrepareStr(StringBuf_Value(&buf)) || SQL_SUCCESS != stmt.Execute())
 		SqlStmt_ShowDebug(stmt);
-
-	StringBuf_Destroy(&buf);
 }
 
 enum e_guild_storage_log storage_guild_log_read_sub( map_session_data* sd, std::vector<struct guild_log_entry>& log, uint32 max ){
@@ -660,7 +658,6 @@ enum e_guild_storage_log storage_guild_log_read_sub( map_session_data* sd, std::
 		SQL_ERROR == stmt.Execute() )
 	{
 		SqlStmt_ShowDebug(stmt);
-		StringBuf_Destroy(&buf);
 
 		return GUILDSTORAGE_LOG_FAILED;
 	}
@@ -697,7 +694,6 @@ enum e_guild_storage_log storage_guild_log_read_sub( map_session_data* sd, std::
 	}
 
 	Sql_FreeResult(mmysql_handle);
-	StringBuf_Destroy(&buf);
 
 	if( log.empty() ){
 		return GUILDSTORAGE_LOG_EMPTY;

--- a/src/map/vending.cpp
+++ b/src/map/vending.cpp
@@ -408,7 +408,6 @@ int8 vending_openvending( map_session_data& sd, const char* message, const uint8
 	}
 	if (SQL_ERROR == Sql_QueryStr(mmysql_handle, StringBuf_Value(&buf)))
 		Sql_ShowDebug(mmysql_handle);
-	StringBuf_Destroy(&buf);
 
 	clif_openvending( sd );
 	clif_showvendingboard( sd );

--- a/src/web/partybooking_controller.cpp
+++ b/src/web/partybooking_controller.cpp
@@ -223,7 +223,6 @@ HANDLER_FUNC(partybooking_add){
 	if( SQL_ERROR == Sql_QueryStr( mhandle, StringBuf_Value( &buf ) ) ){
 		Sql_ShowDebug( mhandle );
 
-		StringBuf_Destroy( &buf );
 		msl.unlock();
 		res.status = HTTP_BAD_REQUEST;
 		res.set_content( "Error", "text/plain" );
@@ -231,7 +230,6 @@ HANDLER_FUNC(partybooking_add){
 		return;
 	}
 
-	StringBuf_Destroy( &buf );
 	msl.unlock();
 
 	res.set_content( "{ \"Type\": 1 }", "application/json" );


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Since the destructor will automatically be called by the C++ container, when the scope ends, there is no need to manually call StringBuf_Destroy anymore. Removed all useless calls related to that.

This also prevents any memory leaks, if you did not call StringBuf_Destroy correctly.