### PR TITLE
Fixed Clang's string-plus-int warnings

### DIFF
--- a/src/map/script_constants.hpp
+++ b/src/map/script_constants.hpp
@@ -6,7 +6,7 @@
 
 	#define export_constant(a) script_set_constant(#a,a,false,false)
 	#define export_constant2(a,b) script_set_constant(a,b,false,false)
-	#define export_constant_offset(a,offset) script_set_constant(#a + (offset),a,false,false)
+	#define export_constant_offset(a,offset) script_set_constant(static_cast<const char*>(#a) + static_cast<std::ptrdiff_t>(offset),a,false,false)
 	#define export_parameter(a,b) script_set_constant(a,b,true,false)
 	#define export_deprecated_constant(a) script_set_constant(#a,a,false,true)
 	#define export_deprecated_constant2(a,b) script_set_constant(a,b,false,true)


### PR DESCRIPTION
* **Addressed Issue(s)**: Slow build time of Clang CI

* **Server Mode**: Both

* **Description of Pull Request**: 
This should speed up Clang CI and reduce the build output and build time, if you are using Clang in general.

Thanks to @Danil0v3s and @Singe-Horizontal
