### PR TITLE
Fix duplicate item ID check in bio4_reward

### DIFF
--- a/npc/re/merchants/bio4_reward.txt
+++ b/npc/re/merchants/bio4_reward.txt
@@ -642,9 +642,9 @@ lhz_cube,233,24,4	script	Sorcerer#Bio4Reward	4_M_UMDANCEKID,{
 	.@equip_item = getequipid(.@part);
 	setarray .@equip_card[0], getequipcardid(.@part,0), getequipcardid(.@part,1), getequipcardid(.@part,2), getequipcardid(.@part,3);
 	.@lhz_max_num = 4000;
-	if (.@equip_item == 13069 || .@equip_item == 1291 || .@equip_item == 1392 || 
-	    .@equip_item == 1393 || .@equip_item == 1435 || .@equip_item == 1490 || 
-	    .@equip_item == 13069 || .@equip_item == 13070 || .@equip_item == 16017) {
+	if (.@equip_item == 13069 || .@equip_item == 1291 || .@equip_item == 1392 ||
+	    .@equip_item == 1393 || .@equip_item == 1435 || .@equip_item == 1490 ||
+	    .@equip_item == 13070 || .@equip_item == 16017) {
 		.@type = 1;
 		if (.@equip_item == 1490)
 			.@lhz_max_num = 4200;


### PR DESCRIPTION
## 概要

`npc/re/merchants/bio4_reward.txt` の `.@type = 1` 分岐の条件式で、`.@equip_item == 13069` の比較が 2 回出現しており、2 つ目はデッドコードになっていました(#10021)。

重複を除去し、リストを以下の 7 ID に整理しました:
- `1291`, `1392`, `1393`, `1435`, `1490`, `13070`, `16017`
- および先頭の `13069`(重複の片方を残す)

挙動は変わりません: 既存で match していた item は引き続き match し、新規に追加・除外される item はありません。

## 動作確認

- `git diff` で対象行のみが変更されており、他の logic 分岐は無変更
- インデント・末尾スペース・トークン順序を保持(末尾の trailing space のみ統一)
- 変更前後で次の集合が一致することを目視確認:
  - 旧: { 13069, 1291, 1392, 1393, 1435, 1490, 13069(dup), 13070, 16017 }
  - 新: { 13069, 1291, 1392, 1393, 1435, 1490, 13070, 16017 }
- 重複 ID を取り除いた結果、ifブランチ判定はそれまでと同一(`||` の短絡評価で 13069 一致時は最初の比較で true、それ以外も最終結果は同じ)

NPC スクリプトのため compile は不要、サーバ側 reload で読み込み可能な範囲の修正です。

Closes #10021

/claim #10021