### PR TITLE
Split Skill Compilation Per Job

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -13,6 +13,13 @@ file(GLOB_RECURSE MAP_HEADERS ${MAP_SOURCE_DIR}/*.hpp)
 list(FILTER MAP_HEADERS EXCLUDE REGEX ".*/skills/.*")
 file(GLOB_RECURSE MAP_SOURCES ${MAP_SOURCE_DIR}/*.cpp)
 list(FILTER MAP_SOURCES EXCLUDE REGEX ".*/skills/.*")
+# Add skill factory/impl files as separate translation units per job category
+# Individual skill files are NOT compiled directly - they are #included by their job factory TUs
+file(GLOB SKILL_FACTORY_SOURCES ${MAP_SOURCE_DIR}/skills/skill_factory.cpp ${MAP_SOURCE_DIR}/skills/skill_impl.cpp)
+file(GLOB SKILL_JOB_FACTORY_SOURCES ${MAP_SOURCE_DIR}/skills/*/skill_factory_*.cpp)
+list(APPEND MAP_SOURCES ${SKILL_FACTORY_SOURCES} ${SKILL_JOB_FACTORY_SOURCES})
+file(GLOB_RECURSE SKILL_HEADERS ${MAP_SOURCE_DIR}/skills/*.hpp)
+list(APPEND MAP_HEADERS ${SKILL_HEADERS})
 set( DEPENDENCIES common ryml)
 set( LIBRARIES ${GLOBAL_LIBRARIES} ${MYSQL_LIBRARIES} )
 set( INCLUDE_DIRS ${GLOBAL_INCLUDE_DIRS} ${COMMON_BASE_INCLUDE_DIRS} ${RA_INCLUDE_DIRS} ${MYSQL_INCLUDE_DIRS} )

--- a/src/map/Makefile.in
+++ b/src/map/Makefile.in
@@ -28,6 +28,12 @@ MAP_H = $(shell find ../ -type f -name "*.hpp") \
 MAP_OBJ = $(shell find . -type f -name "*.cpp" \
 			-not -path "./skills/*" \
 			| sed -e "s/\.cpp/\.o/g" -e "s/^\.\///")
+# Add skill factory/impl files as separate translation units per job category
+# Individual skill files are NOT compiled directly - they are #included by their job factory TUs
+MAP_OBJ += $(shell find ./skills -maxdepth 1 -type f -name "*.cpp" \
+			| sed -e "s/\.cpp/\.o/g" -e "s/^\.\///")
+MAP_OBJ += $(shell find ./skills -mindepth 2 -type f -name "skill_factory_*.cpp" \
+			| sed -e "s/\.cpp/\.o/g" -e "s/^\.\///")
 #MAP_OBJ += $(shell ls *.c | sed -e "s/\.c/\.o/g")
 MAP_DIR_OBJ = $(MAP_OBJ:%=obj/%)
 MAP_GEN_DIR_OBJ = $(MAP_OBJ:%=obj-gen/%)

--- a/src/map/map-server-generator.vcxproj
+++ b/src/map/map-server-generator.vcxproj
@@ -238,6 +238,8 @@
     <ClInclude Include="script_constants.hpp" />
     <ClInclude Include="searchstore.hpp" />
     <ClInclude Include="skill.hpp" />
+    <ClInclude Include="skills/skill_factory.hpp" />
+    <ClInclude Include="skills/skill_impl.hpp" />
     <ClInclude Include="status.hpp" />
     <ClInclude Include="storage.hpp" />
     <ClInclude Include="trade.hpp" />
@@ -284,6 +286,8 @@
     <ClCompile Include="script.cpp" />
     <ClCompile Include="searchstore.cpp" />
     <ClCompile Include="skill.cpp" />
+    <ClCompile Include="skills/skill_factory.cpp" />
+    <ClCompile Include="skills/skill_impl.cpp" />
     <ClCompile Include="status.cpp" />
     <ClCompile Include="storage.cpp" />
     <ClCompile Include="trade.cpp" />

--- a/src/map/map-server.vcxproj
+++ b/src/map/map-server.vcxproj
@@ -1792,9 +1792,7 @@
     <ClCompile Include="skills/acolyte/silentium.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/acolyte/skill_factory_acolyte.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/acolyte/skill_factory_acolyte.cpp" />
     <ClCompile Include="skills/acolyte/skynetblow.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2125,9 +2123,7 @@
     <ClCompile Include="skills/archer/skidtrap.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/archer/skill_factory_archer.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/archer/skill_factory_archer.cpp" />
     <ClCompile Include="skills/archer/skilledspecialsinger.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2224,9 +2220,7 @@
     <ClCompile Include="skills/archer/winkofcharm.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/custom/skill_factory_custom.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/custom/skill_factory_custom.cpp" />
     <ClCompile Include="skills/elemental/ageofice.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2323,9 +2317,7 @@
     <ClCompile Include="skills/elemental/rocklauncher.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/elemental/skill_factory_elemental.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/elemental/skill_factory_elemental.cpp" />
     <ClCompile Include="skills/elemental/solidskin.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2497,9 +2489,7 @@
     <ClCompile Include="skills/gunslinger/shatterstorm.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/gunslinger/skill_factory_gunslinger.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/gunslinger/skill_factory_gunslinger.cpp" />
     <ClCompile Include="skills/gunslinger/slugshot.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2659,9 +2649,7 @@
     <ClCompile Include="skills/homunculus/homunculus_xenoslasher.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/homunculus/skill_factory_homunculus.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/homunculus/skill_factory_homunculus.cpp" />
     <ClCompile Include="skills/mage/activityburn.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -2962,9 +2950,7 @@
     <ClCompile Include="skills/mage/sightrasher.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/mage/skill_factory_mage.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/mage/skill_factory_mage.cpp" />
     <ClCompile Include="skills/mage/soulexhale.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3202,9 +3188,7 @@
     <ClCompile Include="skills/mercenary/mercenary_tender.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/mercenary/skill_factory_mercenary.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/mercenary/skill_factory_mercenary.cpp" />
     <ClCompile Include="skills/merchant/abrbattlewarior.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3448,9 +3432,7 @@
     <ClCompile Include="skills/merchant/selfdestruction.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/merchant/skill_factory_merchant.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/merchant/skill_factory_merchant.cpp" />
     <ClCompile Include="skills/merchant/skill_vending.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3685,9 +3667,7 @@
     <ClCompile Include="skills/ninja/shadowwarrior.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/ninja/skill_factory_ninja.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/ninja/skill_factory_ninja.cpp" />
     <ClCompile Include="skills/ninja/soulcutter.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -3757,9 +3737,7 @@
     <ClCompile Include="skills/novice/shieldchainrush.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/novice/skill_factory_novice.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/novice/skill_factory_novice.cpp" />
     <ClCompile Include="skills/novice/spiralpiercemax.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4087,9 +4065,7 @@
     <ClCompile Include="skills/npc/silenceattack.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/npc/skill_factory_npc.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/npc/skill_factory_npc.cpp" />
     <ClCompile Include="skills/npc/sleepattack.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4339,9 +4315,7 @@
     <ClCompile Include="skills/other/sequoiadust.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/other/skill_factory_other.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/other/skill_factory_other.cpp" />
     <ClCompile Include="skills/other/snowflip.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4351,12 +4325,8 @@
     <ClCompile Include="skills/other/weaponenchantment.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/skill_factory.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="skills/skill_impl.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/skill_factory.cpp" />
+    <ClCompile Include="skills/skill_impl.cpp" />
     <ClCompile Include="skills/summoner/bite.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4450,9 +4420,7 @@
     <ClCompile Include="skills/summoner/silvervinestemspear.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/summoner/skill_factory_summoner.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/summoner/skill_factory_summoner.cpp" />
     <ClCompile Include="skills/summoner/spiritofsavage.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4666,9 +4634,7 @@
     <ClCompile Include="skills/swordman/shieldspell.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/swordman/skill_factory_swordman.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/swordman/skill_factory_swordman.cpp" />
     <ClCompile Include="skills/swordman/smite.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -4846,9 +4812,7 @@
     <ClCompile Include="skills/taekwon/shadowssoul.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/taekwon/skill_factory_taekwon.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/taekwon/skill_factory_taekwon.cpp" />
     <ClCompile Include="skills/taekwon/skymoon.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -5221,9 +5185,7 @@
     <ClCompile Include="skills/thief/sightlessmind.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="skills/thief/skill_factory_thief.cpp">
-      <ExcludedFromBuild>true</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="skills/thief/skill_factory_thief.cpp" />
     <ClCompile Include="skills/thief/snatch.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -46,9 +46,9 @@
 #include "status.hpp"
 #include "unit.hpp"
 
-// Include .cpp files into the TU to optimize compile time
-// For reference see unity builds or amalgamated builds
-#include "skills/skill_factory.cpp"
+// Skill factory is compiled as separate translation units per job category
+// to reduce peak memory usage during compilation
+#include "skills/skill_factory.hpp"
 
 using namespace rathena;
 

--- a/src/map/skills/skill_factory.cpp
+++ b/src/map/skills/skill_factory.cpp
@@ -10,26 +10,24 @@
 // This will save compile time
 #ifndef MAP_GENERATOR
 
-// Include .cpp files into the TU to optimize compile time
-// For reference see unity builds or amalgamated builds
-#include "./skill_impl.cpp"
-#include "./acolyte/skill_factory_acolyte.cpp"
-#include "./archer/skill_factory_archer.cpp"
-#include "./custom/skill_factory_custom.cpp"
-#include "./elemental/skill_factory_elemental.cpp"
-#include "./gunslinger/skill_factory_gunslinger.cpp"
-#include "./homunculus/skill_factory_homunculus.cpp"
-#include "./mage/skill_factory_mage.cpp"
-#include "./mercenary/skill_factory_mercenary.cpp"
-#include "./merchant/skill_factory_merchant.cpp"
-#include "./npc/skill_factory_npc.cpp"
-#include "./ninja/skill_factory_ninja.cpp"
-#include "./novice/skill_factory_novice.cpp"
-#include "./other/skill_factory_other.cpp"
-#include "./summoner/skill_factory_summoner.cpp"
-#include "./swordman/skill_factory_swordman.cpp"
-#include "./taekwon/skill_factory_taekwon.cpp"
-#include "./thief/skill_factory_thief.cpp"
+// Include job factory headers for the create() dispatcher
+#include "./acolyte/skill_factory_acolyte.hpp"
+#include "./archer/skill_factory_archer.hpp"
+#include "./custom/skill_factory_custom.hpp"
+#include "./elemental/skill_factory_elemental.hpp"
+#include "./gunslinger/skill_factory_gunslinger.hpp"
+#include "./homunculus/skill_factory_homunculus.hpp"
+#include "./mage/skill_factory_mage.hpp"
+#include "./mercenary/skill_factory_mercenary.hpp"
+#include "./merchant/skill_factory_merchant.hpp"
+#include "./npc/skill_factory_npc.hpp"
+#include "./ninja/skill_factory_ninja.hpp"
+#include "./novice/skill_factory_novice.hpp"
+#include "./other/skill_factory_other.hpp"
+#include "./summoner/skill_factory_summoner.hpp"
+#include "./swordman/skill_factory_swordman.hpp"
+#include "./taekwon/skill_factory_taekwon.hpp"
+#include "./thief/skill_factory_thief.hpp"
 
 std::unique_ptr<const SkillImpl> SkillFactoryImpl::create(const e_skill skill_id) const {
 	static const std::vector<std::shared_ptr<SkillFactory>> factories = {


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: None.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Not related.

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Split skill compilation into per-job which can reduce memory used during compiling skill.cpp

Currently, 2GB ram isn't enough to compile skill, it needs around 4.5GB RAM to successfully compile. For 4GB RAM and lower most probably having issue compiling skill right now.

Adding swapfile around 4GB most probably helps without this PR.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

My Visual Studio Build Test using  Ryzen 5 3500 :

Clean rathena
map only
========== Rebuild All: 4 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 8:19 AM and took 53.118 seconds ==========
full
========== Rebuild All: 15 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 8:21 AM and took 01:43.516 minutes ==========

PR
map only
========== Rebuild All: 4 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 8:23 AM and took 56.889 seconds ==========
full
========== Rebuild All: 15 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 8:25 AM and took 01:52.193 minutes ========== 
