### PR TITLE
Added mesemotion script command

### DIFF
--- a/doc/script_commands.txt
+++ b/doc/script_commands.txt
@@ -11441,7 +11441,7 @@ Notes:
 
 ---------------------------------------
 
-*mesemotiontype(<emotion_id>);
+*mesemotion(<emotion_id>);
 
 Generates an emotion type string that can be used with an NPCs mes command.
 This allows NPC dialogue to display a client-side emotion icon inline with the message.
@@ -11452,8 +11452,7 @@ This command requires packet version 2023-03-02 or newer.
 
 Examples:
 
-	mes mesemotiontype(ET_SMILE) + " Hello there!"; // Displays an NPC message with a smile emotion icon before the text.
-	mes mesemotiontype(3) + " I'm angry!"; // Displays an NPC message using emotion ID 3.
+	mes mesemotion(ET_SMILE) + " Hello there!"; // Displays an NPC message with a smile emotion icon before the text.
 
 ---------------------------------------
 

--- a/src/map/script.cpp
+++ b/src/map/script.cpp
@@ -27859,7 +27859,7 @@ BUILDIN_FUNC(mesemotion){
 	// Validates emotion range
 	if (id < ET_SURPRISE || id >= ET_MAX) {
 		ShowError("buildin_mesemotion: Emotion ID %d is invalid.\n", id);
-		script_pushconststr(st, "");
+		st->state = END;
 		return SCRIPT_CMD_FAILURE;
 	}
 
@@ -27870,6 +27870,7 @@ BUILDIN_FUNC(mesemotion){
 	return SCRIPT_CMD_SUCCESS;
 #else
 	ShowError( "buildin_mesemotion: This command requires PACKETVER 2023-03-02 or newer.\n" );
+	st->state = END;
 	return SCRIPT_CMD_FAILURE;
 #endif
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9782

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**:
This PR adds a new script command mesemotion() that allows scripts to embed emotion control codes directly into NPC dialog messages.

  This simplifies script readability and removes the need for hardcoded emotion control codes in NPC dialogs, making scripts easier to maintain and understand.

* **Details:**
  * Supports both numeric emotion IDs and emotion constants
  * Validates emotion ID range to prevent invalid values
  * Returns an empty string and reports an error on invalid input
  * Registered as a standard script builtin function
* Usage Example
```
louyang,196,49,4	script	mesemotion	909,{
	mes "[Script Command: mesemotion]";
	mes mesemotion(ET_SWEAT)+" This is emotion for mes dialog.";
	close;
}
```

**Screen Record:**
https://github.com/user-attachments/assets/d944efbf-6ec6-4ea1-aca6-5d1908985bcf


