### PR TITLE
Guild Storage Update

### DIFF
--- a/src/char/int_guild.cpp
+++ b/src/char/int_guild.cpp
@@ -544,7 +544,6 @@ uint16 inter_guild_storagemax(int32 guild_id)
 {
 #ifdef OFFICIAL_GUILD_STORAGE
 	auto g = inter_guild_fromsql( guild_id );
-	uint16 level = guild_checkskill(g, GD_GUILD_STORAGE);
 	uint16 max = 0;
 
 	if( g == nullptr ){
@@ -552,8 +551,9 @@ uint16 inter_guild_storagemax(int32 guild_id)
 		return 0;
 	}
 
-	if (level)
-		max = 100 + level * 100; // Level 1..5 => 200..600
+	max = guild_checkskill(g, GD_GUILD_STORAGE);
+	if (max)
+		max = 100 + max * 100; // Level 1..5 => 200..600
 
 	return max;
 #else

--- a/src/char/int_guild.cpp
+++ b/src/char/int_guild.cpp
@@ -544,6 +544,7 @@ uint16 inter_guild_storagemax(int32 guild_id)
 {
 #ifdef OFFICIAL_GUILD_STORAGE
 	auto g = inter_guild_fromsql( guild_id );
+	uint16 level = guild_checkskill(g, GD_GUILD_STORAGE);
 	uint16 max = 0;
 
 	if( g == nullptr ){
@@ -551,9 +552,8 @@ uint16 inter_guild_storagemax(int32 guild_id)
 		return 0;
 	}
 
-	max = guild_checkskill(g, GD_GUILD_STORAGE);
-	if (max)
-		max *= 100;
+	if (level)
+		max = 100 + level * 100; // Level 1..5 => 200..600
 
 	return max;
 #else

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -584,9 +584,12 @@ char storage_guild_storageopen(map_session_data* sd)
 		return GSTORAGE_ALREADY_OPEN;
 	}
 
+	uint16 level = guild_checkskill(sd->guild->guild, GD_GUILD_STORAGE);
+	uint16 max = 100 + level * 100; // Lv1..5 => 200..600
+
 	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr
 #ifdef OFFICIAL_GUILD_STORAGE
-		|| (gstor->max_amount != guild_checkskill(sd->guild->guild, GD_GUILD_STORAGE) * 100)
+		|| (gstor->max_amount != max)
 #endif
 	) {
 		intif_request_guild_storage(sd->status.account_id,sd->status.guild_id);

--- a/src/map/storage.cpp
+++ b/src/map/storage.cpp
@@ -563,8 +563,12 @@ char storage_guild_storageopen(map_session_data* sd)
 		return GSTORAGE_NO_GUILD;
 
 #ifdef OFFICIAL_GUILD_STORAGE
-	if (!guild_checkskill(sd->guild->guild, GD_GUILD_STORAGE))
+	uint16 level = guild_checkskill(sd->guild->guild, GD_GUILD_STORAGE);
+
+	if (level == 0)
 		return GSTORAGE_NO_STORAGE; // Can't open storage if the guild has not learned the skill
+
+	uint16 max = 100 + level * 100; // Lv1..5 => 200..600
 #endif
 
 	if (sd->state.storage_flag == 2)
@@ -583,9 +587,6 @@ char storage_guild_storageopen(map_session_data* sd)
 		clif_displaymessage( sd->fd, msg_txt( sd, 246 ) ); // Your GM level doesn't authorize you to perform this action.
 		return GSTORAGE_ALREADY_OPEN;
 	}
-
-	uint16 level = guild_checkskill(sd->guild->guild, GD_GUILD_STORAGE);
-	uint16 max = 100 + level * 100; // Lv1..5 => 200..600
 
 	if((gstor = guild2storage2(sd->status.guild_id)) == nullptr
 #ifdef OFFICIAL_GUILD_STORAGE


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: kRO has updated the max storage value on 2021.02.26 https://ro.gnjoy.com/news/notice/View.asp?seq=7374
>길드 창고 최대 슬롯이 확장됩니다.
　→ 길드 창고 확장 스킬의 효과가 다음과 같이 변경됩니다.
　　> 스킬 레벨 1: 길드 창고 슬롯 200개 이용 가능
　　> 스킬 레벨 2: 길드 창고 슬롯 300개 이용 가능
　　> 스킬 레벨 3: 길드 창고 슬롯 400개 이용 가능
　　> 스킬 레벨 4: 길드 창고 슬롯 500개 이용 가능
　　> 스킬 레벨 5: 길드 창고 슬롯 600개 이용 가능

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
