### PR TITLE
NPC_MENTALBREAKER SP Drain, Element and Hitrate

### DIFF
--- a/db/pre-re/skill_db.yml
+++ b/db/pre-re/skill_db.yml
@@ -5343,14 +5343,12 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Attack
-    DamageFlags:
-      IgnoreFlee: true
     Flags:
       IsNpc: true
     Range: -7
     Hit: Single
     HitCount: 1
-    Element: Weapon
+    Element: Ghost
   - Id: 160
     Name: NPC_RANGEATTACK
     Description: Stand off attack

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -5431,14 +5431,12 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Attack
-    DamageFlags:
-      IgnoreFlee: true
     Flags:
       IsNpc: true
     Range: -7
     Hit: Single
     HitCount: 1
-    Element: Weapon
+    Element: Ghost
   - Id: 160
     Name: NPC_RANGEATTACK
     Description: Stand off attack

--- a/src/map/skills/npc/spiritdestruction.cpp
+++ b/src/map/skills/npc/spiritdestruction.cpp
@@ -11,13 +11,32 @@ SkillSpiritDestruction::SkillSpiritDestruction() : WeaponSkillImpl(NPC_MENTALBRE
 }
 
 void SkillSpiritDestruction::applyAdditionalEffects(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const {
-	status_data* sstatus = status_get_status_data(*src);
+	//SP Damage 12%/16%/25%/50%/100% of MaxSP
+	int32 rate;
+	switch (skill_lv) {
+		case 1:
+			rate = 12;
+			break;
+		case 2:
+			rate = 16;
+			break;
+		case 3:
+			rate = 25;
+			break;
+		case 4:
+			rate = 50;
+			break;
+		case 5:
+			rate = 100;
+			break;
+		default:
+			// For easy customization
+			rate = skill_lv;
+			break;
+	}
+	status_percent_damage(src, target, 0, -rate, false);
+}
 
-	//Based on observations by Tharis, Mental Breaker should do SP damage
-	//equal to Matk*skLevel.
-	int32 rate = sstatus->matk_min;
-	if (rate < sstatus->matk_max)
-		rate += rnd()%(sstatus->matk_max - sstatus->matk_min);
-	rate*=skill_lv;
-	status_zap(target, 0, rate);
+void SkillSpiritDestruction::modifyHitRate(int16& hit_rate, const block_list* src, const block_list* target, uint16 skill_lv) const {
+	hit_rate += hit_rate * 20 / 100;
 }

--- a/src/map/skills/npc/spiritdestruction.hpp
+++ b/src/map/skills/npc/spiritdestruction.hpp
@@ -10,4 +10,5 @@ public:
 	SkillSpiritDestruction();
 
 	void applyAdditionalEffects(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const override;
+	void modifyHitRate(int16& hit_rate, const block_list* src, const block_list* target, uint16 skill_lv) const override;
 };


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #9916 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- NPC_MENTALBREAKER will now drain 12%/16%/25%/50%/100% of MaxSP based on level
- NPC_MENTALBREAKER now deals ghost element HP damage
- NPC_MENTALBREAKER can now miss, but has a 20% hit rate bonus
- Fixes #9916

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
