### PR TITLE
Small cleanup for premium storages

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -550,11 +550,18 @@ int32 char_memitemdata_to_sql(const struct item items[], int32 max, int32 id, en
 			tablename = schema_config.cart_db;
 			selectoption = "char_id";
 			break;
-		case TABLE_STORAGE:
-			printname = inter_premiumStorage_getPrintableName(stor_id);
-			tablename = inter_premiumStorage_getTableName(stor_id);
+		case TABLE_STORAGE: {
+			std::shared_ptr<s_storage_table> storage_info = interServerDb.find( stor_id );
+
+			if( storage_info == nullptr ){
+				ShowError( "Invalid storage with id %d\n", id );
+				return 1;
+			}
+
+			printname = storage_info->name;
+			tablename = storage_info->table;
 			selectoption = "account_id";
-			break;
+			} break;
 		case TABLE_GUILD_STORAGE:
 			printname = "Guild Storage";
 			tablename = schema_config.guild_storage_db;
@@ -763,13 +770,20 @@ bool char_memitemdata_from_sql(struct s_storage* p, int32 max, int32 id, enum st
 			storage = p->u.items_cart;
 			max2 = MAX_CART;
 			break;
-		case TABLE_STORAGE:
-			printname = "Storage";
-			tablename = inter_premiumStorage_getTableName(stor_id);
+		case TABLE_STORAGE: {
+			std::shared_ptr<s_storage_table> storage_info = interServerDb.find( stor_id );
+
+			if( storage_info == nullptr ){
+				ShowError( "Invalid storage with id %d\n", id );
+				return false;
+			}
+
+			printname = storage_info->name;
+			tablename = storage_info->table;
 			selectoption = "account_id";
 			storage = p->u.items_storage;
-			max2 = inter_premiumStorage_getMax(p->stor_id);
-			break;
+			max2 = storage_info->max_num;
+			} break;
 		case TABLE_GUILD_STORAGE:
 			printname = "Guild Storage";
 			tablename = schema_config.guild_storage_db;

--- a/src/char/int_storage.hpp
+++ b/src/char/int_storage.hpp
@@ -11,10 +11,6 @@ struct s_storage;
 void inter_storage_sql_init(void);
 void inter_storage_sql_final(void);
 
-int32 inter_premiumStorage_getMax(uint8 id);
-const char *inter_premiumStorage_getTableName(uint8 id);
-const char *inter_premiumStorage_getPrintableName(uint8 id);
-
 bool inter_storage_parse_frommap(int32 fd);
 
 bool guild_storage_tosql(int32 guild_id, struct s_storage *p);

--- a/src/char/inter.cpp
+++ b/src/char/inter.cpp
@@ -908,13 +908,7 @@ uint64 InterServerDatabase::parseBodyNode( const ryml::NodeRef& node ){
 	bool existing = storage_table != nullptr;
 
 	if( !existing ){
-		if( !this->nodeExists( node, "Name" ) ){
-			this->invalidWarning( node, "Node \"Name\" is missing.\n" );
-			return 0;
-		}
-
-		if( !this->nodeExists( node, "Table" ) ){
-			this->invalidWarning( node, "Node \"Table\" is missing.\n" );
+		if( !this->nodesExist( node, { "Name", "Table" } ) ){
 			return 0;
 		}
 


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**: 
Fixed to do multiple useless lookups for the same storage
Removed unused default values
Removed (now) unused functions
Used nodesExist instead of calling nodeExists two times
mapif_parse_StorageLoad now correctly informs the map-server, if it fails to load a storage
mapif_parse_StorageSave now correctly informs the map-server, if it fails to save a storage
