### PR TITLE
Fix HW_GANBANTEIN gemstone check when under Soul Link buff

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -19785,8 +19785,11 @@ void skill_consume_requirement(map_session_data *sd, uint16 skill_id, uint16 ski
 		{
 			if( !require.itemid[i] )
 				continue;
-
+#ifdef RENEWAL
+			if( itemdb_group.item_exists(IG_GEMSTONE, require.itemid[i]) && skill_id != HW_GANBANTEIN && sc && sc->getSCE(SC_SPIRIT) && sc->getSCE(SC_SPIRIT)->val2 == SL_WIZARD )
+#else
 			if( itemdb_group.item_exists(IG_GEMSTONE, require.itemid[i]) && sc && sc->getSCE(SC_SPIRIT) && sc->getSCE(SC_SPIRIT)->val2 == SL_WIZARD )
+#endif
 				continue; //Gemstones are checked, but not substracted from inventory.
 
 			switch( skill_id ){


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: In regards to discord post
<img width="838" height="228" alt="image" src="https://github.com/user-attachments/assets/797bf1e6-2ae0-47bc-b62c-a14bf25223e3" />


<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: This PR fixes the behavior of HW_GANBANTEIN when the caster is affected by Soul Link (Wizard).
<!-- Describe how this pull request will resolve the issue(s) listed above. -->

* **The Fix:** By removing the explicit HW_GANBANTEIN condition, the skill now behaves consistently with other Wizard skills under Soul Link, correctly validating gemstone requirements without subtracting them.
