### PR TITLE
Remade Base/Job Exp Table

### DIFF
--- a/db/re/job_exp.yml
+++ b/db/re/job_exp.yml
@@ -138,6 +138,9 @@ Body:
       Star_Gladiator: true
       Star_Gladiator2: true
       Soul_Linker: true
+      Gangsi: true
+      Death_Knight: true
+      Dark_Collector: true
       Baby_Ninja: true
       Baby_Taekwon: true
       Baby_Star_Gladiator: true
@@ -343,7 +346,7 @@ Body:
       - Level: 98
         Exp: 1252761
       - Level: 99
-        Exp: 99999999
+        Exp: 9999999
   - Jobs:
       Novice_High: true
       Swordman_High: true
@@ -566,424 +569,7 @@ Body:
       - Level: 98
         Exp: 1258714
       - Level: 99
-        Exp: 99999999
-  - Jobs:
-      Super_Novice_E: true
-      Super_Baby_E: true
-      Kagerou: true
-      Oboro: true
-      Rebellion: true
-      Star_Emperor: true
-      Soul_Reaper: true
-      Baby_Kagerou: true
-      Baby_Oboro: true
-      Baby_Rebellion: true
-      Baby_Star_Emperor: true
-      Baby_Soul_Reaper: true
-      Star_Emperor2: true
-      Baby_Star_Emperor2: true
-    MaxBaseLevel: 200
-    BaseExp:
-      - Level: 1
-        Exp: 548
-      - Level: 2
-        Exp: 894
-      - Level: 3
-        Exp: 1486
-      - Level: 4
-        Exp: 2173
-      - Level: 5
-        Exp: 3152
-      - Level: 6
-        Exp: 3732
-      - Level: 7
-        Exp: 4112
-      - Level: 8
-        Exp: 4441
-      - Level: 9
-        Exp: 4866
-      - Level: 10
-        Exp: 5337
-      - Level: 11
-        Exp: 5804
-      - Level: 12
-        Exp: 5883
-      - Level: 13
-        Exp: 6106
-      - Level: 14
-        Exp: 6424
-      - Level: 15
-        Exp: 7026
-      - Level: 16
-        Exp: 7624
-      - Level: 17
-        Exp: 7981
-      - Level: 18
-        Exp: 8336
-      - Level: 19
-        Exp: 8689
-      - Level: 20
-        Exp: 9134
-      - Level: 21
-        Exp: 9670
-      - Level: 22
-        Exp: 10296
-      - Level: 23
-        Exp: 11012
-      - Level: 24
-        Exp: 12095
-      - Level: 25
-        Exp: 12986
-      - Level: 26
-        Exp: 13872
-      - Level: 27
-        Exp: 14753
-      - Level: 28
-        Exp: 15628
-      - Level: 29
-        Exp: 16498
-      - Level: 30
-        Exp: 17362
-      - Level: 31
-        Exp: 18221
-      - Level: 32
-        Exp: 19074
-      - Level: 33
-        Exp: 19923
-      - Level: 34
-        Exp: 20947
-      - Level: 35
-        Exp: 21604
-      - Level: 36
-        Exp: 23334
-      - Level: 37
-        Exp: 24606
-      - Level: 38
-        Exp: 25871
-      - Level: 39
-        Exp: 26682
-      - Level: 40
-        Exp: 27932
-      - Level: 41
-        Exp: 29175
-      - Level: 42
-        Exp: 29969
-      - Level: 43
-        Exp: 31636
-      - Level: 44
-        Exp: 32856
-      - Level: 45
-        Exp: 33194
-      - Level: 46
-        Exp: 34836
-      - Level: 47
-        Exp: 36468
-      - Level: 48
-        Exp: 38523
-      - Level: 49
-        Exp: 40565
-      - Level: 50
-        Exp: 42165
-      - Level: 51
-        Exp: 43754
-      - Level: 52
-        Exp: 45334
-      - Level: 53
-        Exp: 46903
-      - Level: 54
-        Exp: 48463
-      - Level: 55
-        Exp: 50013
-      - Level: 56
-        Exp: 51976
-      - Level: 57
-        Exp: 53084
-      - Level: 58
-        Exp: 54605
-      - Level: 59
-        Exp: 56116
-      - Level: 60
-        Exp: 57618
-      - Level: 61
-        Exp: 58277
-      - Level: 62
-        Exp: 60593
-      - Level: 63
-        Exp: 63721
-      - Level: 64
-        Exp: 66005
-      - Level: 65
-        Exp: 69097
-      - Level: 66
-        Exp: 72171
-      - Level: 67
-        Exp: 74407
-      - Level: 68
-        Exp: 77445
-      - Level: 69
-        Exp: 89404
-      - Level: 70
-        Exp: 103722
-      - Level: 71
-        Exp: 113105
-      - Level: 72
-        Exp: 124848
-      - Level: 73
-        Exp: 130898
-      - Level: 74
-        Exp: 136110
-      - Level: 75
-        Exp: 143684
-      - Level: 76
-        Exp: 149620
-      - Level: 77
-        Exp: 154725
-      - Level: 78
-        Exp: 158216
-      - Level: 79
-        Exp: 175461
-      - Level: 80
-        Exp: 194586
-      - Level: 81
-        Exp: 215795
-      - Level: 82
-        Exp: 239316
-      - Level: 83
-        Exp: 265401
-      - Level: 84
-        Exp: 294329
-      - Level: 85
-        Exp: 326410
-      - Level: 86
-        Exp: 361988
-      - Level: 87
-        Exp: 401444
-      - Level: 88
-        Exp: 445201
-      - Level: 89
-        Exp: 493727
-      - Level: 90
-        Exp: 547543
-      - Level: 91
-        Exp: 607225
-      - Level: 92
-        Exp: 673412
-      - Level: 93
-        Exp: 746813
-      - Level: 94
-        Exp: 828215
-      - Level: 95
-        Exp: 918490
-      - Level: 96
-        Exp: 1018605
-      - Level: 97
-        Exp: 1129632
-      - Level: 98
-        Exp: 1252761
-      - Level: 99
-        Exp: 1272747
-      - Level: 100
-        Exp: 1354202
-      - Level: 101
-        Exp: 1440870
-      - Level: 102
-        Exp: 1533085
-      - Level: 103
-        Exp: 1631202
-      - Level: 104
-        Exp: 1735598
-      - Level: 105
-        Exp: 1846676
-      - Level: 106
-        Exp: 1964863
-      - Level: 107
-        Exp: 2090614
-      - Level: 108
-        Exp: 2224413
-      - Level: 109
-        Exp: 2366775
-      - Level: 110
-        Exp: 2518248
-      - Level: 111
-        Exp: 2679415
-      - Level: 112
-        Exp: 2850897
-      - Level: 113
-        Exp: 3033354
-      - Level: 114
-        Exp: 3227488
-      - Level: 115
-        Exp: 3434047
-      - Level: 116
-        Exp: 3653826
-      - Level: 117
-        Exp: 3887670
-      - Level: 118
-        Exp: 4136480
-      - Level: 119
-        Exp: 4401214
-      - Level: 120
-        Exp: 4755467
-      - Level: 121
-        Exp: 5138234
-      - Level: 122
-        Exp: 5551810
-      - Level: 123
-        Exp: 5998675
-      - Level: 124
-        Exp: 6481508
-      - Level: 125
-        Exp: 7003204
-      - Level: 126
-        Exp: 7566891
-      - Level: 127
-        Exp: 8175950
-      - Level: 128
-        Exp: 8834032
-      - Level: 129
-        Exp: 9545083
-      - Level: 130
-        Exp: 10313366
-      - Level: 131
-        Exp: 11143488
-      - Level: 132
-        Exp: 12040427
-      - Level: 133
-        Exp: 13009560
-      - Level: 134
-        Exp: 14056699
-      - Level: 135
-        Exp: 15188122
-      - Level: 136
-        Exp: 16410613
-      - Level: 137
-        Exp: 17731503
-      - Level: 138
-        Exp: 19158711
-      - Level: 139
-        Exp: 20700795
-      - Level: 140
-        Exp: 22367001
-      - Level: 141
-        Exp: 24167320
-      - Level: 142
-        Exp: 26112547
-      - Level: 143
-        Exp: 28214345
-      - Level: 144
-        Exp: 30485317
-      - Level: 145
-        Exp: 32939080
-      - Level: 146
-        Exp: 35590346
-      - Level: 147
-        Exp: 38455012
-      - Level: 148
-        Exp: 41550255
-      - Level: 149
-        Exp: 44894635
-      - Level: 150
-        Exp: 48508204
-      - Level: 151
-        Exp: 52412629
-      - Level: 152
-        Exp: 56631321
-      - Level: 153
-        Exp: 61189576
-      - Level: 154
-        Exp: 66114724
-      - Level: 155
-        Exp: 71436298
-      - Level: 156
-        Exp: 77186205
-      - Level: 157
-        Exp: 83398922
-      - Level: 158
-        Exp: 90111701
-      - Level: 159
-        Exp: 97364791
-      - Level: 160
-        Exp: 105201683
-      - Level: 161
-        Exp: 113669366
-      - Level: 162
-        Exp: 122818613
-      - Level: 163
-        Exp: 132704283
-      - Level: 164
-        Exp: 143385650
-      - Level: 165
-        Exp: 154926760
-      - Level: 166
-        Exp: 167396814
-      - Level: 167
-        Exp: 180870583
-      - Level: 168
-        Exp: 195428856
-      - Level: 169
-        Exp: 211158924
-      - Level: 170
-        Exp: 228155105
-      - Level: 171
-        Exp: 246519309
-      - Level: 172
-        Exp: 266361648
-      - Level: 173
-        Exp: 287801097
-      - Level: 174
-        Exp: 310966207
-      - Level: 175
-        Exp: 320295193
-      - Level: 176
-        Exp: 329904048
-      - Level: 177
-        Exp: 339801169
-      - Level: 178
-        Exp: 349995204
-      - Level: 179
-        Exp: 360495060
-      - Level: 180
-        Exp: 371309911
-      - Level: 181
-        Exp: 382449208
-      - Level: 182
-        Exp: 393922684
-      - Level: 183
-        Exp: 405740364
-      - Level: 184
-        Exp: 417912574
-      - Level: 185
-        Exp: 430449951
-      - Level: 186
-        Exp: 443363449
-      - Level: 187
-        Exp: 456664352
-      - Level: 188
-        Exp: 470364282
-      - Level: 189
-        Exp: 484475210
-      - Level: 190
-        Exp: 499009466
-      - Level: 191
-        Exp: 513979749
-      - Level: 192
-        Exp: 529399141
-      - Level: 193
-        Exp: 545281115
-      - Level: 194
-        Exp: 561639548
-      - Level: 195
-        Exp: 578488734
-      - Level: 196
-        Exp: 595843396
-      - Level: 197
-        Exp: 613718697
-      - Level: 198
-        Exp: 632130257
-      - Level: 199
-        Exp: 651094164
-      - Level: 200
-        Exp: 99999999
+        Exp: 9999999
   - Jobs:
       Rune_Knight: true
       Warlock: true
@@ -991,6 +577,12 @@ Body:
       Arch_Bishop: true
       Mechanic: true
       Guillotine_Cross: true
+      Rune_Knight_T: true
+      Warlock_T: true
+      Ranger_T: true
+      Arch_Bishop_T: true
+      Mechanic_T: true
+      Guillotine_Cross_T: true
       Royal_Guard: true
       Sorcerer: true
       Minstrel: true
@@ -998,12 +590,6 @@ Body:
       Sura: true
       Genetic: true
       Shadow_Chaser: true
-      Rune_Knight_T: true
-      Warlock_T: true
-      Ranger_T: true
-      Arch_Bishop_T: true
-      Mechanic_T: true
-      Guillotine_Cross_T: true
       Royal_Guard_T: true
       Sorcerer_T: true
       Minstrel_T: true
@@ -1036,6 +622,20 @@ Body:
       Baby_Royal_Guard2: true
       Baby_Ranger2: true
       Baby_Mechanic2: true
+      Super_Novice_E: true
+      Super_Baby_E: true
+      Kagerou: true
+      Oboro: true
+      Rebellion: true
+      Baby_Kagerou: true
+      Baby_Oboro: true
+      Baby_Rebellion: true
+      Star_Emperor: true
+      Soul_Reaper: true
+      Baby_Star_Emperor: true
+      Baby_Soul_Reaper: true
+      Star_Emperor2: true
+      Baby_Star_Emperor2: true
     MaxBaseLevel: 200
     BaseExp:
       - Level: 1
@@ -1437,1912 +1037,6 @@ Body:
       - Level: 199
         Exp: 651094164
       - Level: 200
-        Exp: 99999999
-  - Jobs:
-      Summoner: true
-      Baby_Summoner: true
-    MaxBaseLevel: 200
-    BaseExp:
-      - Level: 1
-        Exp: 55
-      - Level: 2
-        Exp: 90
-      - Level: 3
-        Exp: 150
-      - Level: 4
-        Exp: 220
-      - Level: 5
-        Exp: 320
-      - Level: 6
-        Exp: 380
-      - Level: 7
-        Exp: 420
-      - Level: 8
-        Exp: 455
-      - Level: 9
-        Exp: 500
-      - Level: 10
-        Exp: 600
-      - Level: 11
-        Exp: 700
-      - Level: 12
-        Exp: 800
-      - Level: 13
-        Exp: 900
-      - Level: 14
-        Exp: 1000
-      - Level: 15
-        Exp: 1100
-      - Level: 16
-        Exp: 1200
-      - Level: 17
-        Exp: 1300
-      - Level: 18
-        Exp: 1400
-      - Level: 19
-        Exp: 1500
-      - Level: 20
-        Exp: 1800
-      - Level: 21
-        Exp: 2100
-      - Level: 22
-        Exp: 2400
-      - Level: 23
-        Exp: 2700
-      - Level: 24
-        Exp: 3000
-      - Level: 25
-        Exp: 3300
-      - Level: 26
-        Exp: 3600
-      - Level: 27
-        Exp: 3900
-      - Level: 28
-        Exp: 4200
-      - Level: 29
-        Exp: 4500
-      - Level: 30
-        Exp: 5400
-      - Level: 31
-        Exp: 6300
-      - Level: 32
-        Exp: 7200
-      - Level: 33
-        Exp: 8100
-      - Level: 34
-        Exp: 9000
-      - Level: 35
-        Exp: 9900
-      - Level: 36
-        Exp: 10800
-      - Level: 37
-        Exp: 11700
-      - Level: 38
-        Exp: 12600
-      - Level: 39
-        Exp: 13500
-      - Level: 40
-        Exp: 16200
-      - Level: 41
-        Exp: 18900
-      - Level: 42
-        Exp: 21600
-      - Level: 43
-        Exp: 24300
-      - Level: 44
-        Exp: 27000
-      - Level: 45
-        Exp: 29700
-      - Level: 46
-        Exp: 32400
-      - Level: 47
-        Exp: 35100
-      - Level: 48
-        Exp: 37800
-      - Level: 49
-        Exp: 40500
-      - Level: 50
-        Exp: 43200
-      - Level: 51
-        Exp: 45900
-      - Level: 52
-        Exp: 48600
-      - Level: 53
-        Exp: 51300
-      - Level: 54
-        Exp: 54000
-      - Level: 55
-        Exp: 56700
-      - Level: 56
-        Exp: 59400
-      - Level: 57
-        Exp: 62100
-      - Level: 58
-        Exp: 64800
-      - Level: 59
-        Exp: 67500
-      - Level: 60
-        Exp: 70200
-      - Level: 61
-        Exp: 72900
-      - Level: 62
-        Exp: 75600
-      - Level: 63
-        Exp: 78300
-      - Level: 64
-        Exp: 81000
-      - Level: 65
-        Exp: 83700
-      - Level: 66
-        Exp: 86400
-      - Level: 67
-        Exp: 89100
-      - Level: 68
-        Exp: 91800
-      - Level: 69
-        Exp: 94500
-      - Level: 70
-        Exp: 103950
-      - Level: 71
-        Exp: 114345
-      - Level: 72
-        Exp: 125779
-      - Level: 73
-        Exp: 138356
-      - Level: 74
-        Exp: 152201
-      - Level: 75
-        Exp: 167421
-      - Level: 76
-        Exp: 184163
-      - Level: 77
-        Exp: 202579
-      - Level: 78
-        Exp: 222836
-      - Level: 79
-        Exp: 240662
-      - Level: 80
-        Exp: 259914
-      - Level: 81
-        Exp: 280707
-      - Level: 82
-        Exp: 303163
-      - Level: 83
-        Exp: 327416
-      - Level: 84
-        Exp: 353609
-      - Level: 85
-        Exp: 381897
-      - Level: 86
-        Exp: 412448
-      - Level: 87
-        Exp: 445443
-      - Level: 88
-        Exp: 481078
-      - Level: 89
-        Exp: 519564
-      - Level: 90
-        Exp: 561129
-      - Level: 91
-        Exp: 606019
-      - Level: 92
-        Exp: 654500
-      - Level: 93
-        Exp: 706860
-      - Level: 94
-        Exp: 763408
-      - Level: 95
-        Exp: 824480
-      - Level: 96
-        Exp: 890438
-      - Level: 97
-        Exp: 961673
-      - Level: 98
-        Exp: 1038606
-      - Level: 99
-        Exp: 1121694
-      - Level: 100
-        Exp: 1206943
-      - Level: 101
-        Exp: 1298670
-      - Level: 102
-        Exp: 1397369
-      - Level: 103
-        Exp: 1503569
-      - Level: 104
-        Exp: 1617841
-      - Level: 105
-        Exp: 1740797
-      - Level: 106
-        Exp: 1873097
-      - Level: 107
-        Exp: 2015453
-      - Level: 108
-        Exp: 2168627
-      - Level: 109
-        Exp: 2333443
-      - Level: 110
-        Exp: 2510784
-      - Level: 111
-        Exp: 2701604
-      - Level: 112
-        Exp: 2906926
-      - Level: 113
-        Exp: 3127852
-      - Level: 114
-        Exp: 3365569
-      - Level: 115
-        Exp: 3621352
-      - Level: 116
-        Exp: 3896575
-      - Level: 117
-        Exp: 4192714
-      - Level: 118
-        Exp: 4511361
-      - Level: 119
-        Exp: 4854224
-      - Level: 120
-        Exp: 5223145
-      - Level: 121
-        Exp: 5620104
-      - Level: 122
-        Exp: 6047232
-      - Level: 123
-        Exp: 6506822
-      - Level: 124
-        Exp: 7001340
-      - Level: 125
-        Exp: 7533442
-      - Level: 126
-        Exp: 8105984
-      - Level: 127
-        Exp: 8722038
-      - Level: 128
-        Exp: 9384913
-      - Level: 129
-        Exp: 10098167
-      - Level: 130
-        Exp: 10865627
-      - Level: 131
-        Exp: 11691415
-      - Level: 132
-        Exp: 12579963
-      - Level: 133
-        Exp: 13536040
-      - Level: 134
-        Exp: 14564779
-      - Level: 135
-        Exp: 15671702
-      - Level: 136
-        Exp: 16862751
-      - Level: 137
-        Exp: 18144320
-      - Level: 138
-        Exp: 19523289
-      - Level: 139
-        Exp: 21007059
-      - Level: 140
-        Exp: 22603595
-      - Level: 141
-        Exp: 24321468
-      - Level: 142
-        Exp: 26169900
-      - Level: 143
-        Exp: 28158812
-      - Level: 144
-        Exp: 30298882
-      - Level: 145
-        Exp: 32601597
-      - Level: 146
-        Exp: 35079319
-      - Level: 147
-        Exp: 37745347
-      - Level: 148
-        Exp: 40613993
-      - Level: 149
-        Exp: 43700657
-      - Level: 150
-        Exp: 47021907
-      - Level: 151
-        Exp: 50595572
-      - Level: 152
-        Exp: 54440835
-      - Level: 153
-        Exp: 58578338
-      - Level: 154
-        Exp: 63030292
-      - Level: 155
-        Exp: 67820594
-      - Level: 156
-        Exp: 72974960
-      - Level: 157
-        Exp: 78521056
-      - Level: 158
-        Exp: 84488657
-      - Level: 159
-        Exp: 90909795
-      - Level: 160
-        Exp: 97818939
-      - Level: 161
-        Exp: 105253178
-      - Level: 162
-        Exp: 113252420
-      - Level: 163
-        Exp: 121859604
-      - Level: 164
-        Exp: 131120934
-      - Level: 165
-        Exp: 141086125
-      - Level: 166
-        Exp: 151808670
-      - Level: 167
-        Exp: 163346129
-      - Level: 168
-        Exp: 175760435
-      - Level: 169
-        Exp: 189118228
-      - Level: 170
-        Exp: 203491213
-      - Level: 171
-        Exp: 218956546
-      - Level: 172
-        Exp: 235597243
-      - Level: 173
-        Exp: 253502633
-      - Level: 174
-        Exp: 272768834
-      - Level: 175
-        Exp: 293499265
-      - Level: 176
-        Exp: 315805209
-      - Level: 177
-        Exp: 339806405
-      - Level: 178
-        Exp: 365631692
-      - Level: 179
-        Exp: 377331906
-      - Level: 180
-        Exp: 389406527
-      - Level: 181
-        Exp: 401867536
-      - Level: 182
-        Exp: 414727297
-      - Level: 183
-        Exp: 427998570
-      - Level: 184
-        Exp: 441694525
-      - Level: 185
-        Exp: 455828749
-      - Level: 186
-        Exp: 470415269
-      - Level: 187
-        Exp: 485468558
-      - Level: 188
-        Exp: 501003552
-      - Level: 189
-        Exp: 517035666
-      - Level: 190
-        Exp: 533580807
-      - Level: 191
-        Exp: 550655393
-      - Level: 192
-        Exp: 568276365
-      - Level: 193
-        Exp: 586461209
-      - Level: 194
-        Exp: 605227968
-      - Level: 195
-        Exp: 624595263
-      - Level: 196
-        Exp: 644582311
-      - Level: 197
-        Exp: 665208945
-      - Level: 198
-        Exp: 686495631
-      - Level: 199
-        Exp: 708463491
-      - Level: 200
-        Exp: 99999999
-  - Jobs:
-      Novice: true
-      Baby: true
-    MaxJobLevel: 10
-    JobExp:
-      - Level: 1
-        Exp: 10
-      - Level: 2
-        Exp: 18
-      - Level: 3
-        Exp: 28
-      - Level: 4
-        Exp: 40
-      - Level: 5
-        Exp: 91
-      - Level: 6
-        Exp: 151
-      - Level: 7
-        Exp: 205
-      - Level: 8
-        Exp: 268
-      - Level: 9
-        Exp: 340
-      - Level: 10
-        Exp: 999999999
-  - Jobs:
-      Swordman: true
-      Mage: true
-      Archer: true
-      Acolyte: true
-      Merchant: true
-      Thief: true
-      Baby_Swordman: true
-      Baby_Mage: true
-      Baby_Archer: true
-      Baby_Acolyte: true
-      Baby_Merchant: true
-      Baby_Thief: true
-      Taekwon: true
-      Baby_Taekwon: true
-    MaxJobLevel: 50
-    JobExp:
-      - Level: 1
-        Exp: 60
-      - Level: 2
-        Exp: 130
-      - Level: 3
-        Exp: 260
-      - Level: 4
-        Exp: 460
-      - Level: 5
-        Exp: 780
-      - Level: 6
-        Exp: 1060
-      - Level: 7
-        Exp: 1300
-      - Level: 8
-        Exp: 1560
-      - Level: 9
-        Exp: 1910
-      - Level: 10
-        Exp: 2290
-      - Level: 11
-        Exp: 2680
-      - Level: 12
-        Exp: 2990
-      - Level: 13
-        Exp: 3340
-      - Level: 14
-        Exp: 3740
-      - Level: 15
-        Exp: 4360
-      - Level: 16
-        Exp: 4970
-      - Level: 17
-        Exp: 5530
-      - Level: 18
-        Exp: 6120
-      - Level: 19
-        Exp: 6700
-      - Level: 20
-        Exp: 8090
-      - Level: 21
-        Exp: 8920
-      - Level: 22
-        Exp: 9970
-      - Level: 23
-        Exp: 11080
-      - Level: 24
-        Exp: 12690
-      - Level: 25
-        Exp: 14440
-      - Level: 26
-        Exp: 15850
-      - Level: 27
-        Exp: 17400
-      - Level: 28
-        Exp: 19220
-      - Level: 29
-        Exp: 21060
-      - Level: 30
-        Exp: 22870
-      - Level: 31
-        Exp: 24910
-      - Level: 32
-        Exp: 26840
-      - Level: 33
-        Exp: 29080
-      - Level: 34
-        Exp: 31320
-      - Level: 35
-        Exp: 33300
-      - Level: 36
-        Exp: 37110
-      - Level: 37
-        Exp: 40500
-      - Level: 38
-        Exp: 43570
-      - Level: 39
-        Exp: 46180
-      - Level: 40
-        Exp: 53510
-      - Level: 41
-        Exp: 57200
-      - Level: 42
-        Exp: 60310
-      - Level: 43
-        Exp: 65690
-      - Level: 44
-        Exp: 70090
-      - Level: 45
-        Exp: 72130
-      - Level: 46
-        Exp: 77540
-      - Level: 47
-        Exp: 83320
-      - Level: 48
-        Exp: 90120
-      - Level: 49
-        Exp: 97180
-      - Level: 50
-        Exp: 999999999
-  - Jobs:
-      Knight: true
-      Priest: true
-      Wizard: true
-      Blacksmith: true
-      Hunter: true
-      Assassin: true
-      Knight2: true
-      Crusader: true
-      Monk: true
-      Sage: true
-      Rogue: true
-      Alchemist: true
-      Bard: true
-      Dancer: true
-      Crusader2: true
-      Baby_Knight: true
-      Baby_Priest: true
-      Baby_Wizard: true
-      Baby_Blacksmith: true
-      Baby_Hunter: true
-      Baby_Assassin: true
-      Baby_Knight2: true
-      Baby_Crusader: true
-      Baby_Monk: true
-      Baby_Sage: true
-      Baby_Rogue: true
-      Baby_Alchemist: true
-      Baby_Bard: true
-      Baby_Dancer: true
-      Baby_Crusader2: true
-      Soul_Linker: true
-      Baby_Soul_Linker: true
-    MaxJobLevel: 50
-    JobExp:
-      - Level: 1
-        Exp: 2500
-      - Level: 2
-        Exp: 4200
-      - Level: 3
-        Exp: 7000
-      - Level: 4
-        Exp: 10300
-      - Level: 5
-        Exp: 15900
-      - Level: 6
-        Exp: 18900
-      - Level: 7
-        Exp: 20900
-      - Level: 8
-        Exp: 22600
-      - Level: 9
-        Exp: 24900
-      - Level: 10
-        Exp: 28800
-      - Level: 11
-        Exp: 31500
-      - Level: 12
-        Exp: 32000
-      - Level: 13
-        Exp: 33300
-      - Level: 14
-        Exp: 35100
-      - Level: 15
-        Exp: 40500
-      - Level: 16
-        Exp: 44100
-      - Level: 17
-        Exp: 46300
-      - Level: 18
-        Exp: 48500
-      - Level: 19
-        Exp: 50700
-      - Level: 20
-        Exp: 56000
-      - Level: 21
-        Exp: 59400
-      - Level: 22
-        Exp: 63500
-      - Level: 23
-        Exp: 68100
-      - Level: 24
-        Exp: 75000
-      - Level: 25
-        Exp: 85700
-      - Level: 26
-        Exp: 90500
-      - Level: 27
-        Exp: 96600
-      - Level: 28
-        Exp: 102600
-      - Level: 29
-        Exp: 108600
-      - Level: 30
-        Exp: 119700
-      - Level: 31
-        Exp: 126000
-      - Level: 32
-        Exp: 132300
-      - Level: 33
-        Exp: 138600
-      - Level: 34
-        Exp: 146100
-      - Level: 35
-        Exp: 157500
-      - Level: 36
-        Exp: 170600
-      - Level: 37
-        Exp: 180400
-      - Level: 38
-        Exp: 190300
-      - Level: 39
-        Exp: 196800
-      - Level: 40
-        Exp: 214900
-      - Level: 41
-        Exp: 225200
-      - Level: 42
-        Exp: 232000
-      - Level: 43
-        Exp: 245700
-      - Level: 44
-        Exp: 255900
-      - Level: 45
-        Exp: 279300
-      - Level: 46
-        Exp: 294000
-      - Level: 47
-        Exp: 308700
-      - Level: 48
-        Exp: 327000
-      - Level: 49
-        Exp: 345400
-      - Level: 50
-        Exp: 999999999
-  - Jobs:
-      Gunslinger: true
-      Ninja: true
-      Baby_Ninja: true
-      Baby_Gunslinger: true
-    MaxJobLevel: 70
-    JobExp:
-      - Level: 1
-        Exp: 200
-      - Level: 2
-        Exp: 300
-      - Level: 3
-        Exp: 400
-      - Level: 4
-        Exp: 600
-      - Level: 5
-        Exp: 700
-      - Level: 6
-        Exp: 1000
-      - Level: 7
-        Exp: 1200
-      - Level: 8
-        Exp: 1400
-      - Level: 9
-        Exp: 1700
-      - Level: 10
-        Exp: 1900
-      - Level: 11
-        Exp: 2400
-      - Level: 12
-        Exp: 2700
-      - Level: 13
-        Exp: 3200
-      - Level: 14
-        Exp: 3600
-      - Level: 15
-        Exp: 4200
-      - Level: 16
-        Exp: 4900
-      - Level: 17
-        Exp: 5500
-      - Level: 18
-        Exp: 6100
-      - Level: 19
-        Exp: 6900
-      - Level: 20
-        Exp: 7700
-      - Level: 21
-        Exp: 8400
-      - Level: 22
-        Exp: 9300
-      - Level: 23
-        Exp: 10100
-      - Level: 24
-        Exp: 11100
-      - Level: 25
-        Exp: 12100
-      - Level: 26
-        Exp: 13000
-      - Level: 27
-        Exp: 14600
-      - Level: 28
-        Exp: 16100
-      - Level: 29
-        Exp: 17500
-      - Level: 30
-        Exp: 18600
-      - Level: 31
-        Exp: 21500
-      - Level: 32
-        Exp: 23300
-      - Level: 33
-        Exp: 24700
-      - Level: 34
-        Exp: 27000
-      - Level: 35
-        Exp: 29000
-      - Level: 36
-        Exp: 30000
-      - Level: 37
-        Exp: 32400
-      - Level: 38
-        Exp: 35000
-      - Level: 39
-        Exp: 38100
-      - Level: 40
-        Exp: 41100
-      - Level: 41
-        Exp: 44000
-      - Level: 42
-        Exp: 46700
-      - Level: 43
-        Exp: 49600
-      - Level: 44
-        Exp: 52500
-      - Level: 45
-        Exp: 55600
-      - Level: 46
-        Exp: 58900
-      - Level: 47
-        Exp: 62700
-      - Level: 48
-        Exp: 65500
-      - Level: 49
-        Exp: 69200
-      - Level: 50
-        Exp: 72300
-      - Level: 51
-        Exp: 81200
-      - Level: 52
-        Exp: 84100
-      - Level: 53
-        Exp: 89300
-      - Level: 54
-        Exp: 95500
-      - Level: 55
-        Exp: 100900
-      - Level: 56
-        Exp: 107800
-      - Level: 57
-        Exp: 114900
-      - Level: 58
-        Exp: 120700
-      - Level: 59
-        Exp: 128600
-      - Level: 60
-        Exp: 150500
-      - Level: 61
-        Exp: 176900
-      - Level: 62
-        Exp: 196100
-      - Level: 63
-        Exp: 219600
-      - Level: 64
-        Exp: 234200
-      - Level: 65
-        Exp: 247900
-      - Level: 66
-        Exp: 266400
-      - Level: 67
-        Exp: 281300
-      - Level: 68
-        Exp: 296600
-      - Level: 69
-        Exp: 308000
-      - Level: 70
-        Exp: 999999999
-  - Jobs:
-      Star_Gladiator: true
-      Star_Gladiator2: true
-      Baby_Star_Gladiator: true
-      Baby_Star_Gladiator2: true
-    MaxJobLevel: 50
-    JobExp:
-      - Level: 1
-        Exp: 50700
-      - Level: 2
-        Exp: 50700
-      - Level: 3
-        Exp: 50700
-      - Level: 4
-        Exp: 50700
-      - Level: 5
-        Exp: 50700
-      - Level: 6
-        Exp: 50700
-      - Level: 7
-        Exp: 50700
-      - Level: 8
-        Exp: 50700
-      - Level: 9
-        Exp: 50700
-      - Level: 10
-        Exp: 50700
-      - Level: 11
-        Exp: 50700
-      - Level: 12
-        Exp: 50700
-      - Level: 13
-        Exp: 50700
-      - Level: 14
-        Exp: 50700
-      - Level: 15
-        Exp: 50700
-      - Level: 16
-        Exp: 50700
-      - Level: 17
-        Exp: 50700
-      - Level: 18
-        Exp: 50700
-      - Level: 19
-        Exp: 101400
-      - Level: 20
-        Exp: 112000
-      - Level: 21
-        Exp: 118800
-      - Level: 22
-        Exp: 127000
-      - Level: 23
-        Exp: 136200
-      - Level: 24
-        Exp: 150000
-      - Level: 25
-        Exp: 171400
-      - Level: 26
-        Exp: 181000
-      - Level: 27
-        Exp: 193200
-      - Level: 28
-        Exp: 205200
-      - Level: 29
-        Exp: 217200
-      - Level: 30
-        Exp: 239400
-      - Level: 31
-        Exp: 252000
-      - Level: 32
-        Exp: 264600
-      - Level: 33
-        Exp: 277200
-      - Level: 34
-        Exp: 292200
-      - Level: 35
-        Exp: 315000
-      - Level: 36
-        Exp: 341200
-      - Level: 37
-        Exp: 360800
-      - Level: 38
-        Exp: 380600
-      - Level: 39
-        Exp: 393600
-      - Level: 40
-        Exp: 429800
-      - Level: 41
-        Exp: 450400
-      - Level: 42
-        Exp: 464000
-      - Level: 43
-        Exp: 491400
-      - Level: 44
-        Exp: 511800
-      - Level: 45
-        Exp: 558600
-      - Level: 46
-        Exp: 588000
-      - Level: 47
-        Exp: 617400
-      - Level: 48
-        Exp: 654000
-      - Level: 49
-        Exp: 690800
-      - Level: 50
-        Exp: 999999999
-  - Jobs:
-      Novice_High: true
-    MaxJobLevel: 10
-    JobExp:
-      - Level: 1
-        Exp: 11
-      - Level: 2
-        Exp: 20
-      - Level: 3
-        Exp: 31
-      - Level: 4
-        Exp: 44
-      - Level: 5
-        Exp: 100
-      - Level: 6
-        Exp: 166
-      - Level: 7
-        Exp: 226
-      - Level: 8
-        Exp: 295
-      - Level: 9
-        Exp: 374
-      - Level: 10
-        Exp: 999999999
-  - Jobs:
-      Swordman_High: true
-      Mage_High: true
-      Archer_High: true
-      Acolyte_High: true
-      Merchant_High: true
-      Thief_High: true
-    MaxJobLevel: 50
-    JobExp:
-      - Level: 1
-        Exp: 100
-      - Level: 2
-        Exp: 200
-      - Level: 3
-        Exp: 350
-      - Level: 4
-        Exp: 550
-      - Level: 5
-        Exp: 800
-      - Level: 6
-        Exp: 1100
-      - Level: 7
-        Exp: 1450
-      - Level: 8
-        Exp: 1850
-      - Level: 9
-        Exp: 2300
-      - Level: 10
-        Exp: 2800
-      - Level: 11
-        Exp: 3350
-      - Level: 12
-        Exp: 3950
-      - Level: 13
-        Exp: 4600
-      - Level: 14
-        Exp: 5300
-      - Level: 15
-        Exp: 6050
-      - Level: 16
-        Exp: 6850
-      - Level: 17
-        Exp: 7700
-      - Level: 18
-        Exp: 8600
-      - Level: 19
-        Exp: 9550
-      - Level: 20
-        Exp: 10550
-      - Level: 21
-        Exp: 11600
-      - Level: 22
-        Exp: 12700
-      - Level: 23
-        Exp: 13850
-      - Level: 24
-        Exp: 15050
-      - Level: 25
-        Exp: 16300
-      - Level: 26
-        Exp: 17600
-      - Level: 27
-        Exp: 18950
-      - Level: 28
-        Exp: 20350
-      - Level: 29
-        Exp: 21800
-      - Level: 30
-        Exp: 23300
-      - Level: 31
-        Exp: 24850
-      - Level: 32
-        Exp: 26450
-      - Level: 33
-        Exp: 28100
-      - Level: 34
-        Exp: 29800
-      - Level: 35
-        Exp: 31550
-      - Level: 36
-        Exp: 33350
-      - Level: 37
-        Exp: 35200
-      - Level: 38
-        Exp: 37100
-      - Level: 39
-        Exp: 39050
-      - Level: 40
-        Exp: 41050
-      - Level: 41
-        Exp: 43100
-      - Level: 42
-        Exp: 45200
-      - Level: 43
-        Exp: 47350
-      - Level: 44
-        Exp: 49550
-      - Level: 45
-        Exp: 51800
-      - Level: 46
-        Exp: 54100
-      - Level: 47
-        Exp: 56450
-      - Level: 48
-        Exp: 58850
-      - Level: 49
-        Exp: 61300
-      - Level: 50
-        Exp: 999999999
-  - Jobs:
-      Lord_Knight: true
-      High_Priest: true
-      High_Wizard: true
-      Whitesmith: true
-      Sniper: true
-      Assassin_Cross: true
-      Lord_Knight2: true
-      Paladin: true
-      Champion: true
-      Professor: true
-      Stalker: true
-      Creator: true
-      Clown: true
-      Gypsy: true
-      Paladin2: true
-    MaxJobLevel: 70
-    JobExp:
-      - Level: 1
-        Exp: 1354
-      - Level: 2
-        Exp: 1624
-      - Level: 3
-        Exp: 1949
-      - Level: 4
-        Exp: 2339
-      - Level: 5
-        Exp: 2807
-      - Level: 6
-        Exp: 3368
-      - Level: 7
-        Exp: 4042
-      - Level: 8
-        Exp: 4850
-      - Level: 9
-        Exp: 5820
-      - Level: 10
-        Exp: 6984
-      - Level: 11
-        Exp: 8381
-      - Level: 12
-        Exp: 10057
-      - Level: 13
-        Exp: 12069
-      - Level: 14
-        Exp: 14483
-      - Level: 15
-        Exp: 17379
-      - Level: 16
-        Exp: 20855
-      - Level: 17
-        Exp: 25026
-      - Level: 18
-        Exp: 30031
-      - Level: 19
-        Exp: 36037
-      - Level: 20
-        Exp: 43245
-      - Level: 21
-        Exp: 51894
-      - Level: 22
-        Exp: 55163
-      - Level: 23
-        Exp: 58638
-      - Level: 24
-        Exp: 62333
-      - Level: 25
-        Exp: 66260
-      - Level: 26
-        Exp: 70434
-      - Level: 27
-        Exp: 74871
-      - Level: 28
-        Exp: 79588
-      - Level: 29
-        Exp: 84602
-      - Level: 30
-        Exp: 89932
-      - Level: 31
-        Exp: 95598
-      - Level: 32
-        Exp: 101620
-      - Level: 33
-        Exp: 108023
-      - Level: 34
-        Exp: 114828
-      - Level: 35
-        Exp: 122062
-      - Level: 36
-        Exp: 129752
-      - Level: 37
-        Exp: 137926
-      - Level: 38
-        Exp: 146616
-      - Level: 39
-        Exp: 155853
-      - Level: 40
-        Exp: 165671
-      - Level: 41
-        Exp: 176109
-      - Level: 42
-        Exp: 187203
-      - Level: 43
-        Exp: 198997
-      - Level: 44
-        Exp: 211534
-      - Level: 45
-        Exp: 224861
-      - Level: 46
-        Exp: 239027
-      - Level: 47
-        Exp: 254086
-      - Level: 48
-        Exp: 270093
-      - Level: 49
-        Exp: 287109
-      - Level: 50
-        Exp: 305197
-      - Level: 51
-        Exp: 324424
-      - Level: 52
-        Exp: 344863
-      - Level: 53
-        Exp: 366589
-      - Level: 54
-        Exp: 389684
-      - Level: 55
-        Exp: 414234
-      - Level: 56
-        Exp: 440331
-      - Level: 57
-        Exp: 468072
-      - Level: 58
-        Exp: 497561
-      - Level: 59
-        Exp: 528907
-      - Level: 60
-        Exp: 562228
-      - Level: 61
-        Exp: 597649
-      - Level: 62
-        Exp: 635300
-      - Level: 63
-        Exp: 675324
-      - Level: 64
-        Exp: 717870
-      - Level: 65
-        Exp: 763096
-      - Level: 66
-        Exp: 811171
-      - Level: 67
-        Exp: 862274
-      - Level: 68
-        Exp: 916598
-      - Level: 69
-        Exp: 974343
-      - Level: 70
-        Exp: 999999
-  - Jobs:
-      Rune_Knight: true
-      Warlock: true
-      Ranger: true
-      Arch_Bishop: true
-      Mechanic: true
-      Guillotine_Cross: true
-      Rune_Knight_T: true
-      Warlock_T: true
-      Ranger_T: true
-      Arch_Bishop_T: true
-      Mechanic_T: true
-      Guillotine_Cross_T: true
-      Royal_Guard: true
-      Sorcerer: true
-      Minstrel: true
-      Wanderer: true
-      Sura: true
-      Genetic: true
-      Shadow_Chaser: true
-      Royal_Guard_T: true
-      Sorcerer_T: true
-      Minstrel_T: true
-      Wanderer_T: true
-      Sura_T: true
-      Genetic_T: true
-      Shadow_Chaser_T: true
-      Rune_Knight2: true
-      Rune_Knight_T2: true
-      Royal_Guard2: true
-      Royal_Guard_T2: true
-      Ranger2: true
-      Ranger_T2: true
-      Mechanic2: true
-      Mechanic_T2: true
-      Baby_Rune_Knight: true
-      Baby_Warlock: true
-      Baby_Ranger: true
-      Baby_Arch_Bishop: true
-      Baby_Mechanic: true
-      Baby_Guillotine_Cross: true
-      Baby_Royal_Guard: true
-      Baby_Sorcerer: true
-      Baby_Minstrel: true
-      Baby_Wanderer: true
-      Baby_Sura: true
-      Baby_Genetic: true
-      Baby_Shadow_Chaser: true
-      Baby_Rune_Knight2: true
-      Baby_Royal_Guard2: true
-      Baby_Ranger2: true
-      Baby_Mechanic2: true
-      Kagerou: true
-      Oboro: true
-      Rebellion: true
-      Baby_Kagerou: true
-      Baby_Oboro: true
-      Baby_Rebellion: true
-      Star_Emperor: true
-      Soul_Reaper: true
-      Baby_Star_Emperor: true
-      Baby_Soul_Reaper: true
-      Star_Emperor2: true
-      Baby_Star_Emperor2: true
-    MaxJobLevel: 70
-    JobExp:
-      - Level: 1
-        Exp: 12800
-      - Level: 2
-        Exp: 16384
-      - Level: 3
-        Exp: 20971
-      - Level: 4
-        Exp: 26843
-      - Level: 5
-        Exp: 34359
-      - Level: 6
-        Exp: 43980
-      - Level: 7
-        Exp: 56294
-      - Level: 8
-        Exp: 72057
-      - Level: 9
-        Exp: 92233
-      - Level: 10
-        Exp: 118059
-      - Level: 11
-        Exp: 151115
-      - Level: 12
-        Exp: 193428
-      - Level: 13
-        Exp: 247588
-      - Level: 14
-        Exp: 316912
-      - Level: 15
-        Exp: 405648
-      - Level: 16
-        Exp: 519229
-      - Level: 17
-        Exp: 664613
-      - Level: 18
-        Exp: 850705
-      - Level: 19
-        Exp: 1088903
-      - Level: 20
-        Exp: 1393796
-      - Level: 21
-        Exp: 1784059
-      - Level: 22
-        Exp: 2283596
-      - Level: 23
-        Exp: 2923003
-      - Level: 24
-        Exp: 3741444
-      - Level: 25
-        Exp: 4231573
-      - Level: 26
-        Exp: 4785909
-      - Level: 27
-        Exp: 5412863
-      - Level: 28
-        Exp: 6121948
-      - Level: 29
-        Exp: 6923924
-      - Level: 30
-        Exp: 7830958
-      - Level: 31
-        Exp: 8856813
-      - Level: 32
-        Exp: 10017056
-      - Level: 33
-        Exp: 11329290
-      - Level: 34
-        Exp: 12813427
-      - Level: 35
-        Exp: 14491986
-      - Level: 36
-        Exp: 16390436
-      - Level: 37
-        Exp: 18537584
-      - Level: 38
-        Exp: 20966007
-      - Level: 39
-        Exp: 23712554
-      - Level: 40
-        Exp: 26818899
-      - Level: 41
-        Exp: 30332175
-      - Level: 42
-        Exp: 34305690
-      - Level: 43
-        Exp: 38799735
-      - Level: 44
-        Exp: 43882500
-      - Level: 45
-        Exp: 49631108
-      - Level: 46
-        Exp: 56132783
-      - Level: 47
-        Exp: 63486178
-      - Level: 48
-        Exp: 71802867
-      - Level: 49
-        Exp: 81209043
-      - Level: 50
-        Exp: 91847428
-      - Level: 51
-        Exp: 103879441
-      - Level: 52
-        Exp: 117487647
-      - Level: 53
-        Exp: 132878529
-      - Level: 54
-        Exp: 150285617
-      - Level: 55
-        Exp: 169973033
-      - Level: 56
-        Exp: 192239500
-      - Level: 57
-        Exp: 217422874
-      - Level: 58
-        Exp: 245905271
-      - Level: 59
-        Exp: 278118862
-      - Level: 60
-        Exp: 319836691
-      - Level: 61
-        Exp: 367812195
-      - Level: 62
-        Exp: 422984024
-      - Level: 63
-        Exp: 486431628
-      - Level: 64
-        Exp: 559396372
-      - Level: 65
-        Exp: 632361116
-      - Level: 66
-        Exp: 705325860
-      - Level: 67
-        Exp: 778290604
-      - Level: 68
-        Exp: 851255348
-      - Level: 69
-        Exp: 924220092
-      - Level: 70
-        Exp: 999999999
-  - Jobs:
-      Super_Novice_E: true
-      Super_Baby_E: true
-    MaxJobLevel: 70
-    JobExp:
-      - Level: 1
-        Exp: 12800
-      - Level: 2
-        Exp: 16384
-      - Level: 3
-        Exp: 20971
-      - Level: 4
-        Exp: 26843
-      - Level: 5
-        Exp: 34359
-      - Level: 6
-        Exp: 43980
-      - Level: 7
-        Exp: 56294
-      - Level: 8
-        Exp: 72057
-      - Level: 9
-        Exp: 92233
-      - Level: 10
-        Exp: 118059
-      - Level: 11
-        Exp: 151115
-      - Level: 12
-        Exp: 193428
-      - Level: 13
-        Exp: 247588
-      - Level: 14
-        Exp: 316912
-      - Level: 15
-        Exp: 405648
-      - Level: 16
-        Exp: 519229
-      - Level: 17
-        Exp: 664613
-      - Level: 18
-        Exp: 850705
-      - Level: 19
-        Exp: 1088903
-      - Level: 20
-        Exp: 1393796
-      - Level: 21
-        Exp: 1784059
-      - Level: 22
-        Exp: 2283596
-      - Level: 23
-        Exp: 2923003
-      - Level: 24
-        Exp: 3741444
-      - Level: 25
-        Exp: 4231573
-      - Level: 26
-        Exp: 4785909
-      - Level: 27
-        Exp: 5412863
-      - Level: 28
-        Exp: 6121948
-      - Level: 29
-        Exp: 6923924
-      - Level: 30
-        Exp: 7830958
-      - Level: 31
-        Exp: 8856813
-      - Level: 32
-        Exp: 10017056
-      - Level: 33
-        Exp: 11329290
-      - Level: 34
-        Exp: 12813427
-      - Level: 35
-        Exp: 14491986
-      - Level: 36
-        Exp: 16390436
-      - Level: 37
-        Exp: 18537584
-      - Level: 38
-        Exp: 20966007
-      - Level: 39
-        Exp: 23712554
-      - Level: 40
-        Exp: 26818899
-      - Level: 41
-        Exp: 30332175
-      - Level: 42
-        Exp: 34305690
-      - Level: 43
-        Exp: 38799735
-      - Level: 44
-        Exp: 43882500
-      - Level: 45
-        Exp: 49631108
-      - Level: 46
-        Exp: 56132783
-      - Level: 47
-        Exp: 63486178
-      - Level: 48
-        Exp: 71802867
-      - Level: 49
-        Exp: 81209043
-      - Level: 50
-        Exp: 91847428
-      - Level: 51
-        Exp: 103879441
-      - Level: 52
-        Exp: 117487647
-      - Level: 53
-        Exp: 132878529
-      - Level: 54
-        Exp: 150285617
-      - Level: 55
-        Exp: 169973033
-      - Level: 56
-        Exp: 192239500
-      - Level: 57
-        Exp: 217422874
-      - Level: 58
-        Exp: 245905271
-      - Level: 59
-        Exp: 278118862
-      - Level: 60
-        Exp: 319836691
-      - Level: 61
-        Exp: 367812195
-      - Level: 62
-        Exp: 422984024
-      - Level: 63
-        Exp: 486431628
-      - Level: 64
-        Exp: 559396372
-      - Level: 65
-        Exp: 632361116
-      - Level: 66
-        Exp: 705325860
-      - Level: 67
-        Exp: 778290604
-      - Level: 68
-        Exp: 851255348
-      - Level: 69
-        Exp: 924220092
-      - Level: 70
-        Exp: 999999999
-  - Jobs:
-      Super_Novice: true
-      Super_Baby: true
-    MaxJobLevel: 99
-    JobExp:
-      - Level: 1
-        Exp: 60
-      - Level: 2
-        Exp: 130
-      - Level: 3
-        Exp: 260
-      - Level: 4
-        Exp: 460
-      - Level: 5
-        Exp: 780
-      - Level: 6
-        Exp: 1060
-      - Level: 7
-        Exp: 1300
-      - Level: 8
-        Exp: 1560
-      - Level: 9
-        Exp: 1910
-      - Level: 10
-        Exp: 2290
-      - Level: 11
-        Exp: 2680
-      - Level: 12
-        Exp: 2990
-      - Level: 13
-        Exp: 3340
-      - Level: 14
-        Exp: 3740
-      - Level: 15
-        Exp: 4360
-      - Level: 16
-        Exp: 4970
-      - Level: 17
-        Exp: 5530
-      - Level: 18
-        Exp: 6120
-      - Level: 19
-        Exp: 6700
-      - Level: 20
-        Exp: 8090
-      - Level: 21
-        Exp: 8920
-      - Level: 22
-        Exp: 9970
-      - Level: 23
-        Exp: 11080
-      - Level: 24
-        Exp: 12690
-      - Level: 25
-        Exp: 14440
-      - Level: 26
-        Exp: 15850
-      - Level: 27
-        Exp: 17400
-      - Level: 28
-        Exp: 19220
-      - Level: 29
-        Exp: 21060
-      - Level: 30
-        Exp: 22870
-      - Level: 31
-        Exp: 24910
-      - Level: 32
-        Exp: 26840
-      - Level: 33
-        Exp: 29080
-      - Level: 34
-        Exp: 31320
-      - Level: 35
-        Exp: 33300
-      - Level: 36
-        Exp: 37110
-      - Level: 37
-        Exp: 40500
-      - Level: 38
-        Exp: 43570
-      - Level: 39
-        Exp: 46180
-      - Level: 40
-        Exp: 53510
-      - Level: 41
-        Exp: 57200
-      - Level: 42
-        Exp: 60310
-      - Level: 43
-        Exp: 65690
-      - Level: 44
-        Exp: 70090
-      - Level: 45
-        Exp: 72130
-      - Level: 46
-        Exp: 77540
-      - Level: 47
-        Exp: 83320
-      - Level: 48
-        Exp: 90120
-      - Level: 49
-        Exp: 99132
-      - Level: 50
-        Exp: 109045
-      - Level: 51
-        Exp: 119950
-      - Level: 52
-        Exp: 131945
-      - Level: 53
-        Exp: 145139
-      - Level: 54
-        Exp: 159653
-      - Level: 55
-        Exp: 175618
-      - Level: 56
-        Exp: 193180
-      - Level: 57
-        Exp: 212498
-      - Level: 58
-        Exp: 233748
-      - Level: 59
-        Exp: 257123
-      - Level: 60
-        Exp: 282835
-      - Level: 61
-        Exp: 311119
-      - Level: 62
-        Exp: 342231
-      - Level: 63
-        Exp: 376454
-      - Level: 64
-        Exp: 414099
-      - Level: 65
-        Exp: 455509
-      - Level: 66
-        Exp: 501060
-      - Level: 67
-        Exp: 551166
-      - Level: 68
-        Exp: 606282
-      - Level: 69
-        Exp: 617195
-      - Level: 70
-        Exp: 628305
-      - Level: 71
-        Exp: 639614
-      - Level: 72
-        Exp: 651127
-      - Level: 73
-        Exp: 662848
-      - Level: 74
-        Exp: 674779
-      - Level: 75
-        Exp: 686925
-      - Level: 76
-        Exp: 699290
-      - Level: 77
-        Exp: 711877
-      - Level: 78
-        Exp: 724691
-      - Level: 79
-        Exp: 737735
-      - Level: 80
-        Exp: 751014
-      - Level: 81
-        Exp: 764533
-      - Level: 82
-        Exp: 778294
-      - Level: 83
-        Exp: 792303
-      - Level: 84
-        Exp: 806565
-      - Level: 85
-        Exp: 821083
-      - Level: 86
-        Exp: 835863
-      - Level: 87
-        Exp: 850908
-      - Level: 88
-        Exp: 866224
-      - Level: 89
-        Exp: 881817
-      - Level: 90
-        Exp: 897689
-      - Level: 91
-        Exp: 913848
-      - Level: 92
-        Exp: 930297
-      - Level: 93
-        Exp: 947042
-      - Level: 94
-        Exp: 964089
-      - Level: 95
-        Exp: 981443
-      - Level: 96
-        Exp: 999109
-      - Level: 97
-        Exp: 1017092
-      - Level: 98
-        Exp: 1035400
-      - Level: 99
-        Exp: 999999999
-  - Jobs:
-      Summoner: true
-      Baby_Summoner: true
-    MaxJobLevel: 60
-    JobExp:
-      - Level: 1
-        Exp: 60
-      - Level: 2
-        Exp: 130
-      - Level: 3
-        Exp: 260
-      - Level: 4
-        Exp: 460
-      - Level: 5
-        Exp: 780
-      - Level: 6
-        Exp: 1060
-      - Level: 7
-        Exp: 1300
-      - Level: 8
-        Exp: 1560
-      - Level: 9
-        Exp: 1910
-      - Level: 10
-        Exp: 2500
-      - Level: 11
-        Exp: 4200
-      - Level: 12
-        Exp: 7000
-      - Level: 13
-        Exp: 10300
-      - Level: 14
-        Exp: 15900
-      - Level: 15
-        Exp: 18900
-      - Level: 16
-        Exp: 20900
-      - Level: 17
-        Exp: 22600
-      - Level: 18
-        Exp: 24900
-      - Level: 19
-        Exp: 28800
-      - Level: 20
-        Exp: 33300
-      - Level: 21
-        Exp: 35100
-      - Level: 22
-        Exp: 40500
-      - Level: 23
-        Exp: 44100
-      - Level: 24
-        Exp: 46300
-      - Level: 25
-        Exp: 48500
-      - Level: 26
-        Exp: 50700
-      - Level: 27
-        Exp: 56000
-      - Level: 28
-        Exp: 59400
-      - Level: 29
-        Exp: 63500
-      - Level: 30
-        Exp: 68100
-      - Level: 31
-        Exp: 75000
-      - Level: 32
-        Exp: 85700
-      - Level: 33
-        Exp: 90500
-      - Level: 34
-        Exp: 106000
-      - Level: 35
-        Exp: 112000
-      - Level: 36
-        Exp: 355000
-      - Level: 37
-        Exp: 615000
-      - Level: 38
-        Exp: 917000
-      - Level: 39
-        Exp: 1253000
-      - Level: 40
-        Exp: 1595000
-      - Level: 41
-        Exp: 2007000
-      - Level: 42
-        Exp: 2430000
-      - Level: 43
-        Exp: 2868000
-      - Level: 44
-        Exp: 3420000
-      - Level: 45
-        Exp: 3863000
-      - Level: 46
-        Exp: 4504000
-      - Level: 47
-        Exp: 4998000
-      - Level: 48
-        Exp: 5769000
-      - Level: 49
-        Exp: 6321000
-      - Level: 50
-        Exp: 7585200
-      - Level: 51
-        Exp: 9860760
-      - Level: 52
-        Exp: 13805064
-      - Level: 53
-        Exp: 20707596
-      - Level: 54
-        Exp: 33132154
-      - Level: 55
-        Exp: 53011447
-      - Level: 56
-        Exp: 72890740
-      - Level: 57
-        Exp: 92770033
-      - Level: 58
-        Exp: 112649326
-      - Level: 59
-        Exp: 132528619
-      - Level: 60
         Exp: 999999999
   - Jobs:
       Dragon_Knight: true
@@ -3369,6 +1063,7 @@ Body:
       Night_Watch: true
       Hyper_Novice: true
       Spirit_Handler: true
+      Sky_Emperor2: true
     MaxBaseLevel: 275
     BaseExp:
       - Level: 1
@@ -3922,6 +1617,1176 @@ Body:
       - Level: 275
         Exp: 999999999999
   - Jobs:
+      Summoner: true
+      Baby_Summoner: true
+    MaxBaseLevel: 200
+    BaseExp:
+      - Level: 1
+        Exp: 55
+      - Level: 2
+        Exp: 90
+      - Level: 3
+        Exp: 150
+      - Level: 4
+        Exp: 220
+      - Level: 5
+        Exp: 320
+      - Level: 6
+        Exp: 380
+      - Level: 7
+        Exp: 420
+      - Level: 8
+        Exp: 455
+      - Level: 9
+        Exp: 500
+      - Level: 10
+        Exp: 600
+      - Level: 11
+        Exp: 700
+      - Level: 12
+        Exp: 800
+      - Level: 13
+        Exp: 900
+      - Level: 14
+        Exp: 1000
+      - Level: 15
+        Exp: 1100
+      - Level: 16
+        Exp: 1200
+      - Level: 17
+        Exp: 1300
+      - Level: 18
+        Exp: 1400
+      - Level: 19
+        Exp: 1500
+      - Level: 20
+        Exp: 1800
+      - Level: 21
+        Exp: 2100
+      - Level: 22
+        Exp: 2400
+      - Level: 23
+        Exp: 2700
+      - Level: 24
+        Exp: 3000
+      - Level: 25
+        Exp: 3300
+      - Level: 26
+        Exp: 3600
+      - Level: 27
+        Exp: 3900
+      - Level: 28
+        Exp: 4200
+      - Level: 29
+        Exp: 4500
+      - Level: 30
+        Exp: 5400
+      - Level: 31
+        Exp: 6300
+      - Level: 32
+        Exp: 7200
+      - Level: 33
+        Exp: 8100
+      - Level: 34
+        Exp: 9000
+      - Level: 35
+        Exp: 9900
+      - Level: 36
+        Exp: 10800
+      - Level: 37
+        Exp: 11700
+      - Level: 38
+        Exp: 12600
+      - Level: 39
+        Exp: 13500
+      - Level: 40
+        Exp: 16200
+      - Level: 41
+        Exp: 18900
+      - Level: 42
+        Exp: 21600
+      - Level: 43
+        Exp: 24300
+      - Level: 44
+        Exp: 27000
+      - Level: 45
+        Exp: 29700
+      - Level: 46
+        Exp: 32400
+      - Level: 47
+        Exp: 35100
+      - Level: 48
+        Exp: 37800
+      - Level: 49
+        Exp: 40500
+      - Level: 50
+        Exp: 43200
+      - Level: 51
+        Exp: 45900
+      - Level: 52
+        Exp: 48600
+      - Level: 53
+        Exp: 51300
+      - Level: 54
+        Exp: 54000
+      - Level: 55
+        Exp: 56700
+      - Level: 56
+        Exp: 59400
+      - Level: 57
+        Exp: 62100
+      - Level: 58
+        Exp: 64800
+      - Level: 59
+        Exp: 67500
+      - Level: 60
+        Exp: 70200
+      - Level: 61
+        Exp: 72900
+      - Level: 62
+        Exp: 75600
+      - Level: 63
+        Exp: 78300
+      - Level: 64
+        Exp: 81000
+      - Level: 65
+        Exp: 83700
+      - Level: 66
+        Exp: 86400
+      - Level: 67
+        Exp: 89100
+      - Level: 68
+        Exp: 91800
+      - Level: 69
+        Exp: 94500
+      - Level: 70
+        Exp: 103950
+      - Level: 71
+        Exp: 114345
+      - Level: 72
+        Exp: 125779
+      - Level: 73
+        Exp: 138356
+      - Level: 74
+        Exp: 152201
+      - Level: 75
+        Exp: 167421
+      - Level: 76
+        Exp: 184163
+      - Level: 77
+        Exp: 202579
+      - Level: 78
+        Exp: 222836
+      - Level: 79
+        Exp: 240662
+      - Level: 80
+        Exp: 259914
+      - Level: 81
+        Exp: 280707
+      - Level: 82
+        Exp: 303163
+      - Level: 83
+        Exp: 327416
+      - Level: 84
+        Exp: 353609
+      - Level: 85
+        Exp: 381897
+      - Level: 86
+        Exp: 412448
+      - Level: 87
+        Exp: 445443
+      - Level: 88
+        Exp: 481078
+      - Level: 89
+        Exp: 519564
+      - Level: 90
+        Exp: 561129
+      - Level: 91
+        Exp: 606019
+      - Level: 92
+        Exp: 654500
+      - Level: 93
+        Exp: 706860
+      - Level: 94
+        Exp: 763408
+      - Level: 95
+        Exp: 824480
+      - Level: 96
+        Exp: 890438
+      - Level: 97
+        Exp: 961673
+      - Level: 98
+        Exp: 1038606
+      - Level: 99
+        Exp: 1121694
+      - Level: 100
+        Exp: 1206943
+      - Level: 101
+        Exp: 1298670
+      - Level: 102
+        Exp: 1397369
+      - Level: 103
+        Exp: 1503569
+      - Level: 104
+        Exp: 1617841
+      - Level: 105
+        Exp: 1740797
+      - Level: 106
+        Exp: 1873097
+      - Level: 107
+        Exp: 2015453
+      - Level: 108
+        Exp: 2168627
+      - Level: 109
+        Exp: 2333443
+      - Level: 110
+        Exp: 2510784
+      - Level: 111
+        Exp: 2701604
+      - Level: 112
+        Exp: 2906926
+      - Level: 113
+        Exp: 3127852
+      - Level: 114
+        Exp: 3365569
+      - Level: 115
+        Exp: 3621352
+      - Level: 116
+        Exp: 3896575
+      - Level: 117
+        Exp: 4192714
+      - Level: 118
+        Exp: 4511361
+      - Level: 119
+        Exp: 4854224
+      - Level: 120
+        Exp: 5223145
+      - Level: 121
+        Exp: 5620104
+      - Level: 122
+        Exp: 6047232
+      - Level: 123
+        Exp: 6506822
+      - Level: 124
+        Exp: 7001340
+      - Level: 125
+        Exp: 7533442
+      - Level: 126
+        Exp: 8105984
+      - Level: 127
+        Exp: 8722038
+      - Level: 128
+        Exp: 9384913
+      - Level: 129
+        Exp: 10098167
+      - Level: 130
+        Exp: 10865627
+      - Level: 131
+        Exp: 11691415
+      - Level: 132
+        Exp: 12579963
+      - Level: 133
+        Exp: 13536040
+      - Level: 134
+        Exp: 14564779
+      - Level: 135
+        Exp: 15671702
+      - Level: 136
+        Exp: 16862751
+      - Level: 137
+        Exp: 18144320
+      - Level: 138
+        Exp: 19523289
+      - Level: 139
+        Exp: 21007059
+      - Level: 140
+        Exp: 22603595
+      - Level: 141
+        Exp: 24321468
+      - Level: 142
+        Exp: 26169900
+      - Level: 143
+        Exp: 28158812
+      - Level: 144
+        Exp: 30298882
+      - Level: 145
+        Exp: 32601597
+      - Level: 146
+        Exp: 35079319
+      - Level: 147
+        Exp: 37745347
+      - Level: 148
+        Exp: 40613993
+      - Level: 149
+        Exp: 43700657
+      - Level: 150
+        Exp: 47021907
+      - Level: 151
+        Exp: 50595572
+      - Level: 152
+        Exp: 54440835
+      - Level: 153
+        Exp: 58578338
+      - Level: 154
+        Exp: 63030292
+      - Level: 155
+        Exp: 67820594
+      - Level: 156
+        Exp: 72974960
+      - Level: 157
+        Exp: 78521056
+      - Level: 158
+        Exp: 84488657
+      - Level: 159
+        Exp: 90909795
+      - Level: 160
+        Exp: 97818939
+      - Level: 161
+        Exp: 105253178
+      - Level: 162
+        Exp: 113252420
+      - Level: 163
+        Exp: 121859604
+      - Level: 164
+        Exp: 131120934
+      - Level: 165
+        Exp: 141086125
+      - Level: 166
+        Exp: 151808670
+      - Level: 167
+        Exp: 163346129
+      - Level: 168
+        Exp: 175760435
+      - Level: 169
+        Exp: 189118228
+      - Level: 170
+        Exp: 203491213
+      - Level: 171
+        Exp: 218956546
+      - Level: 172
+        Exp: 235597243
+      - Level: 173
+        Exp: 253502633
+      - Level: 174
+        Exp: 272768834
+      - Level: 175
+        Exp: 293499265
+      - Level: 176
+        Exp: 315805209
+      - Level: 177
+        Exp: 339806405
+      - Level: 178
+        Exp: 365631692
+      - Level: 179
+        Exp: 377331906
+      - Level: 180
+        Exp: 389406527
+      - Level: 181
+        Exp: 401867536
+      - Level: 182
+        Exp: 414727297
+      - Level: 183
+        Exp: 427998570
+      - Level: 184
+        Exp: 441694525
+      - Level: 185
+        Exp: 455828749
+      - Level: 186
+        Exp: 470415269
+      - Level: 187
+        Exp: 485468558
+      - Level: 188
+        Exp: 501003552
+      - Level: 189
+        Exp: 517035666
+      - Level: 190
+        Exp: 533580807
+      - Level: 191
+        Exp: 550655393
+      - Level: 192
+        Exp: 568276365
+      - Level: 193
+        Exp: 586461209
+      - Level: 194
+        Exp: 605227968
+      - Level: 195
+        Exp: 624595263
+      - Level: 196
+        Exp: 644582311
+      - Level: 197
+        Exp: 665208945
+      - Level: 198
+        Exp: 686495631
+      - Level: 199
+        Exp: 708463491
+      - Level: 200
+        Exp: 999999999
+  - Jobs:
+      Novice: true
+      Baby: true
+    MaxJobLevel: 10
+    JobExp:
+      - Level: 1
+        Exp: 10
+      - Level: 2
+        Exp: 18
+      - Level: 3
+        Exp: 28
+      - Level: 4
+        Exp: 40
+      - Level: 5
+        Exp: 91
+      - Level: 6
+        Exp: 151
+      - Level: 7
+        Exp: 205
+      - Level: 8
+        Exp: 268
+      - Level: 9
+        Exp: 340
+      - Level: 10
+        Exp: 999
+  - Jobs:
+      Novice_High: true
+    MaxJobLevel: 10
+    JobExp:
+      - Level: 1
+        Exp: 11
+      - Level: 2
+        Exp: 20
+      - Level: 3
+        Exp: 31
+      - Level: 4
+        Exp: 44
+      - Level: 5
+        Exp: 100
+      - Level: 6
+        Exp: 166
+      - Level: 7
+        Exp: 226
+      - Level: 8
+        Exp: 295
+      - Level: 9
+        Exp: 374
+      - Level: 10
+        Exp: 999
+  - Jobs:
+      Swordman: true
+      Mage: true
+      Archer: true
+      Acolyte: true
+      Merchant: true
+      Thief: true
+      Baby_Swordman: true
+      Baby_Mage: true
+      Baby_Archer: true
+      Baby_Acolyte: true
+      Baby_Merchant: true
+      Baby_Thief: true
+      Taekwon: true
+      Gangsi: true
+      Baby_Taekwon: true
+    MaxJobLevel: 50
+    JobExp:
+      - Level: 1
+        Exp: 60
+      - Level: 2
+        Exp: 130
+      - Level: 3
+        Exp: 260
+      - Level: 4
+        Exp: 460
+      - Level: 5
+        Exp: 780
+      - Level: 6
+        Exp: 1060
+      - Level: 7
+        Exp: 1300
+      - Level: 8
+        Exp: 1560
+      - Level: 9
+        Exp: 1910
+      - Level: 10
+        Exp: 2290
+      - Level: 11
+        Exp: 2680
+      - Level: 12
+        Exp: 2990
+      - Level: 13
+        Exp: 3340
+      - Level: 14
+        Exp: 3740
+      - Level: 15
+        Exp: 4360
+      - Level: 16
+        Exp: 4970
+      - Level: 17
+        Exp: 5530
+      - Level: 18
+        Exp: 6120
+      - Level: 19
+        Exp: 6700
+      - Level: 20
+        Exp: 8090
+      - Level: 21
+        Exp: 8920
+      - Level: 22
+        Exp: 9970
+      - Level: 23
+        Exp: 11080
+      - Level: 24
+        Exp: 12690
+      - Level: 25
+        Exp: 14440
+      - Level: 26
+        Exp: 15850
+      - Level: 27
+        Exp: 17400
+      - Level: 28
+        Exp: 19220
+      - Level: 29
+        Exp: 21060
+      - Level: 30
+        Exp: 22870
+      - Level: 31
+        Exp: 24910
+      - Level: 32
+        Exp: 26840
+      - Level: 33
+        Exp: 29080
+      - Level: 34
+        Exp: 31320
+      - Level: 35
+        Exp: 33300
+      - Level: 36
+        Exp: 37110
+      - Level: 37
+        Exp: 40500
+      - Level: 38
+        Exp: 43570
+      - Level: 39
+        Exp: 46180
+      - Level: 40
+        Exp: 53510
+      - Level: 41
+        Exp: 57200
+      - Level: 42
+        Exp: 60310
+      - Level: 43
+        Exp: 65690
+      - Level: 44
+        Exp: 70090
+      - Level: 45
+        Exp: 72130
+      - Level: 46
+        Exp: 77540
+      - Level: 47
+        Exp: 83320
+      - Level: 48
+        Exp: 90120
+      - Level: 49
+        Exp: 97180
+      - Level: 50
+        Exp: 99999
+  - Jobs:
+      Swordman_High: true
+      Mage_High: true
+      Archer_High: true
+      Acolyte_High: true
+      Merchant_High: true
+      Thief_High: true
+    MaxJobLevel: 50
+    JobExp:
+      - Level: 1
+        Exp: 100
+      - Level: 2
+        Exp: 200
+      - Level: 3
+        Exp: 350
+      - Level: 4
+        Exp: 550
+      - Level: 5
+        Exp: 800
+      - Level: 6
+        Exp: 1100
+      - Level: 7
+        Exp: 1450
+      - Level: 8
+        Exp: 1850
+      - Level: 9
+        Exp: 2300
+      - Level: 10
+        Exp: 2800
+      - Level: 11
+        Exp: 3350
+      - Level: 12
+        Exp: 3950
+      - Level: 13
+        Exp: 4600
+      - Level: 14
+        Exp: 5300
+      - Level: 15
+        Exp: 6050
+      - Level: 16
+        Exp: 6850
+      - Level: 17
+        Exp: 7700
+      - Level: 18
+        Exp: 8600
+      - Level: 19
+        Exp: 9550
+      - Level: 20
+        Exp: 10550
+      - Level: 21
+        Exp: 11600
+      - Level: 22
+        Exp: 12700
+      - Level: 23
+        Exp: 13850
+      - Level: 24
+        Exp: 15050
+      - Level: 25
+        Exp: 16300
+      - Level: 26
+        Exp: 17600
+      - Level: 27
+        Exp: 18950
+      - Level: 28
+        Exp: 20350
+      - Level: 29
+        Exp: 21800
+      - Level: 30
+        Exp: 23300
+      - Level: 31
+        Exp: 24850
+      - Level: 32
+        Exp: 26450
+      - Level: 33
+        Exp: 28100
+      - Level: 34
+        Exp: 29800
+      - Level: 35
+        Exp: 31550
+      - Level: 36
+        Exp: 33350
+      - Level: 37
+        Exp: 35200
+      - Level: 38
+        Exp: 37100
+      - Level: 39
+        Exp: 39050
+      - Level: 40
+        Exp: 41050
+      - Level: 41
+        Exp: 43100
+      - Level: 42
+        Exp: 45200
+      - Level: 43
+        Exp: 47350
+      - Level: 44
+        Exp: 49550
+      - Level: 45
+        Exp: 51800
+      - Level: 46
+        Exp: 54100
+      - Level: 47
+        Exp: 56450
+      - Level: 48
+        Exp: 58850
+      - Level: 49
+        Exp: 61300
+      - Level: 50
+        Exp: 99999
+  - Jobs:
+      Knight: true
+      Priest: true
+      Wizard: true
+      Blacksmith: true
+      Hunter: true
+      Assassin: true
+      Knight2: true
+      Crusader: true
+      Monk: true
+      Sage: true
+      Rogue: true
+      Alchemist: true
+      Bard: true
+      Dancer: true
+      Crusader2: true
+      Baby_Knight: true
+      Baby_Priest: true
+      Baby_Wizard: true
+      Baby_Blacksmith: true
+      Baby_Hunter: true
+      Baby_Assassin: true
+      Baby_Knight2: true
+      Baby_Crusader: true
+      Baby_Monk: true
+      Baby_Sage: true
+      Baby_Rogue: true
+      Baby_Alchemist: true
+      Baby_Bard: true
+      Baby_Dancer: true
+      Baby_Crusader2: true
+      Soul_Linker: true
+      Death_Knight: true
+      Dark_Collector: true
+      Baby_Soul_Linker: true
+    MaxJobLevel: 50
+    JobExp:
+      - Level: 1
+        Exp: 2500
+      - Level: 2
+        Exp: 4200
+      - Level: 3
+        Exp: 7000
+      - Level: 4
+        Exp: 10300
+      - Level: 5
+        Exp: 15900
+      - Level: 6
+        Exp: 18900
+      - Level: 7
+        Exp: 20900
+      - Level: 8
+        Exp: 22600
+      - Level: 9
+        Exp: 24900
+      - Level: 10
+        Exp: 28800
+      - Level: 11
+        Exp: 31500
+      - Level: 12
+        Exp: 32000
+      - Level: 13
+        Exp: 33300
+      - Level: 14
+        Exp: 35100
+      - Level: 15
+        Exp: 40500
+      - Level: 16
+        Exp: 44100
+      - Level: 17
+        Exp: 46300
+      - Level: 18
+        Exp: 48500
+      - Level: 19
+        Exp: 50700
+      - Level: 20
+        Exp: 56000
+      - Level: 21
+        Exp: 59400
+      - Level: 22
+        Exp: 63500
+      - Level: 23
+        Exp: 68100
+      - Level: 24
+        Exp: 75000
+      - Level: 25
+        Exp: 85700
+      - Level: 26
+        Exp: 90500
+      - Level: 27
+        Exp: 96600
+      - Level: 28
+        Exp: 102600
+      - Level: 29
+        Exp: 108600
+      - Level: 30
+        Exp: 119700
+      - Level: 31
+        Exp: 126000
+      - Level: 32
+        Exp: 132300
+      - Level: 33
+        Exp: 138600
+      - Level: 34
+        Exp: 146100
+      - Level: 35
+        Exp: 157500
+      - Level: 36
+        Exp: 170600
+      - Level: 37
+        Exp: 180400
+      - Level: 38
+        Exp: 190300
+      - Level: 39
+        Exp: 196800
+      - Level: 40
+        Exp: 214900
+      - Level: 41
+        Exp: 225200
+      - Level: 42
+        Exp: 232000
+      - Level: 43
+        Exp: 245700
+      - Level: 44
+        Exp: 255900
+      - Level: 45
+        Exp: 279300
+      - Level: 46
+        Exp: 294000
+      - Level: 47
+        Exp: 308700
+      - Level: 48
+        Exp: 327000
+      - Level: 49
+        Exp: 345400
+      - Level: 50
+        Exp: 999999
+  - Jobs:
+      Lord_Knight: true
+      High_Priest: true
+      High_Wizard: true
+      Whitesmith: true
+      Sniper: true
+      Assassin_Cross: true
+      Lord_Knight2: true
+      Paladin: true
+      Champion: true
+      Professor: true
+      Stalker: true
+      Creator: true
+      Clown: true
+      Gypsy: true
+      Paladin2: true
+    MaxJobLevel: 70
+    JobExp:
+      - Level: 1
+        Exp: 1354
+      - Level: 2
+        Exp: 1624
+      - Level: 3
+        Exp: 1949
+      - Level: 4
+        Exp: 2339
+      - Level: 5
+        Exp: 2807
+      - Level: 6
+        Exp: 3368
+      - Level: 7
+        Exp: 4042
+      - Level: 8
+        Exp: 4850
+      - Level: 9
+        Exp: 5820
+      - Level: 10
+        Exp: 6984
+      - Level: 11
+        Exp: 8381
+      - Level: 12
+        Exp: 10057
+      - Level: 13
+        Exp: 12069
+      - Level: 14
+        Exp: 14483
+      - Level: 15
+        Exp: 17379
+      - Level: 16
+        Exp: 20855
+      - Level: 17
+        Exp: 25026
+      - Level: 18
+        Exp: 30031
+      - Level: 19
+        Exp: 36037
+      - Level: 20
+        Exp: 43245
+      - Level: 21
+        Exp: 51894
+      - Level: 22
+        Exp: 55163
+      - Level: 23
+        Exp: 58638
+      - Level: 24
+        Exp: 62333
+      - Level: 25
+        Exp: 66260
+      - Level: 26
+        Exp: 70434
+      - Level: 27
+        Exp: 74871
+      - Level: 28
+        Exp: 79588
+      - Level: 29
+        Exp: 84602
+      - Level: 30
+        Exp: 89932
+      - Level: 31
+        Exp: 95598
+      - Level: 32
+        Exp: 101620
+      - Level: 33
+        Exp: 108023
+      - Level: 34
+        Exp: 114828
+      - Level: 35
+        Exp: 122062
+      - Level: 36
+        Exp: 129752
+      - Level: 37
+        Exp: 137926
+      - Level: 38
+        Exp: 146616
+      - Level: 39
+        Exp: 155853
+      - Level: 40
+        Exp: 165671
+      - Level: 41
+        Exp: 176109
+      - Level: 42
+        Exp: 187203
+      - Level: 43
+        Exp: 198997
+      - Level: 44
+        Exp: 211534
+      - Level: 45
+        Exp: 224861
+      - Level: 46
+        Exp: 239027
+      - Level: 47
+        Exp: 254086
+      - Level: 48
+        Exp: 270093
+      - Level: 49
+        Exp: 287109
+      - Level: 50
+        Exp: 305197
+      - Level: 51
+        Exp: 324424
+      - Level: 52
+        Exp: 344863
+      - Level: 53
+        Exp: 366589
+      - Level: 54
+        Exp: 389684
+      - Level: 55
+        Exp: 414234
+      - Level: 56
+        Exp: 440331
+      - Level: 57
+        Exp: 468072
+      - Level: 58
+        Exp: 497561
+      - Level: 59
+        Exp: 528907
+      - Level: 60
+        Exp: 562228
+      - Level: 61
+        Exp: 597649
+      - Level: 62
+        Exp: 635300
+      - Level: 63
+        Exp: 675324
+      - Level: 64
+        Exp: 717870
+      - Level: 65
+        Exp: 763096
+      - Level: 66
+        Exp: 811171
+      - Level: 67
+        Exp: 862274
+      - Level: 68
+        Exp: 916598
+      - Level: 69
+        Exp: 974343
+      - Level: 70
+        Exp: 999999
+  - Jobs:
+      Rune_Knight: true
+      Warlock: true
+      Ranger: true
+      Arch_Bishop: true
+      Mechanic: true
+      Guillotine_Cross: true
+      Rune_Knight_T: true
+      Warlock_T: true
+      Ranger_T: true
+      Arch_Bishop_T: true
+      Mechanic_T: true
+      Guillotine_Cross_T: true
+      Royal_Guard: true
+      Sorcerer: true
+      Minstrel: true
+      Wanderer: true
+      Sura: true
+      Genetic: true
+      Shadow_Chaser: true
+      Royal_Guard_T: true
+      Sorcerer_T: true
+      Minstrel_T: true
+      Wanderer_T: true
+      Sura_T: true
+      Genetic_T: true
+      Shadow_Chaser_T: true
+      Rune_Knight2: true
+      Rune_Knight_T2: true
+      Royal_Guard2: true
+      Royal_Guard_T2: true
+      Ranger2: true
+      Ranger_T2: true
+      Mechanic2: true
+      Mechanic_T2: true
+      Baby_Rune_Knight: true
+      Baby_Warlock: true
+      Baby_Ranger: true
+      Baby_Arch_Bishop: true
+      Baby_Mechanic: true
+      Baby_Guillotine_Cross: true
+      Baby_Royal_Guard: true
+      Baby_Sorcerer: true
+      Baby_Minstrel: true
+      Baby_Wanderer: true
+      Baby_Sura: true
+      Baby_Genetic: true
+      Baby_Shadow_Chaser: true
+      Baby_Rune_Knight2: true
+      Baby_Royal_Guard2: true
+      Baby_Ranger2: true
+      Baby_Mechanic2: true
+    MaxJobLevel: 70
+    JobExp:
+      - Level: 1
+        Exp: 12800
+      - Level: 2
+        Exp: 16384
+      - Level: 3
+        Exp: 20971
+      - Level: 4
+        Exp: 26843
+      - Level: 5
+        Exp: 34359
+      - Level: 6
+        Exp: 43980
+      - Level: 7
+        Exp: 56294
+      - Level: 8
+        Exp: 72057
+      - Level: 9
+        Exp: 92233
+      - Level: 10
+        Exp: 118059
+      - Level: 11
+        Exp: 151115
+      - Level: 12
+        Exp: 193428
+      - Level: 13
+        Exp: 247588
+      - Level: 14
+        Exp: 316912
+      - Level: 15
+        Exp: 405648
+      - Level: 16
+        Exp: 519229
+      - Level: 17
+        Exp: 664613
+      - Level: 18
+        Exp: 850705
+      - Level: 19
+        Exp: 1088903
+      - Level: 20
+        Exp: 1393796
+      - Level: 21
+        Exp: 1784059
+      - Level: 22
+        Exp: 2283596
+      - Level: 23
+        Exp: 2923003
+      - Level: 24
+        Exp: 3741444
+      - Level: 25
+        Exp: 4231573
+      - Level: 26
+        Exp: 4785909
+      - Level: 27
+        Exp: 5412863
+      - Level: 28
+        Exp: 6121948
+      - Level: 29
+        Exp: 6923924
+      - Level: 30
+        Exp: 7830958
+      - Level: 31
+        Exp: 8856813
+      - Level: 32
+        Exp: 10017056
+      - Level: 33
+        Exp: 11329290
+      - Level: 34
+        Exp: 12813427
+      - Level: 35
+        Exp: 14491986
+      - Level: 36
+        Exp: 16390436
+      - Level: 37
+        Exp: 18537584
+      - Level: 38
+        Exp: 20966007
+      - Level: 39
+        Exp: 23712554
+      - Level: 40
+        Exp: 26818899
+      - Level: 41
+        Exp: 30332175
+      - Level: 42
+        Exp: 34305690
+      - Level: 43
+        Exp: 38799735
+      - Level: 44
+        Exp: 43882500
+      - Level: 45
+        Exp: 49631108
+      - Level: 46
+        Exp: 56132783
+      - Level: 47
+        Exp: 63486178
+      - Level: 48
+        Exp: 71802867
+      - Level: 49
+        Exp: 81209043
+      - Level: 50
+        Exp: 91847428
+      - Level: 51
+        Exp: 103879441
+      - Level: 52
+        Exp: 117487647
+      - Level: 53
+        Exp: 132878529
+      - Level: 54
+        Exp: 150285617
+      - Level: 55
+        Exp: 169973033
+      - Level: 56
+        Exp: 192239500
+      - Level: 57
+        Exp: 217422874
+      - Level: 58
+        Exp: 245905271
+      - Level: 59
+        Exp: 278118862
+      - Level: 60
+        Exp: 319836691
+      - Level: 61
+        Exp: 367812195
+      - Level: 62
+        Exp: 422984024
+      - Level: 63
+        Exp: 486431628
+      - Level: 64
+        Exp: 559396372
+      - Level: 65
+        Exp: 632361116
+      - Level: 66
+        Exp: 705325860
+      - Level: 67
+        Exp: 778290604
+      - Level: 68
+        Exp: 851255348
+      - Level: 69
+        Exp: 924220092
+      - Level: 70
+        Exp: 999999999
+  - Jobs:
       Dragon_Knight: true
       Meister: true
       Shadow_Cross: true
@@ -3946,6 +2811,7 @@ Body:
       Night_Watch: true
       Hyper_Novice: true
       Spirit_Handler: true
+      Sky_Emperor2: true
     MaxJobLevel: 60
     JobExp:
       - Level: 1
@@ -4068,3 +2934,885 @@ Body:
         Exp: 13194183036
       - Level: 60
         Exp: 99999999999
+  - Jobs:
+      Gunslinger: true
+      Ninja: true
+      Baby_Ninja: true
+      Baby_Gunslinger: true
+    MaxJobLevel: 70
+    JobExp:
+      - Level: 1
+        Exp: 200
+      - Level: 2
+        Exp: 300
+      - Level: 3
+        Exp: 400
+      - Level: 4
+        Exp: 600
+      - Level: 5
+        Exp: 700
+      - Level: 6
+        Exp: 1000
+      - Level: 7
+        Exp: 1200
+      - Level: 8
+        Exp: 1400
+      - Level: 9
+        Exp: 1700
+      - Level: 10
+        Exp: 1900
+      - Level: 11
+        Exp: 2400
+      - Level: 12
+        Exp: 2700
+      - Level: 13
+        Exp: 3200
+      - Level: 14
+        Exp: 3600
+      - Level: 15
+        Exp: 4200
+      - Level: 16
+        Exp: 4900
+      - Level: 17
+        Exp: 5500
+      - Level: 18
+        Exp: 6100
+      - Level: 19
+        Exp: 6900
+      - Level: 20
+        Exp: 7700
+      - Level: 21
+        Exp: 8400
+      - Level: 22
+        Exp: 9300
+      - Level: 23
+        Exp: 10100
+      - Level: 24
+        Exp: 11100
+      - Level: 25
+        Exp: 12100
+      - Level: 26
+        Exp: 13000
+      - Level: 27
+        Exp: 14600
+      - Level: 28
+        Exp: 16100
+      - Level: 29
+        Exp: 17500
+      - Level: 30
+        Exp: 18600
+      - Level: 31
+        Exp: 21500
+      - Level: 32
+        Exp: 23300
+      - Level: 33
+        Exp: 24700
+      - Level: 34
+        Exp: 27000
+      - Level: 35
+        Exp: 29000
+      - Level: 36
+        Exp: 30000
+      - Level: 37
+        Exp: 32400
+      - Level: 38
+        Exp: 35000
+      - Level: 39
+        Exp: 38100
+      - Level: 40
+        Exp: 41100
+      - Level: 41
+        Exp: 44000
+      - Level: 42
+        Exp: 46700
+      - Level: 43
+        Exp: 49600
+      - Level: 44
+        Exp: 52500
+      - Level: 45
+        Exp: 55600
+      - Level: 46
+        Exp: 58900
+      - Level: 47
+        Exp: 62700
+      - Level: 48
+        Exp: 65500
+      - Level: 49
+        Exp: 69200
+      - Level: 50
+        Exp: 72300
+      - Level: 51
+        Exp: 81200
+      - Level: 52
+        Exp: 84100
+      - Level: 53
+        Exp: 89300
+      - Level: 54
+        Exp: 95500
+      - Level: 55
+        Exp: 100900
+      - Level: 56
+        Exp: 107800
+      - Level: 57
+        Exp: 114900
+      - Level: 58
+        Exp: 120700
+      - Level: 59
+        Exp: 128600
+      - Level: 60
+        Exp: 150500
+      - Level: 61
+        Exp: 176900
+      - Level: 62
+        Exp: 196100
+      - Level: 63
+        Exp: 219600
+      - Level: 64
+        Exp: 234200
+      - Level: 65
+        Exp: 247900
+      - Level: 66
+        Exp: 266400
+      - Level: 67
+        Exp: 281300
+      - Level: 68
+        Exp: 296600
+      - Level: 69
+        Exp: 308000
+      - Level: 70
+        Exp: 999999
+  - Jobs:
+      Star_Gladiator: true
+      Star_Gladiator2: true
+      Baby_Star_Gladiator: true
+      Baby_Star_Gladiator2: true
+    MaxJobLevel: 50
+    JobExp:
+      - Level: 1
+        Exp: 50700
+      - Level: 2
+        Exp: 50700
+      - Level: 3
+        Exp: 50700
+      - Level: 4
+        Exp: 50700
+      - Level: 5
+        Exp: 50700
+      - Level: 6
+        Exp: 50700
+      - Level: 7
+        Exp: 50700
+      - Level: 8
+        Exp: 50700
+      - Level: 9
+        Exp: 50700
+      - Level: 10
+        Exp: 50700
+      - Level: 11
+        Exp: 50700
+      - Level: 12
+        Exp: 50700
+      - Level: 13
+        Exp: 50700
+      - Level: 14
+        Exp: 50700
+      - Level: 15
+        Exp: 50700
+      - Level: 16
+        Exp: 50700
+      - Level: 17
+        Exp: 50700
+      - Level: 18
+        Exp: 50700
+      - Level: 19
+        Exp: 101400
+      - Level: 20
+        Exp: 112000
+      - Level: 21
+        Exp: 118800
+      - Level: 22
+        Exp: 127000
+      - Level: 23
+        Exp: 136200
+      - Level: 24
+        Exp: 150000
+      - Level: 25
+        Exp: 171400
+      - Level: 26
+        Exp: 181000
+      - Level: 27
+        Exp: 193200
+      - Level: 28
+        Exp: 205200
+      - Level: 29
+        Exp: 217200
+      - Level: 30
+        Exp: 239400
+      - Level: 31
+        Exp: 252000
+      - Level: 32
+        Exp: 264600
+      - Level: 33
+        Exp: 277200
+      - Level: 34
+        Exp: 292200
+      - Level: 35
+        Exp: 315000
+      - Level: 36
+        Exp: 341200
+      - Level: 37
+        Exp: 360800
+      - Level: 38
+        Exp: 380600
+      - Level: 39
+        Exp: 393600
+      - Level: 40
+        Exp: 429800
+      - Level: 41
+        Exp: 450400
+      - Level: 42
+        Exp: 464000
+      - Level: 43
+        Exp: 491400
+      - Level: 44
+        Exp: 511800
+      - Level: 45
+        Exp: 558600
+      - Level: 46
+        Exp: 588000
+      - Level: 47
+        Exp: 617400
+      - Level: 48
+        Exp: 654000
+      - Level: 49
+        Exp: 690800
+      - Level: 50
+        Exp: 999999
+  - Jobs:
+      Super_Novice: true
+      Super_Baby: true
+    MaxJobLevel: 99
+    JobExp:
+      - Level: 1
+        Exp: 60
+      - Level: 2
+        Exp: 130
+      - Level: 3
+        Exp: 260
+      - Level: 4
+        Exp: 460
+      - Level: 5
+        Exp: 780
+      - Level: 6
+        Exp: 1060
+      - Level: 7
+        Exp: 1300
+      - Level: 8
+        Exp: 1560
+      - Level: 9
+        Exp: 1910
+      - Level: 10
+        Exp: 2290
+      - Level: 11
+        Exp: 2680
+      - Level: 12
+        Exp: 2990
+      - Level: 13
+        Exp: 3340
+      - Level: 14
+        Exp: 3740
+      - Level: 15
+        Exp: 4360
+      - Level: 16
+        Exp: 4970
+      - Level: 17
+        Exp: 5530
+      - Level: 18
+        Exp: 6120
+      - Level: 19
+        Exp: 6700
+      - Level: 20
+        Exp: 8090
+      - Level: 21
+        Exp: 8920
+      - Level: 22
+        Exp: 9970
+      - Level: 23
+        Exp: 11080
+      - Level: 24
+        Exp: 12690
+      - Level: 25
+        Exp: 14440
+      - Level: 26
+        Exp: 15850
+      - Level: 27
+        Exp: 17400
+      - Level: 28
+        Exp: 19220
+      - Level: 29
+        Exp: 21060
+      - Level: 30
+        Exp: 22870
+      - Level: 31
+        Exp: 24910
+      - Level: 32
+        Exp: 26840
+      - Level: 33
+        Exp: 29080
+      - Level: 34
+        Exp: 31320
+      - Level: 35
+        Exp: 33300
+      - Level: 36
+        Exp: 37110
+      - Level: 37
+        Exp: 40500
+      - Level: 38
+        Exp: 43570
+      - Level: 39
+        Exp: 46180
+      - Level: 40
+        Exp: 53510
+      - Level: 41
+        Exp: 57200
+      - Level: 42
+        Exp: 60310
+      - Level: 43
+        Exp: 65690
+      - Level: 44
+        Exp: 70090
+      - Level: 45
+        Exp: 72130
+      - Level: 46
+        Exp: 77540
+      - Level: 47
+        Exp: 83320
+      - Level: 48
+        Exp: 90120
+      - Level: 49
+        Exp: 99132
+      - Level: 50
+        Exp: 109045
+      - Level: 51
+        Exp: 119950
+      - Level: 52
+        Exp: 131945
+      - Level: 53
+        Exp: 145139
+      - Level: 54
+        Exp: 159653
+      - Level: 55
+        Exp: 175618
+      - Level: 56
+        Exp: 193180
+      - Level: 57
+        Exp: 212498
+      - Level: 58
+        Exp: 233748
+      - Level: 59
+        Exp: 257123
+      - Level: 60
+        Exp: 282835
+      - Level: 61
+        Exp: 311119
+      - Level: 62
+        Exp: 342231
+      - Level: 63
+        Exp: 376454
+      - Level: 64
+        Exp: 414099
+      - Level: 65
+        Exp: 455509
+      - Level: 66
+        Exp: 501060
+      - Level: 67
+        Exp: 551166
+      - Level: 68
+        Exp: 606282
+      - Level: 69
+        Exp: 617195
+      - Level: 70
+        Exp: 628305
+      - Level: 71
+        Exp: 639614
+      - Level: 72
+        Exp: 651127
+      - Level: 73
+        Exp: 662848
+      - Level: 74
+        Exp: 674779
+      - Level: 75
+        Exp: 686925
+      - Level: 76
+        Exp: 699290
+      - Level: 77
+        Exp: 711877
+      - Level: 78
+        Exp: 724691
+      - Level: 79
+        Exp: 737735
+      - Level: 80
+        Exp: 751014
+      - Level: 81
+        Exp: 764533
+      - Level: 82
+        Exp: 778294
+      - Level: 83
+        Exp: 792303
+      - Level: 84
+        Exp: 806565
+      - Level: 85
+        Exp: 821083
+      - Level: 86
+        Exp: 835863
+      - Level: 87
+        Exp: 850908
+      - Level: 88
+        Exp: 866224
+      - Level: 89
+        Exp: 881817
+      - Level: 90
+        Exp: 897689
+      - Level: 91
+        Exp: 913848
+      - Level: 92
+        Exp: 930297
+      - Level: 93
+        Exp: 947042
+      - Level: 94
+        Exp: 964089
+      - Level: 95
+        Exp: 981443
+      - Level: 96
+        Exp: 999109
+      - Level: 97
+        Exp: 1017092
+      - Level: 98
+        Exp: 1035400
+      - Level: 99
+        Exp: 9999999
+  - Jobs:
+      Super_Novice_E: true
+      Super_Baby_E: true
+    MaxJobLevel: 70
+    JobExp:
+      - Level: 1
+        Exp: 12800
+      - Level: 2
+        Exp: 16384
+      - Level: 3
+        Exp: 20971
+      - Level: 4
+        Exp: 26843
+      - Level: 5
+        Exp: 34359
+      - Level: 6
+        Exp: 43980
+      - Level: 7
+        Exp: 56294
+      - Level: 8
+        Exp: 72057
+      - Level: 9
+        Exp: 92233
+      - Level: 10
+        Exp: 118059
+      - Level: 11
+        Exp: 151115
+      - Level: 12
+        Exp: 193428
+      - Level: 13
+        Exp: 247588
+      - Level: 14
+        Exp: 316912
+      - Level: 15
+        Exp: 405648
+      - Level: 16
+        Exp: 519229
+      - Level: 17
+        Exp: 664613
+      - Level: 18
+        Exp: 850705
+      - Level: 19
+        Exp: 1088903
+      - Level: 20
+        Exp: 1393796
+      - Level: 21
+        Exp: 1784059
+      - Level: 22
+        Exp: 2283596
+      - Level: 23
+        Exp: 2923003
+      - Level: 24
+        Exp: 3741444
+      - Level: 25
+        Exp: 4231573
+      - Level: 26
+        Exp: 4785909
+      - Level: 27
+        Exp: 5412863
+      - Level: 28
+        Exp: 6121948
+      - Level: 29
+        Exp: 6923924
+      - Level: 30
+        Exp: 7830958
+      - Level: 31
+        Exp: 8856813
+      - Level: 32
+        Exp: 10017056
+      - Level: 33
+        Exp: 11329290
+      - Level: 34
+        Exp: 12813427
+      - Level: 35
+        Exp: 14491986
+      - Level: 36
+        Exp: 16390436
+      - Level: 37
+        Exp: 18537584
+      - Level: 38
+        Exp: 20966007
+      - Level: 39
+        Exp: 23712554
+      - Level: 40
+        Exp: 26818899
+      - Level: 41
+        Exp: 30332175
+      - Level: 42
+        Exp: 34305690
+      - Level: 43
+        Exp: 38799735
+      - Level: 44
+        Exp: 43882500
+      - Level: 45
+        Exp: 49631108
+      - Level: 46
+        Exp: 56132783
+      - Level: 47
+        Exp: 63486178
+      - Level: 48
+        Exp: 71802867
+      - Level: 49
+        Exp: 81209043
+      - Level: 50
+        Exp: 91847428
+      - Level: 51
+        Exp: 103879441
+      - Level: 52
+        Exp: 117487647
+      - Level: 53
+        Exp: 132878529
+      - Level: 54
+        Exp: 150285617
+      - Level: 55
+        Exp: 169973033
+      - Level: 56
+        Exp: 192239500
+      - Level: 57
+        Exp: 217422874
+      - Level: 58
+        Exp: 245905271
+      - Level: 59
+        Exp: 278118862
+      - Level: 60
+        Exp: 319836691
+      - Level: 61
+        Exp: 367812195
+      - Level: 62
+        Exp: 422984024
+      - Level: 63
+        Exp: 486431628
+      - Level: 64
+        Exp: 559396372
+      - Level: 65
+        Exp: 632361116
+      - Level: 66
+        Exp: 705325860
+      - Level: 67
+        Exp: 778290604
+      - Level: 68
+        Exp: 851255348
+      - Level: 69
+        Exp: 924220092
+      - Level: 70
+        Exp: 999999999
+  - Jobs:
+      Kagerou: true
+      Oboro: true
+      Rebellion: true
+      Baby_Kagerou: true
+      Baby_Oboro: true
+      Baby_Rebellion: true
+      Star_Emperor: true
+      Soul_Reaper: true
+      Baby_Star_Emperor: true
+      Baby_Soul_Reaper: true
+      Star_Emperor2: true
+      Baby_Star_Emperor2: true
+    MaxJobLevel: 70
+    JobExp:
+      - Level: 1
+        Exp: 12800
+      - Level: 2
+        Exp: 16384
+      - Level: 3
+        Exp: 20971
+      - Level: 4
+        Exp: 26843
+      - Level: 5
+        Exp: 34359
+      - Level: 6
+        Exp: 43980
+      - Level: 7
+        Exp: 56294
+      - Level: 8
+        Exp: 72057
+      - Level: 9
+        Exp: 92233
+      - Level: 10
+        Exp: 118059
+      - Level: 11
+        Exp: 151115
+      - Level: 12
+        Exp: 193428
+      - Level: 13
+        Exp: 247588
+      - Level: 14
+        Exp: 316912
+      - Level: 15
+        Exp: 405648
+      - Level: 16
+        Exp: 519229
+      - Level: 17
+        Exp: 664613
+      - Level: 18
+        Exp: 850705
+      - Level: 19
+        Exp: 1088903
+      - Level: 20
+        Exp: 1393796
+      - Level: 21
+        Exp: 1784059
+      - Level: 22
+        Exp: 2283596
+      - Level: 23
+        Exp: 2923003
+      - Level: 24
+        Exp: 3741444
+      - Level: 25
+        Exp: 4231573
+      - Level: 26
+        Exp: 4785909
+      - Level: 27
+        Exp: 5412863
+      - Level: 28
+        Exp: 6121948
+      - Level: 29
+        Exp: 6923924
+      - Level: 30
+        Exp: 7830958
+      - Level: 31
+        Exp: 8856813
+      - Level: 32
+        Exp: 10017056
+      - Level: 33
+        Exp: 11329290
+      - Level: 34
+        Exp: 12813427
+      - Level: 35
+        Exp: 14491986
+      - Level: 36
+        Exp: 16390436
+      - Level: 37
+        Exp: 18537584
+      - Level: 38
+        Exp: 20966007
+      - Level: 39
+        Exp: 23712554
+      - Level: 40
+        Exp: 26818899
+      - Level: 41
+        Exp: 30332175
+      - Level: 42
+        Exp: 34305690
+      - Level: 43
+        Exp: 38799735
+      - Level: 44
+        Exp: 43882500
+      - Level: 45
+        Exp: 49631108
+      - Level: 46
+        Exp: 56132783
+      - Level: 47
+        Exp: 63486178
+      - Level: 48
+        Exp: 71802867
+      - Level: 49
+        Exp: 81209043
+      - Level: 50
+        Exp: 91847428
+      - Level: 51
+        Exp: 103879441
+      - Level: 52
+        Exp: 117487647
+      - Level: 53
+        Exp: 132878529
+      - Level: 54
+        Exp: 150285617
+      - Level: 55
+        Exp: 169973033
+      - Level: 56
+        Exp: 192239500
+      - Level: 57
+        Exp: 217422874
+      - Level: 58
+        Exp: 245905271
+      - Level: 59
+        Exp: 278118862
+      - Level: 60
+        Exp: 319836691
+      - Level: 61
+        Exp: 367812195
+      - Level: 62
+        Exp: 422984024
+      - Level: 63
+        Exp: 486431628
+      - Level: 64
+        Exp: 559396372
+      - Level: 65
+        Exp: 632361116
+      - Level: 66
+        Exp: 705325860
+      - Level: 67
+        Exp: 778290604
+      - Level: 68
+        Exp: 851255348
+      - Level: 69
+        Exp: 924220092
+      - Level: 70
+        Exp: 999999999
+  - Jobs:
+      Summoner: true
+      Baby_Summoner: true
+    MaxJobLevel: 60
+    JobExp:
+      - Level: 1
+        Exp: 60
+      - Level: 2
+        Exp: 130
+      - Level: 3
+        Exp: 260
+      - Level: 4
+        Exp: 460
+      - Level: 5
+        Exp: 780
+      - Level: 6
+        Exp: 1060
+      - Level: 7
+        Exp: 1300
+      - Level: 8
+        Exp: 1560
+      - Level: 9
+        Exp: 1910
+      - Level: 10
+        Exp: 2500
+      - Level: 11
+        Exp: 4200
+      - Level: 12
+        Exp: 7000
+      - Level: 13
+        Exp: 10300
+      - Level: 14
+        Exp: 15900
+      - Level: 15
+        Exp: 18900
+      - Level: 16
+        Exp: 20900
+      - Level: 17
+        Exp: 22600
+      - Level: 18
+        Exp: 24900
+      - Level: 19
+        Exp: 28800
+      - Level: 20
+        Exp: 33300
+      - Level: 21
+        Exp: 35100
+      - Level: 22
+        Exp: 40500
+      - Level: 23
+        Exp: 44100
+      - Level: 24
+        Exp: 46300
+      - Level: 25
+        Exp: 48500
+      - Level: 26
+        Exp: 50700
+      - Level: 27
+        Exp: 56000
+      - Level: 28
+        Exp: 59400
+      - Level: 29
+        Exp: 63500
+      - Level: 30
+        Exp: 68100
+      - Level: 31
+        Exp: 75000
+      - Level: 32
+        Exp: 85700
+      - Level: 33
+        Exp: 90500
+      - Level: 34
+        Exp: 106000
+      - Level: 35
+        Exp: 112000
+      - Level: 36
+        Exp: 355000
+      - Level: 37
+        Exp: 615000
+      - Level: 38
+        Exp: 917000
+      - Level: 39
+        Exp: 1253000
+      - Level: 40
+        Exp: 1595000
+      - Level: 41
+        Exp: 2007000
+      - Level: 42
+        Exp: 2430000
+      - Level: 43
+        Exp: 2868000
+      - Level: 44
+        Exp: 3420000
+      - Level: 45
+        Exp: 3863000
+      - Level: 46
+        Exp: 4504000
+      - Level: 47
+        Exp: 4998000
+      - Level: 48
+        Exp: 5769000
+      - Level: 49
+        Exp: 6321000
+      - Level: 50
+        Exp: 7585200
+      - Level: 51
+        Exp: 9860760
+      - Level: 52
+        Exp: 13805064
+      - Level: 53
+        Exp: 20707596
+      - Level: 54
+        Exp: 33132154
+      - Level: 55
+        Exp: 53011447
+      - Level: 56
+        Exp: 72890740
+      - Level: 57
+        Exp: 92770033
+      - Level: 58
+        Exp: 112649326
+      - Level: 59
+        Exp: 132528619
+      - Level: 60
+        Exp: 999999999


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Remade Base/Job Exp Table

Remade the entire base/job exp tables from scratch.
This was done due to a number of issues I was finding with the current exp tables when reviewing it.
So I felt it was best to remake the entire thing to make sure its organized and up-to-date without errors.
Here are the resulting changes....

1. Organized base/job exp tables placements.
As newer groups of jobs got added, new tables were added to the end of the file which lead to the base/job exp
tables getting scattered around. Example of this is how the 4th jobs base exp table is close to the end of the
file past nearly every job exp table. Now all base exp tables will be listed first, followed by job exp tables.

2. Removes duplicate tables.
In the past, 1st upper expanded jobs had a lower level then 3rd jobs but slowly caught up to them, leading
to needing 2 seprate tables. Now that both of these groups of jobs have the same max level and are confirmed to
use the same tables (base exp mostly), we no longer need the extra tables. 4th's/2nd Upper Expandeds appear to
stay on the same table as well since their max levels are the same. Hopefully it stays that way.

3. Groups jobs to their correct tables.
Some expanded jobs use the same tables as the regular ones while other's don't and it depends on if were
talking about base or job tables. Its quite confusing and we do the best with what we got when it comes to
having official info or no info making us have to guess. Now that I have info on all the tables I was able to
group all the jobs to their correct tables.

4. Update exp values on some tables.
While some jobs start off at base level 99 or 200 we still start the exp tables for those jobs at level 1. This
is for technical reasons but its also best to have exp values for these levels for other reasons. Even if those
jobs are not officially played on those lower levels, its best to keep their exp values true to the ones from
their previous jobs. Never know if someone may want to do a custom setup or whatever.

5. Organized all tables to be in official order.
This may not seem like a big deal but it is to me. To do the 4 things I listed above, I used kRO's official
site as a source for this info. Each of the tables there are named and some of them were difficult to make out
when translating. Once done I built all the tables in order of the listings on the site. This will make it
easier to keep track of which table is which in both rAthena's and officials, should they decide to do something
like increase a level cap or reduce the amount of exp needed to level on lower levels, or add a new table.

Below is a TXT version of the exp database I made to easily manage things before running it through the converter tool to generate the YAML version. It gives a more clearer look into how things are organized.

[job_exp.txt](https://github.com/user-attachments/files/23519874/job_exp.txt)

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
