### PR TITLE
6th rebalance - Abyss Chaser part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -38401,15 +38401,15 @@ Body:
         Time: 150000
     Duration2:
       - Level: 1
-        Time: 3000
-      - Level: 2
         Time: 2500
-      - Level: 3
+      - Level: 2
         Time: 2000
-      - Level: 4
+      - Level: 3
         Time: 1500
-      - Level: 5
+      - Level: 4
         Time: 1000
+      - Level: 5
+        Time: 500
     Cooldown: 30000
     Requires:
       SpCost:

--- a/src/map/skills/thief/abysssquare.cpp
+++ b/src/map/skills/thief/abysssquare.cpp
@@ -26,8 +26,9 @@ void SkillAbyssSquare::calculateSkillRatio(const Damage* wd, const block_list* s
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 750 * skill_lv;
-	skillratio += 40 * pc_checkskill(sd, ABC_MAGIC_SWORD_M) * skill_lv;
+	skillratio += -100 + 900 * skill_lv;
+	skillratio += 50 * pc_checkskill(sd, ABC_MAGIC_SWORD_M) * skill_lv;
 	skillratio += 5 * sstatus->spl;
+
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/thief/chainreactionshot.cpp
+++ b/src/map/skills/thief/chainreactionshot.cpp
@@ -36,6 +36,6 @@ void SkillChainReactionShotAttack::calculateSkillRatio(const Damage* wd, const b
 	skillratio += -100 + 800 + 2550 * skill_lv;
 	skillratio += 15 * sstatus->con;
 	if (sc != nullptr && sc->hasSCE(SC_CHASING))
-		skillratio += 700 * skill_lv;
+		skillratio += 1100 * skill_lv;
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/thief/chainreactionshot.cpp
+++ b/src/map/skills/thief/chainreactionshot.cpp
@@ -33,7 +33,10 @@ void SkillChainReactionShotAttack::calculateSkillRatio(const Damage* wd, const b
 	const status_change* sc = status_get_sc(src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 800 + 2550 * skill_lv;
+	if (skill_lv == 4)
+		skillratio += -100 + 11500;
+	else
+		skillratio += -100 + 950 + 2650 * skill_lv;
 	skillratio += 15 * sstatus->con;
 	if (sc != nullptr && sc->hasSCE(SC_CHASING))
 		skillratio += 1100 * skill_lv;

--- a/src/map/skills/thief/chasingshot.cpp
+++ b/src/map/skills/thief/chasingshot.cpp
@@ -25,7 +25,7 @@ void SkillChasingShot::calculateSkillRatio(const Damage* wd, const block_list* s
 	const status_change* sc = status_get_sc(src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 1500 + 700 * skill_lv;
+	skillratio += -100 + 1750 + 850 * skill_lv;
 	skillratio += 5 * sstatus->con;
 	if (sc != nullptr && sc->hasSCE(SC_CHASING))
 		skillratio += 250 * skill_lv;

--- a/src/map/skills/thief/frenzyshot.cpp
+++ b/src/map/skills/thief/frenzyshot.cpp
@@ -27,7 +27,8 @@ void SkillFrenzyShot::castendDamageId(block_list* src, block_list* target, uint1
 void SkillFrenzyShot::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 250 + 800 * skill_lv;
+	skillratio += -100 + 350 + 825 * skill_lv;
 	skillratio += 15 * sstatus->con;
+
 	RE_LVL_DMOD(100);
 }


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Skill updated
----------------------------------------
From the Abyss
- Reduces abyss sphere creation interval from 1 second to 0.5 seconds based on level 5.

Abyss Square
- Increases base damage from (3750 + (Magic Sword Mastery skill level x 200))% MATK to (4500 + (Magic Sword Mastery skill level x 250))% MATK per hit based on level 5.

Chasing Shot
- Increases base damage from 5000% ATK to 6000% ATK per hit based on level 5.
- Increases base damage (Chasing) from 5250% ATK to 6250% ATK per hit based on level 5.

Hit and Sliding
- Increases damage bonus of secondary damage of Chain Reaction Shot from 700% to 1100%.

Chain reaction shot
- Increases base damage from 13550% ATK to 14200% ATK based on level 5.

Frenzy Shot
- Increases base damage from 8250% ATK to 8600% ATK per hit based on level 10. 

Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
