### PR TITLE
Add default implementations for SkillImpl that throw an exception

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -7496,7 +7496,12 @@ int32 skill_castend_damage_id (struct block_list* src, struct block_list *bl, ui
 
 	default:
 		if (std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id); skill != nullptr && skill->impl != nullptr) {
-			skill->impl->castendDamageId(src, bl, skill_lv, tick, flag);
+			try {
+				skill->impl->castendDamageId(src, bl, skill_lv, tick, flag);
+			} catch (const SkillImplException& e) {
+				ShowWarning(e.what());
+				return 1;
+			}
 			break;
 		}
 
@@ -13671,7 +13676,12 @@ int32 skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, 
 		std::shared_ptr<s_skill_db> skill = skill_db.find(skill_id);
 
 		if( skill != nullptr && skill->impl != nullptr ){
-			skill->impl->castendNoDamageId( src, bl, skill_lv, tick, flag );
+			try {
+				skill->impl->castendNoDamageId( src, bl, skill_lv, tick, flag );
+			} catch(const SkillImplException& e) {
+				ShowWarning(e.what());
+				return 1;
+			}
 			break;
 		}
 

--- a/src/map/skills/skill_impl.cpp
+++ b/src/map/skills/skill_impl.cpp
@@ -3,6 +3,9 @@
 
 #include "skill_impl.hpp"
 
+#include "../clif.hpp"
+#include "../status.hpp"
+
 SkillImpl::SkillImpl(e_skill skill_id) : skill_id_(skill_id) {
 }
 
@@ -11,11 +14,15 @@ e_skill SkillImpl::getSkillId() const {
 }
 
 void SkillImpl::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {
-	// no-op
+	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
+	throw SkillImplException("castendNoDamageId is not implemented for skill " + std::to_string(getSkillId()));
 }
 
 void SkillImpl::castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {
-	// no-op
+	clif_skill_damage(*src, *target, tick, status_get_amotion(src), status_get_dmotion(target), 0,
+					  abs(skill_get_num(getSkillId(), skill_lv)), getSkillId(), skill_lv,
+					  skill_get_hit(getSkillId()));
+	throw SkillImplException("castendDamageId is not implemented for skill " + std::to_string(getSkillId()));
 }
 
 void SkillImpl::calculateSkillRatio(const Damage*, const block_list*, const block_list*, uint16, int32&) const {

--- a/src/map/skills/skill_impl.hpp
+++ b/src/map/skills/skill_impl.hpp
@@ -40,3 +40,9 @@ public:
 protected:
 	e_skill skill_id_;
 };
+
+
+class SkillImplException : public std::runtime_error {
+public:
+	using std::runtime_error::runtime_error;
+};


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Add default implementations for castendDamageId and castendNoDamageId that throw exceptions, so we can cleanly exit skill_castend_damage_id and skill_castsend_nodamage_id, respectively.
