### PR TITLE
Corrected the name of the yml field in doc and db folders vs usage

### DIFF
--- a/db/enchantgrade.yml
+++ b/db/enchantgrade.yml
@@ -45,7 +45,7 @@
 #               Item                    Required item.
 #               Amount                  Amount of required item. (Default: 1)
 #                                       Set to 0 to remove an option.
-#               Price                   Amount of zeny required. (Default: 0)
+#               Zeny                    Amount of zeny required. (Default: 0)
 #               BreakingRate            Chance of item breaking out of 0~10000. (Default: 0)
 #               DowngradeAmount         Number of refine levels reduced on failure. (Default: 0)
 ###########################################################################

--- a/db/homunculus_db.yml
+++ b/db/homunculus_db.yml
@@ -22,7 +22,7 @@
 # Homunculus Settings
 #
 ###########################################################################
-# - BaseClass               Base class.
+# - Class                   Base class.
 #   Name                    Name of homunculus.
 #   EvolutionClass          Evolution class.
 #   Food                    Homunculus food item. (Default: Pet_Food)

--- a/db/import-tmpl/enchantgrade.yml
+++ b/db/import-tmpl/enchantgrade.yml
@@ -45,7 +45,7 @@
 #               Item                    Required item.
 #               Amount                  Amount of required item. (Default: 1)
 #                                       Set to 0 to remove an option.
-#               Price                   Amount of zeny required. (Default: 0)
+#               Zeny                    Amount of zeny required. (Default: 0)
 #               BreakingRate            Chance of item breaking out of 0~10000. (Default: 0)
 #               DowngradeAmount         Number of refine levels reduced on failure. (Default: 0)
 ###########################################################################

--- a/db/import-tmpl/homunculus_db.yml
+++ b/db/import-tmpl/homunculus_db.yml
@@ -22,7 +22,7 @@
 # Homunculus Settings
 #
 ###########################################################################
-# - BaseClass               Base class.
+# - Class                   Base class.
 #   Name                    Name of homunculus.
 #   EvolutionClass          Evolution class.
 #   Food                    Homunculus food item. (Default: Pet_Food)

--- a/db/pre-re/homunculus_db.yml
+++ b/db/pre-re/homunculus_db.yml
@@ -22,7 +22,7 @@
 # Homunculus Settings
 #
 ###########################################################################
-# - BaseClass               Base class.
+# - Class                   Base class.
 #   Name                    Name of homunculus.
 #   EvolutionClass          Evolution class.
 #   Food                    Homunculus food item. (Default: Pet_Food)

--- a/db/re/achievement_db.yml
+++ b/db/re/achievement_db.yml
@@ -1788,7 +1788,7 @@ Body:
     Group: Chatting
     Name: Who made the king
     Rewards:
-      TitleID: 1046
+      TitleId: 1046
     Score: 10
   - Id: 170000
     Group: Chatting

--- a/db/re/enchantgrade.yml
+++ b/db/re/enchantgrade.yml
@@ -45,7 +45,7 @@
 #               Item                    Required item.
 #               Amount                  Amount of required item. (Default: 1)
 #                                       Set to 0 to remove an option.
-#               Price                   Amount of zeny required. (Default: 0)
+#               Zeny                    Amount of zeny required. (Default: 0)
 #               BreakingRate            Chance of item breaking out of 0~10000. (Default: 0)
 #               DowngradeAmount         Number of refine levels reduced on failure. (Default: 0)
 ###########################################################################

--- a/db/re/homunculus_db.yml
+++ b/db/re/homunculus_db.yml
@@ -22,7 +22,7 @@
 # Homunculus Settings
 #
 ###########################################################################
-# - BaseClass               Base class.
+# - Class                   Base class.
 #   Name                    Name of homunculus.
 #   EvolutionClass          Evolution class.
 #   Food                    Homunculus food item. (Default: Pet_Food)

--- a/db/re/item_combos.yml
+++ b/db/re/item_combos.yml
@@ -30958,8 +30958,8 @@ Body:
     Script: |
       bonus2 bResEff,Eff_Confusion,10000;
       skill "AM_CP_HELM",5;
-    UnEquipScript: |
-      sc_end SC_CP_HELM;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_CP_HELM;
   - Combos:
       - Combo:
           - ILL_Kraken_Card    # 300151
@@ -33374,8 +33374,8 @@ Body:
       bonus2 bSkillCooldown,"WL_TELEKINESIS_INTENSE",-120000;
       bonus2 bSkillAtk,"WL_CRIMSONROCK",BaseLevel/3;
       bonus2 bSkillAtk,"WL_SOULEXPANSION",BaseLevel/3;
-    UnEquipScript: |
-      sc_end SC_TELEKINESIS_INTENSE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_TELEKINESIS_INTENSE;
   - Combos:
       - Combo:
           - Noblesse_oblige    # 490206
@@ -33405,8 +33405,8 @@ Body:
     Script: |
       skill "RA_UNLIMIT",5;
       bonus2 bSkillAtk,"WM_SEVERE_RAINSTORM_MELEE",BaseLevel/2;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - CannonConverter_TW    # 32259
@@ -34729,8 +34729,8 @@ Body:
       .@r = getequiprefinerycnt(EQI_GARMENT);
       if (eaclass()&EAJL_THIRD && BaseJob == Job_Hunter)
          bonus2 bSkillCooldown,"RA_UNLIMIT",-18000;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - aegis_29725    # 29725
@@ -35035,8 +35035,8 @@ Body:
       .@r = getequiprefinerycnt(EQI_HEAD_TOP);
       if (eaclass()&EAJL_THIRD && BaseJob == Job_Wizard)
          bonus2 bSkillCooldown,"WL_TELEKINESIS_INTENSE",-8000*.@r;
-    UnEquipScript: |
-      sc_end  SC_TELEKINESIS_INTENSE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_TELEKINESIS_INTENSE;
   - Combos:
       - Combo:
           - aegis_29725    # 29725
@@ -35070,8 +35070,8 @@ Body:
          bonus bMatkRate,15;
          bonus2 bSkillCooldown,"WL_TELEKINESIS_INTENSE",-75000;
       }
-    UnEquipScript: |
-      sc_end SC_TELEKINESIS_INTENSE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_TELEKINESIS_INTENSE;
   - Combos:
       - Combo:
           - aegis_29725    # 29725
@@ -37919,8 +37919,8 @@ Body:
     Script: |
       bonus2 bAddEle,Ele_All,15;
       bonus2 bSkillCooldown,"RA_UNLIMIT",-45000;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Water_Sprits_Armor    # 2346
@@ -40081,8 +40081,8 @@ Body:
           - aegis_311439    # 311439
     Script: |
       skill "RA_CAMOUFLAGE",5;
-    UnEquipScript: |
-      sc_end SC_CAMOUFLAGE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_CAMOUFLAGE;
   - Combos:
       - Combo:
           - Bone_Detale_Card    # 300021
@@ -48243,8 +48243,8 @@ Body:
     Script: |
       bonus2 bSkillCooldown,"WL_CRIMSONROCK",-100;
       bonus2 bSkillCooldown,"WL_TELEKINESIS_INTENSE",-185000;
-    UnEquipScript: |
-      sc_end SC_TELEKINESIS_INTENSE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_TELEKINESIS_INTENSE;
   - Combos:
       - Combo:
           - Hero    # 29509
@@ -48252,8 +48252,8 @@ Body:
     Script: |
       bonus2 bSkillCooldown,"RA_ARROWSTORM",-200;
       bonus2 bSkillCooldown,"RA_UNLIMIT",-240000;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Hero    # 29509
@@ -48309,8 +48309,8 @@ Body:
           - aegis_312841    # 312841
     Script: |
       autobonus3 "{}",30,100,"SC_TRIANGLESHOT","{ sc_start SC_UNLIMIT,20000,5; }";
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Hero    # 29509
@@ -49453,8 +49453,8 @@ Body:
          bonus2 bSkillUseSPrate,"WM_SEVERE_RAINSTORM",60;
          bonus2 bSkillCooldown,"WM_SEVERE_RAINSTORM",-2000;
       }
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Old_Camo_RabbitHood    # 18984
@@ -50592,8 +50592,8 @@ Body:
           - aegis_313318    # 313318
     Script: |
       bonus2 bSkillCooldown,"WL_TELEKINESIS_INTENSE",-75000;
-    UnEquipScript: |
-      sc_end SC_TELEKINESIS_INTENSE;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_TELEKINESIS_INTENSE;
   - Combos:
       - Combo:
           - Tendrilion_Card    # 4463
@@ -50708,8 +50708,8 @@ Body:
     Script: |
       if ((eaclass()&EAJL_FOURTH) && (BaseJob == Job_Bard || BaseJob == Job_Dancer))
          skill "RA_UNLIMIT",5;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Hero    # 29509
@@ -50734,8 +50734,8 @@ Body:
           - aegis_313301    # 313301
     Script: |
       bonus2 bSkillCooldown,"RA_UNLIMIT",-60000;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Hero    # 29509
@@ -50787,8 +50787,8 @@ Body:
     Script: |
       if (eaclass()&EAJL_FOURTH && BaseJob == Job_Rogue)
          skill "RA_UNLIMIT",5;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Release_Of_Magic    # 29371
@@ -51724,8 +51724,8 @@ Body:
     Script: |
       autobonus3 "{}",50,100,"WH_HAWKBOOMERANG","{ sc_start SC_UNLIMIT,20000,5; }";
       autobonus3 "{}",50,100,"WH_HAWKRUSH","{ sc_start SC_UNLIMIT,20000,5; }";
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Release_Of_Magic    # 29371
@@ -51980,8 +51980,8 @@ Body:
       bonus bNoCastCancel;
       bonus5 bAutoSpell,"NPC_WIDESLEEP",2,50,BF_MAGIC,1;
       bonus5 bAutoSpell,"RA_UNLIMIT",3,50,BF_WEAPON,0;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Grand_Pere_Card    # 27106
@@ -52446,8 +52446,8 @@ Body:
     Script: |
       bonus2 bAddSize,Size_All,25;
       bonus2 bSkillCooldown,"RK_IGNITIONBREAK",-1000;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Real_Katrinn_Card    # 4686
@@ -52455,8 +52455,8 @@ Body:
     Script: |
       bonus2 bMagicAddSize,Size_All,25;
       bonus2 bSkillCooldown,"WL_CRIMSONROCK",-1500;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Real_Magaleta_Card    # 4685
@@ -52464,8 +52464,8 @@ Body:
     Script: |
       bonus2 bMagicAddSize,Size_All,25;
       bonus2 bSkillCooldown,"AB_ADORAMUS",-1000;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Real_Eremes_Card    # 4684
@@ -52473,8 +52473,8 @@ Body:
     Script: |
       bonus2 bAddSize,Size_All,25;
       bonus2 bSkillCooldown,"GC_DARKCROW",-10000;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Real_Shecil_Card    # 4687
@@ -52482,8 +52482,8 @@ Body:
     Script: |
       bonus2 bAddSize,Size_All,25;
       bonus2 bSkillCooldown,"RA_ARROWSTORM",-1500;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Real_Harword_Card    # 4688
@@ -52491,8 +52491,8 @@ Body:
     Script: |
       bonus2 bAddSize,Size_All,25;
       bonus2 bSkillCooldown,"NC_AXETORNADO",-2000;
-    UnEquipScript: |
-      heal 0,-2000;
+#   UnEquipScript: |     # TODO: field not supported
+#     heal 0,-2000;
   - Combos:
       - Combo:
           - Raven_Of_Tomb    # 410136
@@ -52556,8 +52556,8 @@ Body:
       bonus2 bSubEle,Ele_All,30;
       bonus2 bAddRace,RC_All,4*(.@r/2);
       bonus2 bSkillAtk,"SC_TRIANGLESHOT",10*(.@r/2);
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Old_Driver_Band_R    # 18973
@@ -56090,8 +56090,8 @@ Body:
       bonus bAspd,1;
       bonus5 bAutoSpell,"RA_UNLIMIT",1,20,BF_LONG,0;
       bonus2 bSkillAtk,"ASC_BREAKER",10*(getequiprefinerycnt(EQI_HAND_R)/3);
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Mercenary_Ring_A    # 28425
@@ -56695,8 +56695,8 @@ Body:
       bonus bNoCastCancel;
       bonus5 bAutoSpell,"NPC_WIDESLEEP",2,50,BF_MAGIC,1;
       bonus5 bAutoSpell,"RA_UNLIMIT",3,50,BF_LONG,0;
-    UnEquipScript: |
-      sc_end SC_UNLIMIT;
+#   UnEquipScript: |     # TODO: field not supported
+#     sc_end SC_UNLIMIT;
   - Combos:
       - Combo:
           - Thanos_Dagger    # 13093

--- a/db/re/stylist.yml
+++ b/db/re/stylist.yml
@@ -139,28 +139,28 @@ Body:
         Value: 7
         CostsHuman:
             Price: 100000
-        CostDoram:
+        CostsDoram:
             RequiredItem: J_Shop_Coupon2
             RequiredItemBox: J_Shop_Coupon2
       - Index: 8
         Value: 8
         CostsHuman:
             Price: 100000
-        CostDoram:
+        CostsDoram:
             RequiredItem: J_Shop_Coupon2
             RequiredItemBox: J_Shop_Coupon2
       - Index: 9
         Value: 9
         CostsHuman:
             Price: 100000
-        CostDoram:
+        CostsDoram:
             RequiredItem: J_Shop_Coupon2
             RequiredItemBox: J_Shop_Coupon2
       - Index: 10
         Value: 10
         CostsHuman:
             Price: 100000
-        CostDoram:
+        CostsDoram:
             RequiredItem: J_Shop_Coupon2
             RequiredItemBox: J_Shop_Coupon2
       - Index: 11

--- a/doc/yaml/db/castle_db.yml
+++ b/doc/yaml/db/castle_db.yml
@@ -9,4 +9,11 @@
 #   Map               Map name to be considered as the castle map.
 #   Name              Name of the castle (used by scripts and guardian name tags).
 #   Npc               NPC unique name to invoke ::OnGuildBreak on, when a occupied castle is abandoned during guild break.
+#   Type              The WoE type this castle belongs to. (Default: First_Edition)
+#   ClientId          Client side ID of the castle. (Default: 0)
+#   WarpEnabled       If the warp to the castle is enabled. (Default: false)
+#   WarpX             X coordinate to warp to. (Default: 0)
+#   WarpY             Y coordinate to warp to. (Default: 0)
+#   WarpCost          Zeny cost to use the warp. (Default: 100)
+#   WarpCostSiege     Zeny cost to use the warp during WoE. (Default: 100000)
 ###########################################################################

--- a/doc/yaml/db/enchantgrade.yml
+++ b/doc/yaml/db/enchantgrade.yml
@@ -28,7 +28,7 @@
 #               Item                    Required item.
 #               Amount                  Amount of required item. (Default: 1)
 #                                       Set to 0 to remove an option.
-#               Price                   Amount of zeny required. (Default: 0)
+#               Zeny                    Amount of zeny required. (Default: 0)
 #               BreakingRate            Chance of item breaking out of 0~10000. (Default: 0)
 #               DowngradeAmount         Number of refine levels reduced on failure. (Default: 0)
 ###########################################################################

--- a/doc/yaml/db/homunculus_db.yml
+++ b/doc/yaml/db/homunculus_db.yml
@@ -5,7 +5,7 @@
 # Homunculus Settings
 #
 ###########################################################################
-# - BaseClass               Base class.
+# - Class                   Base class.
 #   Name                    Name of homunculus.
 #   EvolutionClass          Evolution class.
 #   Food                    Homunculus food item. (Default: Pet_Food)


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: N/A

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: both

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

Content
---------------------------------------
Correction of block names in the doc and db for yaml files.

For example:
`UnEquipScript` is now commented in `item_combos.yml` (block not supported).
`BaseClass` is in the doc of homonculus db but the field name should be `Class`.
..

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
