### PR TITLE
Fixed Primary 4th Jobs Not Able To Access Trans Skill Trees Correctly

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -2996,6 +2996,11 @@ uint64 pc_calc_skilltree_normalize_job( map_session_data* sd ){
 		}
 	}
 
+	// Primary 4th Jobs Can Access Trans Job Skill Trees.
+	if (pc_is_primary_fourth(sd->class_) && !pc_is_primary_fourth(c)) {
+		c |= JOBL_UPPER;
+	}
+
 	return c;
 }
 


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9721

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

In certain situations, the player may not be able to access trans skills
until all 3rd job skills points are invested. This bug is mainly noticed
when resetting your skills. This pull request fixes the issue.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
