### PR TITLE
Fix refine level in item group announcements

### DIFF
--- a/src/char/inter.cpp
+++ b/src/char/inter.cpp
@@ -1136,13 +1136,13 @@ int32 mapif_parse_broadcast(int32 fd)
 
 /**
  * Parse received item broadcast and sends it to all connected map-serves
- * ZI 3009 <cmd>.W <len>.W <nameid>.L <source>.W <type>.B <name>.24B <srcname>.24B
- * IZ 3809 <cmd>.W <len>.W <nameid>.L <source>.W <type>.B <name>.24B <srcname>.24B
+ * ZI 3009 <cmd>.W <len>.W <nameid>.L <source>.W <type>.B <name>.24B <srcname>.24B <refine level>.L
+ * IZ 3809 <cmd>.W <len>.W <nameid>.L <source>.W <type>.B <name>.24B <srcname>.24B <refine level>.L
  * @param fd
  * @return
  **/
 int32 mapif_parse_broadcast_item(int32 fd) {
-	unsigned char buf[11 + NAME_LENGTH*2];
+	unsigned char buf[11 + NAME_LENGTH*2 + sizeof(uint32)];
 
 	memcpy(WBUFP(buf, 0), RFIFOP(fd, 0), RFIFOW(fd,2));
 	WBUFW(buf, 0) = 0x3809;
@@ -1451,5 +1451,4 @@ int32 inter_parse_frommap(int32 fd)
 	RFIFOSKIP(fd, len);
 	return 1;
 }
-
 

--- a/src/map/clif.cpp
+++ b/src/map/clif.cpp
@@ -21342,7 +21342,7 @@ static std::string clif_hide_name(const char* original_name)
  * type: ITEMOBTAIN_TYPE_BOXITEM & ITEMOBTAIN_TYPE_MONSTER_ITEM "[playername] ... [sourcename] ... [itemname]" -> MsgStringTable[1629]
  * type: ITEMOBTAIN_TYPE_NPC "[playername] ... [itemname]" -> MsgStringTable[1870]
  **/
-void clif_broadcast_obtain_special_item( const char *char_name, t_itemid nameid, t_itemid container, enum BROADCASTING_SPECIAL_ITEM_OBTAIN type ){
+void clif_broadcast_obtain_special_item( const char *char_name, t_itemid nameid, t_itemid container, enum BROADCASTING_SPECIAL_ITEM_OBTAIN type, uint32 refine_level ){
 	char name[NAME_LENGTH];
 
 	if( battle_config.broadcast_hide_name ){
@@ -21358,7 +21358,7 @@ void clif_broadcast_obtain_special_item( const char *char_name, t_itemid nameid,
 			{
 				PACKET_ZC_BROADCASTING_SPECIAL_ITEM_OBTAIN_item p = {};
 
-				p.PacketType = package_item_announceType;
+				p.PacketType = HEADER_ZC_BROADCASTING_SPECIAL_ITEM_OBTAIN_item;
 				p.PacketLength = sizeof( p );
 				p.type = type;
 				p.ItemID = client_nameid( nameid );
@@ -21368,7 +21368,7 @@ void clif_broadcast_obtain_special_item( const char *char_name, t_itemid nameid,
 				p.BoxItemID = client_nameid( container );
 #if PACKETVER_MAIN_NUM >= 20220518 || PACKETVER_ZERO_NUM >= 20220518
 				p.refineLevel_len = (int8)sizeof( p.refineLevel );
-				p.refineLevel = 0; // TODO: implement
+				p.refineLevel = refine_level;
 #endif
 
 				clif_send( &p, p.PacketLength, nullptr, ALL_CLIENT );

--- a/src/map/clif.hpp
+++ b/src/map/clif.hpp
@@ -1394,7 +1394,7 @@ void clif_notify_bindOnEquip( const map_session_data& sd, int16 index );
 
 void clif_merge_item_open( const map_session_data& sd );
 
-void clif_broadcast_obtain_special_item(const char *char_name, t_itemid nameid, t_itemid container, enum BROADCASTING_SPECIAL_ITEM_OBTAIN type);
+void clif_broadcast_obtain_special_item(const char *char_name, t_itemid nameid, t_itemid container, enum BROADCASTING_SPECIAL_ITEM_OBTAIN type, uint32 refine_level);
 
 void clif_dressing_room( const map_session_data& sd );
 void clif_navigateTo( const map_session_data* sd, const char* mapname, uint16 x, uint16 y, uint8 flag, bool hideWindow, uint16 mob_id );

--- a/src/map/intif.cpp
+++ b/src/map/intif.cpp
@@ -3258,14 +3258,15 @@ void intif_parse_MessageToFD(int32 fd) {
 
 /**
  * Request to send broadcast item to all servers
- * ZI 3009 <cmd>.W <len>.W <nameid>.N <source>.W <type>.B <name>.?B
+ * ZI 3009 <cmd>.W <len>.W <nameid>.N <source>.W <type>.B <name>.?B <refine level>.L
  * @param sd Player who obtain the item
  * @param nameid Obtained item
  * @param sourceid Source of item, another item ID or monster ID
  * @param type Obtain type @see enum BROADCASTING_SPECIAL_ITEM_OBTAIN
+ * @param refine_level Refine level of obtained item
  * @return
  **/
-int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid, t_itemid sourceid, unsigned char type) {
+int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid, t_itemid sourceid, unsigned char type, uint32 refine_level) {
 	nullpo_retr(0, sd);
 
 	// Should not be here!
@@ -3275,7 +3276,7 @@ int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid,
 	}
 
 	// Send local
-	clif_broadcast_obtain_special_item(sd->status.name, nameid, sourceid, (enum BROADCASTING_SPECIAL_ITEM_OBTAIN)type);
+	clif_broadcast_obtain_special_item(sd->status.name, nameid, sourceid, (enum BROADCASTING_SPECIAL_ITEM_OBTAIN)type, refine_level);
 
 	if (CheckForCharServer())
 		return 0;
@@ -3283,13 +3284,14 @@ int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid,
 	if (other_mapserver_count < 1)
 		return 0;
 
-	WFIFOHEAD(inter_fd, 11 + NAME_LENGTH);
+	WFIFOHEAD(inter_fd, 11 + NAME_LENGTH + sizeof(refine_level));
 	WFIFOW(inter_fd, 0) = 0x3009;
-	WFIFOW(inter_fd, 2) = 11 + NAME_LENGTH;
+	WFIFOW(inter_fd, 2) = 11 + NAME_LENGTH + sizeof(refine_level);
 	WFIFOL(inter_fd, 4) = nameid;
 	WFIFOW(inter_fd, 8) = sourceid;
 	WFIFOB(inter_fd, 10) = type;
 	safestrncpy(WFIFOCP(inter_fd, 11), sd->status.name, NAME_LENGTH);
+	WFIFOL(inter_fd, 11 + NAME_LENGTH) = refine_level;
 	WFIFOSET(inter_fd, WFIFOW(inter_fd, 2));
 
 	return 1;
@@ -3308,7 +3310,7 @@ int32 intif_broadcast_obtain_special_item_npc(map_session_data *sd, t_itemid nam
 	nullpo_retr(0, sd);
 
 	// Send local
-	clif_broadcast_obtain_special_item(sd->status.name, nameid, 0, ITEMOBTAIN_TYPE_NPC);
+	clif_broadcast_obtain_special_item(sd->status.name, nameid, 0, ITEMOBTAIN_TYPE_NPC, 0);
 
 	if (CheckForCharServer())
 		return 0;
@@ -3335,13 +3337,16 @@ int32 intif_broadcast_obtain_special_item_npc(map_session_data *sd, t_itemid nam
  **/
 void intif_parse_broadcast_obtain_special_item(int32 fd) {
 	int32 type = RFIFOB(fd, 10);
+	uint32 refine_level = 0;
 	char name[NAME_LENGTH];
 
 	safestrncpy(name, RFIFOCP(fd, 11), NAME_LENGTH);
 	if (type == ITEMOBTAIN_TYPE_NPC)
 		safestrncpy(name, RFIFOCP(fd, 11 + NAME_LENGTH), NAME_LENGTH);
+	else if (RFIFOW(fd, 2) >= 11 + NAME_LENGTH + sizeof(refine_level))
+		refine_level = RFIFOL(fd, 11 + NAME_LENGTH);
 
-	clif_broadcast_obtain_special_item(name, RFIFOL(fd, 4), RFIFOW(fd, 8), (enum BROADCASTING_SPECIAL_ITEM_OBTAIN)type);
+	clif_broadcast_obtain_special_item(name, RFIFOL(fd, 4), RFIFOW(fd, 8), (enum BROADCASTING_SPECIAL_ITEM_OBTAIN)type, refine_level);
 }
 
 /*==========================================

--- a/src/map/intif.hpp
+++ b/src/map/intif.hpp
@@ -25,7 +25,7 @@ int32 intif_parse(int32 fd);
 
 int32 intif_broadcast( const char* mes, size_t len, int32 type );
 int32 intif_broadcast2( const char* mes, size_t len, unsigned long fontColor, int16 fontType, int16 fontSize, int16 fontAlign, int16 fontY );
-int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid, uint32 sourceid, unsigned char type);
+int32 intif_broadcast_obtain_special_item(map_session_data *sd, t_itemid nameid, uint32 sourceid, unsigned char type, uint32 refine_level = 0);
 int32 intif_broadcast_obtain_special_item_npc(map_session_data *sd, t_itemid nameid);
 int32 intif_main_message(map_session_data* sd, const char* message);
 

--- a/src/map/itemdb.cpp
+++ b/src/map/itemdb.cpp
@@ -3105,7 +3105,7 @@ void ItemGroupDatabase::pc_get_itemgroup_sub( map_session_data& sd, bool identif
 
 		if( flag == ADDITEM_SUCCESS ){
 			if( data->isAnnounced ){
-				intif_broadcast_obtain_special_item( &sd, data->nameid, sd.itemid, ITEMOBTAIN_TYPE_BOXITEM );
+				intif_broadcast_obtain_special_item( &sd, data->nameid, sd.itemid, ITEMOBTAIN_TYPE_BOXITEM, tmp.refine );
 			}
 		}else{
 			clif_additem( &sd, 0, 0, flag );


### PR DESCRIPTION
* **Addressed Issue(s)**: Fixes #10040

* **Server Mode**: Renewal

* **Description of Pull Request**:

Use the packet-specific header for item group announcements and include the awarded item refine level. Preserve the refine level when forwarding announcements between map servers.

Testing:
- git diff --check