### PR TITLE
2023-12-20 CLIENT bodystylefix

### DIFF
--- a/conf/battle/client.conf
+++ b/conf/battle/client.conf
@@ -10,7 +10,7 @@
 //--------------------------------------------------------------
 
 // Minimum delay between whisper/global/party/guild messages (in ms)
-// Messages that break this threshold are silently omitted. 
+// Messages that break this threshold are silently omitted.
 min_chat_delay: 0
 
 // Valid range of dyes and styles on the client.
@@ -18,10 +18,10 @@ min_hair_style: 0
 max_hair_style: 42
 min_hair_color: 0
 max_hair_color: 8
-min_cloth_color: 0 
+min_cloth_color: 0
 max_cloth_color: 7
-min_body_style: 0
-max_body_style: 1
+//min_body_style: 0 // 2023-12-20 CLIENT bodystylefix - Ossa/Conan
+//max_body_style: 1 // 2023-12-20 CLIENT bodystylefix - Ossa/Conan
 
 // When set to yes, the damage field in packets sent from woe maps will be set
 // to -1, making it impossible for GMs, Bots and Hexed clients to know the
@@ -75,7 +75,7 @@ save_body_style: yes
 
 // Do not display cloth colors for the wedding class?
 // Note: Both save_clothcolor and wedding_modifydisplay have to be enabled
-// for this option to take effect. Set this to yes if your cloth palettes 
+// for this option to take effect. Set this to yes if your cloth palettes
 // pack doesn't has wedding palettes (or has less than the other jobs)
 wedding_ignorepalette: no
 

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -180,7 +180,7 @@ void char_set_char_offline(uint32 char_id, uint32 account_id){
 	std::shared_ptr<struct online_char_data> character = util::umap_find( char_get_onlinedb(), account_id );
 
 	// We don't free yet to avoid aCalloc/aFree spamming during char change. [Skotlex]
-	if( character != nullptr ){	
+	if( character != nullptr ){
 		if( character->server > -1 )
 			if( map_server[character->server].users > 0 ) // Prevent this value from going negative.
 				map_server[character->server].users--;
@@ -280,7 +280,7 @@ int32 char_mmo_char_tosql(uint32 char_id, struct mmo_charstatus* p){
 		(p->job_level != cp->job_level) || (p->job_exp != cp->job_exp) ||
 		(p->zeny != cp->zeny) ||
 		( strncmp( p->last_point.map, cp->last_point.map, sizeof( p->last_point.map ) ) != 0 ) ||
-		(p->last_point.x != cp->last_point.x) || (p->last_point.y != cp->last_point.y) || (p->last_point_instanceid != cp->last_point_instanceid) || 
+		(p->last_point.x != cp->last_point.x) || (p->last_point.y != cp->last_point.y) || (p->last_point_instanceid != cp->last_point_instanceid) ||
 		( strncmp( p->save_point.map, cp->save_point.map, sizeof( p->save_point.map ) ) != 0 ) ||
 		( p->save_point.x != cp->save_point.x ) || ( p->save_point.y != cp->save_point.y ) ||
 		(p->max_hp != cp->max_hp) || (p->hp != cp->hp) ||
@@ -635,10 +635,10 @@ int32 char_memitemdata_to_sql(const struct item items[], int32 max, int32 id, en
 			&&  items[i].unique_id == item.unique_id
 			) {	//They are the same item.
 				int32 k;
-				
+
 				ARR_FIND( 0, MAX_SLOTS, j, items[i].card[j] != item.card[j] );
 				ARR_FIND( 0, MAX_ITEM_RDM_OPT, k, items[i].option[k].id != item.option[k].id || items[i].option[k].value != item.option[k].value || items[i].option[k].param != item.option[k].param );
-				
+
 				if( j == MAX_SLOTS &&
 					k == MAX_ITEM_RDM_OPT &&
 					items[i].amount == item.amount &&
@@ -1295,7 +1295,7 @@ int32 char_rename_char_sql(struct char_session_data *sd, uint32 char_id)
 		Sql_ShowDebug(sql_handle);
 		return 3;
 	}
-	
+
 	// Update party and party members with the new player name
 	if( char_dat.party_id )
 		inter_party_charname_changed(char_dat.party_id, char_id, sd->new_name);
@@ -1474,7 +1474,7 @@ int32 char_make_new_char( struct char_session_data* sd, char* name_, int32 str, 
 	}
 
 #if PACKETVER >= 20151001
-	if(!(start_job == JOB_NOVICE && (charserv_config.allowed_job_flag&1)) && 
+	if(!(start_job == JOB_NOVICE && (charserv_config.allowed_job_flag&1)) &&
 		!(start_job == JOB_SUMMONER && (charserv_config.allowed_job_flag&2)))
 		return -2; // Invalid job
 
@@ -1488,13 +1488,19 @@ int32 char_make_new_char( struct char_session_data* sd, char* name_, int32 str, 
 	}
 #endif
 
+#if PACKETVER >= 20231220 // 2023-12-20 CLIENT bodystylefix - START - Ossa/Conan
+	int body = start_job;
+#else
+	int body = 0;
+#endif // 2023-12-20 CLIENT bodystylefix - END - Ossa/Conan
+
 	//Insert the new char entry to the database
 	if( SQL_ERROR == Sql_Query(sql_handle, "INSERT INTO `%s` (`account_id`, `char_num`, `name`, `class`, `zeny`, `status_point`, `str`, `agi`, `vit`, `int`, `dex`, `luk`, `max_hp`, `hp`,"
-		"`max_sp`, `sp`, `hair`, `hair_color`, `last_map`, `last_x`, `last_y`, `save_map`, `save_x`, `save_y`, `sex`, `last_instanceid`) VALUES ("
-		"'%d', '%d', '%s', '%d', '%d',  '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%u', '%u', '%u', '%u', '%d', '%d', '%s', '%d', '%d', '%s', '%d', '%d', '%c', '0')",
+		"`max_sp`, `sp`, `hair`, `hair_color`, `last_map`, `last_x`, `last_y`, `save_map`, `save_x`, `save_y`, `sex`, `last_instanceid`, `body`) VALUES (" // 2023-12-20 CLIENT bodystylefix
+		"'%d', '%d', '%s', '%d', '%d',  '%d', '%d', '%d', '%d', '%d', '%d', '%d', '%u', '%u', '%u', '%u', '%d', '%d', '%s', '%d', '%d', '%s', '%d', '%d', '%c', '0', '%d')", // 2023-12-20 CLIENT bodystylefix
 		schema_config.char_db, sd->account_id , slot, esc_name, start_job, charserv_config.start_zeny, status_points, str, agi, vit, int_, dex, luk,
 		(40 * (100 + vit)/100) , (40 * (100 + vit)/100 ),  (11 * (100 + int_)/100), (11 * (100 + int_)/100), hair_style, hair_color,
-		tmp_start_point[start_point_idx].map, tmp_start_point[start_point_idx].x, tmp_start_point[start_point_idx].y, tmp_start_point[start_point_idx].map, tmp_start_point[start_point_idx].x, tmp_start_point[start_point_idx].y, sex ) )
+		tmp_start_point[start_point_idx].map, tmp_start_point[start_point_idx].x, tmp_start_point[start_point_idx].y, tmp_start_point[start_point_idx].map, tmp_start_point[start_point_idx].x, tmp_start_point[start_point_idx].y, sex, body ) ) // 2023-12-20 CLIENT bodystylefix
 	{
 		Sql_ShowDebug(sql_handle);
 		return -2; //No, stop the procedure!
@@ -1687,7 +1693,7 @@ enum e_char_del_response char_delete(struct char_session_data* sd, uint32 char_i
 	/* delete mail attachments (only received) */
 	if (SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `id` IN ( SELECT `id` FROM `%s` WHERE `dest_id`='%d' )", schema_config.mail_attachment_db, schema_config.mail_db, char_id))
 		Sql_ShowDebug(sql_handle);
-	
+
 	/* delete mails (only received) */
 	if (SQL_ERROR == Sql_Query(sql_handle, "DELETE FROM `%s` WHERE `dest_id`='%d'", schema_config.mail_db, char_id))
 		Sql_ShowDebug(sql_handle);
@@ -2176,7 +2182,7 @@ TIMER_FUNC(char_chardb_waiting_disconnect){
 	std::shared_ptr<struct online_char_data> character = util::umap_find( char_get_onlinedb(), static_cast<uint32>( id ) );
 
 	// Mark it offline due to timeout.
-	if( character != nullptr && character->waiting_disconnect == tid ){	
+	if( character != nullptr && character->waiting_disconnect == tid ){
 		character->waiting_disconnect = INVALID_TIMER;
 		char_set_char_offline(character->char_id, character->account_id);
 	}
@@ -2283,14 +2289,14 @@ int32 char_lan_config_read(const char *lancfgName) {
 bool char_checkdb(void){
 	int32 i;
 	const char* sqltable[] = {
-		schema_config.char_db, schema_config.hotkey_db, schema_config.scdata_db, schema_config.cart_db, 
+		schema_config.char_db, schema_config.hotkey_db, schema_config.scdata_db, schema_config.cart_db,
                 schema_config.inventory_db, schema_config.charlog_db,
                 schema_config.char_reg_str_table, schema_config.char_reg_num_table, schema_config.acc_reg_str_table,
                 schema_config.acc_reg_num_table, schema_config.skill_db, schema_config.interlog_db, schema_config.memo_db,
-		schema_config.guild_db, schema_config.guild_alliance_db, schema_config.guild_castle_db, 
-                schema_config.guild_expulsion_db, schema_config.guild_member_db, 
+		schema_config.guild_db, schema_config.guild_alliance_db, schema_config.guild_castle_db,
+                schema_config.guild_expulsion_db, schema_config.guild_member_db,
                 schema_config.guild_skill_db, schema_config.guild_position_db, schema_config.guild_storage_db,
-		schema_config.party_db, schema_config.pet_db, schema_config.friend_db, schema_config.mail_db, 
+		schema_config.party_db, schema_config.pet_db, schema_config.friend_db, schema_config.mail_db,
                 schema_config.auction_db, schema_config.quest_db,
                 schema_config.homunculus_db, schema_config.skill_homunculus_db, schema_config.skillcooldown_homunculus_db,
                 schema_config.mercenary_db, schema_config.mercenary_owner_db, schema_config.skillcooldown_mercenary_db,
@@ -2759,7 +2765,7 @@ void char_set_defaults(){
 	charserv_config.char_check_db =1;
 
 	// See const.hpp to change the default values
-	safestrncpy( charserv_config.start_point[0].map, MAP_DEFAULT_NAME, sizeof( charserv_config.start_point[0].map ) ); 
+	safestrncpy( charserv_config.start_point[0].map, MAP_DEFAULT_NAME, sizeof( charserv_config.start_point[0].map ) );
 	charserv_config.start_point[0].x = MAP_DEFAULT_X;
 	charserv_config.start_point[0].y = MAP_DEFAULT_Y;
 	charserv_config.start_point_count = 1;

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -1963,7 +1963,7 @@ ACMD_FUNC(bodystyle)
 	nullpo_retr(-1, sd);
 
 	memset(atcmd_output, '\0', sizeof(atcmd_output));
-
+#if PACKETVER < 20231220 // 2023-12-20 CLIENT bodystylefix
 	if ( (sd->class_ & JOBL_FOURTH) || !(sd->class_ & JOBL_THIRD) || (sd->class_ & MAPID_THIRDMASK) == MAPID_SUPER_NOVICE_E || (sd->class_ & MAPID_THIRDMASK) == MAPID_STAR_EMPEROR || (sd->class_ & MAPID_THIRDMASK) == MAPID_SOUL_REAPER) {
 		clif_displaymessage(fd, msg_txt(sd,740));	// This job has no alternate body styles.
 		return -1;
@@ -1974,7 +1974,7 @@ ACMD_FUNC(bodystyle)
 		clif_displaymessage(fd, atcmd_output);
 		return -1;
 	}
-
+#endif// 2023-12-20 CLIENT bodystylefix
 	if (body_style >= MIN_BODY_STYLE && body_style <= MAX_BODY_STYLE) {
 		pc_changelook(sd, LOOK_BODY2, body_style);
 		clif_displaymessage(fd, msg_txt(sd,36)); // Appearence changed.
@@ -3017,7 +3017,7 @@ ACMD_FUNC(stat_all)
 				max_status[i] = pc_maxparameter(sd, static_cast<e_params>(i));
 		}
 	}
-	
+
 	count = 0;
 	for (i = PARAM_STR; i < PARAM_POW; i++) {
 		int16 new_value;
@@ -3195,7 +3195,7 @@ ACMD_FUNC(makeegg) {
 
 		// for egg name
 		std::shared_ptr<item_data> item_data = item_db.searchname( message );
-		
+
 		if( item_data != nullptr ){
 			nameid = item_data->nameid;
 		}else{
@@ -3215,10 +3215,10 @@ ACMD_FUNC(makeegg) {
 				res = -2; //char server down
 			}
 		}
-	} 
-	
+	}
+
 	switch(res){
-		case -1:		
+		case -1:
 			clif_displaymessage(fd, msg_txt(sd,180)); // The monster/egg name/id doesn't exist.
 			break;
 		case -2:
@@ -3443,7 +3443,7 @@ ACMD_FUNC(ban)
 		clif_displaymessage(fd, msg_txt(sd,702)); // Time parameter format is +/-<value> to alter. y/a = Year, m = Month, d/j = Day, h = Hour, n/mn = Minute, s = Second.
 		return -1;
 	}
-	
+
 	if( timediff < 0 ){
 		clif_displaymessage(fd,msg_txt(sd,1023)); // You are not allowed to alter the time of a ban.
 		return -1;
@@ -3488,7 +3488,7 @@ ACMD_FUNC(char_ban)
 		clif_displaymessage(fd, msg_txt(sd,702)); // Time parameter format is +/-<value> to alter. y/a = Year, m = Month, d/j = Day, h = Hour, n/mn = Minute, s = Second.
 		return -1;
 	}
-	
+
 	if( timediff < 0 ){
 		clif_displaymessage(fd,msg_txt(sd,1023)); // You are not allowed to alter the time of a ban.
 		return -1;
@@ -5261,7 +5261,7 @@ ACMD_FUNC(loadnpc)
 		clif_displaymessage(fd, msg_txt(sd,1132)); // Please enter a script file name (usage: @loadnpc <file name>).
 		return -1;
 	}
-	
+
 	if (!npc_addsrcfile(message, true)) {
 		clif_displaymessage(fd, msg_txt(sd,261)); // Script could not be loaded.
 		return -1;
@@ -5529,7 +5529,7 @@ ACMD_FUNC(jailfor) {
 	nullpo_retr(-1, sd);
 
 	memset(atcmd_output, '\0', sizeof(atcmd_output));
-	
+
 	if (!message || !*message || sscanf(message, "%255s %23[^\n]",atcmd_output,atcmd_player_name) < 2) {
 		clif_displaymessage(fd, msg_txt(sd,400));	//Usage: @jailfor <time> <character name>
 		return -1;
@@ -6030,7 +6030,7 @@ ACMD_FUNC(npcmove)
 		return -1;
 	}
 
-	if ( npc_movenpc( nd, x, y ) ) 
+	if ( npc_movenpc( nd, x, y ) )
 	{ //actually failed to move
 		clif_displaymessage(fd, msg_txt(sd,1154)); // NPC is not on this map.
 		return -1;	//Not on a map.
@@ -6124,7 +6124,7 @@ ACMD_FUNC(dropall)
 	uint16 i, count = 0, count2 = 0;
 
 	nullpo_retr(-1, sd);
-	
+
 	if( message[0] ) {
 		type = atoi(message);
 		if( type != -1 && type != IT_HEALING && type != IT_USABLE && type != IT_ETC && type != IT_WEAPON &&
@@ -6164,7 +6164,7 @@ ACMD_FUNC(dropall)
 		}
 	}
 	sprintf(atcmd_output, msg_txt(sd,1494), count,count2); // %d items are dropped (%d skipped)!
-	clif_displaymessage(fd, atcmd_output); 
+	clif_displaymessage(fd, atcmd_output);
 	return 0;
 }
 
@@ -6175,7 +6175,7 @@ ACMD_FUNC(dropall)
 ACMD_FUNC(stockall)
 {
 	nullpo_retr(-1, sd);
-	
+
 	if (!pc_iscarton(sd)) {
 		clif_displaymessage(fd, msg_txt(sd,1533)); // You do not have a cart.
 		return -1;
@@ -6224,7 +6224,7 @@ ACMD_FUNC(stockall)
 		}
 	}
 	sprintf(atcmd_output, msg_txt(sd,1535), count,count2); // %d items are transferred (%d skipped)!
-	clif_displaymessage(fd, atcmd_output); 
+	clif_displaymessage(fd, atcmd_output);
 	return 0;
 }
 
@@ -7758,7 +7758,7 @@ ACMD_FUNC(uptime)
 }
 
 /*==========================================
- * @changesex 
+ * @changesex
  * => Changes one's account sex. Switch from male to female or visversa
  *------------------------------------------*/
 ACMD_FUNC(changesex)
@@ -8652,7 +8652,7 @@ ACMD_FUNC(whereis)
 		clif_displaymessage(fd, msg_txt(sd,1288)); // Please enter a monster name/ID (usage: @whereis <monster_name_or_monster_ID>).
 		return -1;
 	}
-	
+
 	int32 i_message = atoi(message);
 	if (mobdb_checkid(i_message)) {
 		// ID given
@@ -8662,7 +8662,7 @@ ACMD_FUNC(whereis)
 		// Name given, get all monster associated whith this name
 		count = mobdb_searchname_array(message, mob_ids, MAX_SEARCH);
 	}
-	
+
 	if (count <= 0) {
 		clif_displaymessage(fd, msg_txt(sd,40)); // Invalid monster ID or name.
 		return -1;
@@ -8681,7 +8681,7 @@ ACMD_FUNC(whereis)
 		if(!mob) continue;
 		snprintf(atcmd_output, sizeof atcmd_output, msg_txt(sd,1289), mob->jname.c_str()); // %s spawns in:
 		clif_displaymessage(fd, atcmd_output);
-		
+
 		const std::vector<spawn_info> spawns = mob_get_spawns(mob_id);
 		if (spawns.size() <= 0) {
 			 // This monster does not spawn normally.
@@ -10000,7 +10000,7 @@ static void atcommand_commands_sub(map_session_data* sd, const int32 fd, AtComma
 		if ( count_bind )
 			clif_displaymessage(fd,line_buff);// last one
 		count += count_bind;
-		
+
 	}
 
 	sprintf(atcmd_output, msg_txt(sd,274), count); // "%d commands found."
@@ -10055,7 +10055,7 @@ ACMD_FUNC(accinfo) {
 
 /**
  * @set <variable name{[index]}>{ <value>}
- * 
+ *
  * Gets or sets a value of a non server variable.
  * If a value is specified it is used to set the variable's value,
  * if not the variable's value is read.
@@ -10543,11 +10543,11 @@ ACMD_FUNC(vip) {
 	char * modif_p;
 	int32 vipdifftime = 0;
 	time_t now=time(nullptr);
-	
+
 	nullpo_retr(-1, sd);
 
 	memset(atcmd_output, '\0', sizeof(atcmd_output));
-	
+
 	if (!message || !*message || sscanf(message, "%255s %23[^\n]",atcmd_output,atcmd_player_name) < 2) {
 		clif_displaymessage(fd, msg_txt(sd,700));	//Usage: @vip <timef> <character name>
 		return -1;
@@ -10580,7 +10580,7 @@ ACMD_FUNC(vip) {
 
 	if(pl_sd->vip.time==0) pl_sd->vip.time=now;
 	pl_sd->vip.time += vipdifftime; //increase or reduce VIP duration
-	
+
 	if (pl_sd->vip.time <= now) {
 		clif_displaymessage(pl_sd->fd, msg_txt(pl_sd,703)); // GM has removed your VIP time.
 
@@ -10591,7 +10591,7 @@ ACMD_FUNC(vip) {
 	} else {
 		int32 year,month,day,hour,minute,second;
 		char timestr[21];
-		
+
 		split_time((int32)(pl_sd->vip.time-now),&year,&month,&day,&hour,&minute,&second);
 		sprintf(atcmd_output,msg_txt(pl_sd,705),year,month,day,hour,minute,second); // Your VIP status is valid for %d years, %d months, %d days, %d hours, %d minutes and %d seconds.
 		clif_displaymessage(pl_sd->fd,atcmd_output);
@@ -10606,7 +10606,7 @@ ACMD_FUNC(vip) {
 			clif_displaymessage(fd,atcmd_output);
 		}
 	}
-	chrif_req_login_operation(pl_sd->status.account_id, pl_sd->status.name, CHRIF_OP_LOGIN_VIP, vipdifftime, 7, 0); 
+	chrif_req_login_operation(pl_sd->status.account_id, pl_sd->status.name, CHRIF_OP_LOGIN_VIP, vipdifftime, 7, 0);
 	return 0;
 #else
 	clif_displaymessage( fd, msg_txt( sd, 774 ) ); // This command is disabled via configuration.
@@ -10636,7 +10636,7 @@ ACMD_FUNC(showrate) {
 ACMD_FUNC(fullstrip) {
 	int32 i;
 	TBL_PC *tsd;
-	
+
 	nullpo_retr(-1,sd);
 
 	memset(atcmd_player_name, '\0', sizeof(atcmd_player_name));
@@ -10650,7 +10650,7 @@ ACMD_FUNC(fullstrip) {
 		clif_displaymessage(fd, msg_txt(sd,3)); // Character not found.
 		return -1;
 	}
-	
+
 	for( i = 0; i < EQI_MAX; i++ ) {
 		if( tsd->equip_index[ i ] >= 0 )
 			pc_unequipitem( tsd , tsd->equip_index[ i ] , 2 );

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -279,7 +279,7 @@ static t_tick battle_calc_walkdelay(block_list& bl, int64 damage, int16 div_, t_
 	if (div_ == 0)
 		return 0;
 
-	t_tick delay = status_get_status_data(bl)->dmotion;	
+	t_tick delay = status_get_status_data(bl)->dmotion;
 
 	// Multi-hit skills mean higher delays
 	if (div_ > 1) {
@@ -1314,7 +1314,7 @@ bool battle_status_block_damage(struct block_list *src, struct block_list *targe
 		element = battle_get_magic_element(src, target, skill_id, skill_lv, d->miscflag);
 	else
 		element = battle_get_misc_element(src, target, skill_id, skill_lv, d->miscflag);
-	
+
 	switch( element ){
 		case ELE_NEUTRAL:
 			if( sc->getSCE( SC_IMMUNE_PROPERTY_NOTHING ) ){
@@ -1635,7 +1635,7 @@ bool battle_status_block_damage(struct block_list *src, struct block_list *targe
 			status_change_end(target, SC_BUNSINJYUTSU);
 		return false;
 	}
-	
+
 	if ((sce = sc->getSCE(SC_DAMAGE_HEAL))) {
 		if (damage > 0 && (flag & sce->val2)) {
 			int32 heal = static_cast<int32>( i64min( damage, INT32_MAX ) );
@@ -1967,7 +1967,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			switch (skill_id) {
 				case HN_SHIELD_CHAIN_RUSH:
 				case HN_DOUBLEBOWLINGBASH:
-					damage += damage * 120 / 100; 
+					damage += damage * 120 / 100;
 					break;
 				case HN_MEGA_SONIC_BLOW:
 				case HN_SPIRAL_PIERCE_MAX:
@@ -2048,7 +2048,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 		if (md && md->damagetaken != 100)
 			damage = i64max(damage * md->damagetaken / 100, 1);
 	}
-	
+
 	if (tsc != nullptr && !tsc->empty()) {
 		if (!battle_status_block_damage(src, bl, tsc, d, damage, skill_id, skill_lv)) // Statuses that reduce damage to 0.
 			return 0;
@@ -3642,7 +3642,7 @@ int32 battle_get_magic_element(struct block_list* src, struct block_list* target
 	map_session_data *sd = BL_CAST(BL_PC, src);
 	status_change *sc = status_get_sc(src);
 	status_data* sstatus = status_get_status_data(*src);
-	
+
 	if (element == ELE_WEAPON) { // pl=-1 : the skill takes the weapon's element
 		element = sstatus->rhw.ele;
 		if(sd && sd->spiritcharm_type != CHARM_TYPE_NONE && sd->spiritcharm >= MAX_SPIRITCHARM)
@@ -3737,7 +3737,7 @@ int32 battle_get_magic_element(struct block_list* src, struct block_list* target
 
 int32 battle_get_misc_element(struct block_list* src, struct block_list* target, uint16 skill_id, uint16 skill_lv, int32 mflag) {
 	int32 element = skill_get_ele(skill_id, skill_lv);
-	
+
 	if (element == ELE_WEAPON || element == ELE_ENDOWED) //Attack that takes weapon's element for misc attacks? Make it neutral [Skotlex]
 		element = ELE_NEUTRAL;
 	else if (element == ELE_RANDOM) //Use random element
@@ -4399,7 +4399,7 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 				if(sd->status.party_id && (skill=pc_checkskill(sd,TK_POWER)) > 0) {
 					if( (i = party_foreachsamemap(party_sub_count, sd, 0)) > 1 ) { // exclude the player himself [Inkfish]
 						// Reduce count by one (self) [Tydus1]
-						i -= 1; 
+						i -= 1;
 						ATK_ADDRATE(wd->damage, wd->damage2, 2*skill*i);
 					}
 				}
@@ -5337,7 +5337,7 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			if (sc && sc->getSCE(SC_FEARBREEZE))
 				skillratio += -100 + 800 + 35 * skill_lv;
 			else
-				skillratio += -100 + 500 + 20 * skill_lv;	
+				skillratio += -100 + 500 + 20 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case RA_CLUSTERBOMB:
@@ -5589,9 +5589,9 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			break;
 		case SR_HOWLINGOFLION:
 			skillratio += -100 + 500 * skill_lv;
-			RE_LVL_DMOD(100);	
+			RE_LVL_DMOD(100);
 			break;
-		case SR_RIDEINLIGHTNING: 
+		case SR_RIDEINLIGHTNING:
 			skillratio += -100 + 40 * skill_lv;
 			if (sd && sd->status.weapon == W_KNUCKLE)
 				skillratio += 50 * skill_lv;
@@ -6441,7 +6441,7 @@ static int32 battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list
 			skillratio += 5 * sstatus->con;
 			if (sc && sc->getSCE(SC_INTENSIVE_AIM_COUNT))
 				skillratio += sc->getSCE(SC_INTENSIVE_AIM_COUNT)->val1 * 150 * skill_lv;
-			if (sd && sd->weapontype1 == W_RIFLE) 
+			if (sd && sd->weapontype1 == W_RIFLE)
 				skillratio += 200 + 1100 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
@@ -7690,7 +7690,7 @@ void battle_do_reflect(int32 attack_type, struct Damage *wd, struct block_list* 
 			if (!tsc->getSCE(SC_KYOMU) && !(tsc->getSCE(SC_DARKCROW) && (wd->flag&BF_SHORT))) //SC_KYOMU invalidates reflecting ability. SC_DARKCROW also does, but only for short weapon attack.
 				skill_castend_damage_id(target, src, NPC_MAXPAIN_ATK, sce->val1, tick, ((wd->flag & 1) ? wd->flag - 1 : wd->flag));
 		}
-		
+
 		// Calculate skill reflect damage separately
 		if ((ud && !ud->immune_attack) || !status_bl_has_mode(target, MD_SKILLIMMUNE))
 			rdamage = battle_calc_return_damage(target, src, &damage, wd->flag, skill_id,true);
@@ -8040,7 +8040,7 @@ static struct Damage battle_calc_weapon_attack(struct block_list *src, struct bl
 						wd.damage = sce->val3 * skill_lv / 10;
 				}
 			}
-			else 
+			else
 				wd.damage = 0;
 			break;
 	}
@@ -10123,7 +10123,7 @@ struct Damage battle_calc_attack(int32 attack_type,struct block_list *bl,struct 
 		d.dmotion = 0;
 		if(bl->type == BL_PC)
 			d.div_ = 1;
-		
+
 		status_change *tsc = status_get_sc(target);
 
 		// Weapon Blocking has the ability to trigger on ATK_MISS as well.
@@ -12112,8 +12112,8 @@ static const struct _battle_data {
 	{ "feature.roulette",                   &battle_config.feature_roulette,                1,      0,      1,              },
 	{ "feature.roulette_bonus_reward",      &battle_config.feature_roulette_bonus_reward,   1,      0,      1,              },
 	{ "monster_hp_bars_info",               &battle_config.monster_hp_bars_info,            1,      0,      1,              },
-	{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       },
-	{ "max_body_style",                     &battle_config.max_body_style,                  1,      0,      SHRT_MAX,       },
+	//{ "min_body_style",                     &battle_config.min_body_style,                  0,      0,      SHRT_MAX,       }, // 2023-12-20 CLIENT bodystylefix
+	//{ "max_body_style",                     &battle_config.max_body_style,                  1,      0,      SHRT_MAX,       }, // 2023-12-20 CLIENT bodystylefix
 	{ "save_body_style",                    &battle_config.save_body_style,                 1,      0,      1,              },
 	{ "monster_eye_range_bonus",            &battle_config.mob_eye_range_bonus,             0,      0,      10,             },
 	{ "monster_stuck_warning",              &battle_config.mob_stuck_warning,               0,      0,      1,              },

--- a/src/map/battle.hpp
+++ b/src/map/battle.hpp
@@ -156,8 +156,14 @@ bool is_infinite_defense(struct block_list *target, int32 flag);
 #define MAX_HAIR_COLOR battle_config.max_hair_color
 #define MIN_CLOTH_COLOR battle_config.min_cloth_color
 #define MAX_CLOTH_COLOR battle_config.max_cloth_color
-#define MIN_BODY_STYLE battle_config.min_body_style
-#define MAX_BODY_STYLE battle_config.max_body_style
+//#define MIN_BODY_STYLE battle_config.min_body_style // 2023-12-20 CLIENT bodystylefix - START - Ossa/Conan
+//#define MAX_BODY_STYLE battle_config.max_body_style
+#define MIN_BODY_STYLE 0
+#if PACKETVER >= 20231220
+#define MAX_BODY_STYLE (JOB_MAX-1)
+#else
+#define MAX_BODY_STYLE 1
+#endif // 2023-12-20 CLIENT bodystylefix - END - Ossa/Conan
 
 struct Battle_Config
 {
@@ -647,8 +653,8 @@ struct Battle_Config
 	int32 feature_roulette;
 	int32 feature_roulette_bonus_reward;
 	int32 monster_hp_bars_info;
-	int32 min_body_style;
-	int32 max_body_style;
+	//int32 min_body_style; // 2023-12-20 CLIENT bodystylefix - Ossa/Conan
+	//int32 max_body_style; // 2023-12-20 CLIENT bodystylefix - Ossa/Conan
 	int32 save_body_style;
 	int32 mob_eye_range_bonus; //Vulture's Eye and Snake's Eye range bonus
 	int32 mob_stuck_warning; //Show warning if a monster is stuck too long

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -826,7 +826,7 @@ void clif_authfail_fd(int32 fd, int32 type)
 {
 	if (!session_isValid(fd) || session[fd]->func_parse != clif_parse) //clif_authfail should only be invoked on players!
 		return;
-	
+
 	PACKET_SC_NOTIFY_BAN packet{};
 
 	packet.packetType = HEADER_SC_NOTIFY_BAN;
@@ -1934,7 +1934,7 @@ void clif_send_homdata( homun_data& hd, e_hom_state2 state ){
 		default:
 			return;
 	}
-	
+
 	PACKET_ZC_CHANGESTATE_MER packet{};
 
 	packet.packetType = HEADER_ZC_CHANGESTATE_MER;
@@ -1955,7 +1955,7 @@ void clif_homskillinfoblock( homun_data& hd ){
 	if( sd == nullptr ){
 		return;
 	}
-	
+
 	PACKET_ZC_HOSKILLINFO_LIST* packet = reinterpret_cast<PACKET_ZC_HOSKILLINFO_LIST*>(packet_buffer);
 
 	packet->packetType = HEADER_ZC_HOSKILLINFO_LIST;
@@ -2183,7 +2183,7 @@ void clif_blown(struct block_list *bl)
 /// isn't walkable, the char doesn't move at all. If the char is
 /// sitting it will stand up.
 /// 0088 <id>.L <x>.W <y>.W (ZC_STOPMOVE)
-void clif_fixpos( block_list& bl ){	
+void clif_fixpos( block_list& bl ){
 	PACKET_ZC_STOPMOVE packet = {};
 
 	packet.packetType = HEADER_ZC_STOPMOVE;
@@ -2292,7 +2292,7 @@ void clif_selllist( map_session_data& sd){
 		packet->packetLength += sizeof( packet->items[0] );
 		c++;
 	}
-	
+
 	clif_send( packet, packet->packetLength, &sd, SELF );
 }
 
@@ -2610,7 +2610,7 @@ void clif_sendfakenpc( map_session_data& sd, uint32 npcid ){
 /// TODO investigate behavior of other windows [FlavioJS]
 void clif_scriptmenu( map_session_data& sd, uint32 npcid, const char* mes ){
 	struct block_list *bl = nullptr;
-	
+
 	if (!sd.state.using_fake_npc && (npcid == fake_nd->id || ((bl = map_id2bl(npcid)) && (bl->m!=sd.m ||
 	   bl->x<sd.x-AREA_SIZE-1 || bl->x>sd.x+AREA_SIZE+1 ||
 	   bl->y<sd.y-AREA_SIZE-1 || bl->y>sd.y+AREA_SIZE+1))))
@@ -2799,7 +2799,7 @@ static void clif_add_random_options( struct ItemOptions buf[MAX_ITEM_RDM_OPT], s
 			buf[i].param = 0;
 		}
 	}
-	
+
 #if MAX_ITEM_RDM_OPT < 5
 	for( ; i < 5; i++ ){
 		buf[i].index = 0;	// OptIndex
@@ -3452,7 +3452,7 @@ void clif_parse_guild_castle_teleport_request(int32 fd, map_session_data* sd){
 	if (gc->guild_id != g->guild.guild_id)
 		return;
 
-	if (map_getmapflag(sd->m, MF_GVG_CASTLE) 
+	if (map_getmapflag(sd->m, MF_GVG_CASTLE)
 		|| map_getmapflag(sd->m, MF_NOTELEPORT)
 		|| map_getmapflag(sd->m, MF_NOWARP))
 		return;
@@ -3876,7 +3876,7 @@ void clif_updatestatus( map_session_data& sd, enum _sp type ){
 			if( sd.status.party_id ){
 				struct party_data* p;
 				int32 i;
-		
+
 				if( ( p = party_search( sd.status.party_id ) ) != nullptr ){
 					ARR_FIND(0, MAX_PARTY, i, p->party.member[i].char_id == sd.status.char_id);
 
@@ -3949,7 +3949,7 @@ void clif_changelook(struct block_list *bl, int32 type, int32 val) {
 					sd->update_look( LOOK_SHIELD );
 					val = vd->look[LOOK_WEAPON];
 				}
-				else 
+				else
 					vd->look[LOOK_WEAPON] = val;
 				break;
 			case LOOK_SHIELD:
@@ -3958,7 +3958,7 @@ void clif_changelook(struct block_list *bl, int32 type, int32 val) {
 					sd->update_look( LOOK_SHIELD );
 					val = vd->look[LOOK_SHIELD];
 				}
-				else 
+				else
 					vd->look[LOOK_SHIELD] = val;
 				break;
 			case LOOK_BASE:
@@ -4040,10 +4040,11 @@ void clif_changelook(struct block_list *bl, int32 type, int32 val) {
 #if PACKETVER < 20150513
 				return;
 #else
+#if PACKETVER < 20231220 // 2023-12-20 CLIENT bodystylefix
 				if( val != 0 && sc != nullptr && sc->option&OPTION_COSTUME ){
  					val = 0;
 				}
-
+#endif // 2023-12-20 CLIENT bodystylefix
  				vd->look[LOOK_BODY2] = val;
 #endif
 				break;
@@ -4416,10 +4417,10 @@ void clif_changeoption2( block_list& bl ){
 
 	if (disguised(&bl)) {
 		clif_send( &packet, sizeof( packet ), &bl, AREA_WOS );
-		
+
 		packet.gid = disguised_bl_id( bl.id );
 		clif_send( &packet, sizeof( packet ), &bl, SELF );
-		
+
 		packet.gid = bl.id;
 		packet.effectState = OPTION_INVISIBLE;
 		clif_send( &packet, sizeof( packet ), &bl, SELF );
@@ -4599,7 +4600,7 @@ void clif_joinchatok(map_session_data& sd, chat_data& cd){
 	p->packetType = HEADER_ZC_ENTER_ROOM;
 	p->packetSize = sizeof(*p);
 	p->chatId = cd.id;
-	
+
 	if(cd.owner->type == BL_NPC){
 		PACKET_ZC_ENTER_ROOM_sub& owner = p->members[0];
 		owner.flag = 0;
@@ -5265,7 +5266,7 @@ void clif_damage(block_list& src, block_list& dst, t_tick tick, int32 sdelay, in
 		clif_send( &p, sizeof(p), &src, SELF);
 	}
 
-	if(&src == &dst) 
+	if(&src == &dst)
 		unit_setdir(&src, unit_getdir(&src));
 }
 
@@ -5673,7 +5674,7 @@ void clif_skillinfoblock(map_session_data *sd)
 			// workaround for bugreport:5348
 			if (len + 37 > 8192)
 				break;
-			
+
 			// skip WE_CALLPARTNER and send it in special way
 			if (id == WE_CALLPARTNER) {
 				haveCallPartnerSkill = true;
@@ -5781,7 +5782,7 @@ void clif_skillup( map_session_data& sd, uint16 skill_id, uint16 lv, uint16 rang
 	if( idx == 0 ){
 		return;
 	}
-	
+
 	PACKET_ZC_SKILLINFO_UPDATE p{};
 
 	p.packetType = HEADER_ZC_SKILLINFO_UPDATE;
@@ -5808,7 +5809,7 @@ void clif_skillinfo( map_session_data& sd, uint16 skill_id, int32 inf ){
 
 	PACKET_ZC_SKILLINFO_UPDATE2 p = {};
 
-	p.packetType = HEADER_ZC_SKILLINFO_UPDATE2;	
+	p.packetType = HEADER_ZC_SKILLINFO_UPDATE2;
 	p.id = skill_id;
 	p.level = sd.status.skill[idx].lv;
 	p.sp = static_cast<decltype(p.sp)>( skill_get_sp( skill_id,sd.status.skill[idx].lv ) );
@@ -6035,7 +6036,7 @@ void clif_skill_damage( block_list& src, block_list& dst, t_tick tick, int32 sde
 	} else {
 		clif_send( &packet, sizeof( packet ), &dst, AREA );
 	}
-	
+
 	if (disguised(&src)) {
 		packet.AID = disguised_bl_id( src.id );
 		if (disguised(&dst)) {
@@ -6153,7 +6154,7 @@ void clif_skill_poseffect( block_list& bl, uint16 skill_id, uint16 skill_lv, uin
 
 	if (disguised(&bl)) {
 		clif_send( &packet, sizeof( packet ), &bl, AREA_WOS );
-		
+
 		packet.AID = disguised_bl_id( bl.id );
 		clif_send( &packet, sizeof( packet ), &bl, SELF );
 	} else {
@@ -6625,7 +6626,7 @@ void clif_displaymessage(const int32 fd, const char* mes)
 			unsigned long color = (color_table[COLOR_DEFAULT] & 0x0000FF) << 16 | (color_table[COLOR_DEFAULT] & 0x00FF00) | (color_table[COLOR_DEFAULT] & 0xFF0000) >> 16; // RGB to BGR
 			uint16 len = strnlen(line, CHAT_SIZE_MAX);
 
-			if (len > 0) { 
+			if (len > 0) {
 				WFIFOHEAD(fd, 13 + len);
 				WFIFOW(fd, 0) = 0x2C1;
 				WFIFOW(fd, 2) = 13 + len;
@@ -6825,7 +6826,7 @@ void clif_map_property(struct block_list *bl, enum map_property property, enum s
 	int16 cmd = 0x199;
 	unsigned char buf[4];
 #endif
-	
+
 	WBUFW(buf,0)=cmd;
 	WBUFW(buf,2)=property;
 
@@ -6846,7 +6847,7 @@ void clif_map_property(struct block_list *bl, enum map_property property, enum s
 		((!mapdata->getMapFlag(MF_NOSUNMOONSTARMIRACLE))<<10); // SUNMOONSTAR_MIRACLE - Allows Star Gladiator's Miracle to activate
 		//(1<<11); // Unused bits. 1 - 10 is 0x1 length and 11 is 0x15 length. May be used for future settings.
 #endif
-	
+
 	clif_send(buf,packet_len(cmd),bl,t);
 }
 
@@ -6903,7 +6904,7 @@ void clif_map_property_mapall(int32 map_idx, enum map_property property)
 	bl.id = 0;
 	bl.type = BL_NUL;
 	bl.m = map_idx;
-	
+
 	clif_map_property( &bl, property, ALL_SAMEMAP );
 }
 
@@ -6978,7 +6979,7 @@ void clif_wis_message(map_session_data* sd, const char* nick, const char* mes, s
 }
 
 
-/// Inform the player about the result of his whisper action 
+/// Inform the player about the result of his whisper action
 /// 0098 <result>.B (ZC_ACK_WHISPER).
 /// 09df <result>.B <CID>.L (ZC_ACK_WHISPER02).
 /// result:
@@ -7317,7 +7318,7 @@ void clif_cart_additem_ack( map_session_data& sd, e_ack_additem_to_cart flag ){
 
 	packet.packetType = HEADER_ZC_ACK_ADDITEM_TO_CART;
 	packet.result = static_cast<decltype(packet.result)>(flag);
-	
+
 	clif_send( &packet, sizeof( packet ), &sd, SELF );
 }
 
@@ -8633,7 +8634,7 @@ void clif_guild_belonginfo( map_session_data& sd ){
 void clif_guild_memberlogin_notice(const struct mmo_guild &g,int32 idx,int32 flag)
 {
 	map_session_data* sd;
-	
+
 	PACKET_ZC_UPDATE_CHARSTAT p = {};
 
 	p.packetType = HEADER_ZC_UPDATE_CHARSTAT;
@@ -8700,7 +8701,7 @@ void clif_guild_send_onlineinfo(map_session_data *sd)
 }
 
 
-/// Bitmask of enabled guild window tabs 
+/// Bitmask of enabled guild window tabs
 /// 014e <menu flag>.L (ZC_ACK_GUILD_MENUINTERFACE)
 /// menu flag:
 ///      0x00 = Basic Info (always on)
@@ -8765,7 +8766,7 @@ void clif_guild_basicinfo( map_session_data& sd ){
 }
 
 
-/// Guild alliance and opposition list 
+/// Guild alliance and opposition list
 /// 014c <packet len>.W { <relation>.L <guild id>.L <guild name>.24B }* (ZC_MYGUILD_BASIC_INFO)
 void clif_guild_allianceinfo(map_session_data& sd){
 	auto &g = sd.guild;
@@ -8879,7 +8880,7 @@ void clif_guild_positionnamelist(map_session_data *sd)
 }
 
 
-/// Guild position information 
+/// Guild position information
 /// 0160 <packet len>.W { <position id>.L <mode>.L <ranking>.L <pay rate>.L }* (ZC_POSITION_INFO)
 /// mode:
 ///     See enum e_guild_permission
@@ -9157,7 +9158,7 @@ void clif_guild_expulsion( map_session_data& sd, const char* name, uint32 char_i
 }
 
 
-/// Guild expulsion list 
+/// Guild expulsion list
 /// 0163 <packet len>.W { <char name>.24B <account name>.24B <reason>.40B }* (ZC_BAN_LIST)
 /// 0163 <packet len>.W { <char name>.24B <reason>.40B }* (PACKETVER >= 20100803) (ZC_BAN_LIST)
 /// 0a87 <packet len>.W { <charid>.L <reason>.40B }* (ZC_BAN_LIST2)
@@ -9186,7 +9187,7 @@ static void clif_guild_expulsionlist(map_session_data& sd){
 		banned.char_id = e.char_id;
 #elif PACKETVER < 20100803
 		// account name (not used for security reasons)
-		safestrncpy(banned.account_name, "", sizeof(banned.account_name)); 
+		safestrncpy(banned.account_name, "", sizeof(banned.account_name));
 #endif
 
 #if PACKETVER >= 20200902 || PACKETVER < 20161019
@@ -9202,7 +9203,7 @@ static void clif_guild_expulsionlist(map_session_data& sd){
 }
 
 
-/// Guild chat message 
+/// Guild chat message
 /// 017f <packet len>.W <message>.?B (ZC_GUILD_CHAT)
 void clif_guild_message( const struct mmo_guild& g, const char* mes, size_t len ){
 	PACKET_ZC_GUILD_CHAT *p = reinterpret_cast<PACKET_ZC_GUILD_CHAT*>( packet_buffer );
@@ -9230,7 +9231,7 @@ void clif_guild_message( const struct mmo_guild& g, const char* mes, size_t len 
 	clif_send(p, p->packetLength, sd, GUILD_NOBG);
 }
 
-/// Request for guild alliance 
+/// Request for guild alliance
 /// 0171 <inviter account id>.L <guild name>.24B (ZC_REQ_ALLY_GUILD).
 void clif_guild_reqalliance(map_session_data& sd,uint32 account_id,const char *name)
 {
@@ -9282,7 +9283,7 @@ void clif_guild_delalliance(map_session_data& sd,uint32 guild_id,uint32 flag)
 }
 
 
-/// Notifies the client about the result of a opposition request. 
+/// Notifies the client about the result of a opposition request.
 /// 0181 <result>.B (ZC_ACK_REQ_HOSTILE_GUILD)
 /// result:
 ///     0 = Antagonist has been set.
@@ -9754,7 +9755,7 @@ void clif_messagecolor_target(struct block_list *bl, unsigned long color, const 
 /**
  * Notifies the client that the storage window is still open
  *
- * Should only be used in cases where the client closed the 
+ * Should only be used in cases where the client closed the
  * storage window without server's consent
  */
 void clif_refresh_storagewindow(map_session_data *sd) {
@@ -9847,7 +9848,7 @@ void clif_refresh(map_session_data *sd)
 	clif_efst_status_change_sub(sd,sd,SELF);
 
 	//Issue #2143
-	//Cancel Trading State 
+	//Cancel Trading State
 	if (sd->state.trading)
 		trade_tradecancel(sd);
 	//Cancel Buying/Selling State
@@ -10406,7 +10407,7 @@ static bool clif_process_message(map_session_data* sd, bool whisperFormat, char*
 	}
 
 	// process <name> part of the packet
-	if( whisperFormat ) {	
+	if( whisperFormat ) {
 		// name has fixed width
 		if( inputLength < NAME_LENGTH + 1 ) {
 			ShowWarning("clif_process_message: Received malformed packet from player '%s' (packet length is incorrect)!\n", sd->status.name);
@@ -10425,13 +10426,13 @@ static bool clif_process_message(map_session_data* sd, bool whisperFormat, char*
 		}
 
 		message = input + NAME_LENGTH;
-		messageLength = inputLength - NAME_LENGTH;		
+		messageLength = inputLength - NAME_LENGTH;
 	}else{
 		// name and message are separated by ' : '
 		size_t seperatorLength = strnlen( seperator, NAME_LENGTH );
 
 		nameLength = strnlen( sd->status.name, NAME_LENGTH - 1 ); // name length (w/o zero byte)
-		
+
 		// check if there's enough data provided
 		if( inputLength < nameLength + seperatorLength + 1 ){
 			ShowWarning("clif_process_message: Received malformed packet from player '%s' (no username data)!\n", sd->status.name);
@@ -10480,7 +10481,7 @@ static bool clif_process_message(map_session_data* sd, bool whisperFormat, char*
 		ShowWarning("clif_process_message: Player '%s' sent a message too long ('%.*s')!\n", sd->status.name, CHAT_SIZE_MAX-1, message);
 		return false;
 	}
-	
+
 	// If it is not a whisper message, set the name to the fakename of the player
 	if( whisperFormat == false && sd->fakename[0] != '\0' ){
 		strcpy( out_name, sd->fakename );
@@ -10531,7 +10532,7 @@ inline void clif_pk_mode_message(map_session_data * sd)
 		if( (int32)sd->status.base_level < battle_config.pk_min_level ) {
 			char output[CHAT_SIZE_MAX];
 			// 1504: You've entered a PK Zone (safe until level %d).
-			safesnprintf(output, CHAT_SIZE_MAX, msg_txt(sd,1504), 
+			safesnprintf(output, CHAT_SIZE_MAX, msg_txt(sd,1504),
 						 battle_config.pk_min_level);
 			clif_showscript(sd, output, SELF);
 		} else {
@@ -10620,7 +10621,7 @@ void clif_parse_WantToConnection(int32 fd, map_session_data* sd)
 				*/
 				err == 6 ? ", possibly for having an invalid sex." :
 				". ERROR invalid error code"));
-		
+
 		WFIFOHEAD(fd,packet_len(0x6a));
 		WFIFOW(fd,0) = 0x6a;
 		WFIFOB(fd,2) = err;
@@ -11056,7 +11057,7 @@ void clif_parse_LoadEndAck(int32 fd,map_session_data *sd)
 
 		clif_pk_mode_message(sd);
 	}
-	
+
 	if( sd->guild && ( battle_config.guild_notice_changemap == 2 || guild_notice ) ){
 		// Displays at end
 		clif_guild_notice( *sd );
@@ -11568,7 +11569,7 @@ void clif_parse_ChangeDir(int32 fd, map_session_data *sd)
 }
 
 
-/// Request to show an emotion 
+/// Request to show an emotion
 /// 00bf <type>.B (CZ_REQ_EMOTION).
 void clif_parse_Emotion(int32 fd, map_session_data *sd){
 	if( sd == nullptr ){
@@ -11580,7 +11581,7 @@ void clif_parse_Emotion(int32 fd, map_session_data *sd){
 	if( p->emotion_type >= ET_MAX ){
 		return;
 	}
-	
+
 	emotion_type emoticon = static_cast<emotion_type>( p->emotion_type );
 
 	if (battle_config.basic_skill_check == 0 || pc_checkskill(sd, NV_BASIC) >= 2 || pc_checkskill(sd, SU_BASIC_SKILL) >= 1) {
@@ -12298,7 +12299,7 @@ void clif_parse_NpcSellListSend(int32 fd,map_session_data *sd)
 	const PACKET_CZ_PC_SELL_ITEMLIST* p = reinterpret_cast<PACKET_CZ_PC_SELL_ITEMLIST*>( RFIFOP( fd, 0 ) );
 
 	int32 n = ( p->packetLength - sizeof( *p ) ) / sizeof( p->sellList[0] );
-	
+
 	if (sd->state.trading || !sd->npc_shopid)
 		fail = 1;
 	else
@@ -12616,7 +12617,7 @@ void clif_parse_SelectCart(int32 fd,map_session_data *sd) {
 	type = (int32)RFIFOB(fd,6);
 
 	// Check type
-	if( type < 10 || type > 12 ) 
+	if( type < 10 || type > 12 )
 		return;
 
 	pc_setcart(sd, type);
@@ -12642,7 +12643,7 @@ void clif_parse_ChangeCart(int32 fd,map_session_data *sd)
 
 	type = (int32)RFIFOW(fd,packet_db[RFIFOW(fd,0)].pos[0]);
 
-	if( 
+	if(
 #ifdef NEW_CARTS
 #if PACKETVER >= 20191106
 		(type == 13 && sd->status.base_level > 100) ||
@@ -12861,8 +12862,8 @@ void clif_parse_skill_toid( map_session_data* sd, uint16 skill_id, uint16 skill_
 		}
 	}
 
-	if ((pc_cant_act2(sd) || sd->chatID) && 
-		skill_id != RK_REFRESH && 
+	if ((pc_cant_act2(sd) || sd->chatID) &&
+		skill_id != RK_REFRESH &&
 		!( ( skill_id == SR_GENTLETOUCH_CURE || skill_id == SU_GROOMING ) && (sd->sc.opt1 == OPT1_STONE || sd->sc.opt1 == OPT1_FREEZE || sd->sc.opt1 == OPT1_STUN)) &&
 		!(sd->state.storage_flag && (inf&INF_SELF_SKILL))) //SELF skills can be used with the storage open, issue: 8027
 		return;
@@ -14223,7 +14224,7 @@ void clif_parse_CreateGuild(int32 fd,map_session_data *sd){
 }
 
 
-/// Request for guild window interface permissions 
+/// Request for guild window interface permissions
 /// 014d (CZ_REQ_GUILD_MENUINTERFACE)
 static void clif_parse_GuildCheckMaster(int32 fd, map_session_data *sd){
 	if(sd == nullptr)
@@ -14962,7 +14963,7 @@ void clif_parse_GMHide(int32 fd, map_session_data *sd) {
 }
 
 
-/// /resetcooltime 
+/// /resetcooltime
 /// 0a88 (CZ_CMD_RESETCOOLTIME).
 void clif_parse_gm_resetcooltime( int32 fd, map_session_data* sd ){
 #if PACKETVER_MAIN_NUM >= 20160622 || PACKETVER_RE_NUM >= 20160622 || defined(PACKETVER_ZERO)
@@ -16095,7 +16096,7 @@ void clif_Mail_refreshinbox(map_session_data *sd,enum mail_inbox_type type,int64
 		i = md->amount;
 	}
 #endif
-	
+
 	// Count the remaining mails from the starting mail or the beginning
 	// Only count mails of the target type(before 2017-04-19) and those that should not have been deleted already
 	for( j = i, remaining = 0; j >= 0; j-- ){
@@ -16520,7 +16521,7 @@ void clif_parse_Mail_getattach( int32 fd, map_session_data *sd ){
 	if( attachment&MAIL_ATT_ZENY && msg->zeny < 1 ){
 		attachment &= ~MAIL_ATT_ZENY;
 	}
-	
+
 	if( attachment&MAIL_ATT_ITEM ){
 		ARR_FIND(0, MAIL_MAX_ITEM, i, msg->item[i].nameid > 0 || msg->item[i].amount > 0);
 
@@ -16868,7 +16869,7 @@ void clif_Auction_results(map_session_data *sd, int16 count, int16 pages, uint8 
 		memcpy(&auction, RBUFP(buf,i * len), len);
 
 		WFIFOL(fd,k) = auction.auction_id;
-		safestrncpy(WFIFOCP(fd,4+k), auction.seller_name, NAME_LENGTH);			
+		safestrncpy(WFIFOCP(fd,4+k), auction.seller_name, NAME_LENGTH);
 		WFIFOW(fd,28+k) = client_nameid( auction.item.nameid );
 		WFIFOL(fd,30+k) = auction.type;
 		WFIFOW(fd,34+k) = auction.item.amount; // Always 1
@@ -17115,7 +17116,7 @@ void clif_parse_Auction_bid( int32 fd, map_session_data* sd ){
 		clif_displaymessage( sd->fd, msg_txt( sd, 246 ) ); // Your GM level doesn't authorize you to perform this action.
 		return;
 	}
-		
+
 	// Check if char server is down (bugreport:1138)
 	if( CheckForCharServer() ){
 		clif_Auction_message(fd, 0); // You have failed to bid into the auction
@@ -17807,7 +17808,7 @@ std::string clif_quest_string( std::shared_ptr<s_quest_objective> objective ){
 
 		str += ele_name;
 	}
-	
+
 	return str;
 }
 
@@ -17853,7 +17854,7 @@ void clif_quest_send_list(map_session_data *sd)
 		offset += 4;
 		WFIFOW(fd, offset) = static_cast<uint16>(qi->objectives.size());
 		offset += 2;
-		
+
 		if (!qi->objectives.empty()) {
 			std::shared_ptr<s_mob_db> mob;
 
@@ -17905,7 +17906,7 @@ void clif_quest_send_list(map_session_data *sd)
 		WFIFOB(fd, offset) = sd->quest_log[i].state;
 		offset += 1;
 	}
-	
+
 	WFIFOW(fd, 2) = offset;
 	WFIFOSET(fd, offset);
 #endif
@@ -19723,7 +19724,7 @@ void clif_autoshadowspell_list( map_session_data& sd ){
 	p->packetType = HEADER_ZC_SKILL_SELECT_REQUEST;
 	p->packetLength = sizeof( *p );
 	p->flag = 1; // enum PACKET_ZC_SKILL_SELECT_REQUEST::enumWHY::WHY_SC_AUTOSHADOWSPELL =  0x1
-	
+
 	size_t count = 0;
 	for( size_t i = 0; i < MAX_SKILL; i++ ){
 		if( sd.status.skill[i].flag == SKILL_FLAG_PLAGIARIZED && sd.status.skill[i].id > 0 &&
@@ -19926,7 +19927,7 @@ void clif_ackworldinfo(map_session_data* sd) {
 /// 0978 <AID>.L
 void clif_parse_reqworldinfo(int32 fd,map_session_data *sd) {
 	//uint32 aid = RFIFOL(fd,2); //should we trust client ?
-	if(sd) 
+	if(sd)
 		clif_ackworldinfo(sd);
 }
 
@@ -19948,7 +19949,7 @@ static void clif_loadConfirm( map_session_data *sd ){
 /// 0447
 void clif_parse_blocking_playcancel( int32 fd, map_session_data *sd ){
 	clif_loadConfirm( sd );
-	
+
 	int32 mf = map_getmapflag(sd->m, MF_SPECIALPOPUP);
 
 	if (mf > 0) {
@@ -20078,7 +20079,7 @@ void clif_ranklist( map_session_data& sd, e_rank rankingtype ){
 			break;
 		default:
 			p.mypoints = 0;
-			break;			
+			break;
 	}
 
 	clif_send( &p, sizeof( p ), &sd, SELF );
@@ -20097,7 +20098,7 @@ void clif_ranklist( map_session_data& sd, e_rank rankingtype ){
 			break;
 		default:
 			p.mypoints = 0;
-			break;			
+			break;
 	}
 
 	clif_send( &p, sizeof( p ), &sd, SELF );
@@ -20562,7 +20563,7 @@ void clif_clan_message( struct clan& clan, const char *mes, size_t len ){
 
 	p->PacketType = HEADER_ZC_NOTIFY_CLAN_CHAT;
 	p->PacketLength = sizeof( *p );
-	
+
 	// Offially the sender name should also be filled here, but it is not required by the client and since it's in the message too we do not fill it
 	safestrncpy( p->MemberName, "", sizeof( p->MemberName ) );
 
@@ -20717,7 +20718,7 @@ void clif_parse_change_title(int32 fd, map_session_data *sd)
 
 		sd->status.title_id = title_id;
 	}
-	
+
 	clif_name_area(sd);
 	clif_change_title_ack(sd, 0, title_id);
 }
@@ -21438,7 +21439,7 @@ void clif_hat_effects( block_list& bl, enum send_target target, block_list& tbl 
 	}
 
 	unit_data* ud = unit_bl2ud( &bl );
-	
+
 	if( ud == nullptr ){
 		return;
 	}
@@ -21703,7 +21704,7 @@ void clif_parse_sale_add( int32 fd, map_session_data* sd ){
 	if( !sd->state.sale_open ){
 		return;
 	}
-	
+
 	time_t endTime = p->startTime + p->hours * 60 * 60;
 
 	clif_sale_add_reply( sd, sale_add_item( p->itemId, p->amount, p->startTime, endTime ) );
@@ -21780,7 +21781,7 @@ void clif_achievement_list_all(map_session_data *sd)
 	for (int32 i = 0; i < count; i++) {
 		WFIFOL(fd, i * 50 + 22) = (uint32)sd->achievement_data.achievements[i].achievement_id;
 		WFIFOB(fd, i * 50 + 26) = (uint32)sd->achievement_data.achievements[i].completed > 0;
-		for (int32 j = 0; j < MAX_ACHIEVEMENT_OBJECTIVES; j++) 
+		for (int32 j = 0; j < MAX_ACHIEVEMENT_OBJECTIVES; j++)
 			WFIFOL(fd, (i * 50) + 27 + (j * 4)) = (uint32)sd->achievement_data.achievements[i].count[j];
 		WFIFOL(fd, i * 50 + 67) = (uint32)sd->achievement_data.achievements[i].completed;
 		WFIFOB(fd, i * 50 + 71) = sd->achievement_data.achievements[i].rewarded > 0;
@@ -21889,7 +21890,7 @@ void clif_parse_changedress( int32 fd, map_session_data* sd ){
 	char command[CHAT_SIZE_MAX];
 
 	safesnprintf( command, sizeof(command), "%cchangedress", atcommand_symbol );
-	
+
 	is_atcommand( fd, sd, command, 1 );
 #endif
 }
@@ -22126,7 +22127,7 @@ void clif_guild_storage_log( map_session_data& sd, std::vector<struct guild_log_
 	}else{
 		p->amount = 0;
 	}
-	
+
 	clif_send( p, p->PacketLength, &sd, SELF );
 #endif
 }
@@ -24418,7 +24419,7 @@ void clif_enchantwindow_open( map_session_data& sd, uint64 clientLuaIndex ){
 		clif_msg_color( sd, MSI_ENCHANT_FAILED_OVER_WEIGHT, color_table[COLOR_RED] );
 		sd.state.item_enchant_index = 0;
 		return;
-		
+
 	}
 
 	PACKET_ZC_UI_OPEN_V3 p = {};
@@ -25804,7 +25805,7 @@ void do_init_clif(void) {
 	add_timer_func_list( clif_ping_timer, "clif_ping_timer" );
 
 	if( battle_config.ping_timer_interval > 0 ){
-		add_timer_interval( gettick() + battle_config.ping_timer_interval * 1000, clif_ping_timer, 0, 0, battle_config.ping_timer_interval * 1000 );	
+		add_timer_interval( gettick() + battle_config.ping_timer_interval * 1000, clif_ping_timer, 0, 0, battle_config.ping_timer_interval * 1000 );
 	}
 #endif
 

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -1349,7 +1349,13 @@ void pc_makesavestatus(map_session_data *sd) {
 		sd->status.clothes_color = 0;
 
 	if(!battle_config.save_body_style)
+	{ // 2023-12-20 CLIENT bodystylefix
+#if PACKETVER >= 20231220 // 2023-12-20 CLIENT bodystylefix
+		sd->status.body = sd->status.class_; // 2023-12-20 CLIENT bodystylefix
+#else // 2023-12-20 CLIENT bodystylefix
 		sd->status.body = 0;
+#endif // 2023-12-20 CLIENT bodystylefix
+	} // 2023-12-20 CLIENT bodystylefix
 
 	//Only copy the Cart/Peco/Falcon options, the rest are handled via
 	//status change load/saving. [Skotlex]
@@ -1634,7 +1640,7 @@ bool pc_isequipped(map_session_data *sd, t_itemid nameid)
 			continue;
 		if( pc_is_same_equip_index((enum equip_index)i, sd->equip_index, index) )
 			continue;
-		if( !sd->inventory_data[index] ) 
+		if( !sd->inventory_data[index] )
 			continue;
 		if( sd->inventory_data[index]->nameid == nameid )
 			return true;
@@ -2273,7 +2279,7 @@ bool pc_authok(map_session_data *sd, uint32 login_id2, time_t expiration_time, i
 	sd->status.cashshop_sent = false;
 
 	sd->last_addeditem_index = -1;
-	
+
 	sd->bonus_script.head = nullptr;
 	sd->bonus_script.count = 0;
 
@@ -2642,7 +2648,7 @@ void pc_calc_skilltree(map_session_data *sd)
 	// Removes Taekwon Ranker skill bonus
 	if ((sd->class_&MAPID_UPPERMASK) != MAPID_TAEKWON) {
 		std::shared_ptr<s_skill_tree> tree = skill_tree_db.find(JOB_TAEKWON);
-	
+
 		if (tree != nullptr && !tree->skills.empty()) {
 			for (const auto &it : tree->skills) {
 				uint16 sk_idx = skill_get_index(it.first);
@@ -3496,7 +3502,7 @@ TIMER_FUNC(pc_endautobonus){
 			break;
 		}
 	}
-	
+
 	status_calc_pc(sd,SCO_FORCE);
 	return 0;
 }
@@ -4357,7 +4363,7 @@ void pc_bonus(map_session_data *sd,int32 type,int32 val)
 		case SP_LONG_HP_GAIN_VALUE:
 			if (sd->state.lr_flag == LR_FLAG_NONE)
 				sd->bonus.long_hp_gain_value += val;
-			break;		
+			break;
 		case SP_MAGIC_SP_GAIN_VALUE:
 			if (sd->state.lr_flag == LR_FLAG_NONE)
 				sd->bonus.magic_sp_gain_value += val;
@@ -4711,7 +4717,7 @@ void pc_bonus2(map_session_data *sd,int32 type,int32 type2,int32 val)
 			ShowWarning("pc_bonus2: SP_SKILL_HEAL: Reached max (%d) number of skills per character, bonus skill %d (+%d%%) lost.\n", MAX_PC_BONUS, type2, val);
 			break;
 		}
-		
+
 		pc_bonus_itembonus(sd->skillheal, type2, val, false);
 		break;
 	case SP_SKILL_HEAL2: // bonus2 bSkillHeal2,sk,n;
@@ -4721,7 +4727,7 @@ void pc_bonus2(map_session_data *sd,int32 type,int32 type2,int32 val)
 			ShowWarning("pc_bonus2: SP_SKILL_HEAL2: Reached max (%d) number of skills per character, bonus skill %d (+%d%%) lost.\n", MAX_PC_BONUS, type2, val);
 			break;
 		}
-		
+
 		pc_bonus_itembonus(sd->skillheal2, type2, val, false);
 		break;
 	case SP_ADD_SKILL_BLOW: // bonus2 bAddSkillBlow,sk,n;
@@ -4731,7 +4737,7 @@ void pc_bonus2(map_session_data *sd,int32 type,int32 type2,int32 val)
 			ShowWarning("pc_bonus2: SP_ADD_SKILL_BLOW: Reached max (%d) number of skills per character, bonus skill %d (%d) lost.\n", MAX_PC_BONUS, type2, val);
 			break;
 		}
-		
+
 		pc_bonus_itembonus(sd->skillblown, type2, val, false);
 		break;
 	case SP_HP_LOSS_RATE: // bonus2 bHPLossRate,n,t;
@@ -4921,7 +4927,7 @@ void pc_bonus2(map_session_data *sd,int32 type,int32 type2,int32 val)
 			ShowWarning("pc_bonus2: SP_SKILL_USE_SP_RATE: Reached max (%d) number of skills per character, bonus skill %d (+%d%%) lost.\n", MAX_PC_BONUS, type2, val);
 			break;
 		}
-		
+
 		pc_bonus_itembonus(sd->skillusesprate, type2, val, true);
 		break;
 	case SP_SKILL_DELAY:
@@ -5096,7 +5102,7 @@ void pc_bonus2(map_session_data *sd,int32 type,int32 type2,int32 val)
 	default:
 		if (current_equip_combo_pos > 0) {
 			ShowWarning("pc_bonus2: unknown bonus type %d %d %d in a combo with item #%u\n", type, type2, val, sd->inventory_data[pc_checkequip( sd, current_equip_combo_pos )]->nameid);
-		} 
+		}
 		else if (current_equip_card_id > 0 || current_equip_item_index > 0) {
 			ShowWarning("pc_bonus2: unknown bonus type %d %d %d in item #%u\n", type, type2, val, current_equip_card_id ? current_equip_card_id : sd->inventory_data[current_equip_item_index]->nameid);
 		}
@@ -5358,7 +5364,7 @@ void pc_bonus5(map_session_data *sd,int32 type,int32 type2,int32 type3,int32 typ
 		if (sd->state.lr_flag != LR_FLAG_ARROW)
 			pc_bonus_autospell_onskill(sd->autospell3, type2, type3, type4, type5, current_equip_card_id, val & AUTOSPELL_FORCE_ALL);
 		break;
- 
+
 	case SP_ADDEFF_ONSKILL: // bonus5 bAddEffOnSkill,sk,eff,n,y,t;
 		PC_BONUS_CHK_SC(type3,SP_ADDEFF_ONSKILL);
 		if( sd->state.lr_flag != LR_FLAG_ARROW )
@@ -5513,7 +5519,7 @@ bool pc_skill_plagiarism(map_session_data &sd, uint16 skill_id, uint16 skill_lv)
 bool pc_skill_plagiarism_reset(map_session_data &sd, uint8 type)
 {
 	uint16 idx;
-	if (type == 1) 
+	if (type == 1)
 		idx = sd.cloneskill_idx;
 	else if (type == 2)
 		idx = sd.reproduceskill_idx;
@@ -5528,7 +5534,7 @@ bool pc_skill_plagiarism_reset(map_session_data &sd, uint8 type)
 		sd.status.skill[idx].lv = 0;
 		sd.status.skill[idx].flag = SKILL_FLAG_PERMANENT;
 		clif_deleteskill(sd, skill_id);
-		
+
 		if (type == 1) {
 			sd.cloneskill_idx = 0;
 			pc_setglobalreg(&sd, add_str(SKILL_VAR_PLAGIARISM), 0);
@@ -5540,7 +5546,7 @@ bool pc_skill_plagiarism_reset(map_session_data &sd, uint8 type)
 			pc_setglobalreg(&sd, add_str(SKILL_VAR_REPRODUCE_LV), 0);
 		}
 	}
-	
+
 	return true;
 }
 
@@ -6381,10 +6387,10 @@ bool pc_isUseitem(map_session_data *sd,int32 n)
 	//Not equipable by class. [Skotlex]
 	if (!pc_job_can_use_item(sd,item))
 		return false;
-	
+
 	if (sd->sc.cant.consume)
 		return false;
-	
+
 	if (!pc_isItemClass(sd,item))
 		return false;
 
@@ -6862,8 +6868,8 @@ int32 pc_steal_coin(map_session_data *sd,struct block_list *target)
 	md = (TBL_MOB*)target;
 	target_lv = status_get_lv(target);
 
-	if (md->state.steal_coin_flag || md->sc.getSCE(SC_STONE) || md->sc.getSCE(SC_FREEZE) || md->sc.getSCE(SC_HANDICAPSTATE_FROSTBITE) || 
-		md->sc.getSCE(SC_HANDICAPSTATE_SWOONING) || md->sc.getSCE(SC_HANDICAPSTATE_LIGHTNINGSTRIKE) || md->sc.getSCE(SC_HANDICAPSTATE_CRYSTALLIZATION) || 
+	if (md->state.steal_coin_flag || md->sc.getSCE(SC_STONE) || md->sc.getSCE(SC_FREEZE) || md->sc.getSCE(SC_HANDICAPSTATE_FROSTBITE) ||
+		md->sc.getSCE(SC_HANDICAPSTATE_SWOONING) || md->sc.getSCE(SC_HANDICAPSTATE_LIGHTNINGSTRIKE) || md->sc.getSCE(SC_HANDICAPSTATE_CRYSTALLIZATION) ||
 		status_bl_has_mode(target,MD_STATUSIMMUNE) || util::vector_exists(status_get_race2(md), RC2_TREASURE))
 		return 0;
 
@@ -7060,7 +7066,7 @@ enum e_setpos pc_setpos(map_session_data* sd, uint16 mapindex, int32 x, int32 y,
 			x = rnd()%(mapdata->xs-2)+1;
 			y = rnd()%(mapdata->ys-2)+1;
 			c++;
-			
+
 			if(c > (mapdata->xs * mapdata->ys)*3){ //force out
 				ShowError("pc_setpos: couldn't found a valid coordinates for player '%s' (%d:%d) on (%s), preventing warp\n", sd->status.name, sd->status.account_id, sd->status.char_id, mapindex_id2name(mapindex));
 				return SETPOS_OK; //preventing warp
@@ -7142,14 +7148,14 @@ enum e_setpos pc_setpos(map_session_data* sd, uint16 mapindex, int32 x, int32 y,
 	if(npc_check_areanpc(1,m,x,y,0)){
 		sd->count_rewarp++;
 	}
-	else 
+	else
 		sd->count_rewarp = 0;
 
 	if (sd->state.vending)
 		vending_update(*sd);
 	if (sd->state.buyingstore)
 		buyingstore_update(*sd);
-	
+
 	return SETPOS_OK;
 }
 
@@ -7413,7 +7419,7 @@ static void pc_checkallowskill(map_session_data *sd)
 			if (sd->sc.getSCE(status) && !pc_check_weapontype(sd, skill_get_weapontype(it.second->skill_id)))
 				status_change_end(sd, status);
 		}
-		if (flag[SCF_REQUIRENOWEAPON]) { 
+		if (flag[SCF_REQUIRENOWEAPON]) {
 			if (sd->sc.getSCE(status) && sd->status.weapon)
 				status_change_end( sd, status );
 		}
@@ -8430,7 +8436,7 @@ void pc_gainexp(map_session_data *sd, struct block_list *src, t_exp base_exp, t_
 
 		if (!battle_config.pvp_exp && map_getmapflag(sd->m, MF_PVP))  // [MouseJstr]
 			return; // no exp on pvp maps
-	
+
 		if (sd->status.guild_id>0)
 			base_exp -= guild_payexp(sd,base_exp);
 	}
@@ -9987,7 +9993,7 @@ int32 pc_dead(map_session_data *sd,struct block_list *src)
 				base_penalty = u64min(sd->status.base_exp, base_penalty);
 			}
 		}
-		else 
+		else
 			base_penalty = 0;
 
 		if ((battle_config.death_penalty_maxlv&2 || !pc_is_maxjoblv(sd)) && job_penalty > 0) {
@@ -10550,7 +10556,7 @@ bool pc_setparam(map_session_data *sd,int64 type,int64 val_tmp)
 	case SP_CHARMOVE:
 		sd->status.character_moves = val;
 		return true;
-	case SP_CHARRENAME:	
+	case SP_CHARRENAME:
 		sd->status.rename = val;
 		return true;
 	case SP_CHARFONT:
@@ -10873,7 +10879,11 @@ bool pc_jobchange(map_session_data *sd,int32 job, char upper)
 
 	// Reset body style to 0 before changing job to avoid
 	// errors since not every job has a alternate outfit.
+#if PACKETVER >= 20231220 // 2023-12-20 CLIENT bodystylefix
+	sd->status.body = job; // 2023-12-20 CLIENT bodystylefix
+#else // 2023-12-20 CLIENT bodystylefix
 	sd->status.body = 0;
+#endif // 2023-12-20 CLIENT bodystylefix
 	clif_changelook(sd,LOOK_BODY2,0);
 
 	sd->status.class_ = job;
@@ -11020,7 +11030,7 @@ bool pc_jobchange(map_session_data *sd,int32 job, char upper)
 	achievement_update_objective(sd, AG_JOB_CHANGE, 2, sd->status.base_level, job);
 	if( sd->status.party_id ){
 		struct party_data* p;
-		
+
 		if( ( p = party_search( sd->status.party_id ) ) != nullptr ){
 			ARR_FIND(0, MAX_PARTY, i, p->party.member[i].char_id == sd->status.char_id);
 
@@ -12598,7 +12608,7 @@ void pc_checkitem(map_session_data *sd) {
 			continue;
 		if( it->equipSwitch&~pc_equippoint(sd,i) ||
 			( !pc_has_permission(sd, PC_PERM_USE_ALL_EQUIPMENT) && !battle_config.allow_equip_restricted_item && itemdb_isNoEquip(sd->inventory_data[i], sd->m) ) ){
-			
+
 			for( int32 j = 0; j < EQI_MAX; j++ ){
 				if( sd->equip_switch_index[j] == i ){
 					sd->equip_switch_index[j] = -1;
@@ -13447,7 +13457,7 @@ uint64 SkillTreeDatabase::parseBodyNode(const ryml::NodeRef& node) {
 
 			std::shared_ptr<s_skill_tree_entry> entry;
 			bool skill_exists = tree->skills.count(skill_id) > 0;
-				
+
 			if (skill_exists)
 				entry = tree->skills[skill_id];
 			else
@@ -13551,7 +13561,7 @@ uint64 SkillTreeDatabase::parseBodyNode(const ryml::NodeRef& node) {
 						this->invalidWarning(it["MaxLevel"], "Required skill %s's level %hu exceeds the skill's max level %hu. Capping skill level.\n", skill_name.c_str(), lv_req, lv_req_max);
 						lv_req = lv_req_max;
 					}
-					
+
 					if (lv_req == 0) {
 						if (entry->need.erase(skill_id_req) == 0)
 							this->invalidWarning(Requiresit["Name"], "Failed to erase %s, the skill doesn't exist in for job %s, skipping.\n", skill_name_req.c_str(), job_name.c_str());
@@ -14510,7 +14520,7 @@ void pc_readdb(void) {
 		"/" DBIMPORT,
 		//add other path here
 	};
-		
+
 	//reset
 	job_db.clear(); // job_info table
 
@@ -14804,7 +14814,7 @@ TIMER_FUNC(pc_global_expiration_timer){
   return 0;
 }
 
-void pc_expire_check(map_session_data *sd) {  
+void pc_expire_check(map_session_data *sd) {
 	/* ongoing timer */
 	if( sd->expiration_tid != INVALID_TIMER )
 		return;
@@ -14869,10 +14879,10 @@ enum e_BANKING_WITHDRAW_ACK pc_bank_withdraw(map_session_data *sd, int32 money) 
 		clif_messagecolor(sd,color_table[COLOR_RED],msg_txt(sd,1495),false,SELF); //You can't withdraw that much money
 		return BWA_UNKNOWN_ERROR;
 	}
-	
+
 	if( pc_getzeny(sd,money, LOG_TYPE_BANK) )
 		return BWA_NO_MONEY;
-	
+
 	sd->bank_vault -= money;
 	pc_setreg2(sd, BANK_VAULT_VAR, sd->bank_vault);
 	if( save_settings&CHARSAVE_BANK )
@@ -14972,7 +14982,7 @@ struct s_bonus_script_entry *pc_bonus_script_add(map_session_data *sd, const cha
 
 	if (!sd)
 		return nullptr;
-	
+
 	if (!(script = parse_script(script_str, "bonus_script", 0, SCRIPT_IGNORE_EXTERNAL_BRACKETS))) {
 		ShowError("pc_bonus_script_add: Failed to parse script '%s' (CID:%d).\n", script_str, sd->status.char_id);
 		return nullptr;
@@ -15171,7 +15181,7 @@ int16 pc_maxaspd(map_session_data *sd) {
 
 	return (( sd->class_&JOBL_THIRD) ? battle_config.max_third_aspd : (
 			((sd->class_&MAPID_UPPERMASK) == MAPID_KAGEROUOBORO || (sd->class_&MAPID_UPPERMASK) == MAPID_REBELLION) ? battle_config.max_extended_aspd : (
-			(sd->class_&MAPID_BASEMASK) == MAPID_SUMMONER) ? battle_config.max_summoner_aspd : 
+			(sd->class_&MAPID_BASEMASK) == MAPID_SUMMONER) ? battle_config.max_summoner_aspd :
 			battle_config.max_aspd ));
 }
 
@@ -15723,7 +15733,7 @@ void pc_macro_captcha_register_upload(map_session_data &sd, uint16 upload_size, 
 		captcha_db.put(index, sd.captcha_upload.cd);
 		sd.captcha_upload.cd = nullptr;
 		sd.captcha_upload.upload_size = 0;
-		
+
 		// TODO: write YAML and BMP file?
 	}
 }

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -1018,7 +1018,7 @@ efst_type StatusDatabase::getIcon(sc_type type) {
 /**
  * Get flag of SC (SCB value) for status_calc_ flag
  * @param type: SC type
- * @return cal_flag: Calc value 
+ * @return cal_flag: Calc value
  **/
 std::bitset<SCB_MAX> StatusDatabase::getCalcFlag(sc_type type) {
 	std::shared_ptr<s_status_change_db> status = status_db.find(type);
@@ -1205,7 +1205,7 @@ status_change_entry* status_change::getSCE( enum sc_type type ){
 
 	this->lastStatus.first = type;
 	this->lastStatus.second = sc;
-	
+
 	return this->lastStatus.second;
 }
 
@@ -1346,7 +1346,7 @@ int32 status_set_maxhp(struct block_list *bl, uint32 maxhp, int32 flag)
  * @param bl: Object whose SP will be set [PC|HOM|MER|ELEM]
  * @param sp: What the SP is to be set as
  * @param flag: Used in case final value is higher than current
- *		Use 2 to display healing effect		
+ *		Use 2 to display healing effect
  * @return heal or zapped SP if valid
  */
 int32 status_set_sp(struct block_list *bl, uint32 sp, int32 flag)
@@ -1451,7 +1451,7 @@ int32 status_set_maxap(struct block_list *bl, uint32 maxap, int32 flag)
  * Takes HP/SP from an Object
  * @param bl: Object who will have HP/SP taken [PC|MOB|HOM|MER|ELEM]
  * @param hp: How much HP to charge
- * @param sp: How much SP to charge	
+ * @param sp: How much SP to charge
  * @return hp+sp through status_damage()
  * Note: HP/SP are integer values, not percentages. Values should be
  *	 calculated either within function call or before
@@ -1901,8 +1901,8 @@ int32 status_heal(struct block_list *bl,int64 hhp,int64 hsp, int64 hap, int32 fl
  * @param sp_rate: Percentage of SP to modify. If > 0:percent is of current SP, if < 0:percent is of max SP
  * @param ap_rate: Percentage of AP to modify. If > 0:percent is of current AP, if < 0:percent is of max AP
  * @param flag: \n
- *		0: Heal target \n 
- *		1: Use status_damage \n 
+ *		0: Heal target \n
+ *		1: Use status_damage \n
  *		2: Use status_damage and make sure target must not die from subtraction
  * @return hp+sp+ap through status_heal()
  */
@@ -2610,7 +2610,7 @@ void status_calc_misc(struct block_list *bl, struct status_data *status, int32 l
 		status->cri = status->flee2 =
 		status->patk = status->smatk =
 		status->hplus = status->crate = 0;
-		
+
 		if (bl->type != BL_MOB)	// BL_MOB has values set when loading mob_db
 			status->res = status->mres = 0;
 	}
@@ -2924,7 +2924,7 @@ int32 status_calc_mob_(struct mob_data* md, uint8 opt)
 		// Remove special AI when this is used by regular mobs.
 		if (mbl->type == BL_MOB && !((TBL_MOB*)mbl)->special_state.ai)
 			md->special_state.ai = AI_NONE;
-		if (ud) { 
+		if (ud) {
 			// Different levels of HP according to skill level
 			if(!ud->skill_id) // !FIXME: We lost the unit data for magic decoy in somewhere before this
 				ud->skill_id = ((TBL_PC*)mbl)->menuskill_id;
@@ -4156,7 +4156,7 @@ int32 status_calc_pc_sub(map_session_data* sd, uint8 opt)
 			continue;
 		if (pc_is_same_equip_index((enum equip_index)i, sd->equip_index, index))
 			continue;
-		
+
 		if (sd->inventory_data[index]) {
 			for (uint8 j = 0; j < MAX_ITEM_RDM_OPT; j++) {
 				int16 opt_id = sd->inventory.u.items_inventory[index].option[j].id;
@@ -4533,7 +4533,7 @@ int32 status_calc_pc_sub(map_session_data* sd, uint8 opt)
 #endif
 	if ((skill = pc_checkskill(sd, SHC_SHADOW_SENSE)) > 0)
 	{
-		if (sd->status.weapon == W_DAGGER || sd->status.weapon == W_DOUBLE_DD || 
+		if (sd->status.weapon == W_DAGGER || sd->status.weapon == W_DOUBLE_DD ||
 			sd->status.weapon == W_DOUBLE_DS || sd->status.weapon == W_DOUBLE_DA)
 			base_status->cri += 100 + skill * 40;
 		else if (sd->status.weapon == W_KATAR)
@@ -6246,7 +6246,7 @@ void status_calc_bl_main(struct block_list& bl, std::bitset<SCB_MAX> flag)
 #ifndef RENEWAL
 		int32 matk_min = status_base_matk_min(status);
 		int32 matk_max = status_base_matk_max(status);
-	
+
 		if (sd != nullptr) {
 			matk_min += sd->bonus.ematk;
 			matk_max += sd->bonus.ematk;
@@ -8739,10 +8739,10 @@ static uint32 status_calc_maxsp(struct block_list *bl, uint64 maxsp)
 	int32 rate = 100;
 
 	maxsp += status_get_spbonus(bl,STATUS_BONUS_FIX);
-	
+
 	if ((rate += status_get_spbonus(bl,STATUS_BONUS_RATE)) != 100)
 		maxsp = maxsp * rate / 100;
-	
+
 	return (uint32)cap_value(maxsp,1,UINT_MAX);
 }
 
@@ -8825,7 +8825,7 @@ static unsigned char status_calc_element_lv(struct block_list *bl, status_change
 		return 1;
 	if(sc->getSCE(SC__INVISIBILITY))
 		return 1;
-	if (sc->getSCE(SC_FLAMEARMOR_OPTION) || sc->getSCE(SC_CRYSTAL_ARMOR_OPTION) || sc->getSCE(SC_EYES_OF_STORM_OPTION) || 
+	if (sc->getSCE(SC_FLAMEARMOR_OPTION) || sc->getSCE(SC_CRYSTAL_ARMOR_OPTION) || sc->getSCE(SC_EYES_OF_STORM_OPTION) ||
 		sc->getSCE(SC_STRONG_PROTECTION_OPTION) || sc->getSCE(SC_POISON_SHIELD_OPTION))
 		return 1;
 
@@ -9262,7 +9262,7 @@ std::vector<e_race2> status_get_race2(struct block_list *bl)
 }
 
 /**
- * Checks if an object is dead 
+ * Checks if an object is dead
  * @param bl: Object to check [PC|MOB|HOM|MER|ELEM]
  * @return 1: Is dead or 0: Is alive
  */
@@ -9271,7 +9271,7 @@ bool status_isdead(block_list &bl){
 }
 
 /**
- * Checks if an object is immune to magic 
+ * Checks if an object is immune to magic
  * @param bl: Object to check [PC|MOB|HOM|MER|ELEM]
  * @return value of magic damage to be blocked
  */
@@ -9339,7 +9339,7 @@ bool status_isendure(block_list& bl, t_tick tick, bool visible)
 }
 
 /**
- * Get view data of an object 
+ * Get view data of an object
  * @param bl: Object whose view data to get [PC|MOB|PET|HOM|MER|ELEM|NPC]
  * @return view data structure bl->vd
  */
@@ -9361,7 +9361,7 @@ struct view_data* status_get_viewdata(struct block_list *bl)
 /**
  * Set view data of an object
  * This function deals with class, mount, and item views
- * SC views are set in clif_getareachar_unit() 
+ * SC views are set in clif_getareachar_unit()
  * @param bl: Object whose view data to set [PC|MOB|PET|HOM|MER|ELEM|NPC]
  * @param class_: class of the object
  */
@@ -10360,7 +10360,7 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 					successFlag|=1;
 					pc_unequipitem(sd,i,3); // Left-hand weapon
 				}
-	
+
 				i = sd->equip_index[EQI_HAND_R];
 				if (i>=0 && sd->inventory_data[i] && sd->inventory_data[i]->type == IT_WEAPON) {
 					successFlag|=2;
@@ -11986,7 +11986,7 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 			break;
 		case SC__UNLUCKY:
 		{
-			sc_type rand_eff; 
+			sc_type rand_eff;
 			switch(rnd() % 3) {
 				case 1: rand_eff = SC_BLIND; break;
 				case 2: rand_eff = SC_SILENCE; break;
@@ -13020,7 +13020,9 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 				clif_changelook(bl,LOOK_WEAPON,0);
 				clif_changelook(bl,LOOK_SHIELD,0);
 				clif_changelook(bl,LOOK_CLOTHES_COLOR,vd->look[LOOK_CLOTHES_COLOR]);
+#if PACKETVER < 20231220
 				clif_changelook(bl,LOOK_BODY2,0);
+#endif
 				break;
 			case SC_STONE:
 			case SC_STONEWAIT:
@@ -13890,7 +13892,7 @@ int32 status_change_end( struct block_list* bl, enum sc_type type, int32 tid ){
 			clif_specialeffect(bl, 223, AREA);
 			clif_specialeffect(bl, 330, AREA);
 			break;
-			
+
 		case SC_OVERED_BOOST:
 			switch (bl->type) {
 				case BL_HOM: {
@@ -14076,7 +14078,7 @@ int32 status_change_end( struct block_list* bl, enum sc_type type, int32 tid ){
 			clif_changelook(bl,LOOK_WEAPON,sd->vd.look[LOOK_WEAPON]);
 			clif_changelook(bl,LOOK_SHIELD,sd->vd.look[LOOK_SHIELD]);
 			clif_changelook(bl,LOOK_CLOTHES_COLOR,cap_value(sd->status.clothes_color,0,battle_config.max_cloth_color));
-			clif_changelook(bl,LOOK_BODY2,cap_value(sd->status.body,0,battle_config.max_body_style));
+			clif_changelook(bl,LOOK_BODY2,cap_value(sd->status.body,0,MAX_BODY_STYLE)); // 2023-12-20 CLIENT bodystylefix
 		}
 	}
 	if (calc_flag.any()) {
@@ -14130,7 +14132,7 @@ TIMER_FUNC(status_change_timer){
 		ShowDebug("status_change_timer: Null pointer id: %d data: %" PRIdPTR " bl-type: %d\n", id, data, bl->type);
 		return 0;
 	}
-	
+
 	struct status_change_entry * const sce = sc->getSCE(type);
 	if(!sce) {
 		ShowDebug("status_change_timer: Null pointer id: %d data: %" PRIdPTR " bl-type: %d\n", id, data, bl->type);
@@ -14148,7 +14150,7 @@ TIMER_FUNC(status_change_timer){
 	std::function<void (t_tick)> sc_timer_next = [&sce, &bl, &data](t_tick t) {
 		sce->timer = add_timer(t, status_change_timer, bl->id, data);
 	};
-	
+
 	switch(type) {
 	case SC_MAXIMIZEPOWER:
 	case SC_CLOAKING:
@@ -14246,7 +14248,7 @@ TIMER_FUNC(status_change_timer){
 			status_fix_damage(bl, bl, damage, 1, 0);
 		}
 		break;
-		
+
 	case SC_TOXIN:
 		if (sce->val4 >= 0) { // Damage is every 10 seconds including 3%sp drain.
 			if (sce->val3 == 1) { // Target
@@ -14307,7 +14309,7 @@ TIMER_FUNC(status_change_timer){
 			}
 		}
 		break;
-		
+
 	case SC_PYREXIA:
 		if (sce->val4 >= 0) {
 			map_freeblock_lock();
@@ -14317,7 +14319,7 @@ TIMER_FUNC(status_change_timer){
 			unit_skillcastcancel(bl, 2);
 		}
 		break;
-		
+
 	case SC_LEECHESEND:
 		if (sce->val4 >= 0) {
 			int64 damage = status->vit * (sce->val1 - 3) + (int32)status->max_hp / 100; // {Target VIT x (New Poison Research Skill Level - 3)} + (Target HP/100)
@@ -14559,7 +14561,7 @@ TIMER_FUNC(status_change_timer){
 			sc_timer_next(10000+tick);
 		}
 		break;
-		
+
 	case SC_OBLIVIONCURSE:
 		if( --(sce->val4) >= 0 ) {
 			clif_emotion( *bl, ET_QUESTION );
@@ -15277,7 +15279,7 @@ int32 status_change_timer_sub(struct block_list* bl, va_list ap)
 			status_check_skilluse(src, bl, WZ_SIGHTBLASTER, 2))
 		{
 			if (sce) {
-				struct skill_unit *su = nullptr; 
+				struct skill_unit *su = nullptr;
 				if(bl->type == BL_SKILL)
 					su = (struct skill_unit *)bl;
 				if (skill_attack(BF_MAGIC,src,src,bl,WZ_SIGHTBLASTER,sce->val1,tick,0x1000000)
@@ -15905,7 +15907,7 @@ uint64 StatusDatabase::parseBodyNode(const ryml::NodeRef& node) {
 			this->invalidWarning(node["Icon"], "Icon %s is invalid, defaulting to EFST_BLANK.\n", icon_name.c_str());
 			constant = EFST_BLANK;
 		}
-		
+
 		if (constant < EFST_BLANK || constant >= EFST_MAX) {
 			this->invalidWarning(node["Icon"], "Icon %s is out of bounds, defaulting to EFST_BLANK.\n", icon_name.c_str());
 			constant = EFST_BLANK;
@@ -16196,7 +16198,7 @@ uint64 StatusDatabase::parseBodyNode(const ryml::NodeRef& node) {
 		if (!exists)
 			status->min_rate = 0;
 	}
-	
+
 	if (this->nodeExists(node, "MinDuration")) {
 		int64 duration;
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

Ensures Bodytype is used correctly for Clients past 2023-12-20 such that all characters are not either:
A) A Novice
B) A Swordsman

* **Server Mode**: 

- [x] Renewal
- [x] Pre-Renewal

* **Description of Pull Request**: 

- Updated body style assignment logic in `pc_makesavestatus` and `pc_jobchange` functions to accommodate changes in the 2023-12-20 client.
- Ensured backward compatibility with pre-2023-12-20 clients by using conditional compilation.
- Cleaned up unnecessary whitespace and formatting inconsistencies across multiple files, including `pc.cpp` and `status.cpp`.
- Improved comments for clarity and consistency.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
