### PR TITLE
Delta-driven @reloadscript

### DIFF
--- a/doc/atcommands.txt
+++ b/doc/atcommands.txt
@@ -1465,7 +1465,7 @@ This will also send a packet to clients causing them to close.
 @reloadmsgconf
 @reloadpcdb
 @reloadquestdb
-@reloadscript
+@reloadscript [full]
 @reloadskilldb
 @reloadstatusdb
 @reloadachievementdb
@@ -1473,6 +1473,13 @@ This will also send a packet to clients causing them to close.
 @reloadbarterdb
 
 Reloads a database or configuration file.
+
+@reloadscript performs a fast delta reload by default: only NPC script files
+  (.txt) whose on-disk modification time changed since the last load are
+  re-parsed. Only players whose active NPC dialog belongs to a changed file
+  are disconnected; other players continue unaffected.
+  Use "@reloadscript full" to force a complete wipe-and-reload of all scripts,
+  which also fires all OnInit events globally (the legacy behavior).
 
 Databases:
 -- instancedb: Instance Database

--- a/src/common/database.cpp
+++ b/src/common/database.cpp
@@ -3,6 +3,7 @@
 
 #include "database.hpp"
 
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 
@@ -84,12 +85,30 @@ bool YamlDatabase::load(){
 }
 
 bool YamlDatabase::reload(){
+	this->file_mtimes.clear();
 	this->clear();
 
 	return this->load();
 }
 
 bool YamlDatabase::load(const std::string& path) {
+	// Delta-reload fast path [jezztify]
+	// If we are in delta mode, check whether this file has changed since the
+	// last time it was loaded.  If the mtime is identical, skip re-parsing
+	// entirely and return immediately so unchanged imports are also skipped.
+	if( this->is_delta_mode ){
+		auto it = this->file_mtimes.find( path );
+		if( it != this->file_mtimes.end() ){
+			std::error_code ec;
+			auto current_mtime = std::filesystem::last_write_time( path, ec );
+			if( !ec && current_mtime == it->second ){
+				return true; // Unchanged – skip entirely
+			}
+		}
+		// New file (not yet tracked): fall through to normal load
+	}
+
+
 	ShowStatus("Loading '" CL_WHITE "%s" CL_RESET "'..." CL_CLL "\r", path.c_str());
 	FILE* f = fopen(path.c_str(), "r");
 	if (f == nullptr) {
@@ -127,9 +146,14 @@ bool YamlDatabase::load(const std::string& path) {
 		return false;
 	}
 
+	// Delta-reload atomic swap [jezztify]
+	if( this->is_delta_mode ){
+		this->eraseByPath( path );
+	}
+
 	const ryml::NodeRef& header = tree["Header"];
 
-	if( this->nodeExists( header, "Clear" ) ){
+	if( !this->is_delta_mode && this->nodeExists( header, "Clear" ) ){
 		bool clear;
 
 		if( this->asBool( header, "Clear", clear ) && clear ){
@@ -137,9 +161,15 @@ bool YamlDatabase::load(const std::string& path) {
 		}
 	}
 
+
 	this->parse( tree );
 
 	this->parseImports( tree );
+
+	std::error_code ec;
+	auto mtime = std::filesystem::last_write_time( path, ec );
+	if( !ec )
+		this->file_mtimes[path] = mtime;
 
 	aFree(buf);
 	return true;
@@ -381,6 +411,61 @@ std::string YamlDatabase::getCurrentFile(){
 
 void YamlDatabase::setGenerator(bool shouldLoad) {
 	shouldLoadGenerator = shouldLoad;
+}
+
+bool YamlDatabase::delta_reload(){
+	namespace fs = std::filesystem;
+
+	// Phase 1: remove entries for files that no longer exist on disk 
+	std::vector<std::string> removed;
+	for( const auto& [path, mtime] : this->file_mtimes ){
+		std::error_code ec;
+		if( !fs::exists( path, ec ) || ec ){
+			removed.push_back( path );
+		}
+	}
+	for( const auto& path : removed ){
+		this->eraseByPath( path );
+		this->file_mtimes.erase( path );
+	}
+
+	// Phase 2: reload every modified tracked file (including imports) 
+	// We iterate file_mtimes directly rather than only starting from the root,
+	// so that a changed import whose parent file is unchanged is still caught.
+	//
+	// In delta mode, load(path) will:
+	//   a) Skip the file entirely if mtime is still current.
+	//   b) Verify the new content, then atomically swap (eraseByPath + parse).
+	//
+	// We collect modified paths before iterating to avoid invalidating the
+	// map if load() inserts new import entries into file_mtimes.
+	std::vector<std::string> to_reload;
+	to_reload.reserve( this->file_mtimes.size() );
+	for( const auto& [path, mtime] : this->file_mtimes ){
+		std::error_code ec;
+		auto curr = fs::last_write_time( path, ec );
+		if( !ec && curr != mtime )
+			to_reload.push_back( path );
+	}
+
+	this->is_delta_mode = true;
+
+	struct DeltaScope {
+		bool& flag;
+		explicit DeltaScope( bool& f ) : flag( f ) {}
+		~DeltaScope() { flag = false; }
+	} delta_scope( this->is_delta_mode );
+
+	for( const auto& path : to_reload ){
+		this->load( path );
+	}
+
+	bool ret = this->load( this->getDefaultLocation() );
+
+	this->is_delta_mode = false;
+
+	this->loadingFinished();
+	return ret;
 }
 
 void on_yaml_error( const char* msg, size_t len, ryml::Location loc, void *user_data ){

--- a/src/common/database.hpp
+++ b/src/common/database.hpp
@@ -4,6 +4,7 @@
 #ifndef DATABASE_HPP
 #define DATABASE_HPP
 
+#include <filesystem>
 #include <unordered_map>
 #include <vector>
 
@@ -24,6 +25,9 @@ private:
 	uint16 minimumVersion;
 	std::string currentFile;
 	bool shouldLoadGenerator{false};
+
+	bool is_delta_mode{ false };
+	std::unordered_map<std::string, std::filesystem::file_time_type> file_mtimes;
 
 	bool verifyCompatibility( const ryml::Tree& rootNode );
 	bool load( const std::string& path );
@@ -61,6 +65,8 @@ protected:
 
 	virtual void loadingFinished();
 
+	virtual void eraseByPath( const std::string& path ) {}
+
 public:
 	YamlDatabase( const std::string& type_, uint16 version_, uint16 minimumVersion_ ){
 		this->type = type_;
@@ -74,6 +80,7 @@ public:
 
 	bool load();
 	bool reload();
+	bool delta_reload();
 
 	// Functions that need to be implemented for each type
 	virtual void clear() = 0;
@@ -84,6 +91,7 @@ public:
 template <typename keytype, typename datatype> class TypesafeYamlDatabase : public YamlDatabase{
 protected:
 	std::unordered_map<keytype, std::shared_ptr<datatype>> data;
+	std::unordered_map<keytype, std::string> keySourceFile;
 
 public:
 	TypesafeYamlDatabase( const std::string& type_, uint16 version_, uint16 minimumVersion_ ) : YamlDatabase( type_, version_, minimumVersion_ ){
@@ -94,6 +102,7 @@ public:
 
 	void clear() override{
 		this->data.clear();
+		this->keySourceFile.clear();
 	}
 
 	bool empty(){
@@ -120,6 +129,19 @@ public:
 
 	virtual void put( keytype key, std::shared_ptr<datatype> ptr ){
 		this->data[key] = ptr;
+		this->keySourceFile[key] = this->getCurrentFile();
+	}
+
+	void eraseByPath( const std::string& path ) override{
+		std::vector<keytype> toRemove;
+		for( auto& [key, src] : this->keySourceFile ){
+			if( src == path )
+				toRemove.push_back( key );
+		}
+		for( auto& key : toRemove ){
+			this->erase( key );
+			this->keySourceFile.erase( key );
+		}
 	}
 
 	typename std::unordered_map<keytype, std::shared_ptr<datatype>>::iterator begin(){

--- a/src/map/atcommand.cpp
+++ b/src/map/atcommand.cpp
@@ -4384,34 +4384,52 @@ ACMD_FUNC(reloadskilldb){
 ACMD_FUNC(reloadscript){
 	nullpo_retr(-1, sd);
 
-	struct s_mapiterator* iter;
-	map_session_data* pl_sd;
-	//atcommand_broadcast( fd, sd, "@broadcast", "Server is reloading scripts..." );
-	//atcommand_broadcast( fd, sd, "@broadcast", "You will feel a bit of lag at this point !" );
+	// @reloadscript full  →  legacy wipe-and-reload (guaranteed clean slate) [jezztify]
+	// @reloadscript       →  delta reload (only changed/added/removed files) [jezztify]
+	bool full_reload = ( message[0] != '\0' && strcasecmp( message, "full" ) == 0 );
 
-	iter = mapit_getallusers();
-	for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) ){
-		pc_close_npc(pl_sd,1);
-		clif_cutin( *pl_sd, "", 255 );
-		pl_sd->state.block_action &= ~(PCBLOCK_ALL ^ PCBLOCK_IMMUNE);
-		bg_queue_leave(pl_sd);
+	if( full_reload ){
+		struct s_mapiterator* iter;
+		map_session_data* pl_sd;
+
+		iter = mapit_getallusers();
+		for( pl_sd = (TBL_PC*)mapit_first(iter); mapit_exists(iter); pl_sd = (TBL_PC*)mapit_next(iter) ){
+			pc_close_npc(pl_sd,1);
+			clif_cutin( *pl_sd, "", 255 );
+			pl_sd->state.block_action &= ~(PCBLOCK_ALL ^ PCBLOCK_IMMUNE);
+			bg_queue_leave(pl_sd);
+		}
+		mapit_free(iter);
+
+		for (auto &bg : bg_queues) {
+			for (auto &bg_sd : bg->teama_members)
+				bg_team_leave(bg_sd, false, false); // Kick Team A from battlegrounds
+			for (auto &bg_sd : bg->teamb_members)
+				bg_team_leave(bg_sd, false, false); // Kick Team B from battlegrounds
+			bg_queue_clear(bg, true);
+		}
+
+		flush_fifos();
+		map_reloadnpc(true); // reload config files seeking for npcs
+		script_reload();
+		npc_reload();
+
+		clif_displaymessage(fd, msg_txt(sd,100)); // Scripts have been reloaded.
+	} else {
+		// Delta reload: only re-parse files that changed on disk.
+		int32 mod = 0, add = 0, rem = 0;
+		npc_delta_reload( mod, add, rem );
+
+		char output[CHAT_SIZE_MAX];
+		if( mod == 0 && add == 0 && rem == 0 ){
+			safesnprintf( output, sizeof(output), "[Delta Reload] No script files were changed." );
+		} else {
+			safesnprintf( output, sizeof(output),
+				"[Delta Reload] Scripts reloaded: %d modified, %d added, %d removed.",
+				mod, add, rem );
+		}
+		clif_displaymessage( fd, output );
 	}
-	mapit_free(iter);
-
-	for (auto &bg : bg_queues) {
-		for (auto &bg_sd : bg->teama_members)
-			bg_team_leave(bg_sd, false, false); // Kick Team A from battlegrounds
-		for (auto &bg_sd : bg->teamb_members)
-			bg_team_leave(bg_sd, false, false); // Kick Team B from battlegrounds
-		bg_queue_clear(bg, true);
-	}
-
-	flush_fifos();
-	map_reloadnpc(true); // reload config files seeking for npcs
-	script_reload();
-	npc_reload();
-
-	clif_displaymessage(fd, msg_txt(sd,100)); // Scripts have been reloaded.
 
 	return 0;
 }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -4225,6 +4225,8 @@ void map_reloadnpc_sub(const char *cfgName)
 		return;
 	}
 
+	npc_record_conf_mtime( cfgName );
+
 	while( fgets(line, sizeof(line), fp) )
 	{
 		char* ptr;

--- a/src/map/npc.cpp
+++ b/src/map/npc.cpp
@@ -5,7 +5,9 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <filesystem>
 #include <map>
+#include <unordered_set>
 #include <vector>
 
 #include <common/cbasetypes.hpp>
@@ -41,6 +43,16 @@ npc_data* fake_nd;
 
 
 std::vector<std::string> npc_src_files;
+
+static std::unordered_map<std::string, std::filesystem::file_time_type> npc_file_mtimes;
+static std::unordered_map<std::string, std::filesystem::file_time_type> npc_conf_mtimes;
+
+void npc_record_conf_mtime( const char* path ){
+	std::error_code ec;
+	auto mtime = std::filesystem::last_write_time( path, ec );
+	if( !ec )
+		npc_conf_mtimes[path] = mtime;
+}
 
 static int32 npc_id=START_NPC_NUM;
 static int32 npc_warp=0;
@@ -5818,6 +5830,14 @@ int32 npc_parsesrcfile(const char* filepath)
 	}
 	aFree(buffer);
 
+	// Record mtime so npc_delta_reload() can detect future changes to this file. [jezztify]
+	{
+		std::error_code ec;
+		auto mtime = std::filesystem::last_write_time( filepath, ec );
+		if( !ec )
+			npc_file_mtimes[filepath] = mtime;
+	}
+
 	return 1;
 }
 
@@ -6063,6 +6083,8 @@ int32 npc_reload(void) {
 	/* clear guild flag cache */
 	guild_flags_clear();
 
+	npc_file_mtimes.clear();
+
 	npc_clear_pathlist();
 
 	db_clear(npc_path_db);
@@ -6152,27 +6174,193 @@ int32 npc_reload(void) {
 	return 0;
 }
 
-//Unload all npc in the given file
-bool npc_unloadfile( const char* path ) {
-	DBIterator * iter = db_iterator(npcname_db);
-	npc_data* nd = nullptr;
-	bool found = false;
+/**
+ * Performs an incremental reload of changed NPC source files. [jezztify]
+ *
+ * Phase 1 (Unload)
+ * Phase 2 (Reload)
+ *
+ * Note: if a file fails to parse AFTER being unloaded, the NPCs it defined
+ *   are lost until the next successful reload. For a guaranteed clean state
+ *   use npc_reload() via \@reloadscript full.
+ *
+ * @param[out] modified  Number of modified files reloaded
+ * @param[out] added     Number of new files loaded
+ * @param[out] removed   Number of removed files unloaded
+ */
+void npc_delta_reload( int32& modified, int32& added, int32& removed )
+{
+	namespace fs = std::filesystem;
+	modified = added = removed = 0;
 
-	for( nd = (npc_data*)dbi_first(iter); dbi_exists(iter); nd = (npc_data*)dbi_next(iter) ) {
-		if( nd->path && strcasecmp(nd->path,path) == 0 ) {
-			found = true;
-			npc_unload_duplicates(nd);/* unload any npcs which could duplicate this but be in a different file */
-			npc_unload(nd, true);
+	std::vector<std::string> modified_files, removed_files, added_files;
+
+	// Phase 0: Re-parse .conf files if any changed 
+	{
+		std::vector<std::string> changed_confs;
+		for( const auto& [path, mtime] : npc_conf_mtimes ){
+			std::error_code ec;
+			auto curr = fs::last_write_time( path, ec );
+			if( !ec && curr != mtime )
+				changed_confs.push_back( path );
+		}
+
+		if( !changed_confs.empty() ){
+			ShowStatus( "Script conf changed (%d file(s)) - rebuilding NPC file list:\n", (int32)changed_confs.size() );
+			for( const auto& cp : changed_confs )
+				ShowStatus( "  -- %s\n", cp.c_str() );
+
+			std::vector<std::string> old_src = npc_src_files;
+			map_reloadnpc( true );
+			for( const auto& old_path : old_src ){
+				if( !util::vector_exists( npc_src_files, old_path ) ){
+					// Only queue if the file was actually loaded and tracked.
+					if( npc_file_mtimes.find( old_path ) != npc_file_mtimes.end() )
+						removed_files.push_back( old_path );
+				}
+			}
+		}
+	}
+	// -------------------------------------------------------------------------
+
+	std::unordered_set<std::string> pre_removed( removed_files.begin(), removed_files.end() );
+
+	for( const auto& [path, mtime] : npc_file_mtimes ){
+		if( pre_removed.count( path ) ) continue;
+		std::error_code ec;
+		if( !fs::exists( path, ec ) || ec ){
+			removed_files.push_back( path );
+		} else {
+			auto current_mtime = fs::last_write_time( path, ec );
+			if( !ec && current_mtime != mtime )
+				modified_files.push_back( path );
 		}
 	}
 
-	dbi_destroy(iter);
+	// Detect files in npc_src_files not yet tracked (added since last load).
+	for( const auto& file : npc_src_files ){
+		if( npc_file_mtimes.find( file ) == npc_file_mtimes.end() &&
+		    !pre_removed.count( file ) )
+			added_files.push_back( file );
+	}
+
+	removed  = (int32)removed_files.size();
+	modified = 0;
+	added    = 0;
+
+	if( (int32)removed_files.size() == 0 && modified_files.empty() && added_files.empty() )
+		return; // Nothing changed; skip all work.
+
+	// Print a summary of what changed before doing any work.
+	if( !modified_files.empty() ){
+		ShowStatus( "Delta reload: %d modified NPC file(s):\n", (int32)modified_files.size() );
+		for( const auto& p : modified_files )
+			ShowStatus( "  M  %s\n", p.c_str() );
+	}
+	if( !added_files.empty() ){
+		ShowStatus( "Delta reload: %d added NPC file(s):\n", (int32)added_files.size() );
+		for( const auto& p : added_files )
+			ShowStatus( "  +  %s\n", p.c_str() );
+	}
+	if( !removed_files.empty() ){
+		ShowStatus( "Delta reload: %d removed NPC file(s):\n", (int32)removed_files.size() );
+		for( const auto& p : removed_files )
+			ShowStatus( "  -  %s\n", p.c_str() );
+	}
+
+	// Phase 1: UNLOAD all affected files BEFORE any reloading
+	std::vector<std::string> affected;
+	affected.insert( affected.end(), removed_files.begin(),  removed_files.end()  );
+	affected.insert( affected.end(), modified_files.begin(), modified_files.end() );
+
+	// Disconnect only players whose active NPC dialog was opened from an
+	// affected file; all other players continue uninterrupted.
+	{
+		s_mapiterator* iter = mapit_getallusers();
+		for( map_session_data* pl_sd = (TBL_PC*)mapit_first( iter );
+		     mapit_exists( iter );
+		     pl_sd = (TBL_PC*)mapit_next( iter ) )
+		{
+			if( pl_sd->npc_id == 0 )
+				continue;
+			npc_data* nd = (npc_data*)map_id2bl( pl_sd->npc_id );
+			if( nd != nullptr && nd->path != nullptr ){
+				for( const auto& ap : affected ){
+					if( strcasecmp( nd->path, ap.c_str() ) == 0 ){
+						pc_close_npc( pl_sd, 1 );
+						clif_cutin( *pl_sd, "", 255 );
+						break;
+					}
+				}
+			}
+		}
+		mapit_free( iter );
+	}
+
+	for( const auto& path : removed_files ){
+		bool r = npc_unloadfile( path.c_str(), false );
+		if( !r )
+			ShowWarning( "npc_delta_reload: remove '%s' - no NPCs matched path (already unloaded?).\n", path.c_str() );
+		npc_file_mtimes.erase( path );
+	}
+
+	for( const auto& path : modified_files ){
+		bool r = npc_unloadfile( path.c_str(), false );
+		if( !r )
+			ShowWarning( "npc_delta_reload: unload '%s' - no NPCs matched path (file may already be empty).\n", path.c_str() );
+	}
+
+	// Phase 2: RELOAD modified and added files
+	for( const auto& path : modified_files ){
+		if( check_filepath( path.c_str() ) != 2 ){
+			ShowWarning( "npc_delta_reload: '%s' disappeared before reload. NPC removed.\n", path.c_str() );
+			npc_file_mtimes.erase( path );
+			continue;
+		}
+		npc_addsrcfile( path.c_str(), false );
+		if( npc_parsesrcfile( path.c_str() ) ){
+			npc_event_doall_path( script_config.init_event_name, path.c_str() );
+			modified++;
+		} else {
+			ShowWarning( "npc_delta_reload: Failed to parse '%s'. NPCs from this file were removed.\n", path.c_str() );
+		}
+	}
+
+	for( const auto& path : added_files ){
+		if( npc_parsesrcfile( path.c_str() ) ){
+			npc_event_doall_path( script_config.init_event_name, path.c_str() );
+			added++;
+		} else {
+			ShowWarning( "npc_delta_reload: Failed to parse new file '%s'. NPC not loaded.\n", path.c_str() );
+		}
+	}
+
+	npc_read_event_script();
+}
+
+//Unload all npc in the given file
+bool npc_unloadfile( const char* path, bool rebuild_event_cache ) {
+	std::vector<npc_data*> to_unload;
+	{
+		DBIterator* iter = db_iterator(npcname_db);
+		for( npc_data* nd = (npc_data*)dbi_first(iter); dbi_exists(iter); nd = (npc_data*)dbi_next(iter) ) {
+			if( nd->path && strcasecmp(nd->path,path) == 0 )
+				to_unload.push_back(nd);
+		}
+		dbi_destroy(iter);
+	}
+
+	bool found = !to_unload.empty();
+	for( npc_data* nd : to_unload ) {
+		npc_unload_duplicates(nd);/* unload any npcs which could duplicate this but be in a different file */
+		npc_unload(nd, true);
+	}
 
 	if(npc_remove_mob_spawns( path )){
 		found = true;
 	}
 
-	if( found ) /* refresh event cache */
+	if( found && rebuild_event_cache ) /* refresh event cache */
 		npc_read_event_script();
 
 	npc_delsrcfile(path);

--- a/src/map/npc.hpp
+++ b/src/map/npc.hpp
@@ -1675,6 +1675,8 @@ int32 npc_remove_map(npc_data* nd);
 void npc_unload_duplicates (npc_data* nd);
 int32 npc_unload(npc_data* nd, bool single);
 int32 npc_reload(void);
+void npc_delta_reload( int32& modified, int32& added, int32& removed );
+void npc_record_conf_mtime( const char* path );
 void npc_read_event_script(void);
 size_t npc_script_event( map_session_data& sd, enum npce_event type );
 
@@ -1702,7 +1704,9 @@ void npc_market_delfromsql_(const char *exname, t_itemid nameid, bool clear);
 // @commands (script-based)
 int32 npc_do_atcmd_event(map_session_data* sd, const char* command, const char* message, const char* eventname);
 
-bool npc_unloadfile( const char* path );
+// Pass rebuild_event_cache=false when calling in a batch (e.g. npc_delta_reload)
+// so the event-label table is rebuilt once at the end rather than N times.
+bool npc_unloadfile( const char* path, bool rebuild_event_cache = true );
 bool npc_remove_mob_spawns(const char* path);
 
 #endif /* NPC_HPP */


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  #9895


<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-renewal and Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Add delta reload for `@reloadscript` to only reload changed NPC/DB files

    - Track file mtimes for NPC scripts (.txt) and conf files (.conf)
    - @reloadscript now performs incremental delta reload by default
    - @reloadscript full forces a complete clean reload
    - YamlDatabase gains delta_reload() with mtime-based change detection
    - Log modified/added/removed files during delta reload

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

https://github.com/user-attachments/assets/d94e08d6-c378-4cb2-bcbb-ed48a8fc113d

