### PR TITLE
Auto Berserk Fixes

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19836,6 +19836,7 @@ void skill_consume_requirement(map_session_data *sd, uint16 skill_id, uint16 ski
 		switch( skill_id ) {
 			case CG_TAROTCARD: // TarotCard will consume sp in skill_cast_nodamage_id [Inkfish]
 			case MC_IDENTIFY:
+			case SM_AUTOBERSERK:
 			case BD_ADAPTATION:
 			case BD_ENCORE:
 				require.sp = 0;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #7610 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed a crash that occurred when Provoke from Auto Berserk activated through passive damage
- Fixed Provoke not properly starting / ending in various situations
  * It was for example lost when you teleported, and it didn't start on log in
- Fixed the Provoke icon showing a duration despite lasting infinite
- If you have exactly 25% HP, Provoke from Auto Berserk is now active
- Auto Berserk requires 1 SP, but does not consume it
- Fixes #7610

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
