### PR TITLE
6th rebalance - Inquisitor - Part 1

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35975,6 +35975,7 @@ Body:
     Type: Weapon
     TargetType: Self
     DamageFlags:
+      Critical: true
       Splash: true
     Range: 9
     Hit: Single

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36275,7 +36275,7 @@ Body:
       Splash: true
     Range: 3
     Hit: Multi_Hit
-    HitCount: -3
+    HitCount: 3
     Element: Weapon
     SplashArea: 3
     GiveAp: 4

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36365,7 +36365,7 @@ Body:
     HitCount: 5
     Element: Weapon
     SplashArea: 3
-    Cooldown: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36119,6 +36119,7 @@ Body:
     Type: Weapon
     TargetType: Attack
     DamageFlags:
+      Critical: true
       Splash: true
     Range: 3
     Hit: Single

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -36242,6 +36242,7 @@ Body:
     Type: Weapon
     TargetType: Attack
     DamageFlags:
+      Critical: true
       Splash: true
     Range: 3
     Hit: Multi_Hit

--- a/src/map/skills/acolyte/secondjudgement.cpp
+++ b/src/map/skills/acolyte/secondjudgement.cpp
@@ -14,7 +14,9 @@ SkillSecondJudgement::SkillSecondJudgement() : SkillImplRecursiveDamageSplash(IQ
 void SkillSecondJudgement::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 150 + 2600 * skill_lv + 7 * sstatus->pow;
+	skillratio += -100 + 2000 + 500 * skill_lv;
+	skillratio += 7 * sstatus->pow;	// TODO : pow ratio has changed ?
+
 	RE_LVL_DMOD(100);
 }
 

--- a/src/map/skills/acolyte/thirdconsecration.cpp
+++ b/src/map/skills/acolyte/thirdconsecration.cpp
@@ -14,7 +14,9 @@ SkillThirdConsecration::SkillThirdConsecration() : SkillImplRecursiveDamageSplas
 void SkillThirdConsecration::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 700 * skill_lv + 10 * sstatus->pow;
+	skillratio += -100 + 1200 * skill_lv;
+	skillratio += 10 * sstatus->pow;
+
 	RE_LVL_DMOD(100);
 }
 
@@ -24,7 +26,6 @@ void SkillThirdConsecration::applyAdditionalEffects(block_list* src, block_list*
 
 void SkillThirdConsecration::splashSearch(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {
 	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-	status_heal(src, status_get_max_hp(src) * skill_lv / 100, status_get_max_sp(src) * skill_lv / 100, 0);
 
 	SkillImplRecursiveDamageSplash::splashSearch(src, target, skill_lv, tick, flag);
 }


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Updated
----------------------------------------
First Brand
- Applies critical damage, the critical chance is the user's CRI.

Second Faith
- Applies critical damage, the critical chance is the user's CRI.

Second Judgement
- Changes damage logic from 3 split hits to 3 cumulative hits.
- Changes base damage from 13150% ATK to 4500% ATK per hit based on level 5.

Third Consecration
- Increases base damage from 3500% ATK per hit to 6000% ATK per hit based on level 5.
- Reduces skill cooldown from 1 second to 0.7 seconds.
- No longer recover HP/SP.

Oleum Sanctum
- Applies critical damage, the critical chance is the user's CRI. 

Informations
----------------------------------------

https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8211&curpage=2
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
