### PR TITLE
Improved strnpcinfo

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -2465,6 +2465,7 @@ Whatever it returns is determined by type.
  2 - The hidden part of the NPC's display name
  3 - The NPC's unique name (::name)
  4 - The name of the map the NPC is in.
+ 5 - The path of the NPC file
 
 ---------------------------------------
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -9242,6 +9242,7 @@ BUILDIN_FUNC(strcharinfo)
  *	2 : #str
  *	3 : ::str
  *	4 : map name
+ *	5 : NPC file path
  *------------------------------------------*/
 BUILDIN_FUNC(strnpcinfo)
 {
@@ -9281,6 +9282,9 @@ BUILDIN_FUNC(strnpcinfo)
 		case 4: // map name
 			if (nd->m >= 0)
 				name = aStrdup(map_getmapdata(nd->m)->name);
+			break;
+		case 5: // NPC file path
+			name = aStrdup(nd->path);
 			break;
 	}
 


### PR DESCRIPTION
* **Server Mode**: 
Both
* **Description of Pull Request**: 
  - **Add the possibility to query NPC's name data from its ID.**
  **Motivation**: Currently it is not possible to collect npcs with `get*units`, which return either npc ids or npc names,  and call commands which expect unique npc names, such as `npctalk` or `specialeffect`.
  The addition consistently allows collecting the npc ids to either use their display names / unique names, depending on the needed usage.
  - **Add type 5 for NPC file path.**
  **Motivation**: This information can be useful for testing and maintenance scripts.