### PR TITLE
Removed spawn of monster Pouring in mal_dun01

### DIFF
--- a/npc/re/mobs/dungeons/mal_dun.txt
+++ b/npc/re/mobs/dungeons/mal_dun.txt
@@ -23,4 +23,3 @@ mal_dun01,0,0	monster	Aster	1266,20,5000
 mal_dun01,0,0	monster	Red Eruma	2197,60,5000
 mal_dun01,0,0	monster	Siorava	2199,45,5000
 mal_dun01,0,0	monster	Wild Rider	2208,1,5000
-mal_dun01,0,0	monster	Pouring	1894,30,5000


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: The monster Pouring can currently be found on mal_dun01 and it drops the item Celebrate Egg (ID: 23724).

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
