### PR TITLE
Extend SkillImpl to handle damage display logic

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3602,6 +3602,8 @@ int64 skill_attack (int32 attack_type, block_list* src, block_list *dsrc, block_
 	skill_combo(src,dsrc,bl,skill_id,skill_lv,tick);
 
 	//Display damage.
+	// If SD_NODISPLAY is set, caller handles display - skip the switch entirely
+	if (!(flag & SD_NODISPLAY))
 	switch( skill_id ) {
 		case PA_GOSPEL: //Should look like Holy Cross [Skotlex]
 			clif_skill_damage( *src, *bl, tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, CR_HOLYCROSS, -1, DMG_SPLASH );
@@ -3697,10 +3699,6 @@ int64 skill_attack (int32 attack_type, block_list* src, block_list *dsrc, block_
 			[[fallthrough]];
 		case HT_LANDMINE:
 			clif_skill_damage( *dsrc, *bl, tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, -1, dmg_type );
-			break;
-		case WZ_SIGHTBLASTER:
-			//Sightblaster should never call clif_skill_damage twice
-			clif_skill_damage( *src, *bl, tick, dmg.amotion, dmg.dmotion, damage, dmg.div_, skill_id, (flag&SD_LEVEL) ? -1 : skill_lv, DMG_SPLASH );
 			break;
 		case RL_R_TRIP_PLUSATK:
 		case RL_S_STORM:

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -202,6 +202,7 @@ enum e_skill_display {
 	SD_ANIMATION = 0x2000, // skill_attack will use '5' instead of the skill's 'type' (this makes skills show an animation). Also being used in skill_attack for splash skill (NK_SPLASH) to check status_check_skilluse
 	SD_SPLASH    = 0x4000, // skill_area_sub will count targets in skill_area_temp[2]
 	SD_PREAMBLE  = 0x8000, // skill_area_sub will transmit a 'magic' damage packet (-30000 dmg) for the first target selected
+	SD_NODISPLAY = 0x10000, // skill_attack will skip the display switch, caller handles display
 };
 
 #define MAX_SKILL_ITEM_REQUIRE	10 /// Maximum required items

--- a/src/map/skills/mage/sightblaster.cpp
+++ b/src/map/skills/mage/sightblaster.cpp
@@ -6,6 +6,7 @@
 #include <config/core.hpp>
 
 #include "map/clif.hpp"
+#include "map/skill.hpp"
 #include "map/status.hpp"
 
 SkillSightBlaster::SkillSightBlaster() : SkillImpl(WZ_SIGHTBLASTER) {
@@ -17,7 +18,14 @@ void SkillSightBlaster::castendNoDamageId(block_list* src, block_list* target, u
 }
 
 void SkillSightBlaster::castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_attack(BF_MAGIC,src,src,target,getSkillId(),skill_lv,tick,flag);
+	// Calculate and apply damage without display
+	const e_skill skill_id = getSkillId();
+	int64 damage = skill_attack(BF_MAGIC, src, src, target, skill_id, skill_lv, tick, flag | SD_NODISPLAY);
+
+	// Handle display ourselves - get damage type from skill_db, handle SD_LEVEL flag
+	status_data* sstatus = status_get_status_data(*src);
+	status_data* tstatus = status_get_status_data(*target);
+	clif_skill_damage(*src, *target, tick, sstatus->amotion, tstatus->dmotion, damage, skill_get_num(skill_id, skill_lv), skill_id, (flag & SD_LEVEL) ? -1 : skill_lv, skill_get_hit(skill_id));
 }
 
 void SkillSightBlaster::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const {

--- a/src/map/skills/skill_impl.cpp
+++ b/src/map/skills/skill_impl.cpp
@@ -3,6 +3,7 @@
 
 #include "skill_impl.hpp"
 
+#include "../clif.hpp"
 #include "../status.hpp"
 
 SkillImpl::SkillImpl(e_skill skill_id){

--- a/src/map/skills/thief/souldestroyer.cpp
+++ b/src/map/skills/thief/souldestroyer.cpp
@@ -6,9 +6,22 @@
 #include <config/const.hpp>
 #include <config/core.hpp>
 
+#include "map/clif.hpp"
+#include "map/skill.hpp"
 #include "map/status.hpp"
 
 SkillSoulDestroyer::SkillSoulDestroyer() : WeaponSkillImpl(ASC_BREAKER) {
+}
+
+void SkillSoulDestroyer::castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
+	// Calculate and apply damage without display
+	const e_skill skill_id = getSkillId();
+	int64 damage = skill_attack(BF_WEAPON, src, src, target, skill_id, skill_lv, tick, flag | SD_NODISPLAY);
+
+	// Handle display ourselves - get damage type from skill_db
+	status_data* sstatus = status_get_status_data(*src);
+	status_data* tstatus = status_get_status_data(*target);
+	clif_skill_damage(*src, *target, tick, sstatus->amotion, tstatus->dmotion, damage, skill_get_num(skill_id, skill_lv), skill_id, skill_lv, skill_get_hit(skill_id));
 }
 
 void SkillSoulDestroyer::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {

--- a/src/map/skills/thief/souldestroyer.hpp
+++ b/src/map/skills/thief/souldestroyer.hpp
@@ -9,5 +9,6 @@ class SkillSoulDestroyer : public WeaponSkillImpl {
 public:
 	SkillSoulDestroyer();
 
+	void castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const override;
 	void calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const override;
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9784


<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

This PR adds the ability for individual skill implementations to control their own damage display, isolating display logic from the monolithic switch statement in `skill_attack` into their respective skill implementation files.

- Added `SD_NODISPLAY` flag to enable splitted skills to handle their own damage display
- Added example implementations for `souldestroy.cpp` and `sightblaster.cpp`
