### PR TITLE
Update name_ignoring_case to use numeric value

### DIFF
--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -150,7 +150,7 @@ char_name_min_length: 4
 
 // Allow or not identical name for characters but with a different case (upper/lower):
 // example: Test-test-TEST-TesT; Value: 0 not allowed (default), 1 allowed
-name_ignoring_case: no
+name_ignoring_case: 0
 
 // Manage possible letters/symbol in the name of charater. Control character (0x00-0x1f) are never accepted. Possible values are:
 // NOTE: Applies to character, party and guild names.


### PR DESCRIPTION
Changed name_ignoring_case from 'no' to '0' to specify case sensitivity.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:   #9613 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:  As documented, name_ignoring_case value shouldn't be "no" or "yes", but 0 or 1.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
