### PR TITLE
Fixed bonus calculation for Celine brooch & dress

### DIFF
--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -20142,7 +20142,7 @@ Body:
           - Celine_Brooch_K    # 32237
     Script: |
       .@sum = getequiprefinerycnt(EQI_ARMOR);
-      bonus bMatk,10*.@r;
+      bonus bMatk,(10*.@sum);
       if (.@sum >= 9) {
          bonus bVariableCastrate,-5;
          if (.@sum >= 11) {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Fixed bonus calculation for Celine_Dress and Celine_Brooch_K combo

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: This PR fixes the bonus calculation by replacing the undefined `.@r` variable with the correct count variable (`.@sum`).

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
