### PR TITLE
Devotion Cast Cancel Quick Fix

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -444,6 +444,10 @@ int32 battle_delay_damage(t_tick tick, int32 amotion, struct block_list *src, st
 		}
 
 		damage = 0;
+		// This is a quick fix to make devotion protect from cast cancel and autocasts
+		// TODO: This currently also prevents "status change when hit", but shouldn't
+		if (dmg_lv == ATK_DEF)
+			dmg_lv = ATK_BLOCK;
 	}
 
 	// The client refuses to display animations slower than 1x speed


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Related to #9476 but does not fully fix it

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Devotion will now properly protect from cast-cancel again
  * This happened as any attack blocked by devotion was treated like a zero damage skill
  * Zero damage skill behavior was implemented in 5c72915
  * However this should not apply to devotion, in fact it should behave the opposite to a zero damage skill
  * This also fixes devotion from triggering autocasts on the target
  * However it also blocks "status change when hit", which it shouldn't
  * This is just a quick fix as a full solution is quite some effort
  * Related to #9476

Information for reviewers:

This illustrates what this change effectively does:
<img width="427" height="85" alt="grafik" src="https://github.com/user-attachments/assets/d48b6486-9f02-4d75-9b4e-5e31d982ecd0" />

I think Devotion protecting from Cast Cancel is the most important part here, so I wanted to fix this (as it was also working before my changes). That it also fixes Autocast behavior is a bonus. Unfortunately it break "Status Change When Hit", but this is a much lesser evil.

Long term solution would be to replace dmg_lv with a bitmask that lists exactly what the damage should trigger.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
