### PR TITLE
Fix legacy 0x006d character records

### DIFF
--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1832,7 +1832,9 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.Dex = (uint8)u16min( p.dex, UINT8_MAX );
 	info.Luk = (uint8)u16min( p.luk, UINT8_MAX );
 	info.CharNum = p.slot;
+#if PACKETVER >= 20081217
 	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
+#endif
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
 #elif PACKETVER >= 20061023
 	info.CharNum = p.slot;

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1835,7 +1835,9 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 #if PACKETVER >= 20081217
 	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
 #endif
+#if PACKETVER >= 20061023
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
+#endif
 #elif PACKETVER >= 20061023
 	info.CharNum = p.slot;
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1838,12 +1838,6 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 #if PACKETVER >= 20061023
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
 #endif
-#elif PACKETVER >= 20061023
-	info.CharNum = p.slot;
-	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
-#else
-	info.CharNum = p.slot;
-#endif
 #if (PACKETVER >= 20100720 && PACKETVER <= 20100727) || PACKETVER >= 20100803
 	mapindex_getmapname_ext( p.last_point.map, info.mapName );
 #endif

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1791,10 +1791,17 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.virtue = p.karma;
 	info.honor = p.manner;
 	info.jobpoint = umin( p.status_point, INT16_MAX );
+#if PACKETVER < 20081217
+	info.hp = u32min( p.hp, INT16_MAX );
+	info.maxhp = u32min( p.max_hp, INT16_MAX );
+	info.sp = u32min( p.sp, INT16_MAX );
+	info.maxsp = u32min( p.max_sp, INT16_MAX );
+#else
 	info.hp = p.hp;
 	info.maxhp = p.max_hp;
 	info.sp = min( p.sp, INT16_MAX );
 	info.maxsp = min( p.max_sp, INT16_MAX );
+#endif
 	info.speed = DEFAULT_WALK_SPEED; // p.speed;
 	info.job = p.class_;
 	info.head = p.hair;
@@ -1824,9 +1831,16 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.Int = (uint8)u16min( p.int_, UINT8_MAX );
 	info.Dex = (uint8)u16min( p.dex, UINT8_MAX );
 	info.Luk = (uint8)u16min( p.luk, UINT8_MAX );
+#if PACKETVER < 20061023
+	info.CharNum = p.slot;
+#elif PACKETVER < 20081217
+	info.CharNum = p.slot;
+	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
+#else
 	info.CharNum = p.slot;
 	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
+#endif
 #if (PACKETVER >= 20100720 && PACKETVER <= 20100727) || PACKETVER >= 20100803
 	mapindex_getmapname_ext( p.last_point.map, info.mapName );
 #endif

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1791,16 +1791,16 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.virtue = p.karma;
 	info.honor = p.manner;
 	info.jobpoint = umin( p.status_point, INT16_MAX );
-#if PACKETVER < 20081217
-	info.hp = u32min( p.hp, INT16_MAX );
-	info.maxhp = u32min( p.max_hp, INT16_MAX );
-	info.sp = u32min( p.sp, INT16_MAX );
-	info.maxsp = u32min( p.max_sp, INT16_MAX );
-#else
+#if PACKETVER >= 20081217
 	info.hp = p.hp;
 	info.maxhp = p.max_hp;
 	info.sp = min( p.sp, INT16_MAX );
 	info.maxsp = min( p.max_sp, INT16_MAX );
+#else
+	info.hp = u32min( p.hp, INT16_MAX );
+	info.maxhp = u32min( p.max_hp, INT16_MAX );
+	info.sp = u32min( p.sp, INT16_MAX );
+	info.maxsp = u32min( p.max_sp, INT16_MAX );
 #endif
 	info.speed = DEFAULT_WALK_SPEED; // p.speed;
 	info.job = p.class_;
@@ -1831,15 +1831,15 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.Int = (uint8)u16min( p.int_, UINT8_MAX );
 	info.Dex = (uint8)u16min( p.dex, UINT8_MAX );
 	info.Luk = (uint8)u16min( p.luk, UINT8_MAX );
-#if PACKETVER < 20061023
+#if PACKETVER >= 20081217
 	info.CharNum = p.slot;
-#elif PACKETVER < 20081217
+	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
+	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
+#elif PACKETVER >= 20061023
 	info.CharNum = p.slot;
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
 #else
 	info.CharNum = p.slot;
-	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
-	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;
 #endif
 #if (PACKETVER >= 20100720 && PACKETVER <= 20100727) || PACKETVER >= 20100803
 	mapindex_getmapname_ext( p.last_point.map, info.mapName );

--- a/src/char/char.cpp
+++ b/src/char/char.cpp
@@ -1831,7 +1831,6 @@ int32 char_mmo_char_tobuf( CHARACTER_INFO& info, mmo_charstatus& p ){
 	info.Int = (uint8)u16min( p.int_, UINT8_MAX );
 	info.Dex = (uint8)u16min( p.dex, UINT8_MAX );
 	info.Luk = (uint8)u16min( p.luk, UINT8_MAX );
-#if PACKETVER >= 20081217
 	info.CharNum = p.slot;
 	info.hairColor = (uint8)u16min( p.hair_color, UINT8_MAX );
 	info.bIsChangedCharName = ( p.rename > 0 ) ? 0 : 1;

--- a/src/common/packets.hpp
+++ b/src/common/packets.hpp
@@ -53,14 +53,14 @@ struct CHARACTER_INFO{
 	int64 maxhp;
 	int64 sp;
 	int64 maxsp;
-#elif PACKETVER < 20081217
-	int16 hp;
-	int16 maxhp;
+#elif PACKETVER >= 20081217
+	int32 hp;
+	int32 maxhp;
 	int16 sp;
 	int16 maxsp;
 #else
-	int32 hp;
-	int32 maxhp;
+	int16 hp;
+	int16 maxhp;
 	int16 sp;
 	int16 maxsp;
 #endif
@@ -86,15 +86,15 @@ struct CHARACTER_INFO{
 	uint8 Int;
 	uint8 Dex;
 	uint8 Luk;
-#if PACKETVER < 20061023
-	int16 CharNum;
-#elif PACKETVER < 20081217
-	int16 CharNum;
-	int16 bIsChangedCharName;
-#else
+#if PACKETVER >= 20081217
 	uint8 CharNum;
 	uint8 hairColor;
 	int16 bIsChangedCharName;
+#elif PACKETVER >= 20061023
+	int16 CharNum;
+	int16 bIsChangedCharName;
+#else
+	int16 CharNum;
 #endif
 #if (PACKETVER >= 20100720 && PACKETVER <= 20100727) || PACKETVER >= 20100803
 	char mapName[16];

--- a/src/common/packets.hpp
+++ b/src/common/packets.hpp
@@ -116,12 +116,6 @@ struct CHARACTER_INFO{
 #endif
 } __attribute__((packed));
 
-#if PACKETVER < 20061023
-static_assert( sizeof( CHARACTER_INFO ) == 106, "Legacy CHARACTER_INFO size mismatch" );
-#elif PACKETVER < 20081217
-static_assert( sizeof( CHARACTER_INFO ) == 108, "Legacy CHARACTER_INFO size mismatch" );
-#endif
-
 struct PACKET_CA_LOGIN{
 	int16 packetType;
 	uint32 version;

--- a/src/common/packets.hpp
+++ b/src/common/packets.hpp
@@ -53,6 +53,11 @@ struct CHARACTER_INFO{
 	int64 maxhp;
 	int64 sp;
 	int64 maxsp;
+#elif PACKETVER < 20081217
+	int16 hp;
+	int16 maxhp;
+	int16 sp;
+	int16 maxsp;
 #else
 	int32 hp;
 	int32 maxhp;
@@ -81,9 +86,16 @@ struct CHARACTER_INFO{
 	uint8 Int;
 	uint8 Dex;
 	uint8 Luk;
+#if PACKETVER < 20061023
+	int16 CharNum;
+#elif PACKETVER < 20081217
+	int16 CharNum;
+	int16 bIsChangedCharName;
+#else
 	uint8 CharNum;
 	uint8 hairColor;
 	int16 bIsChangedCharName;
+#endif
 #if (PACKETVER >= 20100720 && PACKETVER <= 20100727) || PACKETVER >= 20100803
 	char mapName[16];
 #endif
@@ -103,6 +115,12 @@ struct CHARACTER_INFO{
 	uint8 sex;
 #endif
 } __attribute__((packed));
+
+#if PACKETVER < 20061023
+static_assert( sizeof( CHARACTER_INFO ) == 106, "Legacy CHARACTER_INFO size mismatch" );
+#elif PACKETVER < 20081217
+static_assert( sizeof( CHARACTER_INFO ) == 108, "Legacy CHARACTER_INFO size mismatch" );
+#endif
 
 struct PACKET_CA_LOGIN{
 	int16 packetType;


### PR DESCRIPTION
- eAthena: db/packet_db.txt changes 0x006d from 110-byte records to 114 bytes at 2008-12-17bRagexeRE.
- Hercules: src/char/char.c writes 16-bit HP/maxHP for the legacy record path.
- Sabine: src/Shared/Network/PacketTable.2500_sakEP12.cs maps 2008-09-10aSakexe to 110-byte HC_ACCEPT_MAKECHAR records.