### PR TITLE
feat: add Docker deployment for offline rAthena server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.vs
+build
+log
+*.exe
+*.pdb
+*.sln
+*.slnLaunch
+*.vcxproj
+*.vcxproj.filters
+login-server
+char-server
+map-server
+web-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM alpine:3.23 AS builder
+
+WORKDIR /rathena
+
+RUN apk add --no-cache \
+        bash \
+        build-base \
+        cmake \
+        linux-headers \
+        mariadb-dev \
+        zlib-dev
+
+COPY . .
+
+# Keep rAthena's checked-in default PACKETVER for the initial bootable image.
+# Client/server packet alignment will be configured in a later step.
+RUN ./configure \
+    && make -j"$(nproc)" login char map import
+
+
+FROM alpine:3.23 AS runtime
+
+RUN apk add --no-cache \
+        ca-certificates \
+        libstdc++ \
+        mariadb-connector-c \
+        netcat-openbsd \
+        tini \
+        zlib \
+    && addgroup -S rathena \
+    && adduser -S -D -H -G rathena rathena \
+    && mkdir -p /rathena/log \
+    && chown -R rathena:rathena /rathena
+
+WORKDIR /rathena
+
+USER rathena
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+
+FROM runtime AS login
+
+COPY --from=builder --chown=rathena:rathena /rathena/login-server ./login-server
+COPY --from=builder --chown=rathena:rathena /rathena/conf ./conf
+
+EXPOSE 6900
+
+CMD ["./login-server"]
+
+
+FROM runtime AS char
+
+COPY --from=builder --chown=rathena:rathena /rathena/char-server ./char-server
+COPY --from=builder --chown=rathena:rathena /rathena/conf ./conf
+COPY --from=builder --chown=rathena:rathena /rathena/db ./db
+
+EXPOSE 6121
+
+CMD ["./char-server"]
+
+
+FROM runtime AS map
+
+COPY --from=builder --chown=rathena:rathena /rathena/map-server ./map-server
+COPY --from=builder --chown=rathena:rathena /rathena/conf ./conf
+COPY --from=builder --chown=rathena:rathena /rathena/db ./db
+COPY --from=builder --chown=rathena:rathena /rathena/npc ./npc
+
+EXPOSE 5121
+
+CMD ["./map-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ COPY . .
 
 # Keep rAthena's checked-in default PACKETVER for the initial bootable image.
 # Client/server packet alignment will be configured in a later step.
+# Build rapidyaml serially first because its generated Makefile can race while
+# creating nested object directories under a parallel top-level build.
 RUN ./configure \
+    && make -j1 rapidyaml \
     && make -j"$(nproc)" login char map import
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,8 @@ services:
   db:
     image: mariadb:11.8.8
     restart: unless-stopped
+    ports:
+      - "127.0.0.1:3306:3306"
     environment:
       MARIADB_RANDOM_ROOT_PASSWORD: "1"
       MARIADB_DATABASE: ragnarok

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,108 @@
+name: ragnarok-offline
+
+services:
+  db:
+    image: mariadb:11.8.8
+    restart: unless-stopped
+    environment:
+      MARIADB_RANDOM_ROOT_PASSWORD: "1"
+      MARIADB_DATABASE: ragnarok
+      MARIADB_USER: ragnarok
+      MARIADB_PASSWORD: ragnarok
+    volumes:
+      - ragnarok-db:/var/lib/mysql
+      - ./sql-files/main.sql:/docker-entrypoint-initdb.d/01-main.sql:ro
+      - ./sql-files/logs.sql:/docker-entrypoint-initdb.d/02-logs.sql:ro
+      - ./sql-files/roulette_default_data.sql:/docker-entrypoint-initdb.d/03-roulette.sql:ro
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  login:
+    image: ragnarok-offline-login:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: login
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+    ports:
+      - "127.0.0.1:6900:6900"
+    volumes:
+      - ./docker/inter_conf.txt:/rathena/conf/import/inter_conf.txt:ro
+      - login-logs:/rathena/log
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "6900"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    stop_grace_period: 30s
+
+  char:
+    image: ragnarok-offline-char:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: char
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+      login:
+        condition: service_healthy
+        restart: true
+    ports:
+      - "127.0.0.1:6121:6121"
+    volumes:
+      - ./docker/inter_conf.txt:/rathena/conf/import/inter_conf.txt:ro
+      - ./docker/char_conf.txt:/rathena/conf/import/char_conf.txt:ro
+      - char-logs:/rathena/log
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "6121"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    stop_grace_period: 30s
+
+  map:
+    image: ragnarok-offline-map:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: map
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+      char:
+        condition: service_healthy
+        restart: true
+    ports:
+      - "127.0.0.1:5121:5121"
+    volumes:
+      - ./docker/inter_conf.txt:/rathena/conf/import/inter_conf.txt:ro
+      - ./docker/map_conf.txt:/rathena/conf/import/map_conf.txt:ro
+      - map-logs:/rathena/log
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "5121"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    stop_grace_period: 30s
+
+volumes:
+  ragnarok-db:
+  login-logs:
+  char-logs:
+  map-logs:

--- a/conf/char_athena.conf
+++ b/conf/char_athena.conf
@@ -178,6 +178,7 @@ char_del_delay: 86400
 // Restrict character deletion by email address or birthdate.
 // This restricts players from changing the langtype and deleting characters.
 // Defaults based on client date.
+// 0: No server-side confirmation-code check
 // 1: Email address
 // 2: Birthdate
 // 3: Email address or Birthdate

--- a/conf/login_athena.conf
+++ b/conf/login_athena.conf
@@ -53,7 +53,7 @@ console: off
 
 // Can you use _M/_F to make new accounts on the server?
 // Note: This only works if client side password encryption is not enabled.
-new_account: no
+new_account: yes
 
 // If new_account is enabled, changes the minimum length for the account name.
 // By default is set to '4' or '6' (depending on the new login UI).

--- a/docker/char_conf.txt
+++ b/docker/char_conf.txt
@@ -2,3 +2,6 @@
 
 login_ip: login
 char_ip: 127.0.0.1
+
+// Disable the secondary security-number/PIN prompt for the offline server.
+pincode_enabled: no

--- a/docker/char_conf.txt
+++ b/docker/char_conf.txt
@@ -1,0 +1,4 @@
+// Docker Compose infrastructure overrides only.
+
+login_ip: login
+char_ip: 127.0.0.1

--- a/docker/char_conf.txt
+++ b/docker/char_conf.txt
@@ -5,3 +5,12 @@ char_ip: 127.0.0.1
 
 // Disable the secondary security-number/PIN prompt for the offline server.
 pincode_enabled: no
+
+// Allow immediate character deletion for the offline single-player server.
+char_del_delay: 0
+
+// Do not require an email address or birthdate confirmation code.
+char_del_option: 0
+
+// Allow deletion while the character belongs to a party or guild.
+char_del_restriction: 0

--- a/docker/inter_conf.txt
+++ b/docker/inter_conf.txt
@@ -1,0 +1,9 @@
+// Docker Compose infrastructure overrides only.
+// Gameplay and balance configuration will be added separately.
+
+login_server_ip: db
+ipban_db_ip: db
+char_server_ip: db
+map_server_ip: db
+web_server_ip: db
+log_db_ip: db

--- a/docker/map_conf.txt
+++ b/docker/map_conf.txt
@@ -1,0 +1,4 @@
+// Docker Compose infrastructure overrides only.
+
+char_ip: char
+map_ip: 127.0.0.1

--- a/src/char/char_clif.cpp
+++ b/src/char/char_clif.cpp
@@ -714,8 +714,9 @@ bool chclif_parse_char_delete2_accept( int32 fd, char_session_data& sd ){
 	birthdate[7] = p->birthdate[5];
 	birthdate[8] = '\0';
 
-	// Only check for birthdate
-	if( !chclif_delchar_check( &sd, birthdate, CHAR_DEL_BIRTHDATE ) ){
+	// Modern clients always send a birthdate field, but an offline server may
+	// explicitly disable the server-side confirmation-code check.
+	if( charserv_config.char_config.char_del_option != 0 && !chclif_delchar_check( &sd, birthdate, CHAR_DEL_BIRTHDATE ) ){
 		chclif_char_delete2_accept_ack( fd, char_id, 5 );
 
 		return true;
@@ -1362,7 +1363,7 @@ bool chclif_parse_delchar( int fd, struct char_session_data& sd ){
 	ShowInfo(CL_RED "Request Char Deletion: " CL_GREEN "%u (%u)" CL_RESET "\n", sd.account_id, cid);
 	safestrncpy( email, p->key, sizeof( email ) );
 
-	if (!chclif_delchar_check(&sd, email, charserv_config.char_config.char_del_option)) {
+	if (charserv_config.char_config.char_del_option != 0 && !chclif_delchar_check(&sd, email, charserv_config.char_config.char_del_option)) {
 		chclif_refuse_delchar(fd,0); // 00 = Incorrect Email address
 		return true;
 	}

--- a/src/custom/defines_pre.hpp
+++ b/src/custom/defines_pre.hpp
@@ -9,6 +9,6 @@
  * For detailed guidance on these check http://rathena.org/wiki/SRC/config/
  **/
 
-
+#define PACKETVER 20250716
 
 #endif /* CONFIG_CUSTOM_DEFINES_PRE_HPP */


### PR DESCRIPTION
## Summary

Add a local Docker Compose deployment for the offline rAthena server, align the compiled server with the selected client, and remove account and character-management barriers that are unnecessary in a single-player environment.

## What changed

- Add multi-stage Alpine images for the login, character, and map servers, including a serial rapidyaml pre-build that avoids its parallel directory-creation race.
- Add a health-checked Compose stack with MariaDB initialization, persistent database and log volumes, service startup ordering, and localhost-only published ports.
- Add container-specific database and inter-server network overrides, disable the secondary PIN prompt, and allow immediate character deletion without confirmation-code, level, party, or guild restrictions.
- Update the character deletion handlers so `char_del_option: 0` bypasses email and birthdate validation for both modern and legacy client packets.
- Enable `_M` and `_F` account registration and compile the server with `PACKETVER 20250716` for the selected client.