### PR TITLE
Fix compiler errors after skill split

### DIFF
--- a/src/map/skills/archer/soundblend.cpp
+++ b/src/map/skills/archer/soundblend.cpp
@@ -6,6 +6,7 @@
 #include <config/core.hpp>
 
 #include "map/clif.hpp"
+#include "map/pc.hpp"
 #include "map/status.hpp"
 
 SkillSoundBlend::SkillSoundBlend() : SkillImpl(TR_SOUNDBLEND) {

--- a/src/map/skills/gunslinger/chainaction.cpp
+++ b/src/map/skills/gunslinger/chainaction.cpp
@@ -3,6 +3,8 @@
 
 #include "chainaction.hpp"
 
+#include "map/clif.hpp"
+
 SkillChainAction::SkillChainAction() : WeaponSkillImpl(GS_CHAINACTION) {
 }
 

--- a/src/map/skills/gunslinger/quickdrawshot.cpp
+++ b/src/map/skills/gunslinger/quickdrawshot.cpp
@@ -4,6 +4,7 @@
 #include "quickdrawshot.hpp"
 
 #include "map/map.hpp"
+#include "map/pc.hpp"
 #include "map/status.hpp"
 
 SkillQuickDrawShot::SkillQuickDrawShot() : SkillImpl(RL_QD_SHOT) {

--- a/src/map/skills/mage/coldbolt.cpp
+++ b/src/map/skills/mage/coldbolt.cpp
@@ -3,6 +3,7 @@
 
 #include "coldbolt.hpp"
 
+#include "map/clif.hpp"
 #include "map/status.hpp"
 
 SkillColdBolt::SkillColdBolt() : SkillImpl(MG_COLDBOLT) {

--- a/src/map/skills/mage/firebolt.cpp
+++ b/src/map/skills/mage/firebolt.cpp
@@ -3,6 +3,7 @@
 
 #include "firebolt.hpp"
 
+#include "map/clif.hpp"
 #include "map/status.hpp"
 
 SkillFireBolt::SkillFireBolt() : SkillImpl(MG_FIREBOLT) {

--- a/src/map/skills/mage/firepillar.cpp
+++ b/src/map/skills/mage/firepillar.cpp
@@ -3,6 +3,7 @@
 
 #include "firepillar.hpp"
 
+#include "map/pc.hpp"
 #include "map/unit.hpp"
 
 SkillFirePillar::SkillFirePillar() : SkillImpl(WZ_FIREPILLAR) {

--- a/src/map/skills/mage/lightningbolt.cpp
+++ b/src/map/skills/mage/lightningbolt.cpp
@@ -3,6 +3,7 @@
 
 #include "lightningbolt.hpp"
 
+#include "map/clif.hpp"
 #include "map/status.hpp"
 
 SkillLightningBolt::SkillLightningBolt() : SkillImpl(MG_LIGHTNINGBOLT) {

--- a/src/map/skills/mage/psychicwave.cpp
+++ b/src/map/skills/mage/psychicwave.cpp
@@ -5,6 +5,7 @@
 
 #include <config/core.hpp>
 
+#include "map/pc.hpp"
 #include "map/status.hpp"
 
 SkillPsychicWave::SkillPsychicWave() : SkillImpl(SO_PSYCHIC_WAVE) {

--- a/src/map/skills/merchant/axestomp.cpp
+++ b/src/map/skills/merchant/axestomp.cpp
@@ -6,6 +6,7 @@
 #include <config/core.hpp>
 
 #include "map/clif.hpp"
+#include "map/pc.hpp"
 #include "map/skill.hpp"
 #include "map/status.hpp"
 

--- a/src/map/skills/thief/doubleattack.cpp
+++ b/src/map/skills/thief/doubleattack.cpp
@@ -3,6 +3,8 @@
 
 #include "doubleattack.hpp"
 
+#include "map/clif.hpp"
+
 SkillDoubleAttack::SkillDoubleAttack() : WeaponSkillImpl(TF_DOUBLE) {
 }
 

--- a/src/map/skills/thief/fatalmenace.cpp
+++ b/src/map/skills/thief/fatalmenace.cpp
@@ -7,6 +7,7 @@
 
 #include "map/clif.hpp"
 #include "map/map.hpp"
+#include "map/pc.hpp"
 #include "map/status.hpp"
 
 SkillFatalMenace::SkillFatalMenace() : WeaponSkillImpl(SC_FATALMENACE) {

--- a/src/map/skills/thief/mug.cpp
+++ b/src/map/skills/thief/mug.cpp
@@ -7,6 +7,7 @@
 
 #include "map/battle.hpp"
 #include "map/clif.hpp"
+#include "map/log.hpp"
 #include "map/mob.hpp"
 #include "map/pc.hpp"
 


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: Both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: Missing some headers in skill split

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
