### PR TITLE
Fix emote packet for clients 2023-07-05+ (CZ_REQ_EMOTION_EXPANSION)

### DIFF
--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -11625,13 +11625,18 @@ void clif_parse_Emotion(int32 fd, map_session_data *sd){
 		return;
 	}
 
-	const PACKET_CZ_REQ_EMOTION* p = reinterpret_cast<PACKET_CZ_REQ_EMOTION*>( RFIFOP( fd, 0 ) );
+/// Fix of emoticon [sofiaisha]
+#if PACKETVER_MAIN_NUM >= 20230705
+	emotion_type emoticon = static_cast<emotion_type>(RFIFOB(fd, packet_db[RFIFOW(fd, 0)].pos[0]));
+#else
+	const PACKET_CZ_REQ_EMOTION* p = reinterpret_cast<PACKET_CZ_REQ_EMOTION*>(RFIFOP(fd, 0));
 
 	if( p->emotion_type >= ET_MAX ){
 		return;
 	}
-	
+
 	emotion_type emoticon = static_cast<emotion_type>( p->emotion_type );
+#endif
 
 	if (battle_config.basic_skill_check == 0 || pc_checkskill(sd, NV_BASIC) >= 2 || pc_checkskill(sd, SU_BASIC_SKILL) >= 1) {
 		if (emoticon == ET_CHAT_PROHIBIT) {// prevent use of the mute emote [Valaris]

--- a/src/map/clif_packetdb.hpp
+++ b/src/map/clif_packetdb.hpp
@@ -2027,7 +2027,8 @@
 #endif
 
 #if PACKETVER_MAIN_NUM >= 20230705
-	parseable_packet( HEADER_CZ_REQ_EMOTION_EXPANSION, sizeof( struct PACKET_CZ_REQ_EMOTION_EXPANSION ), clif_parse_dull, 0 );
+/// Fix of emoticon [sofiaisha]
+	parseable_packet( HEADER_CZ_REQ_EMOTION_EXPANSION, sizeof( struct PACKET_CZ_REQ_EMOTION_EXPANSION), clif_parse_Emotion, 4 );
 #endif
 
 #if PACKETVER_MAIN_NUM >= 20230802


### PR DESCRIPTION
Clients from PACKETVER_MAIN_NUM 20230705 onward send the emote request via CZ_REQ_EMOTION_EXPANSION instead of the legacy CZ_REQ_EMOTION, but that packet was registered with clif_parse_dull (a no-op), so emotes silently did nothing for these clients.

clif_parse_Emotion() now reads the emotion byte from the packet's resolved position for the newer format, and the packet_db entry for CZ_REQ_EMOTION_EXPANSION is wired to the real handler.

Fixes #9514

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
