### PR TITLE
Corrected instant skills dealing recursive damage

### DIFF
--- a/src/map/skills/acolyte/explosionblaster.cpp
+++ b/src/map/skills/acolyte/explosionblaster.cpp
@@ -13,7 +13,7 @@ SkillExplosionBlaster::SkillExplosionBlaster() : SkillImplRecursiveDamageSplash(
 
 void SkillExplosionBlaster::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillExplosionBlaster::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/acolyte/howlingoflion.cpp
+++ b/src/map/skills/acolyte/howlingoflion.cpp
@@ -43,7 +43,7 @@ int64 SkillHowlingOfLion::splashDamage(block_list* src, block_list* target, uint
 
 void SkillHowlingOfLion::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 int32 SkillHowlingOfLion::getSplashTarget(block_list* src) const {

--- a/src/map/skills/acolyte/massiveflameblaster.cpp
+++ b/src/map/skills/acolyte/massiveflameblaster.cpp
@@ -15,7 +15,7 @@ void SkillMassiveFlameBlaster::castendNoDamageId(block_list* src, block_list* ta
 	sc_start(src, target, skill_get_sc(getSkillId()), 100, skill_lv, skill_get_time(getSkillId(), skill_lv));
 
 	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillMassiveFlameBlaster::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/acolyte/oleumsanctum.cpp
+++ b/src/map/skills/acolyte/oleumsanctum.cpp
@@ -13,7 +13,7 @@ SkillOleumSanctum::SkillOleumSanctum() : SkillImplRecursiveDamageSplash(IQ_OLEUM
 
 void SkillOleumSanctum::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillOleumSanctum::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/acolyte/rampageblaster.cpp
+++ b/src/map/skills/acolyte/rampageblaster.cpp
@@ -29,5 +29,5 @@ void SkillRampageBlaster::calculateSkillRatio(const Damage* wd, const block_list
 
 void SkillRampageBlaster::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/acolyte/skynetblow.cpp
+++ b/src/map/skills/acolyte/skynetblow.cpp
@@ -21,7 +21,7 @@ void SkillSkyNetBlow::calculateSkillRatio(const Damage *wd, const block_list *sr
 
 void SkillSkyNetBlow::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 
 	if (skill_area_temp[2] == 0) {
 		clif_skill_damage( *src, *src, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE );

--- a/src/map/skills/acolyte/windmill.cpp
+++ b/src/map/skills/acolyte/windmill.cpp
@@ -35,5 +35,6 @@ void SkillWindmill::calculateSkillRatio(const Damage *wd, const block_list *src,
 
 void SkillWindmill::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/acolyte/windmill.cpp
+++ b/src/map/skills/acolyte/windmill.cpp
@@ -35,6 +35,5 @@ void SkillWindmill::calculateSkillRatio(const Damage *wd, const block_list *src,
 
 void SkillWindmill::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-
 	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/gunslinger/firedance.cpp
+++ b/src/map/skills/gunslinger/firedance.cpp
@@ -22,5 +22,5 @@ void SkillFireDance::calculateSkillRatio(const Damage* wd, const block_list* src
 
 void SkillFireDance::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/gunslinger/roundtrip.cpp
+++ b/src/map/skills/gunslinger/roundtrip.cpp
@@ -19,7 +19,7 @@ void SkillRoundTrip::calculateSkillRatio(const Damage *wd, const block_list *src
 
 void SkillRoundTrip::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 

--- a/src/map/skills/homunculus/homunculus_heiligepferd.cpp
+++ b/src/map/skills/homunculus/homunculus_heiligepferd.cpp
@@ -11,7 +11,7 @@ SkillHeiligePferd::SkillHeiligePferd() : SkillImplRecursiveDamageSplash(MH_HEILI
 
 void SkillHeiligePferd::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillHeiligePferd::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const {

--- a/src/map/skills/homunculus/homunculus_theonefighterrises.cpp
+++ b/src/map/skills/homunculus/homunculus_theonefighterrises.cpp
@@ -19,7 +19,7 @@ void SkillTheOneFighterRises::castendNoDamageId(block_list* src, block_list* tar
 	}
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillTheOneFighterRises::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const {

--- a/src/map/skills/mage/frozenslash.cpp
+++ b/src/map/skills/mage/frozenslash.cpp
@@ -26,5 +26,5 @@ void SkillFrozenSlash::calculateSkillRatio(const Damage *wd, const block_list *s
 
 void SkillFrozenSlash::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/merchant/axestomp.cpp
+++ b/src/map/skills/merchant/axestomp.cpp
@@ -23,7 +23,7 @@ void SkillAxeStomp::castendNoDamageId(block_list* src, block_list* target, uint1
 	sc_start(src, target, skill_get_sc(getSkillId()), 100, skill_lv, skill_get_time(getSkillId(), skill_lv));
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillAxeStomp::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/merchant/axetornado.cpp
+++ b/src/map/skills/merchant/axetornado.cpp
@@ -24,7 +24,7 @@ void SkillAxeTornado::calculateSkillRatio(const Damage *wd, const block_list *sr
 
 void SkillAxeTornado::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 
 	if (skill_area_temp[2] == 0) {
 		clif_skill_damage( *src, *src, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE );

--- a/src/map/skills/merchant/carttornado.cpp
+++ b/src/map/skills/merchant/carttornado.cpp
@@ -24,7 +24,8 @@ void SkillCartTornado::calculateSkillRatio(const Damage *wd, const block_list *s
 
 void SkillCartTornado::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillCartTornado::modifyHitRate(int16& hit_rate, const block_list* src, const block_list* target, uint16 skill_lv) const {

--- a/src/map/skills/merchant/carttornado.cpp
+++ b/src/map/skills/merchant/carttornado.cpp
@@ -24,7 +24,6 @@ void SkillCartTornado::calculateSkillRatio(const Damage *wd, const block_list *s
 
 void SkillCartTornado::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-
 	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 

--- a/src/map/skills/merchant/explosivepowder.cpp
+++ b/src/map/skills/merchant/explosivepowder.cpp
@@ -31,5 +31,5 @@ void SkillExplosivePowder::calculateSkillRatio(const Damage *wd, const block_lis
 
 void SkillExplosivePowder::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/merchant/mightysmash.cpp
+++ b/src/map/skills/merchant/mightysmash.cpp
@@ -20,7 +20,7 @@ void SkillMightySmash::modifyDamageData(Damage& dmg, const block_list& src, cons
 
 void SkillMightySmash::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillMightySmash::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/ninja/kunaisplash.cpp
+++ b/src/map/skills/ninja/kunaisplash.cpp
@@ -11,7 +11,7 @@ SkillKunaiSplash::SkillKunaiSplash() : SkillImplRecursiveDamageSplash(KO_HAPPOKU
 
 void SkillKunaiSplash::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 
 	if (skill_area_temp[2] == 0) {
 		clif_skill_damage( *src, *src, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE );

--- a/src/map/skills/npc/hellsjudgement.cpp
+++ b/src/map/skills/npc/hellsjudgement.cpp
@@ -17,5 +17,5 @@ void SkillHellsJudgement::calculateSkillRatio(const Damage *wd, const block_list
 }
 
 void SkillHellsJudgement::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/npc/hellsjudgement2.cpp
+++ b/src/map/skills/npc/hellsjudgement2.cpp
@@ -38,5 +38,5 @@ void SkillHellsJudgement2::calculateSkillRatio(const Damage *wd, const block_lis
 }
 
 void SkillHellsJudgement2::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/npc/npcrayofgenesis.cpp
+++ b/src/map/skills/npc/npcrayofgenesis.cpp
@@ -22,5 +22,5 @@ void SkillNpcRayOfGenesis::calculateSkillRatio(const Damage *wd, const block_lis
 
 void SkillNpcRayOfGenesis::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/npc/pulsestrike.cpp
+++ b/src/map/skills/npc/pulsestrike.cpp
@@ -11,5 +11,5 @@ void SkillPulseStrike::calculateSkillRatio(const Damage *wd, const block_list *s
 }
 
 void SkillPulseStrike::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/npc/vampiregift.cpp
+++ b/src/map/skills/npc/vampiregift.cpp
@@ -14,7 +14,7 @@ void SkillVampireGift::calculateSkillRatio(const Damage *wd, const block_list *s
 }
 
 void SkillVampireGift::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 int64 SkillVampireGift::splashDamage(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {

--- a/src/map/skills/npc/widecriticalwounds.cpp
+++ b/src/map/skills/npc/widecriticalwounds.cpp
@@ -13,5 +13,5 @@ void SkillWideCriticalWounds::applyAdditionalEffects(block_list *src, block_list
 }
 
 void SkillWideCriticalWounds::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/swordman/cannonspear.cpp
+++ b/src/map/skills/swordman/cannonspear.cpp
@@ -13,7 +13,7 @@ SkillCannonSpear::SkillCannonSpear() : SkillImplRecursiveDamageSplash(LG_CANNONS
 
 void SkillCannonSpear::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 
 	if (skill_area_temp[2] == 0) {
 		clif_skill_damage(*src, *src, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE);

--- a/src/map/skills/swordman/moonslasher.cpp
+++ b/src/map/skills/swordman/moonslasher.cpp
@@ -13,7 +13,9 @@ SkillMoonSlasher::SkillMoonSlasher() : SkillImplRecursiveDamageSplash(LG_MOONSLA
 }
 
 void SkillMoonSlasher::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
-	skill_castend_damage_id(src, src, getSkillId(), skill_lv, tick, flag);
+	clif_skill_damage(*src, *target, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE);
+
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillMoonSlasher::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
@@ -25,10 +27,4 @@ void SkillMoonSlasher::calculateSkillRatio(const Damage* wd, const block_list* s
 
 void SkillMoonSlasher::applyAdditionalEffects(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const {
 	sc_start(src, src, SC_OVERBRANDREADY, 100, skill_lv, skill_get_time2(getSkillId(), skill_lv));
-}
-
-void SkillMoonSlasher::splashSearch(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {
-	clif_skill_damage(*src, *target, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE);
-
-	SkillImplRecursiveDamageSplash::splashSearch(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/swordman/moonslasher.cpp
+++ b/src/map/skills/swordman/moonslasher.cpp
@@ -14,7 +14,6 @@ SkillMoonSlasher::SkillMoonSlasher() : SkillImplRecursiveDamageSplash(LG_MOONSLA
 
 void SkillMoonSlasher::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_damage(*src, *target, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE);
-
 	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 

--- a/src/map/skills/swordman/moonslasher.hpp
+++ b/src/map/skills/swordman/moonslasher.hpp
@@ -12,5 +12,4 @@ public:
 	void castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const override;
 	void calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const override;
 	void applyAdditionalEffects(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const override;
-	void splashSearch(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const override;
 };

--- a/src/map/skills/swordman/overbrand.cpp
+++ b/src/map/skills/swordman/overbrand.cpp
@@ -14,7 +14,7 @@ SkillOverBrand::SkillOverBrand() : SkillImplRecursiveDamageSplash(LG_OVERBRAND) 
 
 void SkillOverBrand::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillOverBrand::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/swordman/rayofgenesis.cpp
+++ b/src/map/skills/swordman/rayofgenesis.cpp
@@ -14,7 +14,7 @@ SkillRayOfGenesis::SkillRayOfGenesis() : SkillImplRecursiveDamageSplash(LG_RAYOF
 
 void SkillRayOfGenesis::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillRayOfGenesis::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/swordman/servantweapondemolition.cpp
+++ b/src/map/skills/swordman/servantweapondemolition.cpp
@@ -21,7 +21,7 @@ void SkillServantWeaponDemolition::modifyDamageData(Damage& dmg, const block_lis
 
 void SkillServantWeaponDemolition::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillServantWeaponDemolition::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/swordman/stormblast.cpp
+++ b/src/map/skills/swordman/stormblast.cpp
@@ -22,5 +22,5 @@ void SkillStormBlast::calculateSkillRatio(const Damage *wd, const block_list *sr
 
 void SkillStormBlast::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/swordman/windcutter.cpp
+++ b/src/map/skills/swordman/windcutter.cpp
@@ -41,7 +41,7 @@ void SkillWindCutter::calculateSkillRatio(const Damage *wd, const block_list *sr
 
 void SkillWindCutter::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 
 	if (skill_area_temp[2] == 0) {
 		clif_skill_damage( *src, *src, tick, status_get_amotion(src), 0, DMGVAL_IGNORE, 1, getSkillId(), skill_lv, DMG_SINGLE );

--- a/src/map/skills/taekwon/dawnbreak.cpp
+++ b/src/map/skills/taekwon/dawnbreak.cpp
@@ -14,7 +14,7 @@ SkillDawnBreak::SkillDawnBreak() : SkillImplRecursiveDamageSplash(SKE_DAWN_BREAK
 
 void SkillDawnBreak::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillDawnBreak::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/taekwon/exorcismofmalicioussoul.cpp
+++ b/src/map/skills/taekwon/exorcismofmalicioussoul.cpp
@@ -40,5 +40,5 @@ void SkillExorcismOfMaliciousSoul::castendNoDamageId(block_list *src, block_list
 	}
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/fallingstar.cpp
+++ b/src/map/skills/taekwon/fallingstar.cpp
@@ -59,7 +59,7 @@ int64 SkillFallingStarAttack::splashDamage(block_list* src, block_list* target, 
 
 void SkillFallingStarAttack::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 

--- a/src/map/skills/taekwon/fullmoonkick.cpp
+++ b/src/map/skills/taekwon/fullmoonkick.cpp
@@ -26,5 +26,5 @@ void SkillFullMoonKick::calculateSkillRatio(const Damage *wd, const block_list *
 
 void SkillFullMoonKick::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/midnightkick.cpp
+++ b/src/map/skills/taekwon/midnightkick.cpp
@@ -14,7 +14,7 @@ SkillMidnightKick::SkillMidnightKick() : SkillImplRecursiveDamageSplash(SKE_MIDN
 
 void SkillMidnightKick::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillMidnightKick::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/taekwon/newmoonkick.cpp
+++ b/src/map/skills/taekwon/newmoonkick.cpp
@@ -26,5 +26,5 @@ void SkillNewMoonKick::castendNoDamageId(block_list *src, block_list *target, ui
 	} else
 		sc_start(src, target, type, 100, skill_lv, skill_get_time(getSkillId(), skill_lv));
 
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/risingmoon.cpp
+++ b/src/map/skills/taekwon/risingmoon.cpp
@@ -26,7 +26,7 @@ void SkillRisingMoon::castendNoDamageId(block_list* src, block_list* target, uin
 	}
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillRisingMoon::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/taekwon/skysun.cpp
+++ b/src/map/skills/taekwon/skysun.cpp
@@ -14,7 +14,8 @@ SkillSkySun::SkillSkySun() : SkillImplRecursiveDamageSplash(SKE_SKY_SUN) {
 
 void SkillSkySun::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillSkySun::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
@@ -25,10 +26,4 @@ void SkillSkySun::calculateSkillRatio(const Damage* wd, const block_list* src, c
 	skillratio += skill_lv * 7 * pc_checkskill(sd, SKE_SKY_MASTERY);
 	skillratio += 5 * sstatus->pow;
 	RE_LVL_DMOD(100);
-}
-
-void SkillSkySun::splashSearch(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const {
-	clif_skill_nodamage(src, *target, getSkillId(), skill_lv);
-
-	SkillImplRecursiveDamageSplash::splashSearch(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/skysun.cpp
+++ b/src/map/skills/taekwon/skysun.cpp
@@ -14,7 +14,6 @@ SkillSkySun::SkillSkySun() : SkillImplRecursiveDamageSplash(SKE_SKY_SUN) {
 
 void SkillSkySun::castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-
 	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 

--- a/src/map/skills/taekwon/skysun.hpp
+++ b/src/map/skills/taekwon/skysun.hpp
@@ -11,5 +11,4 @@ public:
 
 	void castendNoDamageId(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32& flag) const override;
 	void calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& base_skillratio, int32 mflag) const override;
-	void splashSearch(block_list* src, block_list* target, uint16 skill_lv, t_tick tick, int32 flag) const override;
 };

--- a/src/map/skills/taekwon/solarburst.cpp
+++ b/src/map/skills/taekwon/solarburst.cpp
@@ -22,5 +22,5 @@ void SkillSolarBurst::calculateSkillRatio(const Damage *wd, const block_list *sr
 
 void SkillSolarBurst::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/staremperoradvent.cpp
+++ b/src/map/skills/taekwon/staremperoradvent.cpp
@@ -33,5 +33,5 @@ void SkillStarEmperorAdvent::castendNoDamageId(block_list *src, block_list *targ
 	}
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/taekwon/talismanofwhitetiger.cpp
+++ b/src/map/skills/taekwon/talismanofwhitetiger.cpp
@@ -33,5 +33,5 @@ void SkillTalismanOfWhiteTiger::castendNoDamageId(block_list *src, block_list *t
 	}
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/thief/abyssdagger.cpp
+++ b/src/map/skills/thief/abyssdagger.cpp
@@ -15,7 +15,7 @@ void SkillAbyssDagger::castendNoDamageId(block_list* src, block_list* target, ui
 	sc_start(src, target, skill_get_sc(getSkillId()), 100, skill_lv, skill_get_time(getSkillId(), skill_lv));
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 
 void SkillAbyssDagger::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {

--- a/src/map/skills/thief/counterslash.cpp
+++ b/src/map/skills/thief/counterslash.cpp
@@ -26,5 +26,5 @@ void SkillCounterSlash::calculateSkillRatio(const Damage *wd, const block_list *
 
 void SkillCounterSlash::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/thief/impactcrater.cpp
+++ b/src/map/skills/thief/impactcrater.cpp
@@ -24,5 +24,5 @@ void SkillImpactCrater::castendNoDamageId(block_list *src, block_list *target, u
 	sc_start(src, target, type, 100, skill_lv, skill_get_time(getSkillId(), skill_lv));
 
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }

--- a/src/map/skills/thief/meteorassault.cpp
+++ b/src/map/skills/thief/meteorassault.cpp
@@ -22,7 +22,7 @@ void SkillMeteorAssault::calculateSkillRatio(const Damage *wd, const block_list 
 
 void SkillMeteorAssault::castendNoDamageId(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32& flag) const {
 	clif_skill_nodamage(src,*target,getSkillId(),skill_lv);
-	skill_castend_damage_id(src, target, getSkillId(), skill_lv, tick, flag);
+	SkillImplRecursiveDamageSplash::castendDamageId(src, target, skill_lv, tick, flag);
 }
 	
 void SkillMeteorAssault::applyAdditionalEffects(block_list *src, block_list *target, uint16 skill_lv, t_tick tick, int32 attack_type, enum damage_lv dmg_lv) const {


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: https://github.com/rathena/rathena/issues/9937

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

- fixed skill type "magic" missing damage when the caster wears golden thief card by skipping the check of status_isimmune when bl=caster in skill_castend_damage_id
- fixed skill using item requirements by calling skill_castend_damage_id only with flag 1 via SkillImplRecursiveDamageSplash::castendDamageId, only the requirements from skill_castend_nodamage_id are deleted
- updated all instant skills dealing recursive damage for safety

Examples
-------------------------------------------
- [Frozen Slash](https://www.divine-pride.net/database/skill/5237) when caster wears a golden thief bug card
**Before commit**
... -> `skill_castend_nodamage_id` -> `skill->impl->castendNoDamageId` -> `skill_castend_damage_id` (call with caster id) -> caster is immune magic = attack miss
**After commit**
... -> `skill_castend_nodamage_id` -> `skill->impl->castendNoDamageId` -> `SkillImplRecursiveDamageSplash::castendDamageId` -> `SkillImplRecursiveDamageSplash::splashSearch` calls `skill_castend_damage_id` for targets (no call with caster id anymore) -> damage dealt

- [Talisman of White Tiger](https://www.divine-pride.net/database/skill/5427) which consumes 1 Soul Talisman
**Before commit**
... -> `skill_castend_nodamage_id` (with flag NOT 1 = consume item requirement) -> `skill->impl->castendNoDamageId` -> `skill_castend_damage_id` (with flag NOT 1 = consume item requirement) -> etc.. (double consumption)
**After commit**
... -> `skill_castend_nodamage_id` (with flag NOT 1 = consume item requirement) -> `skill->impl->castendNoDamageId` -> `SkillImplRecursiveDamageSplash::castendDamageId` -> `SkillImplRecursiveDamageSplash::splashSearch` calls `skill_castend_damage_id` with flag 1 = DON'T consume item requirement  -> etc.. ( consume item requirement 1 time)


<!-- Describe how this pull request will resolve the issue(s) listed above. -->
