### PR TITLE
Implement resource cleanup in map deletion

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -3738,6 +3738,10 @@ int32 map_addmap(char* mapname)
 static void map_delmapid(int32 id)
 {
 	ShowNotice("Removing map [ %s ] from maplist" CL_CLL "\n",map[id].name);
+	// Free map resources before removing from list
+    if(map[id].cell) aFree(map[id].cell);
+	if(map[id].block) aFree(map[id].block);
+    if(map[id].block_mob) aFree(map[id].block_mob);
 	for (int32 i = id; i < map_num - 1; i++)
 		map[i] = map[i + 1];
 	map_num--;


### PR DESCRIPTION
Added resource cleanup before removing a map from the list.

Memory manager: Memory leaks found at 2025/12/16 18h47m55s (Git Hash 75d6c90b4886955e2adbc983342a1970a2eb255a).
0001 : map.cpp line 3783 size 180000 address 0x0x7f71b9e5a040
0002 : map.cpp line 3783 size 115200 address 0x0x55ffc972acd0
0003 : map.cpp line 3783 size 180000 address 0x0x7f71b9e86040
0004 : map.cpp line 3783 size 180000 address 0x0x7f71b9eb2040
0005 : map.cpp line 3783 size 115200 address 0x0x55ffc970ea90
0006 : map.cpp line 3783 size 80000 address 0x0x55ffc96fb1d0

This occured after 15 maps did not exist. (Maps are my problem)

<img width="819" height="928" alt="image" src="https://github.com/user-attachments/assets/7072c183-2d8f-41ab-91fb-4b3675f1d099" />
