### PR TITLE
Pre-Renewal Perfect Tablature Rounding Issue Fix

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -6752,10 +6752,6 @@ std::shared_ptr<s_skill_unit_group> skill_unitsetting(block_list *src, uint16 sk
 			val1 += pc_checkskill(sd, BA_MUSICALLESSON) / 2;
 			val2 += pc_checkskill(sd, BA_MUSICALLESSON) / 5;
 		}
-		// If val2 is 9, you get +0 Lucky Dodge
-		// If val2 is 10, you get +1 Lucky Dodge
-		// To prevent 0.1 steps we divide it by 10 here and then multiply by 10 when it's applied
-		val2 /= 10;
 		break;
 	case DC_HUMMING:
 		val1 = 1 + 2 * skill_lv + status->dex / 10; // Hit increase

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -7726,7 +7726,7 @@ static int16 status_calc_flee2(block_list *bl, status_change *sc, int32 flee2)
 		return cap_value(flee2,10,SHRT_MAX);
 
 	if(sc->getSCE(SC_WHISTLE))
-		flee2 += sc->getSCE(SC_WHISTLE)->val3*10;
+		flee2 += sc->getSCE(SC_WHISTLE)->val3;
 	if(sc->getSCE(SC__UNLUCKY))
 		flee2 -= flee2 * sc->getSCE(SC__UNLUCKY)->val2 / 100;
 	if (sc->getSCE(SC_HISS))
@@ -11095,7 +11095,7 @@ static bool status_change_start_post_delay(block_list* src, block_list* bl, sc_t
 			break;
 		case SC_WHISTLE:
 			val2 = 18 + 2 * val1; // Flee increase
-			val3 = (val1 + 1) / 2; // Perfect dodge increase
+			val3 = ((val1 + 1) / 2) * 10; // Perfect dodge increase
 			break;
 		case SC_ASSNCROS:
 			val2 = val1 < 10 ? val1 * 2 - 1 : 20; // ASPD increase


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9860 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal (Renewal code adjusted but no effective change)

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Perfect Tablature can now give the Perfect Dodge bonus in 0.1% steps
  * This is how it works on official servers, even though the client rounds it to a full number!
- Adjusted renewal code so it's compatible with the pre-re implementation (no effective change)
- Follow-up to 815ddf2
- Fixes #9860

Note: Details are explained in extra comments in the linked issue.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
