### PR TITLE
Change some DBMap usage to STL unordered map

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -60,7 +60,7 @@ struct fame_list chemist_fame_list[MAX_FAME_LIST];
 struct fame_list taekwon_fame_list[MAX_FAME_LIST];
 
 #define CHAR_MAX_MSG 300	//max number of msg_conf
-static char* msg_table[CHAR_MAX_MSG]; // Login Server messages_conf
+static std::vector<std::string> msg_table; // Login Server messages_conf
 
 // check for exit signal
 // 0 is saving complete
@@ -3118,13 +3118,12 @@ void char_config_adjust() {
  * Message conf function
  */
 int32 char_msg_config_read(const char *cfgName){
+	msg_table.resize(CHAR_MAX_MSG);
+	
 	return _msg_config_read(cfgName,CHAR_MAX_MSG,msg_table);
 }
 const char* char_msg_txt(int32 msg_number){
 	return _msg_txt(msg_number,CHAR_MAX_MSG,msg_table);
-}
-void char_do_final_msg(void){
-	_do_final_msg(CHAR_MAX_MSG,msg_table);
 }
 
 void CharacterServer::finalize(){
@@ -3137,7 +3136,6 @@ void CharacterServer::finalize(){
 
 	flush_fifos();
 
-	do_final_msg();
 	do_final_chmapif();
 	do_final_chlogif();
 

--- a/src/char/char.hpp
+++ b/src/char/char.hpp
@@ -338,10 +338,8 @@ void char_set_session_flag_(int32 account_id, int32 val, bool set);
 
 #define msg_config_read(cfgName) char_msg_config_read(cfgName)
 #define msg_txt(msg_number) char_msg_txt(msg_number)
-#define do_final_msg() char_do_final_msg()
 int32 char_msg_config_read(const char *cfgName);
 const char* char_msg_txt(int32 msg_number);
-void char_do_final_msg(void);
 bool char_config_read(const char* cfgName, bool normal);
 
 #endif /* CHAR_HPP */

--- a/src/common/msg_conf.hpp
+++ b/src/common/msg_conf.hpp
@@ -6,6 +6,9 @@
 
 #include <config/core.hpp>
 
+#include <vector>
+#include <string>
+
 enum lang_types {
 	LANG_RUS = 0x01,
 	LANG_SPN = 0x02,
@@ -27,11 +30,9 @@ enum lang_types {
 #endif
 
 //read msg in table
-const char* _msg_txt(int32 msg_number,int32 size, char ** msg_table);
+const char* _msg_txt(int32 msg_number,int32 size, const std::vector<std::string>& msg_table);
 //store msg from txtfile into msg_table
-int32 _msg_config_read(const char* cfgName,int32 size, char ** msg_table);
-//clear msg_table
-void _do_final_msg(int32 size, char ** msg_table);
+int32 _msg_config_read(const char* cfgName,int32 size, std::vector<std::string>& msg_table);
 //Lookups
 int32 msg_langstr2langtype(char * langtype);
 const char* msg_langtype2langstr(int32 langtype);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -35,7 +35,7 @@ using namespace rathena;
 using namespace rathena::server_login;
 
 #define LOGIN_MAX_MSG 30				/// Max number predefined in msg_conf
-static char* msg_table[LOGIN_MAX_MSG];	/// Login Server messages_conf
+static std::vector<std::string> msg_table;	/// Login Server messages_conf
 
 //definition of exported var declared in header
 struct mmo_char_server ch_server[MAX_SERVERS];	/// char server data
@@ -515,16 +515,13 @@ int32 lan_subnetcheck(uint32 ip) {
 
 /// Msg_conf tayloring
 int32 login_msg_config_read(const char *cfgName){
+	msg_table.resize(LOGIN_MAX_MSG);
+	
 	return _msg_config_read(cfgName,LOGIN_MAX_MSG,msg_table);
 }
 const char* login_msg_txt(int32 msg_number){
 	return _msg_txt(msg_number,LOGIN_MAX_MSG,msg_table);
 }
-void login_do_final_msg(void){
-	_do_final_msg(LOGIN_MAX_MSG,msg_table);
-}
-
-
 
 
 /// Set and read Configurations
@@ -818,7 +815,6 @@ void LoginServer::finalize(){
 	if( login_config.log_login )
 		loginlog_final();
 
-	do_final_msg();
 	ipban_final();
 	do_final_loginclif();
 	do_final_logincnslif();

--- a/src/login/login.hpp
+++ b/src/login/login.hpp
@@ -130,10 +130,8 @@ extern struct Login_Config login_config;
 
 #define msg_config_read(cfgName) login_msg_config_read(cfgName)
 #define msg_txt(msg_number) login_msg_txt(msg_number)
-#define do_final_msg() login_do_final_msg()
 int32 login_msg_config_read(const char *cfgName);
 const char* login_msg_txt(int32 msg_number);
-void login_do_final_msg(void);
 bool login_config_read(const char* cfgName, bool normal);
 
 /// Online User Database [Wizputer]

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1176,10 +1176,10 @@ void map_data_copyall(void);
 void map_data_copy(struct map_data *dst_map, struct map_data *src_map);
 
 // player to map session
-void map_addnickdb(int32 charid, const char* nick);
-void map_delnickdb(int32 charid, const char* nick);
-void map_reqnickdb(map_session_data* sd,int32 charid);
-const char* map_charid2nick(int32 charid);
+void map_addnickdb(uint32 charid, const char* nick);
+void map_delnickdb(uint32 charid, const char* nick);
+void map_reqnickdb(map_session_data* sd,uint32 charid);
+const char* map_charid2nick(uint32 charid);
 map_session_data* map_charid2sd(int32 charid);
 
 map_session_data * map_id2sd(int32 id);

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -13,7 +13,6 @@
 
 #include <common/cbasetypes.hpp>
 #include <common/core.hpp> // CORE_ST_LAST
-#include <common/db.hpp>
 #include <common/mapindex.hpp>
 #include <common/mmo.hpp>
 #include <common/msg_conf.hpp>
@@ -49,10 +48,8 @@ struct Channel;
 struct map_data *map_getmapdata(int16 m);
 #define msg_config_read(cfgName,isnew) map_msg_config_read(cfgName,isnew)
 #define msg_txt(sd,msg_number) map_msg_txt(sd,msg_number)
-#define do_final_msg() map_do_final_msg()
 int32 map_msg_config_read(const char *cfgName,int32 lang);
 const char* map_msg_txt(map_session_data *sd,int32 msg_number);
-void map_do_final_msg(void);
 void map_msg_reload(void);
 
 #define MAX_NPC_PER_MAP 512

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1180,7 +1180,7 @@ void map_addnickdb(uint32 charid, const char* nick);
 void map_delnickdb(uint32 charid, const char* nick);
 void map_reqnickdb(map_session_data* sd,uint32 charid);
 const char* map_charid2nick(uint32 charid);
-map_session_data* map_charid2sd(int32 charid);
+map_session_data* map_charid2sd(uint32 charid);
 
 map_session_data * map_id2sd(int32 id);
 struct mob_data * map_id2md(int32 id);
@@ -1241,8 +1241,6 @@ int32 map_check_dir(int32 s_dir,int32 t_dir);
 uint8 map_calc_dir(struct block_list *src,int16 x,int16 y);
 uint8 map_calc_dir_xy(int16 srcx, int16 srcy, int16 x, int16 y, uint8 srcdir);
 int32 map_random_dir(struct block_list *bl, int16 *x, int16 *y); // [Skotlex]
-
-int32 cleanup_sub(struct block_list *bl, va_list ap);
 
 int32 map_delmap(char* mapname);
 void map_flags_init(void);

--- a/src/web/web.cpp
+++ b/src/web/web.cpp
@@ -38,7 +38,7 @@ using namespace rathena::server_core;
 using namespace rathena::server_web;
 
 #define WEB_MAX_MSG 30				/// Max number predefined in msg_conf
-static char* msg_table[WEB_MAX_MSG];	/// Web Server messages_conf
+static std::vector<std::string> msg_table;	/// Web Server messages_conf
 
 struct Web_Config web_config {};
 struct Inter_Config inter_config {};
@@ -93,13 +93,12 @@ std::thread svr_thr;
 
 /// Msg_conf tayloring
 int32 web_msg_config_read(char *cfgName){
+	msg_table.resize(WEB_MAX_MSG);
+	
 	return _msg_config_read(cfgName,WEB_MAX_MSG,msg_table);
 }
 const char* web_msg_txt(int32 msg_number){
 	return _msg_txt(msg_number,WEB_MAX_MSG,msg_table);
-}
-void web_do_final_msg(void){
-	_do_final_msg(WEB_MAX_MSG,msg_table);
 }
 /// Set and read Configurations
 
@@ -373,7 +372,6 @@ void WebServer::finalize(){
 	svr_thr.join();
 	web_sql_close();
 #endif
-	do_final_msg();
 	ShowStatus("Finished.\n");
 }
 

--- a/src/web/web.hpp
+++ b/src/web/web.hpp
@@ -69,10 +69,8 @@ extern char partybookings_table[32];
 
 #define msg_config_read(cfgName) web_msg_config_read(cfgName)
 #define msg_txt(msg_number) web_msg_txt(msg_number)
-#define do_final_msg() web_do_final_msg()
 int32 web_msg_config_read(char *cfgName);
 const char* web_msg_txt(int32 msg_number);
-void web_do_final_msg(void);
 bool web_config_read(const char* cfgName, bool normal);
 
 #endif /* WEB_HPP */


### PR DESCRIPTION
* **Addressed Issue(s)**: None

* **Server Mode**: Both

* **Description of Pull Request**:

- Replace project-specific DBMap usage with `std::unordered_map` to modernize containers, reduce custom infra, and simplify memory management.
- Data stores migrated:
  - `id_db`, `pc_db`, `mobid_db`, `bossid_db`, `charid_db`, `regen_db` → `std::unordered_map<...>`.
  - `nick_db` → `std::unordered_map<uint32, charid2nick>`; replace linked-list request queue with `std::set<int32>`; change charid function params to `uint32`; simplify add/delete/request flows.
  - `iwall_db` → `std::unordered_map<std::string, iwall_data>`; remove heap allocations and DB iterator usage; direct insert/erase and range iteration.
  - `map_db` split into `map_db_local (map_data*)` and `map_db_remote (map_data_other_server*)`; add `ensure_remote_map()`; free remote entries on finalize/erase; replace all `uidb_*` calls.
  - `map_msg_db` → `std::unordered_map<int32, std::vector<std::string>>`; refactor `msg_conf` to use `std::vector<std::string>` rather than `char**`; remove `_do_final_msg()` and related macros/calls across login/char/map servers.
- Iteration and helpers:
  - Convert `db_iterator` loops to range-based loops over `unordered_map`.
  - Rework map iterator (`mapit_*`) with a small type-erased adapter over `unordered_map` to preserve existing traversal APIs; `mapit_last` now scans forward to return the last match.
- Cleanup/lifecycle:
  - Remove `DBMap` destroy calls for migrated containers; rely on automatic cleanup or explicit clears where needed.
  - In `MapServer::finalize()`, snapshot `id_db` values before cleanup to avoid iterator invalidation.
- Behavior/compatibility notes:
  - `unordered_map` iteration order is not deterministic. Any code depending on previous traversal order should not rely on it; functional behavior is preserved.
  - Public APIs changed from `int32` to `uint32` for charid-related functions: `map_addnickdb`, `map_delnickdb`, `map_reqnickdb`, `map_charid2nick`, and `map_charid2sd` (parameter type).
  - Call sites were updated from `idb_*`, `uidb_*`, `strdb_*`, and `db_iterator` to native `unordered_map` operations. Any out-of-tree modules should be adapted similarly.
- Affected files (highlights):
  - `src/map/map.cpp`, `src/map/map.hpp`
  - `src/common/msg_conf.cpp`, `src/common/msg_conf.hpp`
  - `src/login/login.cpp`, `src/login/login.hpp`
  - `src/char/char.cpp`, `src/char/char.hpp`
  - `src/web/web.cpp`, `src/web/web.hpp`
- Rationale:
  - Simplifies codebase by removing custom DBMap plumbing.
  - Improves clarity and safety (fewer manual allocations, clearer ownership).
  - Prepares for further refactors by standardizing on STL containers.

