### PR TITLE
Corrected item group TRUE_HUNTING_SET, REGIA_HUNTING_SET, AEGIS_102947, AEGIS_102948

### DIFF
--- a/db/re/item_group_db.yml
+++ b/db/re/item_group_db.yml
@@ -114387,57 +114387,93 @@ Body:
             Rate: 800
           - Index: 5
             Item: Gaebolg_Armor
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 6
             Item: Gaebolg_Robe
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 7
             Item: Gaebolg_Boots
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 8
             Item: Gaebolg_Shoes
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 9
             Item: Gaebolg_Manteau
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 10
             Item: Gaebolg_Muffler
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 11
             Item: Gaebolg_Armor
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 12
             Item: Gaebolg_Robe
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 13
             Item: Gaebolg_Boots
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 14
             Item: Gaebolg_Shoes
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 15
             Item: Gaebolg_Manteau
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 16
             Item: Gaebolg_Muffler
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 17
             Item: Gaebolg_Armor
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 18
             Item: Gaebolg_Robe
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 19
             Item: Gaebolg_Boots
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 20
             Item: Gaebolg_Shoes
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 21
             Item: Gaebolg_Manteau
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 22
             Item: Gaebolg_Muffler
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 23
             Item: Gaebolg_Glove
@@ -114674,57 +114710,95 @@ Body:
             Rate: 800
           - Index: 5
             Item: Gaebolg_Armor
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 6
             Item: Gaebolg_Robe
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 7
             Item: Gaebolg_Boots
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 8
             Item: Gaebolg_Shoes
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 9
             Item: Gaebolg_Manteau
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 10
             Item: Gaebolg_Muffler
+            RefineMinimum: 9
+            RefineMaximum: 9
             Rate: 150
           - Index: 11
             Item: Gaebolg_Armor
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 12
             Item: Gaebolg_Robe
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 13
             Item: Gaebolg_Boots
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 14
             Item: Gaebolg_Shoes
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 15
             Item: Gaebolg_Manteau
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 16
             Item: Gaebolg_Muffler
+            RefineMinimum: 10
+            RefineMaximum: 10
             Rate: 100
           - Index: 17
             Item: Gaebolg_Armor
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 18
             Item: Gaebolg_Robe
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 19
             Item: Gaebolg_Boots
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 20
             Item: Gaebolg_Shoes
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 21
             Item: Gaebolg_Manteau
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 22
             Item: Gaebolg_Muffler
+            RefineMinimum: 11
+            RefineMaximum: 11
+            RefineMinimum: 11
+            RefineMaximum: 11
             Rate: 20
           - Index: 23
             Item: Gaebolg_Glove
@@ -118104,10 +118178,16 @@ Body:
         List:
           - Index: 0
             Item: True_Hunting_Mail
+            RefineMinimum: 9
+            RefineMaximum: 9
           - Index: 1
             Item: True_Hunting_Manteau
+            RefineMinimum: 9
+            RefineMaximum: 9
           - Index: 2
             Item: True_Hunting_Boots
+            RefineMinimum: 9
+            RefineMaximum: 9
   - Group: REGIA_HUNTING_SET
     SubGroups:
       - SubGroup: 0
@@ -118115,10 +118195,16 @@ Body:
         List:
           - Index: 0
             Item: Regia_Hunting_Mail
+            RefineMinimum: 9
+            RefineMaximum: 9
           - Index: 1
             Item: Regia_Hunting_Manteau
+            RefineMinimum: 9
+            RefineMaximum: 9
           - Index: 2
             Item: Regia_Hunting_Boots
+            RefineMinimum: 9
+            RefineMaximum: 9
   - Group: MYSTERIOUS_FRUIT_BOX
     SubGroups:
       - SubGroup: 0


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: -

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

These boxes can give refined items on official server, but `RefineMinimum` and `RefineMaximum` were missing on rathena for thoses groups.

Boxes :
AEGIS_102947 : [Antiquity of Ghost Ship (Captain of Ghost Ship)](https://www.divine-pride.net/database/item/102947)
AEGIS_102948 : [Antiquity of Giant Snake (Encroached Tan)](https://www.divine-pride.net/database/item/102948)
TRUE_HUNTING_SET : [True Hunting Equipment Box](https://www.divine-pride.net/database/item/103658)
REGIA_HUNTING_SET : [Regia Hunting Equipment Box](https://www.divine-pride.net/database/item/103659)
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
