### PR TITLE
Infinite Provoke Removed On Logout

### DIFF
--- a/doc/status.txt
+++ b/doc/status.txt
@@ -222,7 +222,7 @@ Flags: Various status flags for specific status change events.
 	NoClearance           - Cannot be removed by AB_CLEARANCE.
 	NoBanishingBuster     - Cannot be removed by RL_BANISHING_BUSTER.
 	NoSave                - Won't be saved when player logs out.
-	NoSaveInfinite        - Infinite duration status won't be saved when player logs out.
+	NoSaveInfinite        - Infinite duration status won't be saved when player logs out (val4>0 or timer=INVALID_TIMER).
 	NoWarning             - Ignores the status_change_start check for statuses that have no defining features associated to them in the status database.
 
 	RemoveOnDamaged       - Removed when receiving damage.

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -2271,7 +2271,7 @@ int32 map_quit(map_session_data *sd) {
 			std::bitset<SCF_MAX> &flag = it.second->flag;
 
 			//No need to save infinite status
-			if (flag[SCF_NOSAVEINFINITE] && sd->sc.getSCE(it.first) && sd->sc.getSCE(it.first)->val4 > 0) {
+			if (flag[SCF_NOSAVEINFINITE] && sd->sc.getSCE(it.first) && (sd->sc.getSCE(it.first)->val4 > 0 || sd->sc.getSCE(it.first)->timer == INVALID_TIMER)) {
 				status_change_end(sd, static_cast<sc_type>(it.first));
 				continue;
 			}


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #10013 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- The NoSaveInfinite tag now actually removes infinite status changes on logout
  * Previously it only removed status changes that had val4 set (special handling for Endure and Regeneration)
- Improved documentation of NoSaveInfinite so that it's clear what the conditions are
- Infinite Provoke from Gospel is now properly removed on logout
- Fixes #10013

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
