### PR TITLE
Fixed login-server not sending unban time to client

### DIFF
--- a/src/login/loginclif.cpp
+++ b/src/login/loginclif.cpp
@@ -172,7 +172,7 @@ static void logclif_auth_failed( int32 fd, int32 result, const char* unblock_tim
 
 	p.packetType = HEADER_AC_REFUSE_LOGIN;
 	p.error = result;
-	safestrncpy( p.unblock_time, "", sizeof( p.unblock_time ) );
+	safestrncpy( p.unblock_time, unblock_time, sizeof( p.unblock_time ) );
 
 	socket_send( fd, p );
 }


### PR DESCRIPTION
* **Addressed Issue(s)**: 
* **Server Mode**: 
* **Description of Pull Request**: 
The login-server currently sends empty string instead of `unblock_time` to the client, preventing banned users from seeing when their ban expires. This PR fixes the issue.
