### PR TITLE
Soul Siphon on Non-Players

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -13659,6 +13659,11 @@ static int8 skill_castend_id_check(block_list *src, block_list *target, uint16 s
 					return -1; //Works on silenced allies
 			}
 			break;
+		case PF_SOULBURN:
+			// Only works on players
+			if (target->type != BL_PC)
+				return USESKILL_FAIL_LEVEL;
+			break;
 		case RA_WUGSTRIKE:
 			// Check if path can be reached
 			if (!path_search(nullptr,src->m,src->x,src->y,target->x,target->y,1,CELL_CHKNOREACH))


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9706 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Fixed Soul Siphon being usable on non-players
  * It will now give a skill has failed message on non-players
  * It will not consume any SP or set any skill delay when used on non-players
- Fixes #9706

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
