### PR TITLE
6th rebalance - Meister - Part 2

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -37845,7 +37845,7 @@ Body:
         Time: 300000
     Requires:
       SpCost: 150
-      ApCost: 150
+      ApCost: 125
     Status: Rush_Quake2
   - Id: 5297
     Name: MT_M_MACHINE
@@ -45434,15 +45434,15 @@ Body:
         Area: 3
     Cooldown:
       - Level: 1
-        Time: 2000
-      - Level: 2
         Time: 1750
-      - Level: 3
+      - Level: 2
         Time: 1500
-      - Level: 4
+      - Level: 3
         Time: 1250
-      - Level: 5
+      - Level: 4
         Time: 1000
+      - Level: 5
+        Time: 750
     Requires:
       SpCost:
         - Level: 1
@@ -45486,15 +45486,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 62
+          Amount: 57
         - Level: 2
-          Amount: 64
+          Amount: 59
         - Level: 3
-          Amount: 66
+          Amount: 61
         - Level: 4
-          Amount: 68
+          Amount: 63
         - Level: 5
-          Amount: 70
+          Amount: 65
       Weapon:
         2hAxe: true
   - Id: 6508

--- a/src/map/skills/merchant/powerfulswing.cpp
+++ b/src/map/skills/merchant/powerfulswing.cpp
@@ -15,7 +15,7 @@ void SkillPowerfulSwing::calculateSkillRatio(const Damage* wd, const block_list*
 	const status_data* sstatus = status_get_status_data(*src);
 	const status_change* sc = status_get_sc(src);
 
-	skillratio += -100 + 300 + 850 * skill_lv;
+	skillratio += -100 + 300 + 880 * skill_lv;
 	skillratio += 5 * sstatus->pow; // !TODO: check POW ratio
 	if (sc && sc->getSCE(SC_AXE_STOMP))
 		skillratio += 100 + 100 * skill_lv;

--- a/src/map/skills/merchant/rushstrike.cpp
+++ b/src/map/skills/merchant/rushstrike.cpp
@@ -16,7 +16,7 @@ SkillRushStrike::SkillRushStrike() : SkillImplRecursiveDamageSplash(MT_RUSH_STRI
 void SkillRushStrike::calculateSkillRatio(const Damage* wd, const block_list* src, const block_list* target, uint16 skill_lv, int32& skillratio, int32 mflag) const {
 	const status_data* sstatus = status_get_status_data(*src);
 
-	skillratio += -100 + 3500 * skill_lv;
+	skillratio += -100 + 650 + 3750 * skill_lv;
 	skillratio += 5 * sstatus->pow; // !TODO: check POW ratio
 	RE_LVL_DMOD(100);
 }


### PR DESCRIPTION

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->

Rush Strike
- Reduces skill cooldown from 1 second to 0.75 seconds based on level 5.
- Increases base damage from 17500% ATK to 19400% ATK based on level 5.

Powerful Swing
- Reduces SP consumption from 70 to 65 based on level 5.
- Increases base damage from 4550% ATK to 4700% ATK per hit based on level 5.
- Increases base damage (Axe Stomp) from 5150% ATK to 5300% ATK per hit based on level 5.

Rush Quake
- Reduces AP consumption from 150 to 125.


Informations
----------------------------------------

https://ro.gnjoy.com/news/devnote/View.asp?category=1&seq=4197956&curpage=1
https://ro.gnjoy.com/news/notice/View.asp?BBSMode=10001&seq=8224&curpage=1
https://www.divine-pride.net/forum/index.php?/topic/3723-kro-jobs-improvement-project/page/15/
