### PR TITLE
6th rebalance - Shinkiro & Shiranui - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -44010,6 +44010,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -3
+    GiveAp: 1
     Element: Weapon
     SplashArea: 2
     ActiveInstance: 13
@@ -44102,6 +44103,7 @@ Body:
     Range: 1
     Hit: Multi_Hit
     HitCount: -3
+    GiveAp: 1
     Element: Weapon
     DamageFlags:
       IgnoreFlee: true
@@ -44152,6 +44154,7 @@ Body:
     Range: 1
     Hit: Single
     HitCount: 1
+    GiveAp: 1
     Element: Weapon
     DamageFlags:
       Splash: true
@@ -44205,6 +44208,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -3
     ActiveInstance: 7
+    GiveAp: 1
     Element: Fire
     DamageFlags:
       Splash: true
@@ -44266,6 +44270,7 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -6
+    GiveAp: 1
     Element: Water
     DamageFlags:
       Splash: true
@@ -44328,6 +44333,7 @@ Body:
     Hit: Multi_Hit
     HitCount: -2
     ActiveInstance: 13
+    GiveAp: 1
     Element: Wind
     DamageFlags:
       Splash: true
@@ -44389,6 +44395,7 @@ Body:
     Range: 9
     Hit: Single
     HitCount: 1
+    GiveAp: 1
     Element: Earth
     DamageFlags:
       Splash: true

--- a/src/map/skills/ninja/darkdragonnightmare.cpp
+++ b/src/map/skills/ninja/darkdragonnightmare.cpp
@@ -19,7 +19,7 @@ void SkillDarkDragonNightmare::applyAdditionalEffects(block_list *src, block_lis
 void SkillDarkDragonNightmare::calculateSkillRatio(const Damage *wd, const block_list *src, const block_list *target, uint16 skill_lv, int32 &skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 15500 * skill_lv;
+	skillratio += -100 + 17500 * skill_lv;
 	skillratio += 5 * sstatus->spl;
 	RE_LVL_DMOD(100);
 }

--- a/src/map/skills/ninja/kunainightmare.cpp
+++ b/src/map/skills/ninja/kunainightmare.cpp
@@ -20,7 +20,8 @@ void SkillKunaiNightmare::calculateSkillRatio(const Damage *wd, const block_list
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change *tsc = status_get_sc(target);
 
-	skillratio += -100 + 22500 + 5 * sstatus->pow;
+	skillratio += -100 + 22500;
+	skillratio += 5 * sstatus->pow;
 
 	if( tsc != nullptr && tsc->getSCE( SC_NIGHTMARE ) != nullptr ){
 		skillratio += skillratio / 2;

--- a/src/map/skills/ninja/kunainightmare.cpp
+++ b/src/map/skills/ninja/kunainightmare.cpp
@@ -20,7 +20,7 @@ void SkillKunaiNightmare::calculateSkillRatio(const Damage *wd, const block_list
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change *tsc = status_get_sc(target);
 
-	skillratio += -100 + 18000 + 5 * sstatus->pow;
+	skillratio += -100 + 22500 + 5 * sstatus->pow;
 
 	if( tsc != nullptr && tsc->getSCE( SC_NIGHTMARE ) != nullptr ){
 		skillratio += skillratio / 2;

--- a/src/map/skills/ninja/kunairefraction.cpp
+++ b/src/map/skills/ninja/kunairefraction.cpp
@@ -17,7 +17,7 @@ void SkillKunaiRefraction::calculateSkillRatio(const Damage *wd, const block_lis
 	const status_data* sstatus = status_get_status_data(*src);
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 
-	skillratio += -100 + 250 + 420 * skill_lv;
+	skillratio += -100 + 300 + 450 * skill_lv;
 	skillratio += pc_checkskill( sd, SS_KUNAIKAITEN ) * 10 * skill_lv;
 	skillratio += 5 * sstatus->pow;
 	RE_LVL_DMOD(100);

--- a/src/map/skills/ninja/kunairotation.cpp
+++ b/src/map/skills/ninja/kunairotation.cpp
@@ -15,7 +15,7 @@ void SkillKunaiRotation::calculateSkillRatio(const Damage *wd, const block_list 
 	const status_data* sstatus = status_get_status_data(*src);
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 
-	skillratio += -100 + 950 + 1050 * skill_lv;
+	skillratio += -100 + 1000 + 1350 * skill_lv;
 	skillratio += pc_checkskill( sd, SS_KUNAIWAIKYOKU ) * 100 * skill_lv;
 	skillratio += 5 * sstatus->pow;
 	RE_LVL_DMOD(100);

--- a/src/map/skills/ninja/shadownightmare.cpp
+++ b/src/map/skills/ninja/shadownightmare.cpp
@@ -20,7 +20,7 @@ void SkillShadowNightmare::calculateSkillRatio(const Damage *wd, const block_lis
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change *tsc = status_get_sc(target);
 
-	skillratio += -100 + 18000 + 5 * sstatus->pow;
+	skillratio += -100 + 22500 + 5 * sstatus->pow;
 
 	if( tsc != nullptr && tsc->getSCE( SC_NIGHTMARE ) != nullptr ){
 		skillratio += skillratio / 2;

--- a/src/map/skills/ninja/shadownightmare.cpp
+++ b/src/map/skills/ninja/shadownightmare.cpp
@@ -20,7 +20,8 @@ void SkillShadowNightmare::calculateSkillRatio(const Damage *wd, const block_lis
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change *tsc = status_get_sc(target);
 
-	skillratio += -100 + 22500 + 5 * sstatus->pow;
+	skillratio += -100 + 22500;
+	skillratio += 5 * sstatus->pow;
 
 	if( tsc != nullptr && tsc->getSCE( SC_NIGHTMARE ) != nullptr ){
 		skillratio += skillratio / 2;


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->


Skipped (already implemented)
----------------------------------------
Shadow Flash
- Applies AP recovery rate by 1.


Updated
----------------------------------------
Huuma Shuriken - Construct
- Applies AP recovery rate by 1.

Red Flame Cannon / Cold Blooded Cannon / Thundering Cannon / Golden Dragon Cannon
- Applies AP recovery rate by 1.

Kunai - Rotation
- Applies AP recovery rate by 1.
- Increases base damage from 6200% ATK to 7750% ATK per hit based on level 5.

Kunai - Refraction
- Applies AP recovery rate by 1.
- Increases base damage from 4450% ATK to 4800% ATK per hit based on level 10.

Kunai - Nightmare
- Increases base damage from 18000% ATK to 22500% ATK based on level 1.

Shadow - Nightmare
- Increases base damage from 18000% ATK to 22500% ATK based on level 1.

Dark Dragon - Nightmare
- Increases base damage from 15500% MATK to 17500% MATK based on level 1.

Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
