### PR TITLE
Added instance_warp script command and improvement for instance_enter

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -9924,7 +9924,7 @@ This will also trigger the "OnInstanceDestroy" label in all NPCs inside the inst
 
 ---------------------------------------
 
-*instance_enter("<instance name>",{<x>,<y>,<char_id>,<instance id>});
+*instance_enter("<instance name>",{<do_warp>,<x>,<y>,<char_id>,<instance id>});
 
 Warps the attached player to the specified <instance id>. If no ID is specified,
 the IM_PARTY instance the invoking player is attached to is used.
@@ -10137,6 +10137,40 @@ Examples:
 	for ( .@i = 0; .@i < .@size; ++.@i )
 		mes instance_mapname("prontera", .@instance_list[.@i]);
 	//the output would be a list of all prontera copies that are active in the server.
+
+---------------------------------------
+
+*instance_warp({<char_id>});
+
+Warps all players in the <instance id> to <map name> to the given coordinates.
+If no ID is specified, The player id attached to the NPC will be used.
+If that fails, the script will come to a halt.
+
+Examples:
+	// This script example will have the player chat with an NPC before being warped to an instance.
+	switch ( instance_enter(.@md_name$, false)) {
+		case IE_OTHER:
+		case IE_NOINSTANCE:
+			mes "[Sierra]";
+			mes "If the party leader does not select a mode, all party members will be unable to perform actions.";
+			mes "Please select a mode again and enter the record after receiving either the quests 'Combat Path' or 'Exploration Path'.";
+			close;
+		case IE_NOMEMBER:
+			mes "Only registered members can enter the " + .@md_name$ + " instance.";
+			close3;
+		case IE_OK:
+			mes "[Sierra]";
+			mes "Connected to mode " + .@mode$ + "Successful."
+			next;
+			mes "[Niner]";
+			mes "Good! Finally, check the connection stability…";
+			mes "All right, done! Now, let's begin analyzing the Virtual Record! ";
+			mes " ";
+			mes "^FF0000 Monster manipulation that doesn't meet internal criteria, such as capturing a monster, is not considered a normal operation. Please note this. ^000000 ";
+			next;
+			instance_warp; // being warp after next;
+			close;
+	}
 
 ---------------------------------------
 

--- a/src/map/instance.hpp
+++ b/src/map/instance.hpp
@@ -57,6 +57,15 @@ struct s_instance_map {
 	int16 m, src_m;
 };
 
+struct s_instance_warp {
+	int32 instance_id;
+	int16 map_id;
+	int16 x, y;
+
+	s_instance_warp(int32 inst_id, int16 m_id, int16 pos_x, int16 pos_y)
+		: instance_id(inst_id), map_id(m_id), x(pos_x), y(pos_y) { }
+};
+
 /// Instance data
 struct s_instance_data {
 	int32 id; ///< Instance DB ID
@@ -122,7 +131,8 @@ void instance_getsd(int32 instance_id, map_session_data *&sd, enum send_target *
 int32 instance_create(int32 owner_id, const char *name, e_instance_mode mode);
 bool instance_destroy(int32 instance_id);
 void instance_destroy_command(map_session_data *sd);
-e_instance_enter instance_enter(map_session_data *sd, int32 instance_id, const char *name, int16 x, int16 y);
+e_instance_enter instance_enter(map_session_data *sd, int32 instance_id, const char *name, int16 x, int16 y, bool do_warp = true);
+e_instance_enter instance_warp(map_session_data *sd);
 bool instance_reqinfo(map_session_data *sd, int32 instance_id);
 bool instance_addusers(int32 instance_id);
 bool instance_delusers(int32 instance_id);

--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -17,6 +17,7 @@
 #include "battleground.hpp"
 #include "buyingstore.hpp" // struct s_buyingstore
 #include "clif.hpp" //e_wip_block
+#include "instance.hpp" // instance data
 #include "itemdb.hpp" // MAX_ITEMGROUP
 #include "map.hpp" // RC_ALL
 #include "mob.hpp" //e_size
@@ -946,6 +947,8 @@ public:
 	std::vector<uint32> party_booking_requests;
 
 	void update_look( _look look );
+
+	std::shared_ptr<s_instance_warp> instance_warp;
 };
 
 extern struct eri *pc_sc_display_ers; /// Player's SC display table

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -21777,20 +21777,20 @@ BUILDIN_FUNC(instance_destroy)
 BUILDIN_FUNC(instance_enter)
 {
 	map_session_data *sd = nullptr;
-	int32 x = script_hasdata(st,3) ? script_getnum(st, 3) : -1;
-	int32 y = script_hasdata(st,4) ? script_getnum(st, 4) : -1;
+	bool do_warp = script_hasdata(st, 3) ? (script_getnum(st, 3) != 0) : true; // Default true
+	int32 x = script_hasdata(st, 4) ? script_getnum(st, 4) : -1;
+	int32 y = script_hasdata(st, 5) ? script_getnum(st, 5) : -1;
 	int32 instance_id;
 
-	if (script_hasdata(st, 6))
-		instance_id = script_getnum(st, 6);
+	if (script_hasdata(st, 7))
+		instance_id = script_getnum(st, 7);
 	else
 		instance_id = script_instancegetid(st, IM_PARTY);
 
-	if (!script_charid2sd(5,sd))
+	if (!script_charid2sd(6, sd))
 		return SCRIPT_CMD_FAILURE;
 
-	script_pushint(st, instance_enter(sd, instance_id, script_getstr(st, 2), x, y));
-
+	script_pushint(st, instance_enter(sd, instance_id, script_getstr(st, 2), x, y, do_warp));
 	return SCRIPT_CMD_SUCCESS;
 }
 
@@ -27754,6 +27754,21 @@ BUILDIN_FUNC(mesitemicon){
 	return SCRIPT_CMD_SUCCESS;
 }
 
+/*==========================================
+ * Execute pending instance warp
+ * instance_warp({<char_id>});
+ *------------------------------------------*/
+BUILDIN_FUNC(instance_warp)
+{
+	map_session_data *sd = nullptr;
+
+	if (!script_charid2sd(2, sd))
+		return SCRIPT_CMD_FAILURE;
+
+	script_pushint(st, instance_warp(sd));
+	return SCRIPT_CMD_SUCCESS;
+}
+
 #include <custom/script.inc>
 
 // declarations that were supposed to be exported from npc_chat.cpp
@@ -28299,7 +28314,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(instance_create,"s??"),
 	BUILDIN_DEF(instance_destroy,"?"),
 	BUILDIN_DEF(instance_id,"?"),
-	BUILDIN_DEF(instance_enter,"s????"),
+	BUILDIN_DEF(instance_enter,"s?????"),
 	BUILDIN_DEF(instance_npcname,"s?"),
 	BUILDIN_DEF(instance_mapname,"s?"),
 	BUILDIN_DEF(instance_warpall,"sii??"),
@@ -28310,6 +28325,7 @@ struct script_function buildin_func[] = {
 	BUILDIN_DEF(instance_info,"si?"),
 	BUILDIN_DEF(instance_live_info,"i?"),
 	BUILDIN_DEF(instance_list, "s?"),
+	BUILDIN_DEF(instance_warp, "?"),
 	/**
 	 * 3rd-related
 	 **/


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9513

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Added support for the instance_enter command that doesn't want the player to be warped to an instance immediately.
Added the `instance_warp` script command to warp players to the active instance.


`
switch ( instance_enter(.@md_name$, false)) {
		case IE_OTHER:
		case IE_NOINSTANCE:
			mes "[Sierra]";
			mes "If the party leader does not select a mode, all party members will be unable to perform actions.";
			mes "Please select a mode again and enter the record after receiving either the quests 'Combat Path' or 'Exploration Path'.";
			close;
		case IE_NOMEMBER:
			mes "Only registered members can enter the " + .@md_name$ + " instance.";
			close3;
		case IE_OK:
			mes "[Sierra]";
			mes "Connected to mode " + .@mode$ + "Successful."
			next;
			mes "[Niner]";
			mes "Good! Finally, check the connection stability…";
			mes "All right, done! Now, let's begin analyzing the Virtual Record! ";
			mes " ";
			mes "^FF0000 Monster manipulation that doesn't meet internal criteria, such as capturing a monster, is not considered a normal operation. Please note this. ^000000 ";
			next;
			instance_warp; // being warp after next;
			close;
	}
`
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
