### PR TITLE
Fixed skill cast ACK PACKETVER definition

### DIFF
--- a/src/map/packets_struct.hpp
+++ b/src/map/packets_struct.hpp
@@ -3975,7 +3975,8 @@ struct PACKET_ZC_USESKILL_ACK {
 	uint8 disposable;
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_USESKILL_ACK, 0x07fb);
-#elif PACKETVER_MAIN_NUM >= 20090406 || PACKETVER_SAK_NUM >= 20080618 || PACKETVER_RE_NUM >= 20080827 || defined(PACKETVER_ZERO)
+// 2008-09-10aSakexe uses shuffled CZ skill packets but still expects the classic cast ACK.
+#elif PACKETVER_MAIN_NUM >= 20090406 || PACKETVER == 20080910 || PACKETVER_SAK_NUM >= 20080618 || PACKETVER_RE_NUM >= 20080827 || defined(PACKETVER_ZERO)
 struct PACKET_ZC_USESKILL_ACK {
 	int16 packetType;
 	uint32 srcId;

--- a/src/map/packets_struct.hpp
+++ b/src/map/packets_struct.hpp
@@ -3975,8 +3975,7 @@ struct PACKET_ZC_USESKILL_ACK {
 	uint8 disposable;
 } __attribute__((packed));
 DEFINE_PACKET_HEADER(ZC_USESKILL_ACK, 0x07fb);
-// 2008-09-10aSakexe uses shuffled CZ skill packets but still expects the classic cast ACK.
-#elif PACKETVER_MAIN_NUM >= 20090406 || PACKETVER == 20080910 || PACKETVER_SAK_NUM >= 20080618 || PACKETVER_RE_NUM >= 20080827 || defined(PACKETVER_ZERO)
+#else
 struct PACKET_ZC_USESKILL_ACK {
 	int16 packetType;
 	uint32 srcId;


### PR DESCRIPTION
- eAthena: db/packet_db.txt maps 2008-09-10aSakexe CZ_USE_SKILL to 0x0438.
- eAthena: src/map/clif.c uses 0x013e for ZC_USESKILL_ACK before 2009-11-24.
- Sabine: docs/network/packet_tables/packet_table_2500.md lists CZ_USE_SKILL 0x0438 and ZC_USESKILL_ACK 0x013e.