### PR TITLE
6th rebalance - Imperial Guard - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -45311,7 +45311,7 @@ Body:
       - Level: 10
         Area: 3
     CastTime: 1000
-    AfterCastActDelay: 1200
+    AfterCastActDelay: 1000
     Cooldown: 700
     FixedCastTime: 1000
     Requires:

--- a/src/map/skills/swordman/imperialpressure.cpp
+++ b/src/map/skills/swordman/imperialpressure.cpp
@@ -16,7 +16,7 @@ void SkillImperialPressure::calculateSkillRatio(const Damage* wd, const block_li
 	const map_session_data* sd = BL_CAST(BL_PC, src);
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 5600 + 1850 * skill_lv;
+	skillratio += -100 + 3750 + 2650 * skill_lv;
 	skillratio += 7 * sstatus->spl;
 	skillratio += 50 * pc_checkskill(sd, IG_SPEAR_SWORD_M);
 	RE_LVL_DMOD(100);

--- a/src/map/skills/swordman/overslash.cpp
+++ b/src/map/skills/swordman/overslash.cpp
@@ -27,8 +27,8 @@ void SkillOverSlash::calculateSkillRatio(const Damage* wd, const block_list* src
 	const status_data* sstatus = status_get_status_data(*src);
 	int32 i;
 
-	skillratio += -100 + 220 * skill_lv;
-	skillratio += pc_checkskill(sd, IG_SPEAR_SWORD_M) * 50 * skill_lv;
+	skillratio += -100 + 260 * skill_lv;
+	skillratio += pc_checkskill(sd, IG_SPEAR_SWORD_M) * 60 * skill_lv;
 	skillratio += 7 * sstatus->pow;
 	RE_LVL_DMOD(100);
 	if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

Radiant Spear
- Reduces global cooldown from 1.2 seconds to 1 second.

Overslash
- Increases base damage from (2200 + (Spear & Sword Mastery skill level x 500))% ATK to (2600 + (Spear & Sword Mastery skill level x 600))% ATK per hit based on level 10.

Imperial Pressure
- Increases base damage from 14850% MATK to 17000% MATK based on level 5.


Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/