### PR TITLE
Fix old packetver cloth color build

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1653,7 +1653,7 @@ static inline bool clif_npc_mayapurple( const block_list& bl ){
 }
 
 /// For the stupid cloth-dye bug. Resends the given view data to the area specified by bl.
-void clif_refresh_clothcolor( const block_list& bl, enum send_target target, block_list* tbl = nullptr ){
+void clif_refresh_clothcolor( const block_list& bl, enum send_target target, const block_list* tbl = nullptr ){
 // Unconfirmed when this was fixed, if you encounter any problems, feel free to report them
 #if PACKETVER < 20091103
 	const view_data* vd = status_get_viewdata( &bl );
@@ -1670,7 +1670,7 @@ void clif_refresh_clothcolor( const block_list& bl, enum send_target target, blo
 		tbl = &bl;
 	}
 
-	clif_sprite_change( tbl, bl.id, LOOK_CLOTHES_COLOR, vd->look[LOOK_CLOTHES_COLOR], 0, target );
+	clif_sprite_change( const_cast<block_list*>( tbl ), bl.id, LOOK_CLOTHES_COLOR, vd->look[LOOK_CLOTHES_COLOR], 0, target );
 #endif
 }
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -1670,7 +1670,7 @@ void clif_refresh_clothcolor( const block_list& bl, enum send_target target, con
 		tbl = &bl;
 	}
 
-	clif_sprite_change( const_cast<block_list*>( tbl ), bl.id, LOOK_CLOTHES_COLOR, vd->look[LOOK_CLOTHES_COLOR], 0, target );
+	clif_sprite_change( tbl, bl.id, LOOK_CLOTHES_COLOR, vd->look[LOOK_CLOTHES_COLOR], 0, target );
 #endif
 }
 


### PR DESCRIPTION
- PACKETVER < 20091103 builds call clif_refresh_clothcolor with a const block_list reference.
- PACKETVER=20080910 fails with an invalid conversion from const block_list* to block_list* in clif_refresh_clothcolor.