### PR TITLE
Enhance item usage logic to prevent script state leaks

### DIFF
--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -6557,7 +6557,11 @@ int32 pc_useitem(map_session_data *sd,int32 n)
 
 	run_script( script, 0, sd->id, fake_nd->id );
 
-	if( sd->st != nullptr ){
+	if( sd->st != nullptr &&
+		( previous_st != nullptr ||
+		 ( sd->st->state != STOP &&
+		   sd->st->state != RERUNLINE &&
+		   sd->st->state != CLOSE ) ) ){
 		script_free_state( sd->st );
 		sd->st = nullptr;
 	}


### PR DESCRIPTION
* **Addressed Issue(s)**:

N/A

* **Server Mode**:

Both

* **Description of Pull Request**:

Fixes item scripts that enter a suspended state (e.g. `mes`, `next`, `select`, `input`) being prematurely destroyed after `run_script()` execution.

Previously, `pc_useitem()` always freed `sd->st` immediately after running an item script. This prevented item scripts from properly resuming when waiting for client interaction, causing item dialogs to become unresponsive.

Example:

```yaml
- Id: 12221
  AegisName: Megaphone_
  Name: Megaphone
  Type: Usable
  Script: |
    input @megaphone$;
    announce strcharinfo(0) + ": " + @megaphone$, bc_all, 0xFF0000;
```

When using this item, the `input` command suspends the script while waiting for the player's response. However, the script state is immediately destroyed by `pc_useitem()`, causing the item to stop functioning after the input dialog appears.

This change preserves the script state when the item script is suspended and awaiting client interaction, allowing item dialogs to resume correctly after user input. The original cleanup behavior is preserved for scripts that finish execution immediately, and item scripts are still discarded when another NPC script is already attached to the player to avoid script-state conflicts.
