### PR TITLE
Corrected Arch Mage and Elemental Master skills ratio

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -8956,7 +8956,7 @@ struct Damage battle_calc_magic_attack(block_list *src,block_list *target,uint16
 					case AG_ASTRAL_STRIKE:
 						skillratio += -100 + 300 + 1800 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DRAGON)
-							skillratio += 400 * skill_lv;
+							skillratio += 100 + 300 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ASTRAL_STRIKE_ATK:
@@ -9129,6 +9129,7 @@ struct Damage battle_calc_magic_attack(block_list *src,block_list *target,uint16
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_PROCELLA ) ){
 							skillratio += 200 * skill_lv;
+							skillratio += 2 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);
@@ -9139,6 +9140,7 @@ struct Damage battle_calc_magic_attack(block_list *src,block_list *target,uint16
 
 						if( sc && sc->getSCE( SC_SUMMON_ELEMENTAL_SERPENS ) ){
 							skillratio += 200 * skill_lv;
+							skillratio += 2 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);
@@ -9149,6 +9151,7 @@ struct Damage battle_calc_magic_attack(block_list *src,block_list *target,uint16
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_ARDOR ) ){
 							skillratio += 200 * skill_lv;
+							skillratio += 2 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Corrected Arch Mage and Elemental Master skills ratio :
- Corrected Astral Strike ratio against undead/dragon races
- Corrected Lightning Land when the caster has summoned the elemental Procella
- Corrected Venom Swamp when the caster has summoned the elemental Serpens
- Corrected Conflagration when the caster has summoned the elemental Ardor


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
