### PR TITLE
Song/Dance SP Handling

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -10679,8 +10679,11 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 		break;
 	case BD_ENCORE:
 		clif_skill_nodamage(src,*bl,skill_id,skill_lv);
-		if(sd)
+		if (sd) {
 			unit_skilluse_id(src,src->id,sd->skill_id_dance,sd->skill_lv_dance);
+			// Need to remove remembered skill to prevent permanent halving of SP cost
+			sd->skill_id_old = 0;
+		}
 		break;
 
 	case TR_RETROSPECTION:
@@ -19808,6 +19811,8 @@ void skill_consume_requirement(map_session_data *sd, uint16 skill_id, uint16 ski
 		switch( skill_id ) {
 			case CG_TAROTCARD: // TarotCard will consume sp in skill_cast_nodamage_id [Inkfish]
 			case MC_IDENTIFY:
+			case BD_ADAPTATION:
+			case BD_ENCORE:
 				require.sp = 0;
 				break;
 			case AL_HOLYLIGHT:

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -14436,7 +14436,7 @@ TIMER_FUNC(status_change_timer){
 				if (sc->getSCE(SC_LONGING))
 					sp*= 3;
 #endif
-				if (!status_charge(bl, 0, sp))
+				if (!status_charge(bl, 0, sp) || status->sp == 0)
 					break;
 			}
 			sc_timer_next(1000+tick);


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9479

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Amp and Encore no longer consume SP (but still require 1 SP to be used)
- When using the same song again after using Encore, the SP cost is no longer halved
  * Cost is only halved when using Encore to repeat the song
- Songs/Dances now immediately end when SP reaches 0
- Fixes #9479

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
