### PR TITLE
Linux build fixes

### DIFF
--- a/3rdparty/libconfig/grammar.c
+++ b/3rdparty/libconfig/grammar.c
@@ -2,20 +2,20 @@
 /* A Bison parser, made by GNU Bison 2.4.1.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C
-
+   
       Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
    Free Software Foundation, Inc.
-
+   
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -28,7 +28,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-
+   
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -43,8 +43,6 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output.  */
-#include "grammar.h"
-#include "scanner.h"
 #define YYBISON 1
 
 /* Bison version.  */
@@ -93,12 +91,10 @@
 
 #include <malloc.h>
 #endif
+#include "grammar.h"
 #include "parsectx.h"
 #include "scanctx.h"
-
-/* these delcarations are provided to suppress compiler warnings */
-extern int libconfig_yylex(YYSTYPE *,yyscan_t);
-extern int libconfig_yyget_lineno(yyscan_t);
+#include "scanner.h"
 
 static const char *err_array_elem_type = "mismatched element type in array";
 static const char *err_duplicate_setting = "duplicate setting name";

--- a/3rdparty/libconfig/grammar.c
+++ b/3rdparty/libconfig/grammar.c
@@ -2,20 +2,20 @@
 /* A Bison parser, made by GNU Bison 2.4.1.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C
-   
+
       Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
    Free Software Foundation, Inc.
-   
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -28,7 +28,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -43,6 +43,8 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output.  */
+#include "grammar.h"
+#include "scanner.h"
 #define YYBISON 1
 
 /* Bison version.  */
@@ -95,8 +97,8 @@
 #include "scanctx.h"
 
 /* these delcarations are provided to suppress compiler warnings */
-extern int libconfig_yylex();
-extern int libconfig_yyget_lineno();
+extern int libconfig_yylex(YYSTYPE *,yyscan_t);
+extern int libconfig_yyget_lineno(yyscan_t);
 
 static const char *err_array_elem_type = "mismatched element type in array";
 static const char *err_duplicate_setting = "duplicate setting name";

--- a/3rdparty/libconfig/scanner.h
+++ b/3rdparty/libconfig/scanner.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "grammar.h"
-
 #ifndef libconfig_yyHEADER_H
 #define libconfig_yyHEADER_H 1
 #define libconfig_yyIN_HEADER 1

--- a/3rdparty/libconfig/scanner.h
+++ b/3rdparty/libconfig/scanner.h
@@ -40,7 +40,7 @@
 #if __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types.
+ * if you want the limit (max/min) macros for int types. 
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -57,7 +57,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t;
+typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 #endif /* ! C99 */
@@ -187,7 +187,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-
+    
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */

--- a/3rdparty/libconfig/scanner.h
+++ b/3rdparty/libconfig/scanner.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "grammar.h"
+
 #ifndef libconfig_yyHEADER_H
 #define libconfig_yyHEADER_H 1
 #define libconfig_yyIN_HEADER 1
@@ -40,7 +42,7 @@
 #if __STDC_VERSION__ >= 199901L
 
 /* C99 says to define __STDC_LIMIT_MACROS before including stdint.h,
- * if you want the limit (max/min) macros for int types. 
+ * if you want the limit (max/min) macros for int types.
  */
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS 1
@@ -57,7 +59,7 @@ typedef uint32_t flex_uint32_t;
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
 typedef int flex_int32_t;
-typedef unsigned char flex_uint8_t; 
+typedef unsigned char flex_uint8_t;
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
 #endif /* ! C99 */
@@ -187,7 +189,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */

--- a/3rdparty/yaml-cpp/src/emitterutils.cpp
+++ b/3rdparty/yaml-cpp/src/emitterutils.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include( TestBigEndian )
 #
 set( PACKETVER CACHE STRING "Sets the PACKETVER define of the servers. (see src/common/mmo.h)" )
 if( PACKETVER )
-	list( APPEND GLOBAL_DEFINITIONS  PACKETVER=${PACKETVER} )
+	set_property( CACHE GLOBAL_DEFINITIONS PROPERTY VALUE "${GLOBAL_DEFINITIONS} -DPACKETVER=${PACKETVER}" )
 endif()
 
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(minicore PUBLIC
 	${COMMON_ADDITIONALL_HPP} # needed by Windows
 )
 
-
+set_target_properties( minicore PROPERTIES COMPILE_FLAGS "${GLOBAL_DEFINITIONS}" )
 target_compile_definitions(minicore PRIVATE "-DMINICORE" ${LIBCONFIG_DEFINITIONS})
 
 #


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
#9518

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
When building on Linux using either gcc or clang, and using either the configure or cmake method, several errors prevent compiling successfully.

1. In **3rdparty/libconfig**, the definitions for **libconfig_yylex** and **libconfig_yylex_lineno** are incorrectly declared. In addition, the correct declarations for their arguments are made in **grammar.h** and **scanner.h**. 

FIX: The declarations have been fixed and the correct headers included.

2. In **3rdparty/yaml-cpp/src/emitterutils.cpp**, the <cstdint> header was missing, causing some fixed-width types to be undefined.

FIX: This header has now been included.

3. Using the **cmake** build, the **minicore** target would fail to build due to **strnlen** being undefined. This was due to the **HAVE_STRNLEN** compile flag not being passed to the target. 

FIX: The **GLOBAL_DEFINITIONS** cmake variable has now been added to the target properties.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
