### PR TITLE
6th rebalance - Spirit Handler - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -40896,7 +40896,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Critical: true
-    Range: -11
+    Range: -9
     Hit: Multi_Hit
     HitCount: -2
     GiveAp: 1
@@ -41283,7 +41283,7 @@ Body:
     MaxLevel: 7
     Type: Magic
     TargetType: Attack
-    Range: -11
+    Range: -9
     GiveAp: 1
     Hit: Single
     HitCount: 1
@@ -41320,18 +41320,18 @@ Body:
     FixedCastTime: 1500
     Duration1:
       - Level: 1
-        Time: 30000
-      - Level: 2
         Time: 60000
-      - Level: 3
+      - Level: 2
         Time: 90000
+      - Level: 3
+        Time: 120000
       - Level: 4
-        Time: 12000
-      - Level: 5
         Time: 150000
+      - Level: 5
+        Time: 180000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 125
     Status: Temporary_Communion
   - Id: 5448
     Name: SH_BLESSING_OF_MYSTICAL_CREATURES
@@ -44818,7 +44818,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Critical: true
-    Range: 7
+    Range: 9
     Hit: Multi_Hit
     HitCount: 5
     GiveAp: 1
@@ -44839,7 +44839,7 @@ Body:
       - Level: 7
         Area: 3
     CastCancel: true
-    AfterCastActDelay: 1000
+    AfterCastActDelay: 700
     Cooldown: 700
     FixedCastTime: 1000
     Requires:

--- a/src/map/skills/summoner/chulhobattering.cpp
+++ b/src/map/skills/summoner/chulhobattering.cpp
@@ -16,7 +16,7 @@ void SkillChulhoBattering::calculateSkillRatio(const Damage *wd, const block_lis
 	const status_data* sstatus = status_get_status_data(*src);
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 
-	skillratio += -100 + 480 + 160 * skill_lv;
+	skillratio += -100 + 550 + 250 * skill_lv;
 	skillratio += 70 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 	skillratio += 5 * sstatus->pow;
 	RE_LVL_DMOD(100);

--- a/src/map/skills/summoner/chulhosonicclaw.cpp
+++ b/src/map/skills/summoner/chulhosonicclaw.cpp
@@ -17,12 +17,12 @@ void SkillChulhoSonicClaw::calculateSkillRatio(const Damage *wd, const block_lis
 	const status_change *sc = status_get_sc(src);
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 
-	skillratio += -100 + 1100 + 2200 * skill_lv;
+	skillratio += -100 + 1450 + 2650 * skill_lv;
 	skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 	skillratio += 5 * sstatus->pow;
 
 	if( pc_checkskill( sd, SH_COMMUNE_WITH_CHUL_HO ) > 0 || ( sc != nullptr && sc->getSCE( SC_TEMPORARY_COMMUNION ) != nullptr ) ){
-		skillratio += 400 * skill_lv;
+		skillratio += -50 + 350 * skill_lv;
 		skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 	}
 	RE_LVL_DMOD(100);

--- a/src/map/skills/summoner/hyunrokcannon.cpp
+++ b/src/map/skills/summoner/hyunrokcannon.cpp
@@ -17,12 +17,12 @@ void SkillHyunrokCannon::calculateSkillRatio(const Damage *wd, const block_list 
 	const status_change *sc = status_get_sc(src);
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 
-	skillratio += -100 + 1100 + 2050 * skill_lv;
+	skillratio += -100 + 1450 + 2250 * skill_lv;
 	skillratio += 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 	skillratio += 5 * sstatus->spl;
 
 	if( pc_checkskill( sd, SH_COMMUNE_WITH_HYUN_ROK ) > 0 || ( sc != nullptr && sc->getSCE( SC_TEMPORARY_COMMUNION ) != nullptr ) ){
-		skillratio += 400 * skill_lv;
+		skillratio += 450 * skill_lv;
 		skillratio += 25 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 	}
 	RE_LVL_DMOD(100);


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Chulho Sonic Claw
- Reduces cast range from 11 cells to 9 cells.
- Increases base damage from 16500% ATK to 20000% ATK based on level 7.
- Increases base damage (Commune with Chulho) from 19300% ATK to 22400% ATK based on level 7.

Hyunrok Cannon
- Reduces cast range from 11 cells to 9 cells.
- Increases base damage from 15450% MATK to 17200% MATK based on level 7.
- Increases base damage (Commune with Hyunrok) from 18250% MATK to 20350% MATK based on level 7.

Chulho Battering
- Increases cast range from 7 cells to 9 cells.
- Reduces global cooldown from 1 second to 0.7 seconds base on level 7.
- Increases base damage from 1600% MATK to 2300% ATK per hit based on level 7.

Temporary Communion
- Reduces AP consumption from 150 to 125.
- Increases skill duration from 150 seconds to 180 seconds based on level 5.


Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/