### PR TITLE
6th rebalance - Shadow Cross - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37403,25 +37403,25 @@ Body:
       SpCost: 100
       ApCost:
         - Level: 1
-          Amount: 152
+          Amount: 156
         - Level: 2
-          Amount: 149
+          Amount: 152
         - Level: 3
-          Amount: 146
+          Amount: 148
         - Level: 4
-          Amount: 143
+          Amount: 144
         - Level: 5
           Amount: 140
         - Level: 6
-          Amount: 137
+          Amount: 136
         - Level: 7
-          Amount: 134
+          Amount: 132
         - Level: 8
-          Amount: 131
-        - Level: 9
           Amount: 128
+        - Level: 9
+          Amount: 124
         - Level: 10
-          Amount: 125
+          Amount: 120
     Status: Shadow_Exceed
   - Id: 5286
     Name: SHC_DANCING_KNIFE

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37728,7 +37728,7 @@ Body:
     FixedCastTime: 500
     Requires:
       SpCost: 150
-      ApCost: 150
+      ApCost: 120
     Status: Darkcrow
   - Id: 5295
     Name: MT_AXE_STOMP

--- a/src/map/skills/thief/impactcrater.cpp
+++ b/src/map/skills/thief/impactcrater.cpp
@@ -14,7 +14,9 @@ SkillImpactCrater::SkillImpactCrater() : SkillImplRecursiveDamageSplash(SHC_IMPA
 void SkillImpactCrater::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 80 * skill_lv + 5 * sstatus->pow;
+	skillratio += -100 + 200 * skill_lv;
+	skillratio += 5 * sstatus->pow;
+
 	RE_LVL_DMOD(100);
 }
 

--- a/src/map/skills/thief/savageimpact.cpp
+++ b/src/map/skills/thief/savageimpact.cpp
@@ -21,11 +21,11 @@ void SkillSavageImpact::calculateSkillRatio(const Damage *wd, const block_list *
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change *sc = status_get_sc(src);
 
-	skillratio += -100 + 105 * skill_lv;
+	skillratio += -100 + 130 * skill_lv;
 	skillratio += 5 * sstatus->pow;
 
 	if( sc != nullptr && sc->hasSCE( SC_SHADOW_EXCEED ) ){
-		skillratio += 20 * skill_lv;
+		skillratio += 30 * skill_lv;
 		skillratio += 2 * sstatus->pow;
 	}
 


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Skill updated
----------------------------------------
Shadow Exceed
- Reduces AP consumption from 125 to 120 based on level 10.

Savage Impact
- Increases base damage from 1050% ATK to 1300% ATK per hit based on level 10.
- Increases base damage (Shadow Exceed) from 1250% ATK to 1600% ATK per hit based on level 10.

Impact Crater
- Increases base damage from 400% ATK to 1000% ATK per hit based on level 5.

Fatal Shadow Claw
- Reduces AP consumption from 150 to 125. 

Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
