### PR TITLE
Flame Manteau / Leather Of Tendrilion Weight

### DIFF
--- a/db/pre-re/item_db_equip.yml
+++ b/db/pre-re/item_db_equip.yml
@@ -20597,7 +20597,7 @@ Body:
     Name: Flame Manteau of Naght Sieger
     Type: Armor
     Buy: 20
-    Weight: 70
+    Weight: 500
     Defense: 4
     Slots: 1
     Jobs:
@@ -20643,7 +20643,7 @@ Body:
     Name: Leather of Tendrilion
     Type: Armor
     Buy: 20
-    Weight: 300
+    Weight: 500
     Defense: 3
     Slots: 1
     Jobs:


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #10019 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Flame Manteau and Leather of Tendrilion now have a weight of 50.0 in both pre-re and re
- Fixes #10019

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
