### PR TITLE
Corrected Tournament Shield item combos

### DIFF
--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -215,7 +215,7 @@ Body:
           - Battle_Hook_    # 1440
           - Tournament_Shield    # 2133
     Script: |
-      bonus bAtkRate,4;
+      bonus2 bAddClass,Class_All,4;
       bonus bDef,2;
       if (Class == 4008 || Class == 4054 || Class == 4060 || Class == 4252) {
          bonus bAspdRate,-5;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

`equipmentproperties.lub` in the client uses `ClassAddDamage` which is our equivalent of `bAddClass`, for

Long_Horn + Tournament_Shield
Battle_Hook + Tournament_Shield
Hunting_Spear + Tournament_Shield
Battle_Hook_ + Tournament_Shield

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
