### PR TITLE
Resolved a potential memory leak in guild.cpp

### DIFF
--- a/src/map/guild.cpp
+++ b/src/map/guild.cpp
@@ -2739,6 +2739,14 @@ void do_init_guild(void) {
 }
 
 void do_final_guild(void) {
+	for (auto &it : castle_db) {
+		if (it.second && it.second->temp_guardians) {
+			aFree(it.second->temp_guardians);
+			it.second->temp_guardians = nullptr;
+			it.second->temp_guardians_max = 0;
+		}
+	}
+
 	for (auto &it : guild_db) {
 		if (!it.second)
 			continue;


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**:  https://github.com/rathena/rathena/issues/9794

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 
Resolve potential map crash and memory leak in guild.cpp in the function void do_final_guild(void).

This cleanup  would fix the leak if ``temp_guardians`` is allocated via RECREATE() and wasn't previously being freed.

1. frees the dynamically allocated array.
2. Prevents accidental use-after-free by nulling the pointer.
3. Resets the capacity counter.

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
