### PR TITLE
Ensemble skills now apply fatigue

### DIFF
--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7465,8 +7465,6 @@ Body:
       Reuse_Limit_Luxanima: true
   - Status: Ensemblefatigue
     Icon: EFST_ENSEMBLEFATIGUE
-    States:
-      NoCast: true
     CalcFlags:
       Speed: true
       Aspd: true

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18269,11 +18269,11 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 						clif_skill_nodamage(tsd, *sd, skill_id, *skill_lv);
 						tsd->skill_id_dance = skill_id;
 						tsd->skill_lv_dance = *skill_lv;
-#ifdef RENEWAL
-						sc_start(sd, sd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
-						sc_start(sd, tsd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
-#endif
 					}
+#ifdef RENEWAL
+					sc_start(sd, sd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
+					sc_start(sd, tsd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
+#endif
 				}
 				return c;
 		}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18263,21 +18263,20 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 				if( is_chorus )
 					break;//Chorus skills are not to be parsed as ensembles
 				if (skill_get_inf2(skill_id, INF2_ISENSEMBLE)) {
-					if (c > 0 && sd->sc.getSCE(SC_DANCING) && (tsd = map_id2sd(p_sd[0])) != nullptr) {
-						sd->sc.getSCE(SC_DANCING)->val4 = tsd->id;
-						sc_start4(sd,tsd,SC_DANCING,100,skill_id,sd->sc.getSCE(SC_DANCING)->val2,*skill_lv,sd->id,skill_get_time(skill_id,*skill_lv)+1000);
-						clif_skill_nodamage(tsd, *sd, skill_id, *skill_lv);
-						tsd->skill_id_dance = skill_id;
-						tsd->skill_lv_dance = *skill_lv;
-					}
-#ifdef RENEWAL
-					sc_start(sd, sd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
-
-					// If the partner is still online, also trigger fatigue on the partner
-					if( tsd != nullptr ){
+					if (c > 0 && (tsd = map_id2sd(p_sd[0])) != nullptr) {
+#ifndef RENEWAL
+						if (sd->sc.getSCE(SC_DANCING)) {
+							sd->sc.getSCE(SC_DANCING)->val4 = tsd->id;
+							sc_start4(sd, tsd, SC_DANCING, 100, skill_id, sd->sc.getSCE(SC_DANCING)->val2, *skill_lv, sd->id, skill_get_time(skill_id, *skill_lv) + 1000);
+							clif_skill_nodamage(tsd, *sd, skill_id, *skill_lv);
+							tsd->skill_id_dance = skill_id;
+							tsd->skill_lv_dance = *skill_lv;
+						}
+#else
+						sc_start(sd, sd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
 						sc_start(sd, tsd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
-					}
 #endif
+					}
 				}
 				return c;
 		}

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18265,7 +18265,7 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 				if (skill_get_inf2(skill_id, INF2_ISENSEMBLE)) {
 					if (c > 0 && (tsd = map_id2sd(p_sd[0])) != nullptr) {
 #ifndef RENEWAL
-						if (sd->sc.getSCE(SC_DANCING)) {
+						if (sd->sc.hasSCE(SC_DANCING)) {
 							sd->sc.getSCE(SC_DANCING)->val4 = tsd->id;
 							sc_start4(sd, tsd, SC_DANCING, 100, skill_id, sd->sc.getSCE(SC_DANCING)->val2, *skill_lv, sd->id, skill_get_time(skill_id, *skill_lv) + 1000);
 							clif_skill_nodamage(tsd, *sd, skill_id, *skill_lv);

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18244,7 +18244,7 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 		return is_chorus ? MAX_PARTY : 99; //As if there were infinite partners.
 
 	if (cast_flag) {	//Execute the skill on the partners.
-		map_session_data* tsd = nullptr;
+		map_session_data* tsd;
 		switch (skill_id) {
 			case PR_BENEDICTIO:
 			case WM_GREAT_ECHO:

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -18244,7 +18244,7 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 		return is_chorus ? MAX_PARTY : 99; //As if there were infinite partners.
 
 	if (cast_flag) {	//Execute the skill on the partners.
-		map_session_data* tsd;
+		map_session_data* tsd = nullptr;
 		switch (skill_id) {
 			case PR_BENEDICTIO:
 			case WM_GREAT_ECHO:
@@ -18272,7 +18272,11 @@ int32 skill_check_pc_partner(map_session_data *sd, uint16 skill_id, uint16 *skil
 					}
 #ifdef RENEWAL
 					sc_start(sd, sd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
-					sc_start(sd, tsd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
+
+					// If the partner is still online, also trigger fatigue on the partner
+					if( tsd != nullptr ){
+						sc_start(sd, tsd, SC_ENSEMBLEFATIGUE, 100, 1, skill_get_time(CG_SPECIALSINGER, *skill_lv));
+					}
 #endif
 				}
 				return c;

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -8295,7 +8295,7 @@ static int16 status_calc_aspd(struct block_list *bl, status_change *sc, bool fix
 			bonus -= sc->getSCE(SC_DONTFORGETME)->val2 / 10;
 #ifdef RENEWAL
 		if (sc->getSCE(SC_ENSEMBLEFATIGUE))
-			bonus -= sc->getSCE(SC_ENSEMBLEFATIGUE)->val2 / 10;
+			bonus -= sc->getSCE(SC_ENSEMBLEFATIGUE)->val2;
 #else
 		if (sc->getSCE(SC_LONGING))
 			bonus -= sc->getSCE(SC_LONGING)->val2 / 10;


### PR DESCRIPTION
* **Addressed Issue(s)**: #7376 #9414

* **Server Mode**: Renewal

* **Description of Pull Request**: 

- Using an Ensemble Skill now properly applies Ensemble Fatique
  * Applies to both the user and the partner for 10 seconds
  * Reduces Speed and ASPD by 30%
  * Prevents usage of any skill except for "Special Singer"
- Fixes #7376 
- Fixes #9414 

Continuation of #9442, since it was closed and the underlying repository was deleted.
