### PR TITLE
Fix typo in DisplayNpc status effect description

### DIFF
--- a/doc/status.txt
+++ b/doc/status.txt
@@ -201,7 +201,7 @@ Flags: Various status flags for specific status change events.
 	None                  - No special flag. (Default)
 	BlEffect              - Status should have BL_SCEFFECT as relevant effect, must have an EFST (displays on BL_PC, BL_HOM, BL_MER, BL_MOB, BL_ELEM). BL_PC is the default value.
 	DisplayPc             - Displays status effect when player logs in.
-	DislpayNpc            - Displays status effect on a NPC.
+	DisplayNpc            - Displays status effect on a NPC.
 	Debuff                - Status is considered a debuff. Used in combination with 'battle_config.debuff_on_logout'.
 	SetStand              - Sets player to standing state.
 	OverlapIgnoreLevel    - The status will successfully activate for any level if the status is already active.


### PR DESCRIPTION
Fixed a typo in the status effect documentation.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: Nothing

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Fixed a typo in doc/status.txt
