### PR TITLE
Fixed drop bonus attribution and autoloot gating on homunculus / mercenary kills

### DIFF
--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -2577,9 +2577,11 @@ static TIMER_FUNC(mob_delay_item_drop) {
  * Sets the item_drop into the item_drop_list.
  * Also performs logging and autoloot if enabled.
  * rate is the drop-rate of the item, required for autoloot.
- * flag : Killed only by homunculus/mercenary?
+ * slavekilltypes : bitmask of AI slave types (BL_HOM|BL_MER) that killed the mob
+ * with no other damage source involved - each participating type must have its
+ * autoloot battle config enabled for the drop to be autolooted.
  *------------------------------------------*/
-static void mob_item_drop(mob_data *md, std::shared_ptr<s_item_drop_list>& dlist, std::shared_ptr<s_item_drop>& ditem, int32 loot, int32 drop_rate, bool flag)
+static void mob_item_drop(mob_data *md, std::shared_ptr<s_item_drop_list>& dlist, std::shared_ptr<s_item_drop>& ditem, int32 loot, int32 drop_rate, int32 slavekilltypes)
 {
 	TBL_PC* sd;
 	bool test_autoloot;
@@ -2591,7 +2593,9 @@ static void mob_item_drop(mob_data *md, std::shared_ptr<s_item_drop_list>& dlist
 	if( sd == nullptr ) sd = map_charid2sd(dlist->third_charid);
 	test_autoloot = sd 
 		&& (drop_rate <= sd->state.autoloot || pc_isautolooting(sd, ditem->item_data.nameid))
-		&& (flag ? ((battle_config.homunculus_autoloot ? (battle_config.hom_idle_no_share == 0 || !pc_isidle_hom(sd)) : 0) || (battle_config.mercenary_autoloot ? (battle_config.mer_idle_no_share == 0 || !pc_isidle_mer(sd)) : 0)) :
+		&& (slavekilltypes ?
+			( !(slavekilltypes&BL_HOM) || (battle_config.homunculus_autoloot && (battle_config.hom_idle_no_share == 0 || !pc_isidle_hom(sd))) ) &&
+			( !(slavekilltypes&BL_MER) || (battle_config.mercenary_autoloot && (battle_config.mer_idle_no_share == 0 || !pc_isidle_mer(sd))) ) :
 			(battle_config.idle_no_autoloot == 0 || DIFF_TICK(last_tick, sd->idletime) < battle_config.idle_no_autoloot));
 #ifdef AUTOLOOT_DISTANCE
 		test_autoloot = test_autoloot && sd->m == md->m
@@ -2673,6 +2677,7 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 {
 	uint32 char_id = 0;
 	int32 flag = MDLF_NORMAL;
+	bool mer_dmg = ( src->type == BL_MER );
 
 	if( damage < 0 )
 		return; //Do nothing for absorbed damage.
@@ -2750,6 +2755,8 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 			// Just add damage to it
 			entry.dmg = util::safe_addition_cap(entry.dmg, damage, INT64_MAX);
 			entry.dmg_tanked = util::safe_addition_cap(entry.dmg_tanked, damage_tanked, INT64_MAX);
+			entry.pc_dmg |= !mer_dmg;
+			entry.mer_dmg |= mer_dmg;
 			return;
 		}
 	}
@@ -2767,6 +2774,8 @@ void mob_log_damage(mob_data* md, block_list* src, int64 damage, int64 damage_ta
 	dmg.flag = flag;
 	dmg.dmg = damage;
 	dmg.dmg_tanked = damage_tanked;
+	dmg.pc_dmg = !mer_dmg;
+	dmg.mer_dmg = mer_dmg;
 
 	md->dmglog.push_back( dmg );
 }
@@ -2946,7 +2955,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 	int32 i, temp, count, m = md->m;
 	int32 dmgbltypes = 0;  // bitfield of all bl types, that caused damage to the mob and are elligible for exp distribution
 	t_tick tick = gettick();
-	bool rebirth, homkillonly, merckillonly;
+	bool rebirth, homkillonly;
 
 	status = &md->status;
 
@@ -3008,7 +3017,10 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 
 		switch( entry.flag ){
 			case MDLF_NORMAL:
-				dmgbltypes |= BL_PC;
+				if( entry.pc_dmg )
+					dmgbltypes |= BL_PC;
+				if( entry.mer_dmg )
+					dmgbltypes |= BL_MER;
 				break;
 			case MDLF_HOMUN:
 				// Skip homunculus' share if inactive
@@ -3064,8 +3076,8 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 
 	// determines, if the monster was killed by homunculus' damage only
 	homkillonly = (bool)( ( dmgbltypes&BL_HOM ) && !( dmgbltypes&~BL_HOM ) );
-	// determines if the monster was killed by mercenary damage only
-	merckillonly = (bool)((dmgbltypes & BL_MER) && !(dmgbltypes & ~BL_MER));
+	// Bitmask of AI slave types (BL_HOM|BL_MER) that killed the mob with no other damage source involved
+	int32 slavekilltypes = ( dmgbltypes&~(BL_HOM|BL_MER) ) ? 0 : ( dmgbltypes&(BL_HOM|BL_MER) );
 
 	// Determine MVP (need to do it here so that it's not influenced by first attacker bonus below)
 	map_session_data* mvp_sd = md->get_mvp_player(first_sd);
@@ -3244,7 +3256,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 	if (md->lootitems) {
 		for (i = 0; i < md->lootitem_count; i++) {
 			std::shared_ptr<s_item_drop> ditem = mob_setlootitem(md->lootitems[i], md->mob_id);
-			mob_item_drop(md, lootlist, ditem, 1, 10000, homkillonly || merckillonly);
+			mob_item_drop(md, lootlist, ditem, 1, 10000, slavekilltypes);
 		}
 	}
 
@@ -3307,7 +3319,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 
 					std::shared_ptr<s_item_drop> ditem = mob_setdropitem(mobdrop, 1, md->mob_id);
 
-					mob_item_drop(md, dlist, ditem, 0, mobdrop->rate, homkillonly || merckillonly);
+					mob_item_drop(md, dlist, ditem, 0, mobdrop->rate, slavekilltypes);
 				}
 			}
 
@@ -3351,7 +3363,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 			}
 			// Announce first, or else ditem will be freed. [Lance]
 			// By popular demand, use base drop rate for autoloot code. [Skotlex]
-			mob_item_drop(md, dlist, ditem, 0, battle_config.autoloot_adjust ? drop_rate : entry->rate, homkillonly || merckillonly);
+			mob_item_drop(md, dlist, ditem, 0, battle_config.autoloot_adjust ? drop_rate : entry->rate, slavekilltypes);
 		}
 
 		// Ore Discovery (triggers if owner has loot priority, does not require to be the killer)
@@ -3365,7 +3377,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 
 				std::shared_ptr<s_item_drop> ditem = mob_setdropitem(mobdrop, 1, md->mob_id);
 
-				mob_item_drop(md, dlist, ditem, 0, mobdrop->rate, homkillonly || merckillonly);
+				mob_item_drop(md, dlist, ditem, 0, mobdrop->rate, slavekilltypes);
 			}
 		}
 
@@ -3394,7 +3406,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 					// 'Cheat' for autoloot command: rate is changed from n/100000 to n/10000
 					int32 map_drops_rate = max(1, (final_rate / 10));
 					std::shared_ptr<s_item_drop> ditem = mob_setdropitem( it.second, 1, md->mob_id );
-					mob_item_drop( md, dlist, ditem, 0, map_drops_rate, homkillonly || merckillonly );
+					mob_item_drop( md, dlist, ditem, 0, map_drops_rate, slavekilltypes );
 				}
 			}
 
@@ -3415,7 +3427,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 						// 'Cheat' for autoloot command: rate is changed from n/100000 to n/10000
 						int32 map_drops_rate = max(1, (final_rate / 10));
 						std::shared_ptr<s_item_drop> ditem = mob_setdropitem( it.second, 1, md->mob_id );
-						mob_item_drop( md, dlist, ditem, 0, map_drops_rate, homkillonly || merckillonly );
+						mob_item_drop( md, dlist, ditem, 0, map_drops_rate, slavekilltypes );
 					}
 				}
 			}

--- a/src/map/mob.cpp
+++ b/src/map/mob.cpp
@@ -3268,10 +3268,10 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 		dlist->second_charid = (second_sd ? second_sd->status.char_id : 0);
 		dlist->third_charid = (third_sd ? third_sd->status.char_id : 0);
 
-		// These trigger for the killer of the monster
-		if(sd) {
+		// These trigger for the player who has the drop priority on the monster
+		if(first_sd) {
 			// process script-granted extra drop bonuses
-			for (const auto &it : sd->add_drop) {
+			for (const auto &it : first_sd->add_drop) {
 				if (!&it || (!it.nameid && !it.group))
 					continue;
 				if ((it.race < RC_NONE_ && it.race == -md->mob_id) || //Race < RC_NONE_, use mob_id
@@ -3312,10 +3312,10 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 			}
 
 			// process script-granted zeny bonus (get_zeny_num) [Skotlex]
-			if( sd->bonus.get_zeny_num && rnd()%100 < sd->bonus.get_zeny_rate ) {
-				i = sd->bonus.get_zeny_num > 0 ? sd->bonus.get_zeny_num : -md->level * sd->bonus.get_zeny_num;
+			if( first_sd->bonus.get_zeny_num && rnd()%100 < first_sd->bonus.get_zeny_rate ) {
+				i = first_sd->bonus.get_zeny_num > 0 ? first_sd->bonus.get_zeny_num : -md->level * first_sd->bonus.get_zeny_num;
 				if (!i) i = 1;
-				pc_getzeny(sd, 1+rnd()%i, LOG_TYPE_PICKDROP_MONSTER);
+				pc_getzeny(first_sd, 1+rnd()%i, LOG_TYPE_PICKDROP_MONSTER);
 			}
 		}
 
@@ -3329,7 +3329,7 @@ int32 mob_dead(mob_data *md, block_list *src, int32 type)
 			if (it == nullptr)
 				continue;
 
-			drop_rate = mob_getdroprate(src, md->db, entry->rate, drop_modifier, md);
+			drop_rate = mob_getdroprate(first_sd, md->db, entry->rate, drop_modifier, md);
 
 			// attempt to drop the item
 			if (rnd() % 10000 >= drop_rate)

--- a/src/map/mob.hpp
+++ b/src/map/mob.hpp
@@ -332,6 +332,10 @@ struct s_dmglog{
 	int64 dmg;
 	int64 dmg_tanked; //Damage tanked from normal attacks of the monster, MVP is the player with highest dmg+dmg_tanked
 	uint32 flag : 2; //0: Normal. 1: Homunc exp. 2: Pet exp
+	// Source types that contributed to a MDLF_NORMAL entry - mercenary damage is
+	// logged under the master's char_id and is indistinguishable by flag alone
+	uint32 pc_dmg : 1; // any non-mercenary contribution (master, master's summons)
+	uint32 mer_dmg : 1; // mercenary contribution
 };
 
 struct mob_data : public block_list {


### PR DESCRIPTION
* **Addressed Issue(s)**: none — I found no existing report of this, so there is
  no issue number to reference. Happy to open one if you would rather track it
  that way.

* **Server Mode**: Both. `src/map/mob.cpp` contains no `PRERE` conditional and
  the changed lines sit outside every `#ifdef`; the only renewal-specific code in
  this path is the `RENEWAL_DROP` rate maths inside `mob_getdroprate()`, which is
  untouched.

* **Description of Pull Request**:

  Drop bonuses (cards, Bubble Gum, VIP rate, `get_zeny_num`) are rolled for
  whoever landed the killing blow, while the item itself is given to the player
  with loot priority. When those are not the same player — a kill steal, or any
  kill finished by a homunculus or mercenary — the wrong inventory is read, or
  none at all. This aligns the roll with the ownership, and fixes the autoloot
  gating for slave kills along the way.

  I am reporting it as an inconsistency rather than asserting it is a regression:
  see "What I could not establish" below, I found nothing saying it was ever
  decided one way or the other.

  In `mob_dead()`, five lines apart:

  - **who owns the drop** — loot priority, `first_sd`;
  - **whose drop bonuses are rolled** — the killing blow, `sd`, which is only set
    when `src->type == BL_PC`.

  **Where this was observed:**

  | | |
  |---|---|
  | GitHub hash | `2fe6ab3d` — branched from it, and the control side of the A/B is a binary built from it |
  | Client date | `20211103`, matching the server's `PACKETVER` |
  | Mode | Pre-renewal for the measurements; the code is shared, see **Server Mode** above |
  | Local modifications | None to the source beyond this patch. The test fixtures live in the `db/import/` and `conf/import/` override layers and are listed in full under **Testing** |

  ## What a player sees today

  **A kill steal reads the wrong inventory.** Player A deals 99 % of the damage,
  player B lands the last hit. rAthena rolls **B's** drop-bonus cards, then
  reserves the item for **A**. If B carries no drop-bonus card, nothing is rolled
  at all and A's Mimic Card / Bubble Gum / VIP rate are ignored, even though A owns
  whatever drops. This is not specific to kill stealing: any time the finisher is
  not the priority holder, the wrong player is asked.

  **A slave killing blow rolls nothing at all.** With a homunculus, mercenary,
  elemental, pet or summoned monster landing the blow, `sd` is `nullptr` and the
  whole block is skipped — no `bonus2 bAddMonsterDropItem[Group]` card ever procs
  for the master, and `bonus.get_zeny_num` never pays out, while the loot is still
  reserved to them.

  **Drop-rate modifiers read the wrong character.** `mob_getdroprate()` receives
  the raw killer, so on a non-`BL_PC` blow its entire `BL_PC` block is skipped: no
  `SC_ITEMBOOST` (Bubble Gum), no VIP bonus, no `bDropAddRace`/`bDropAddClass`, no
  `drop_rate_cap`. Meanwhile `drops_by_luk` and `drops_by_luk2` sit *outside* that
  guard and read the **homunculus'** LUK.

  **Autoloot gating for slave kills is broken in three separate ways.**
  `mercenary_autoloot` has never had any effect — `merckillonly` is computed from
  `dmgbltypes & BL_MER`, but `mob_log_damage()` logs mercenary damage under the
  master's `char_id` as `MDLF_NORMAL` and `dmgbltypes` is never OR'd with
  `BL_MER`, so the bit cannot be set. The gate is also an `||`:

  ```c
  flag ? ((battle_config.homunculus_autoloot ? … : 0) || (battle_config.mercenary_autoloot ? … : 0)) : …
  ```

  so a 100 % **homunculus** kill autoloots when `mercenary_autoloot: yes` even
  with `homunculus_autoloot: no` — one setting overrides the other. And a
  mercenary assist clears `homkillonly` (its damage lands in the master's
  `MDLF_NORMAL` entry), so the kill takes the ordinary branch and autoloots even
  though the player never attacked.

  ## What I could establish

  **In the code.** Verifiable by any reviewer, no server needed:

  - `sd` is assigned only under `if (src && src->type == BL_PC)`, so it is
    `nullptr` for every non-player killing blow.
  - In the *same function*, drop ownership (`dlist->first_charid`), Ore Discovery
    and **both** map-drop `mob_getdroprate()` calls already resolve on `first_sd`.
    Only the two sites this PR changes still ask the killer.
  - rAthena already computes the officially-correct player: slave damage is
    aggregated into the master's loot total in `mob_dead()` (#9238), so `first_sd`
    on a homunculus kill *is* the master. It simply is not the one being asked.

  **From the official iRO forums.** Drop bonuses follow drop priority, not the
  last hit — twice, a year apart, from DrAzzy. Worth being precise about who that
  is, because it sets the weight of everything below: a **VMod**, i.e. a
  volunteer forum moderator with the badge shown under the name. Not a Gravity or
  WarpPortal employee, not a developer, and nothing indicates access to the
  server code. More weight than a random player, less than a developer statement.

  > "It's based on **who has drop priority** (or, almost certainly, who would have
  > drop priority, before accounting for things that transfer the drop priority
  > like item share)" — 2012-07-31

  > "bubble gum boosts drop rates based on who has drop priority (**No, not the
  > one who gets the last hit**)" — 2013-07-12

  A worked example on the same forums — posted by a player, not by staff, so worth
  less — matches: P1 hits for 40, P2 hits for 60 and kills; P1 keeps loot priority
  and P1's Bubble Gum is the one that counted.

  **By measurement, locally.** See "Testing" — an A/B on two binaries that differ
  only by this patch.

  ## What I could NOT establish

  Two gaps, stated plainly because they bound how much this PR proves.

  **1. No recorded justification for the current behaviour — in either
  direction.** I could not find anyone deciding that the bonus roll should follow
  the killer, and I could not find anyone calling it a mistake. What I looked at:

  - A case-insensitive `git log --all --grep` over the full history for
    `add_drop`, `bAddMonsterDropItem`, `killer`, `loot priority`, `drop priority`,
    `loot owner`, `drop bonus`, `homun`, `mercenar` — no commit discusses this
    gate from the priority holder's angle.
  - The commits that shaped the code. The `sd` → master remap further down
    `mob_dead()` arrives in the 2004 SVN import already *inside* the on-death
    event block, i.e. after the drops. `8c699742a` (2006) extends it to homunculi
    and its message scopes it explicitly to the on-death event and `killerrid`,
    saying nothing about drops. `5ad2ab7e2` (2012) adds `BL_ELEM` and moves
    quests, the TK mission and the mercenary kill counter *below* the remap.
    `f01a789` (#9238, 2025) merges slave damage for `first_sd` without touching
    `add_drop`.
  - The one comment that looks like a rationale is not one:
    `// These trigger for the killer of the monster` was added by #8846 (2024), in
    the very commit that pulled Ore Discovery *out* of that gate with the note
    *"Ore Discovery no longer requires you to be the killer, but you still need
    loot priority"*. It reads as a label for what was left behind, not as a
    decision to leave it there.
  - Hercules has the identical ordering, no explanatory comment either, and Ore
    Discovery still gated on the killer — no rationale there that rAthena lacks.
  - Of the recent loot-priority work (#9238, #9246, #9318, #9599) and #8846, none
    changes the bonus roll; they change how priority and MVP are *determined*. I
    found no existing report of this.

  So I am not claiming "this broke in commit X". I am claiming that nothing
  documents it as deliberate, and that three things point the other way: the
  surrounding code already resolves on `first_sd`, official sources describe the
  opposite rule, and the current outcome — roll B's cards, hand the item to A — is
  not a rule anyone would write down on purpose.

  **2. I could not test this on a live official server, and my sources are iRO,
  not kRO.** Two limitations stacked on each other, worth separating:

  - I have no active official account, no mercenary and no Alchemist with a
    homunculus, so nothing here was confirmed by my own observation on an
    official server. The official side of this PR rests entirely on the forum
    quotes above.
  - Those quotes are from the **iRO** forums, and from a volunteer moderator
    rather than a developer. iRO is an official service, but it is not kRO, and
    kRO is the reference. I have no kRO source saying the same thing, no
    developer statement on either service, and I cannot rule out that the two
    differ on this point.

  So the honest ceiling of the official argument is: *this is what a badged
  volunteer moderator on the official iRO forums described, twice, a year
  apart.* If someone can check it on either service —
  a homunculus or mercenary kill with a drop-bonus card equipped, or with Bubble
  Gum active — that is the piece I am missing, and if it contradicts the quotes
  this PR should be reconsidered rather than merged.

  One thing that looks like counter-evidence, and is not: the "Bubble Gum doesn't
  work on homunculus kills" belief that circulates traces back to a single 2014
  forum post by a player, in a thread where DrAzzy replies *"Was this ever
  tested? I don't remember anyone doing the legwork of testing it."*

  ## The proposed fix

  **Commit 1 — `+7 −7`.** Three `sd` → `first_sd` substitutions in `mob_dead()`:
  the `add_drop` loop, the `get_zeny_num` block below it, and the
  `mob_getdroprate()` call for the monster's own drop table. This is what the rest
  of the same function already does.

  **Commit 2 — `+29 −13`.** `s_dmglog` already carries a `uint32` holding a 2-bit
  `flag`; two spare bits in that same word (`pc_dmg`, `mer_dmg`) record which
  source types contributed to a `MDLF_NORMAL` entry, so mercenary damage stops
  being indistinguishable from the master's own. `sizeof(s_dmglog)` does not
  change and no dmglog entry is split, so attacker counting, EXP sharing and MVP
  scoring are untouched. The strict `merckillonly` bool becomes a
  `slavekilltypes` mask (`BL_HOM|BL_MER`, zeroed when any other source
  contributed), and the gate becomes an **AND across every participating slave
  type** instead of an `||`: each type that took part must have its own setting
  enabled.

  ### ⚠ Commit 2 contains a behaviour change

  Making `mercenary_autoloot` work means it starts being obeyed, and it **ships
  default `no`** — so **a mercenary-only kill stops autolooting** on servers that
  never touched the setting. That is what the setting exists for, and it matches
  what `homunculus_autoloot` already does, but it *is* a change for live servers.

  **Restoring it is one line**: `mercenary_autoloot: yes` in
  `conf/battle/drops.conf`. With stock settings that is an exact restore —
  `mer_idle_no_share` defaults to `0` just as `idle_no_autoloot` does, so the
  outcome is identical. One nuance to document: a slave kill is now gated by
  `hom_idle_no_share` / `mer_idle_no_share` rather than by `idle_no_autoloot`, so
  a server that customised the latter should set the matching slave value.

  The `||` leak and the assist bypass are **deliberately not restorable by
  configuration** — they are the bug fixes. An owner who wants homunculus kills to
  autoloot now says so with `homunculus_autoloot: yes`, instead of getting it as a
  side effect of the mercenary setting.

  **Commit 1 stands alone.** If you would rather keep a behaviour change out of a
  bug-fix PR, commit 2 can be dropped and re-proposed separately.

  ## What it becomes

  - The bonuses rolled always belong to the player the item is reserved to.
  - Bonuses roll for the master when a homunculus, mercenary, elemental or pet
    lands the killing blow.
  - Bubble Gum, VIP rate and `bDropAddRace`/`bDropAddClass` apply to the priority
    holder, and `drops_by_luk` reads that player's LUK.
  - Each autoloot setting gates only its own slave type, and every participating
    type must allow it.
  - Solo play is unchanged by construction — `sd` and `first_sd` are the same
    object when you kill something yourself.
  - Drop ownership, MVP determination and EXP sharing are not touched.

  ## Testing

  Run in-game on a local pre-renewal server (`PACKETVER 20211103`) driven by a
  headless client, so every arm is scripted and repeatable. This is what replaces
  the official-server test I could not do: it cannot tell you what kRO does, but
  it does tell you exactly what this patch changes and what it leaves alone.

  **The attribution fix — measured as an A/B.** Same arms, fixtures, config,
  characters and map, run twice, changing only the binary:

  ```
               identical in both runs:
               fixtures · conf · characters · map · arm scripts
                                │
                ┌───────────────┴───────────────┐
                ▼                               ▼
        master (2fe6ab3)                this branch (e28991c)
                └───────────────┬───────────────┘
                                ▼
                  same 11 arms → compare verdicts
  ```

  Tengu Card is a *group* bonus and re-rolls inside `GROUP_ALGORITHM_DROP`, so it
  cannot give a clean signal. The fixtures use a named-item bonus instead —
  `bonus2 bAddMonsterDropItem,<id>,10000` takes the `it.nameid > 0` branch and
  drops with no second roll:

  | accessory | script | worn by |
  |---|---|---|
  | marker A | `bonus2 bAddMonsterDropItem,Jellopy,10000` + `bonus2 bGetZenyNum,500,100` | player A |
  | marker B | `bonus2 bAddMonsterDropItem,Clover,10000` | player B |
  | marker R | `bonus2 bDropAddRace,RC_All,999900` (with `drop_rate_cap: 10000`) | player A |

  The test monsters drop only Red Potion at `Rate: 1`, so no marker item can come
  from a native drop table and every Jellopy or Clover on the ground is
  attributable to exactly one card.

  ```
  slave kill    A wears marker A, homunculus kills, A deals 0 damage
                → expect A's card to roll (A holds priority)

  kill steal    B wears marker B and lands the FIRST hit   → B holds priority
                A wears marker A and lands the KILLING blow
                → expect B's card to roll, A's not to

  control       A wears marker A and kills the monster alone
                → expect identical results on both binaries
  ```

  | tested | master | this branch |
  |---|---|---|
  | homunculus-only kill ×5, master wears marker A | **0/5** | **5/5** |
  | the `get_zeny_num` half of the same block | **0 z** | **+26,534 z** |
  | a `bDropAddRace` modifier on the monster's own drop | **0/5** | **5/5** |
  | kill steal — B holds priority, A lands the blow | **A's card rolls** | **B's card rolls** |
  | player lands the killing blow ×5 (control) | 5/5 | 5/5 |
  | solo ×10 (control) | 10/10 | 10/10 |
  | MVP killed 100 % by the homunculus | MVP → master, no bonus | MVP → master, bonus rolls |
  | MVP kill steal | MVP → priority holder, killer's card | MVP → priority holder, priority holder's card |
  | `mvp_to_loot_priority` off / on | no → damage, yes → priority | identical |

  The kill-steal row is also confirmed server-side, not only from packets. The
  `picklog` table logs what the monster dropped: on `master` the row is
  `Jellopy` — the killer's card — and on this branch it is `Clover`, the priority
  holder's. The same flip, from the server's own log rather than from the client's
  view of it.

  MVP determination is identical on both binaries in every MVP arm; only the bonus
  roll moves. One note on the autoloot rows in that set: the `homunculus_autoloot`
  on/off arms pass on this branch and fail on master, not because the gating
  changed but because on master a homunculus kill produces no bonus item for
  either setting to act on — the scenario is unobservable before the fix rather
  than behaving differently.

  **The autoloot gating — 8 arms, all passing**, judged from the packets the
  server sends: `ZC.ITEM_FALL_ENTRY*` (item on the ground) vs
  `ZC.ITEM_PICKUP_ACK*` (autolooted), plus `ZC.NOTIFY_EXP*` and `ZC.MVP` for the
  two regression arms:

  | arm | expected | |
  |---|---|---|
  | mercenary-only kill, `mercenary_autoloot: no` | ground drops only, no autoloot | ✅ |
  | mercenary-only kill, `mercenary_autoloot: yes` | autoloot fires | ✅ |
  | homunculus-only kill, both settings, no mercenary present | identical to before this PR | ✅ |
  | homunculus + mercenary assist, both settings `no` | no autoloot (bypass fixed) | ✅ |
  | player hit + mercenary assist, both settings `no` | autoloot still fires — settings bite on pure-AI kills only | ✅ |
  | EXP: solo vs mercenary-assisted, same monster | identical, no attacker-count inflation | ✅ |
  | MVP monster, master + mercenary, master dealing the majority | master still gets MVP | ✅ |

  ## What I am asking for

  1. **If anyone can test this on kRO or iRO** — a homunculus or mercenary kill
     with a drop-bonus card equipped, or with Bubble Gum active — that is the
     evidence I am missing. A kRO check would be worth the most: my sources are
     iRO staff, and I have no kRO source confirming them.
  2. **If this gate is on the killer on purpose**, I would rather hear the reason
     than have the PR merged. The argument rests on the absence of one.

  ## Out of scope

  - **Loot proportion.** How `first_sd` is chosen, including the slave damage
    aggregation from #9238, is correct and untouched.
  - **`BL_MOB` summons and `BL_ELEM`.** They are logged `MDLF_NORMAL` and stay
    outside the slave mask, so their current behaviour is preserved on purpose.
