### PR TITLE
data-driven SA_AUTOSPELL via skill_db AutoSpell block

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -136,6 +136,12 @@
 #     Target                  Skill unit target type. (Default: All)
 #     Flag:                   Skill unit flags. (Default: None)
 #   Status                    Status Change that is associated to the skill. (Optional)
+#   AutoSpell:                SA_AUTOSPELL (Hindsight) integration. (Optional)
+#     UnlockedAtLevel         Minimum SA_AUTOSPELL level required to offer this spell to players
+#                             and for NPC/mob auto-cast eligibility.
+#     MobMaxCastLevel         Upper bound on NPC/mob AI cast level.
+#                             Actual cast level = max(1, min(SA_AUTOSPELL_lv / 2, MobMaxCastLevel)).
+#                             No effect on player characters. (Default: 0, no cap)
 ###########################################################################
 
 Header:
@@ -536,6 +542,9 @@ Body:
     Name: MG_SOULSTRIKE
     Description: Soul Strike
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 4
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -616,6 +625,9 @@ Body:
     Name: MG_COLDBOLT
     Description: Cold Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -716,6 +728,9 @@ Body:
     Name: MG_FROSTDIVER
     Description: Frost Diver
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 7
+        MobMaxCastLevel: 1
     Type: Magic
     TargetType: Attack
     Flags:
@@ -821,6 +836,9 @@ Body:
     Name: MG_FIREBALL
     Description: Fire Ball
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 4
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     DamageFlags:
@@ -977,6 +995,9 @@ Body:
     Name: MG_FIREBOLT
     Description: Fire Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -1077,6 +1098,9 @@ Body:
     Name: MG_LIGHTNINGBOLT
     Description: Lightning Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -1177,6 +1201,9 @@ Body:
     Name: MG_THUNDERSTORM
     Description: Thunderstorm
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 10
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Ground
     Flags:
@@ -3614,6 +3641,9 @@ Body:
     Name: WZ_EARTHSPIKE
     Description: Earth Spike
     MaxLevel: 5
+    AutoSpell:
+        UnlockedAtLevel: 7
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -3674,6 +3704,9 @@ Body:
     Name: WZ_HEAVENDRIVE
     Description: Heaven's Drive
     MaxLevel: 5
+    AutoSpell:
+        UnlockedAtLevel: 10
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Ground
     Flags:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -136,6 +136,12 @@
 #     Target                  Skill unit target type. (Default: All)
 #     Flag:                   Skill unit flags. (Default: None)
 #   Status                    Status Change that is associated to the skill. (Optional)
+#   AutoSpell:                SA_AUTOSPELL (Hindsight) integration. (Optional)
+#     UnlockedAtLevel         Minimum SA_AUTOSPELL level required to offer this spell to players
+#                             and for NPC/mob auto-cast eligibility.
+#     MobMaxCastLevel         Upper bound on NPC/mob AI cast level.
+#                             Actual cast level = max(1, min(SA_AUTOSPELL_lv / 2, MobMaxCastLevel)).
+#                             No effect on player characters. (Default: 0, no cap)
 ###########################################################################
 
 Header:
@@ -517,6 +523,9 @@ Body:
     Name: MG_SOULSTRIKE
     Description: Soul Strike
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 4
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -578,6 +587,9 @@ Body:
     Name: MG_COLDBOLT
     Description: Cold Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -679,6 +691,9 @@ Body:
     Name: MG_FROSTDIVER
     Description: Frost Diver
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 7
+        MobMaxCastLevel: 1
     Type: Magic
     TargetType: Attack
     Flags:
@@ -786,6 +801,9 @@ Body:
     Name: MG_FIREBALL
     Description: Fire Ball
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 4
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     DamageFlags:
@@ -924,6 +942,9 @@ Body:
     Name: MG_FIREBOLT
     Description: Fire Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -1025,6 +1046,9 @@ Body:
     Name: MG_LIGHTNINGBOLT
     Description: Lightning Bolt
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 1
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -1126,6 +1150,9 @@ Body:
     Name: MG_THUNDERSTORM
     Description: Thunderstorm
     MaxLevel: 10
+    AutoSpell:
+        UnlockedAtLevel: 10
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Ground
     Flags:
@@ -3670,6 +3697,9 @@ Body:
     Name: WZ_EARTHSPIKE
     Description: Earth Spike
     MaxLevel: 5
+    AutoSpell:
+        UnlockedAtLevel: 7
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Attack
     Flags:
@@ -3731,6 +3761,9 @@ Body:
     Name: WZ_HEAVENDRIVE
     Description: Heaven's Drive
     MaxLevel: 5
+    AutoSpell:
+        UnlockedAtLevel: 10
+        MobMaxCastLevel: 3
     Type: Magic
     TargetType: Ground
     Flags:

--- a/doc/yaml/db/skill_db.yml
+++ b/doc/yaml/db/skill_db.yml
@@ -119,4 +119,10 @@
 #     Target                  Skill unit target type. (Default: All)
 #     Flag:                   Skill unit flags. (Default: None)
 #   Status                    Status Change that is associated to the skill. (Optional)
+#   AutoSpell:                SA_AUTOSPELL (Hindsight) integration. (Optional)
+#     UnlockedAtLevel         Minimum SA_AUTOSPELL level required to offer this spell to players
+#                             and for NPC/mob auto-cast eligibility.
+#     MobMaxCastLevel         Upper bound on NPC/mob AI cast level.
+#                             Actual cast level = max(1, min(SA_AUTOSPELL_lv / 2, MobMaxCastLevel)).
+#                             No effect on player characters. (Default: 0, no cap)
 ###########################################################################

--- a/src/map/skill.hpp
+++ b/src/map/skill.hpp
@@ -319,6 +319,9 @@ struct s_skill_db {
 	uint16 improvisedsong_rate;
 	sc_type sc;									///< Default SC for skill
 
+	uint8 autospell_unlocked_at;				///< Minimum SA_AUTOSPELL level required to offer this spell (0 = not offered)
+	uint8 autospell_mob_max_cast_level;			///< Max cast level used by NPC/mob AI when auto-spelling (MobMaxCastLevel in skill_db)
+
 	std::unique_ptr<const SkillImpl> impl;
 };
 
@@ -551,6 +554,8 @@ int32 skill_get_unit_target( uint16 skill_id );
 bool skill_get_nk_(uint16 skill_id, std::vector<e_skill_nk> nk);
 #define skill_get_inf2(skill_id, inf2) skill_get_inf2_(skill_id, { inf2 })
 bool skill_get_inf2_(uint16 skill_id, std::vector<e_skill_inf2> inf2);
+uint8 skill_get_autospell_unlocked_at(uint16 skill_id);
+uint8 skill_get_autospell_mob_max_cast_level(uint16 skill_id);
 #define skill_get_unit_flag(skill_id, unit) skill_get_unit_flag_(skill_id, { unit })
 bool skill_get_unit_flag_(uint16 skill_id, std::vector<e_skill_unit_flag> unit);
 int32 skill_get_unit_range(uint16 skill_id, uint16 skill_lv);

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -10984,11 +10984,7 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 			// Val1 Skill LV of Autospell
 			// Val2 Skill ID to cast
 			// Val3 Max Lv to cast
-#ifdef RENEWAL
-			val4 = val1 * 2; // Chance of casting
-#else
-			val4 = 5 + val1*2; // Chance of casting
-#endif
+			val4 = val1 * 2; // Chance of casting (2% per level, RE and pre-RE)
 			break;
 		case SC_VOLCANO:
 			{


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: [SA_AUTOSPELL hardcodes all eligible spells. Any expansion to be able to use other skills need to be done in code.](https://github.com/rathena/rathena/issues/9842)

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**:  RENEWAL + PRE-RENEWAL

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

# Summary of changes

| Aspect | Old | New | Applies To |
|---|---|---|---|
| Spell eligibility | `INF2_ISAUTOSPELL` flag per skill | `AutoSpell.UnlockedAtLevel` in `skill_db.yml` | RE + pre-RE |
| Spell unlock data | Hardcoded in `skill_autospell()` and `clif_autospell()` | Data-driven via `skill_db.yml` `AutoSpell:` block | RE + pre-RE |
| Cast level formula | RE: `SA_lv / 2` · pre-RE: `SA_lv - (tier - 1)` per spell | `max(SA_lv / 2, 1)` for both | RE + pre-RE |
| Autocast chance | RE: `SA_lv × 2%` · pre-RE: `5 + SA_lv × 2%` (Lv1 = 7%) | `SA_lv × 2%` for both (Lv1 = 2%) | **pre-RE only** |
| Cast level floor | `max(SA_lv / 2, 1)` → minimum **1**  | Same — unchanged | RE + pre-RE |
| Learned level cap | `min(learned_lv, maxlv)` | Same — unchanged | RE + pre-RE |
| Soul Linker bolt bonus | `maxlv = 10` for bolt spells with SC_SPIRIT/SL_SAGE | Same — unchanged | RE + pre-RE |
| SP cost | `2/3` of normal | Same — unchanged | RE + pre-RE |