### PR TITLE
Implemented official instance errors message packet 0x02C2

### DIFF
--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -560,6 +560,18 @@ enum e_clif_messages : uint16 {
 	// The mercenary has died.
 	MSI_MER_DIE = 1267,
 
+	// Memorial Dungeon, [%s] is booked
+	MSI_MDUNGEON_SUBSCRIPTION_ERROR_UNKNOWN = 1319,
+
+	// Failed to book Memorial Dungeon, [%s]
+	MSI_MDUNGEON_SUBSCRIPTION_ERROR_DUPLICATE = 1320,
+
+	// Memorial Dungeon, [%s] is already booked
+	MSI_MDUNGEON_SUBSCRIPTION_ERROR_RIGHT = 1321,
+
+	// Memorial Dungeon, [%s] is created.\n Please enter in 5 minutes
+	MSI_MDUNGEON_SUBSCRIPTION_ERROR_EXIST = 1322,
+
 	// This skill cannot be used within this area.
 	MSI_IMPOSSIBLE_SKILL_AREA = 1334,
 
@@ -1137,6 +1149,7 @@ void clif_instance_status(int32 instance_id, uint32 limit1, uint32 limit2);
 void clif_instance_changestatus(int32 instance_id, e_instance_notify type, uint32 limit);
 void clif_parse_MemorialDungeonCommand(int32 fd, map_session_data *sd);
 void clif_instance_info( map_session_data& sd );
+void clif_instance_message( map_session_data& sd, uint16 msg_id, const char* instance_name );
 
 // Custom Fonts
 void clif_font(map_session_data *sd);

--- a/src/map/packets.hpp
+++ b/src/map/packets.hpp
@@ -2136,6 +2136,14 @@ struct PACKET_ZC_NPC_EXPANDED_BARTER_MARKET_ITEMINFO {
 DEFINE_PACKET_HEADER(ZC_NPC_EXPANDED_BARTER_MARKET_ITEMINFO, 0x0b56);
 #endif  // PACKETVER_MAIN_NUM >= 20191120 || PACKETVER_RE_NUM >= 20191106 || PACKETVER_ZERO_NUM >= 20191127
 
+struct PACKET_ZC_MEMORIAL_DUNGEON_MESSAGE {
+	int16 packetType;
+	int16 packetLength;
+	uint16 msgId;
+	char instanceName[];
+} __attribute__((packed));
+DEFINE_PACKET_HEADER(ZC_MEMORIAL_DUNGEON_MESSAGE, 0x2c2);
+
 // NetBSD 5 and Solaris don't like pragma pack but accept the packed attribute
 #if !defined( sun ) && ( !defined( __NETBSD__ ) || __NetBSD_Version__ >= 600000000 )
 	#pragma pack( pop )


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9487

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Implemented official packet 0x02C2. Now, users can use instance_create(..) without any further text if an error occurs.
Old usage : 
switch( instance_create(.@md_name$) ) {
	case -3:
		dispbottom "Memorial Dungeon, '" + .@md_name$ + "' is already in progress.",0xFFFFFF;
		break;
	case -4:
	case -2:
	case -1:
		mes "[Magic Scholar]";
		mes "Oops, my hands are slip off. It is required to activate the craks again.";
		close;
}

New usage : 
instance_create(.@md_name$);

If an error occurs in creating the instance, the system will automatically send a message via packet 0x02C2 as specified in msgstringtable. Users can still use the old script if they want.


Additional test : 
From checking on the official server based on thRO, instance Ritual of Blessing 
this message does not appear if instance_create fails.
> if (instance_create("Ritual of Blessing") < 0) {
> 	mes "[Nillem]";
> 	mes "Hum? I don't know what is going on. We don't seem to be able to enter now.";
> 	mes "It is a secret area which is made to open upon showing magical power.";
> 	next;
> 	mes "[Nillem]";
> 	mes "Let's wait until it stabilizes.";
> 	close;
> }

But using packet 0x02C2 to handle this as well.

https://github.com/user-attachments/assets/d58f3bb6-6c6f-4308-8c0e-8038bac6a10a


**TODOs**

- [ ] The actual packet name is beyond my knowledge, so I'm using PACKET_ZC_MEMORIAL_DUNGEON_MESSAGE temporarily.
- [ ] Some conditions cannot be verified at this time.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
