### PR TITLE
Fix compiler errors after skill split

### DIFF
--- a/src/map/skills/swordman/trample.cpp
+++ b/src/map/skills/swordman/trample.cpp
@@ -3,6 +3,8 @@
 
 #include "trample.hpp"
 
+#include <common/nullpo.hpp>
+
 #include "map/battle.hpp"
 #include "map/clif.hpp"
 #include "map/map.hpp"

--- a/src/map/skills/thief/chasingbreak.cpp
+++ b/src/map/skills/thief/chasingbreak.cpp
@@ -9,6 +9,7 @@
 #include "map/map.hpp"
 #include "map/path.hpp"
 #include "map/status.hpp"
+#include "map/unit.hpp"
 
 SkillChasingBreak::SkillChasingBreak() : SkillImplRecursiveDamageSplash(ABC_CHASING_BREAK) {
 }

--- a/src/map/skills/thief/chasingshot.cpp
+++ b/src/map/skills/thief/chasingshot.cpp
@@ -9,6 +9,7 @@
 #include "map/map.hpp"
 #include "map/path.hpp"
 #include "map/status.hpp"
+#include "map/unit.hpp"
 
 SkillChasingShot::SkillChasingShot() : SkillImplRecursiveDamageSplash(ABC_CHASING_SHOT) {
 }


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: These files fail to compile if you don't do the amalgamation. This also causes issues with intellisense/clangd, because some of the used functions/macros/variables aren't declared.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
