### PR TITLE
Fix Rodex mail packet length checks

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -16829,8 +16829,13 @@ void clif_parse_Mail_send(int32 fd, map_session_data *sd){
 	mail_send(sd, RFIFOCP(fd,info->pos[1]), RFIFOCP(fd,info->pos[2]), RFIFOCP(fd,info->pos[4]), RFIFOB(fd,info->pos[3]));
 #else
 	uint16 length = RFIFOW(fd, 2);
+#if PACKETVER <= 20160330
+	constexpr uint16 headerLength = 64;
+#else
+	constexpr uint16 headerLength = 68;
+#endif
 
-	if( length < 0x3e ){
+	if( length < headerLength ){
 		ShowWarning("Too short...\n");
 		clif_Mail_send(sd, WRITE_MAIL_FAILED);
 		return;
@@ -16856,20 +16861,21 @@ void clif_parse_Mail_send(int32 fd, map_session_data *sd){
 	uint64 zeny = RFIFOQ(fd, 52);
 	uint16 titleLength = RFIFOW(fd, 60);
 	uint16 textLength = RFIFOW(fd, 62);
+
+	if( titleLength > length - headerLength || textLength > length - headerLength - titleLength ){
+		ShowWarning("Invalid Rodex mail content length from account %d.\n", sd->status.account_id);
+		clif_Mail_send(sd, WRITE_MAIL_FAILED);
+		return;
+	}
+
 	uint16 realTitleLength = min(titleLength, MAIL_TITLE_LENGTH);
 	uint16 realTextLength = min(textLength, MAIL_BODY_LENGTH);
 
 	char title[MAIL_TITLE_LENGTH];
 	char text[MAIL_BODY_LENGTH];
 
-#if PACKETVER <= 20160330
-	safestrncpy(title, RFIFOCP(fd, 64), realTitleLength);
-	safestrncpy(text, RFIFOCP(fd, 64 + titleLength), realTextLength);
-#else
-	// 64 = <char id>.L
-	safestrncpy(title, RFIFOCP(fd, 68), realTitleLength);
-	safestrncpy(text, RFIFOCP(fd, 68 + titleLength), realTextLength);
-#endif
+	safestrncpy(title, RFIFOCP(fd, headerLength), realTitleLength);
+	safestrncpy(text, RFIFOCP(fd, headerLength + titleLength), realTextLength);
 
 	if( zeny > 0 ){
 		if( mail_setitem(sd,0,(uint32)zeny) != MAIL_ATTACH_SUCCESS ){


### PR DESCRIPTION
Reject mail-send packets whose title or body lengths exceed the packet payload before copying client-controlled content.

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
None
<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both
<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This pull request adds bounds checks to the Rodex mail-send parser before copying client-controlled title and body content.

 - Validates the packet length against the fixed Rodex mail header size for each supported packet layout.
 - Rejects mail-send packets whose title or body lengths exceed the available packet payload.
 - Uses the validated header size when copying title and body data.

This prevents malformed Rodex mail packets from causing out-of-bounds reads in the map-server parser.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
