### PR TITLE
Magic Crasher Damage Fix

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2538,22 +2538,27 @@ static int64 battle_calc_base_damage(block_list *src, struct status_data *status
 		if (atkmin > atkmax)
 			atkmin = atkmax;
 	} else { //PCs
-		atkmax = wa->atk;
-		type = (wa == &status->lhw)?EQI_HAND_L:EQI_HAND_R;
+		if (flag&BDMG_MAGIC) {
+			atkmin = status->matk_min;
+			atkmax = status->matk_max;
+		} else {
+			atkmax = wa->atk;
+			type = (wa == &status->lhw)?EQI_HAND_L:EQI_HAND_R;
 
-		if (!(flag&BDMG_CRIT) || (flag&BDMG_ARROW)) { //Normal attacks
-			atkmin = status->dex;
+			if (!(flag&BDMG_CRIT) || (flag&BDMG_ARROW)) { //Normal attacks
+				atkmin = status->dex;
 
-			if (sd->equip_index[type] >= 0 && sd->inventory_data[sd->equip_index[type]] && sd->inventory_data[sd->equip_index[type]]->type == IT_WEAPON)
-				atkmin = atkmin*(80 + sd->inventory_data[sd->equip_index[type]]->weapon_level*20)/100;
+				if (sd->equip_index[type] >= 0 && sd->inventory_data[sd->equip_index[type]] && sd->inventory_data[sd->equip_index[type]]->type == IT_WEAPON)
+					atkmin = atkmin*(80 + sd->inventory_data[sd->equip_index[type]]->weapon_level*20)/100;
 
-			if (atkmin > atkmax)
-				atkmin = atkmax;
-
-			if(flag&BDMG_ARROW) { //Bows
-				atkmin = atkmin*atkmax/100;
 				if (atkmin > atkmax)
-					atkmax = atkmin;
+					atkmin = atkmax;
+
+				if(flag&BDMG_ARROW) { //Bows
+					atkmin = atkmin*atkmax/100;
+					if (atkmin > atkmax)
+						atkmax = atkmin;
+				}
 			}
 		}
 	}
@@ -2615,9 +2620,7 @@ static int64 battle_calc_base_damage(block_list *src, struct status_data *status
 	}
 
 	//Finally, add baseatk
-	if(flag&BDMG_MAGIC)
-		damage += status->matk_min;
-	else
+	if(!(flag&BDMG_MAGIC))
 		damage += status->batk;
 
 	if (sd)

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -2548,7 +2548,7 @@ static int64 battle_calc_base_damage(block_list *src, struct status_data *status
 			if (!(flag&BDMG_CRIT) || (flag&BDMG_ARROW)) { //Normal attacks
 				atkmin = status->dex;
 
-				if (sd->equip_index[type] >= 0 && sd->inventory_data[sd->equip_index[type]] && sd->inventory_data[sd->equip_index[type]]->type == IT_WEAPON)
+				if (sd->equip_index[type] >= 0 && sd->inventory_data[sd->equip_index[type]] != nullptr && sd->inventory_data[sd->equip_index[type]]->type == IT_WEAPON)
 					atkmin = atkmin*(80 + sd->inventory_data[sd->equip_index[type]]->weapon_level*20)/100;
 
 				if (atkmin > atkmax)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: #10036 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Pre-Renewal

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

**Description of Pull Request**: 

- Magic Crasher now deals MinMATK~MaxMATK base damage instead of WeaponATK+MinMATK in pre-re
  * Damage is still affected by the weapon's refine bonus
- Fixes #10036

Hint:
Github displays the changes a bit bad because of indentation change, the only real change in the first code part is the addition of:
```cpp
		if (flag&BDMG_MAGIC) {
			atkmin = status->matk_min;
			atkmax = status->matk_max;
		} else {
``` 
So essentially we skip all the weapon base damage code and use matk_min and matk_max instead.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
