### PR TITLE
6th rebalance - Arch Mage - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -9895,7 +9895,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastTime: 700
-    Duration1: 60000
+    Duration1: 180000
     FixedCastTime: 700
     CastTimeFlags:
       IgnoreDex: true

--- a/src/map/skills/mage/astralstrike.cpp
+++ b/src/map/skills/mage/astralstrike.cpp
@@ -15,9 +15,11 @@ void SkillAstralStrike::calculateSkillRatio(const Damage *wd, const block_list *
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_data* tstatus = status_get_status_data(*target);
 
-	skillratio += -100 + 300 + 1800 * skill_lv + 10 * sstatus->spl;
+	skillratio += -100 + 700 + 2600 * skill_lv;
+	skillratio += 10 * sstatus->spl;
+
 	if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DRAGON)
-		skillratio += 100 + 300 * skill_lv;
+		skillratio += 150 * skill_lv;
 	RE_LVL_DMOD(100);
 }
 

--- a/src/map/skills/mage/crystalimpact.cpp
+++ b/src/map/skills/mage/crystalimpact.cpp
@@ -22,7 +22,9 @@ void SkillCrystalImpact::modifyDamageData(Damage& dmg, const block_list& src, co
 void SkillCrystalImpact::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 250 + 1300 * skill_lv + 5 * sstatus->spl;
+	skillratio += -100 + 400 + 1400 * skill_lv;
+	skillratio += 10 * sstatus->spl;
+
 	// (climax buff applied with pc_skillatk_bonus)
 	RE_LVL_DMOD(100);
 }
@@ -66,7 +68,9 @@ SkillCrystalImpactAttack::SkillCrystalImpactAttack() : SkillImplRecursiveDamageS
 void SkillCrystalImpactAttack::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 250 + 1300 * skill_lv + 5 * sstatus->spl;
+	skillratio += -100 + 400 + 1400 * skill_lv;
+	skillratio += 10 * sstatus->spl;
+
 	// (climax buff applied with pc_skillatk_bonus)
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/mage/destructivehurricane.cpp
+++ b/src/map/skills/mage/destructivehurricane.cpp
@@ -22,7 +22,9 @@ void SkillDestructiveHurricane::modifyDamageData(Damage& dmg, const block_list& 
 void SkillDestructiveHurricane::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 600 + 2850 * skill_lv + 5 * sstatus->spl;
+	skillratio += -100 + 600 + 3250 * skill_lv;
+	skillratio += 10 * sstatus->spl;
+
 	// (climax buff applied with pc_skillatk_bonus)
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/mage/soulvulcanstrike.cpp
+++ b/src/map/skills/mage/soulvulcanstrike.cpp
@@ -13,6 +13,8 @@ SkillSoulVulcanStrike::SkillSoulVulcanStrike() : SkillImplRecursiveDamageSplash(
 void SkillSoulVulcanStrike::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 300 * skill_lv + 3 * sstatus->spl;
+	skillratio += -100 + 50 + 330 * skill_lv;
+	skillratio += 3 * sstatus->spl;
+
 	RE_LVL_DMOD(100);
 }


### PR DESCRIPTION


<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Skill updated
----------------------------------------
Mystical Amplification (High Wizard)
- Increases skill duration from 60 seconds to 180 seconds.

Soul Vulcan Strike
- Increases base damage from 1500% MATK to 1700% MATK per hit based on level 5.

Destructive Hurricane
- Increases base damage from 14850% MATK to 16850% MATK based on level 5.
- Increases factor weight of SPL in skill formula from 5 to 10.

Crystal Impact
- Increases base damage from 6750% MATK to 7400% MATK based on level 5.
- Increases factor weight of SPL in skill formula from 5 to 10 (affects additional damage as well).

Astral Strike
- Increases base damage of initial damage from 18300% MATK to 26700% MATK based on level 10.
- Increases base damage of initial damage (Undead, Dragon) from 21400% MATK to 28200% MATK based on level 10.
** there is no change regarding overtime damage ** 

Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
<!-- Describe how this pull request will resolve the issue(s) listed above. -->
