### PR TITLE
Bodystyle logic in clif_viewequip_ack

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -10340,8 +10340,14 @@ void clif_viewequip_ack( map_session_data& sd, map_session_data& tsd ){
 #endif
 	p->headpalette = tsd.vd.look[LOOK_HAIR_COLOR];
 	p->bodypalette = tsd.vd.look[LOOK_CLOTHES_COLOR];
-#if PACKETVER_MAIN_NUM >= 20180801 || PACKETVER_RE_NUM >= 20180801 || PACKETVER_ZERO_NUM >= 20180808
+#if PACKETVER >= 20231220 && !defined(PACKETVER_ZERO)
 	p->body2 = tsd.vd.look[LOOK_BODY2];
+#elif PACKETVER_MAIN_NUM >= 20180801 || PACKETVER_RE_NUM >= 20180801 || PACKETVER_ZERO_NUM >= 20180808
+	if( tsd.vd.look[LOOK_BODY2] > JOB_SECOND_JOB_START && tsd.vd.look[LOOK_BODY2] < JOB_SECOND_JOB_END ){
+		p->body2 = 1;
+	}else{
+		p->body2 = 0;
+	}
 #endif
 	p->sex = tsd.vd.sex;
 


### PR DESCRIPTION
* **Addressed Issue(s)**: #9736 and on Discord it was reported that old clients will crash, when the equipment window of other players is viewed.

* **Server Mode**: Both

* **Description of Pull Request**: 
Added the missing bodystyle logic as also pointed out correctly in Discord.