### PR TITLE
Fix JSON response format in partybooking_controller

### DIFF
--- a/src/web/partybooking_controller.cpp
+++ b/src/web/partybooking_controller.cpp
@@ -306,7 +306,7 @@ HANDLER_FUNC(partybooking_get){
 	if( bookings.empty() ){
 		response = "{ \"Type\": 1 }";
 	}else{
-		response = "{ \"Type\": 1, data: " + bookings.at( 0 ).to_json( world_name ) + " }";
+		response = "{ \"Type\": 1, \"data\": " + bookings.at( 0 ).to_json( world_name ) + " }";
 	}
 
 	res.set_content( response, "application/json" );


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 
A small fix to #7853

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 
Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
This fixes an issue in the Adventure Agency where a player’s own registered group would leave a blank space at the top of the list instead of showing the group information. The problem was caused by the /party/get response using invalid JSON

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
