### PR TITLE
Added missing flags to fix visual effects not reappearing after re-entering another player’s view

### DIFF
--- a/db/pre-re/status.yml
+++ b/db/pre-re/status.yml
@@ -305,6 +305,7 @@ Body:
     Flags:
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
   - Status: Concentrate
@@ -592,6 +593,7 @@ Body:
     Flags:
       MadoCancel: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Maxoverthrust: true
   - Status: Maximizepower
@@ -639,6 +641,7 @@ Body:
       EnergyCoat: true
     Flags:
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Brokenarmor
     Icon: EFST_BROKENARMOR
     DurationLookup: NPC_ARMORBRAKE
@@ -954,6 +957,7 @@ Body:
       FailedMado: true
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Quagmire: true
   - Status: Autocounter
@@ -1009,6 +1013,7 @@ Body:
       NoClearance: true
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Combo
     Flags:
       NoClearbuff: true
@@ -1040,6 +1045,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Fireweapon
     Icon: EFST_PROPERTYFIRE
     DurationLookup: SA_FLAMELAUNCHER
@@ -1176,6 +1182,7 @@ Body:
       RequireWeapon: true
       RemoveOnUnequipWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Parrying
     Icon: EFST_PARRYING
     DurationLookup: LK_PARRYING
@@ -1199,6 +1206,7 @@ Body:
       NoSave: true
       RemoveOnUnequip: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Tensionrelax
     Icon: EFST_TENSIONRELAX
     DurationLookup: LK_TENSIONRELAX
@@ -1223,6 +1231,7 @@ Body:
       Berserk: true
     Flags:
       NoSave: true
+      DisplayPc: true
     Fail:
       Saturdaynightfever: true
       _Bloodylust: true
@@ -1250,6 +1259,7 @@ Body:
       Kaite: true
     Flags:
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Basilica
     DurationLookup: HP_BASILICA
     States:
@@ -1375,6 +1385,7 @@ Body:
       Marionette: true
     Flags:
       RemoveOnChangeMap: true
+      DisplayPc: true
     Fail:
       Marionette: true
   - Status: Marionette2
@@ -1391,6 +1402,7 @@ Body:
       Marionette: true
     Flags:
       RemoveOnChangeMap: true
+      DisplayPc: true
     Fail:
       Marionette2: true
   - Status: Changeundead
@@ -1405,6 +1417,7 @@ Body:
       NoClearance: true
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Blessing: true
       Increaseagi: true
@@ -1500,6 +1513,7 @@ Body:
     Flags:
       Debuff: true
       SendOption: true
+      DisplayPc: true
     Options:
       Orcish: true
   - Status: Readystorm
@@ -1636,6 +1650,7 @@ Body:
       NoClearance: true
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
     EndOnStart:
@@ -1695,6 +1710,7 @@ Body:
       MadoCancel: true
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Overthrust: true
   - Status: Longing
@@ -1980,6 +1996,7 @@ Body:
       NoSave: true
       NoBanishingBuster: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Coma
     DurationLookup: NPC_DARKBLESSING
     Flags:
@@ -2123,6 +2140,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      DisplayPc: true
   - Status: Incmatkrate
     CalcFlags:
       All: true
@@ -2274,6 +2292,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       RemoveOnMapWarp: true
+      DisplayPc: true
   - Status: Sun_Comfort
     Icon: EFST_SUN_COMFORT
     DurationLookup: SG_SUN_COMFORT
@@ -2326,6 +2345,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Assumptio: true
   - Status: Swoo
@@ -2337,6 +2357,7 @@ Body:
       OverThrust: true
     Flags:
       NonPlayer: true
+      DisplayPc: true
   - Status: Ska
     DurationLookup: SL_SKA
     CalcFlags:
@@ -2346,6 +2367,7 @@ Body:
       SteelBody: true
     Flags:
       NonPlayer: true
+      DisplayPc: true
   - Status: Earthscroll
     Icon: EFST_EARTHSCROLL
     DurationLookup: TK_SPTIME
@@ -2434,6 +2456,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Kaensin
     Flags:
       NoWarning: true
@@ -2800,6 +2823,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
   - Status: Rebirth

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -326,6 +326,7 @@ Body:
     Flags:
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
   - Status: Concentrate
@@ -617,6 +618,7 @@ Body:
     Flags:
       MadoCancel: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Maxoverthrust: true
   - Status: Maximizepower
@@ -665,6 +667,7 @@ Body:
       EnergyCoat: true
     Flags:
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Brokenarmor
     Icon: EFST_BROKENARMOR
     DurationLookup: NPC_ARMORBRAKE
@@ -981,6 +984,7 @@ Body:
       FailedMado: true
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Quagmire: true
   - Status: Autocounter
@@ -1037,6 +1041,7 @@ Body:
       NoClearance: true
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Combo
     Flags:
       NoClearbuff: true
@@ -1068,6 +1073,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Fireweapon
     Icon: EFST_PROPERTYFIRE
     DurationLookup: SA_FLAMELAUNCHER
@@ -1205,6 +1211,7 @@ Body:
       RequireWeapon: true
       RemoveOnUnequipWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Parrying
     Icon: EFST_PARRYING
     DurationLookup: LK_PARRYING
@@ -1224,6 +1231,7 @@ Body:
     Flags:
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Tensionrelax
     Icon: EFST_TENSIONRELAX
     DurationLookup: LK_TENSIONRELAX
@@ -1248,6 +1256,7 @@ Body:
       Berserk: true
     Flags:
       NoSave: true
+      DisplayPc: true
     Fail:
       Saturdaynightfever: true
       _Bloodylust: true
@@ -1276,6 +1285,7 @@ Body:
       Kaite: true
     Flags:
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Basilica
     Icon: EFST_BASILICA_BUFF
     DurationLookup: HP_BASILICA
@@ -1400,6 +1410,7 @@ Body:
       Marionette: true
     Flags:
       RemoveOnChangeMap: true
+      DisplayPc: true
     Fail:
       Marionette: true
   - Status: Marionette2
@@ -1416,6 +1427,7 @@ Body:
       Marionette: true
     Flags:
       RemoveOnChangeMap: true
+      DisplayPc: true
     Fail:
       Marionette2: true
   - Status: Changeundead
@@ -1430,6 +1442,7 @@ Body:
       NoClearance: true
       NoSave: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Blessing: true
       Increaseagi: true
@@ -1525,6 +1538,7 @@ Body:
     Flags:
       Debuff: true
       SendOption: true
+      DisplayPc: true
     Options:
       Orcish: true
   - Status: Readystorm
@@ -1661,6 +1675,7 @@ Body:
       NoClearance: true
       RequireWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
     EndOnStart:
@@ -1708,6 +1723,7 @@ Body:
       NoSave: true
       RemoveOnUnequipWeapon: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Overthrust: true
   - Status: Hermode
@@ -2089,6 +2105,7 @@ Body:
       NoSave: true
       NoBanishingBuster: true
       RemoveOnHermode: true
+      DisplayPc: true
     Fail:
       Soulgolem: true
       Soulshadow: true
@@ -2237,6 +2254,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      DisplayPc: true
   - Status: Incmatkrate
     CalcFlags:
       All: true
@@ -2388,6 +2406,7 @@ Body:
       NoClearance: true
       RemoveOnChangeMap: true
       RemoveOnMapWarp: true
+      DisplayPc: true
   - Status: Sun_Comfort
     Icon: EFST_SUN_COMFORT
     DurationLookup: SG_SUN_COMFORT
@@ -2440,6 +2459,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnHermode: true
+      DisplayPc: true
     EndOnStart:
       Assumptio: true
   - Status: Swoo
@@ -2451,6 +2471,7 @@ Body:
       OverThrust: true
     Flags:
       NonPlayer: true
+      DisplayPc: true
   - Status: Ska
     DurationLookup: SL_SKA
     CalcFlags:
@@ -2460,6 +2481,7 @@ Body:
       SteelBody: true
     Flags:
       NonPlayer: true
+      DisplayPc: true
   - Status: Earthscroll
     Icon: EFST_EARTHSCROLL
     DurationLookup: TK_SPTIME
@@ -2546,6 +2568,7 @@ Body:
       NoSave: true
       NoClearance: true
       RemoveOnHermode: true
+      DisplayPc: true
   - Status: Kaensin
     Flags:
       NoWarning: true
@@ -2911,6 +2934,7 @@ Body:
       NoDispell: true
       NoBanishingBuster: true
       NoClearance: true
+      DisplayPc: true
     Fail:
       Decreaseagi: true
   - Status: Rebirth


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9945

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Status effects that use opt3 and have a corresponding client EFST were not being stored in the display list, causing their visual effects to disappear when a player leaves and re-enters another player's view.

  This change ensures statuses that are both opt3 and have a defined EFST are correctly tracked and re-sent, keeping visual effects consistent across visibility updates.

  Statuses without a defined EFST are intentionally excluded, as they are not sent to the client.

  Thanks to @Daraen1 for pointing out other status effect that use ``op3``.
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
