### PR TITLE
6th rebalance - Cardinal - Part 1

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37113,7 +37113,7 @@ Body:
     FixedCastTime: 1500
     Requires:
       SpCost: 150
-      ApCost: 20
+      ApCost: 15
     Unit:
       Id: Pneumaticus_Procella
       Range:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36949,14 +36949,14 @@ Body:
     Type: Magic
     TargetType: Attack
     Range: 9
-    Hit: Single
-    HitCount: 1
+    Hit: Multi_Hit
+    HitCount: 2
     Element: Holy
     GiveAp: 2
     CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 1000
+    Cooldown: 750
     FixedCastTime: 1500
     Requires:
       SpCost:
@@ -43545,7 +43545,7 @@ Body:
     Type: Weapon
     TargetType: Attack
     Range: 2
-    Hit: Multi_hit
+    Hit: Multi_Hit
     HitCount: -2
     GiveAp: 3
     Element: Weapon

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36948,10 +36948,13 @@ Body:
     MaxLevel: 10
     Type: Magic
     TargetType: Attack
+    DamageFlags:
+      Splash: true
     Range: 9
     Hit: Multi_Hit
     HitCount: 2
     Element: Holy
+    SplashArea: 4
     GiveAp: 2
     CastTime: 4000
     AfterCastActDelay: 500

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2705,10 +2705,11 @@ static int32 battle_range_type(const block_list* src, const block_list* target, 
 		case SS_SHIMIRU: // 11 cell cast range.
 		case SKE_STAR_LIGHT_KICK: // 7 cell cast range.
 			return BF_SHORT;
-		case CD_PETITIO: { // Skill range is 2 but damage is melee with books and ranged with mace.
-			const map_session_data* sd = BL_CAST(BL_PC,src);
+		case CD_EFFLIGO:	// Skill range is 2 but damage is melee with books and ranged with mace.
+		case CD_PETITIO: {
+			const map_session_data* sd = BL_CAST(BL_PC, src);
 
-			if (sd && (sd->status.weapon == W_MACE || sd->status.weapon == W_2HMACE))
+			if (sd != nullptr && (sd->status.weapon == W_MACE || sd->status.weapon == W_2HMACE))
 				return BF_LONG;
 
 			break;

--- a/src/map/skills/acolyte/arbitrium.cpp
+++ b/src/map/skills/acolyte/arbitrium.cpp
@@ -8,28 +8,21 @@
 #include "map/pc.hpp"
 #include "map/status.hpp"
 
-SkillArbitrium::SkillArbitrium() : SkillImpl(CD_ARBITRIUM) {
-}
-
-void SkillArbitrium::castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_attack(BF_MAGIC, src, src, target, getSkillId(), skill_lv, tick, flag);
+SkillArbitrium::SkillArbitrium() : SkillImplRecursiveDamageSplash(CD_ARBITRIUM) {
 }
 
 void SkillArbitrium::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 1000 * skill_lv + 10 * sstatus->spl;
-	skillratio += 10 * pc_checkskill(sd, CD_FIDUS_ANIMUS) * skill_lv;
+	skillratio += -100 + 950 * skill_lv;
+	skillratio += 10 * sstatus->spl;	// TODO : spl ratio has changed ?
+	skillratio += 35 * pc_checkskill(sd, CD_FIDUS_ANIMUS) * skill_lv;
+
 	RE_LVL_DMOD(100);
 }
 
-void SkillArbitrium::applyAdditionalEffects(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const {
-	// Target is Deep Silenced by chance and is then dealt a 2nd splash hit.
-	sc_start(src, target, SC_HANDICAPSTATE_DEEPSILENCE, 20 + 5 * skill_lv, skill_lv, skill_get_time(getSkillId(), skill_lv));
-	skill_castend_damage_id(src, target, CD_ARBITRIUM_ATK, skill_lv, tick, SD_LEVEL);
-}
-
+// TODO : CD_ARBITRIUM_ATK is no longer used ?
 SkillArbitriumAttack::SkillArbitriumAttack() : SkillImplRecursiveDamageSplash(CD_ARBITRIUM_ATK) {
 }
 

--- a/src/map/skills/acolyte/arbitrium.hpp
+++ b/src/map/skills/acolyte/arbitrium.hpp
@@ -5,13 +5,11 @@
 
 #include "../skill_impl.hpp"
 
-class SkillArbitrium : public SkillImpl {
+class SkillArbitrium : public SkillImplRecursiveDamageSplash {
 public:
 	SkillArbitrium();
 
-	void castendDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const override;
 	void calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const override;
-	void applyAdditionalEffects(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const override;
 };
 
 class SkillArbitriumAttack : public SkillImplRecursiveDamageSplash {

--- a/src/map/skills/acolyte/effligo.cpp
+++ b/src/map/skills/acolyte/effligo.cpp
@@ -23,11 +23,14 @@ void SkillEffligo::calculateSkillRatio(const Damage* wd, const block_list* src, 
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_data* tstatus = status_get_status_data(*target);
 
-	skillratio += -100 + 1650 * skill_lv + 7 * sstatus->pow;
+	skillratio += -100 + 1800 * skill_lv;
+	skillratio += 7 * sstatus->pow;
 	skillratio += 8 * pc_checkskill(sd, CD_MACE_BOOK_M);
+
 	if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DEMON) {
-		skillratio += 150 * skill_lv;
+		skillratio += 200 * skill_lv;
 		skillratio += 7 * pc_checkskill(sd, CD_MACE_BOOK_M);
 	}
+
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/acolyte/petitio.cpp
+++ b/src/map/skills/acolyte/petitio.cpp
@@ -16,7 +16,10 @@ void SkillPetitio::calculateSkillRatio(const Damage* wd, const block_list* src, 
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + (1050 + pc_checkskill(sd, CD_MACE_BOOK_M) * 50) * skill_lv + 5 * sstatus->pow;
+	skillratio += -100 + 1200 * skill_lv;
+	skillratio += pc_checkskill(sd, CD_MACE_BOOK_M) * 50 * skill_lv;
+	skillratio += 5 * sstatus->pow;
+
 	RE_LVL_DMOD(100);
 }
 


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Updated
----------------------------------------
Arbitrium
Reworks skill, removes single-target damage, area damage will deal damage for 2 hits.
- Changes base damage from 10000% MATK to 9500% MATK per hit based on level 10.
- Reduces skill cooldown from 1 second to 0.75 seconds.
- Since single-target damage is removed, the status ailment [quiet] also be removed from the skill. 

Petitio
- Increases base damage from 10500% ATK to 12000% ATK based on level 10.

Effligo
- When equipping mace, damage type is changed to long ranged physical.
- Increases base damage from 16500%/18000%(demon, undead) ATK to 18000%/20000%(demon, undead) ATK based on level 10.

Pneumaticus Procella
- Reduces AP consumption from 20 to 15 based on level 10. 

Informations
----------------------------------------

https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8211&curpage=2
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
