### PR TITLE
6th rebalance - Dragon Knight - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34602,15 +34602,15 @@ Body:
         Time: 150000
     Duration2:
       - Level: 1
-        Time: 5000
+        Time: 2500
       - Level: 2
-        Time: 4000
-      - Level: 3
-        Time: 3000
-      - Level: 4
         Time: 2000
-      - Level: 5
+      - Level: 3
+        Time: 1500
+      - Level: 4
         Time: 1000
+      - Level: 5
+        Time: 500
     Cooldown: 60000
     Requires:
       SpCost:

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34895,7 +34895,7 @@ Body:
     FixedCastTime: 1000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 120
     Status: Dragonic_Aura
   - Id: 5211
     Name: DK_MADNESS_CRUSHER

--- a/src/map/skills/swordman/dragonicpierce.cpp
+++ b/src/map/skills/swordman/dragonicpierce.cpp
@@ -22,11 +22,11 @@ void SkillDragonicPierce::calculateSkillRatio(const Damage* wd, const block_list
 	const status_change* sc = status_get_sc(src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 850 + 600 * skill_lv;
+	skillratio += -100 + 900 + 730 * skill_lv;
 	skillratio += 7 * sstatus->pow;	// !TODO: unknown ratio
 
 	if (sc != nullptr && sc->hasSCE(SC_DRAGONIC_AURA))
-		skillratio += 100 + 50 * skill_lv;
+		skillratio += 250 + 50 * skill_lv;
 
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/swordman/dragonicpierce.cpp
+++ b/src/map/skills/swordman/dragonicpierce.cpp
@@ -26,7 +26,7 @@ void SkillDragonicPierce::calculateSkillRatio(const Damage* wd, const block_list
 	skillratio += 7 * sstatus->pow;	// !TODO: unknown ratio
 
 	if (sc != nullptr && sc->hasSCE(SC_DRAGONIC_AURA))
-		skillratio += 250 + 50 * skill_lv;
+		skillratio += 200 + 50 * skill_lv;
 
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/swordman/hackandslasher.cpp
+++ b/src/map/skills/swordman/hackandslasher.cpp
@@ -15,7 +15,7 @@ SkillHackAndSlasher::SkillHackAndSlasher() : SkillImplRecursiveDamageSplash(DK_H
 void SkillHackAndSlasher::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 350 + 820 * skill_lv;
+	skillratio += -100 + 500 + 1000 * skill_lv;
 	skillratio += 7 * sstatus->pow;
 	RE_LVL_DMOD(100);
 }
@@ -32,7 +32,7 @@ SkillHackAndSlasherAttack::SkillHackAndSlasherAttack() : SkillImpl(DK_HACKANDSLA
 void SkillHackAndSlasherAttack::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 350 + 820 * skill_lv;
+	skillratio += -100 + 500 + 1000 * skill_lv;
 	skillratio += 7 * sstatus->pow;
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/swordman/madnesscrusher.cpp
+++ b/src/map/skills/swordman/madnesscrusher.cpp
@@ -16,8 +16,9 @@ void SkillMadnessCrusher::calculateSkillRatio(const Damage* wd, const block_list
 	const status_change* sc = status_get_sc(src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 1000 + 3800 * skill_lv;
+	skillratio += -100 + 4350 + 1750 * skill_lv;
 	skillratio += 10 * sstatus->pow;
+
 	if (sd != nullptr) {
 		int16 index = sd->equip_index[EQI_HAND_R];
 

--- a/src/map/skills/swordman/madnesscrusher.cpp
+++ b/src/map/skills/swordman/madnesscrusher.cpp
@@ -16,7 +16,7 @@ void SkillMadnessCrusher::calculateSkillRatio(const Damage* wd, const block_list
 	const status_change* sc = status_get_sc(src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 4350 + 1750 * skill_lv;
+	skillratio += -100 + 1750 + 4350 * skill_lv;
 	skillratio += 10 * sstatus->pow;
 
 	if (sd != nullptr) {


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Skill updated
----------------------------------------
Servant Weapon
- Reduces servant weapon creation interval from 1 second to 0.5 seconds based on level 5.

Hack and Slasher
- Increases base damage from 8550% ATK to 10500% ATK based on level 10.

Madness Crusher
- Increases base damage from 20000% ATK to 23000% ATK based on level 5.

Dragonic Pierce
- Increases base damage from 3850% ATK to 4550% ATK per hit based on level 5.
- Increases base damage (Dragonic Aura) from 4200% ATK to 5000% ATK per hit based on level 5.

Dragonic Aura
- Reduces AP consumption from 150 to 120. 

Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
