### PR TITLE
Remove unnecessary assignment in clif_skill_itemlistwindow

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -19807,7 +19807,6 @@ int32 clif_skill_itemlistwindow( map_session_data *sd, uint16 skill_id, uint16 s
 	WFIFOHEAD(fd, packet_len(0x7e3));
 	WFIFOW(fd,0) = 0x7e3;
 	WFIFOL(fd,2) = skill_lv;
-	WFIFOL(fd,4) = 0;
 	WFIFOSET(fd, packet_len(0x7e3));
 #endif
 	return 1;


### PR DESCRIPTION
* **Description of Pull Request**: 

The whole packet is already be initialized with intended values. There is no need for the 0 assignment at offset 4 which will cause 2 bytes out-of-bound writes.
This does not cause vanilla rA to crash due to how rA's socket is implemented. But I still consider it a bug.